### PR TITLE
Fix documentation issue around MaxNumberOfRequestsPerSession property

### DIFF
--- a/version_2/docs/Intro/safe-by-default.markdown
+++ b/version_2/docs/Intro/safe-by-default.markdown
@@ -39,5 +39,5 @@ By default, that limit is set to 30. On request #31, the session will throw an e
 
 You can override this behavior by setting a different limit:
 
+* Per session, by setting: IDocumentSession.Advanced.MaxNumberOfRequestsPerSession
 * Globally, by setting: DocumentConvention.MaxNumberOfRequestsPerSession
-* Per session, by setting: IDocumentSession.MaxNumberOfRequestsPerSession


### PR DESCRIPTION
Update documentation to correct location where this  can be accessed on a session.

Flip order around to emphasize that if people wanted to do more than 30 requests, they should override it at the session level instead of at the global level
