### PR TITLE
Minor spelling change

### DIFF
--- a/version_2/docs/server/deployment/as-iis-application.markdown
+++ b/version_2/docs/server/deployment/as-iis-application.markdown
@@ -87,7 +87,7 @@ You can resolve this problem by executing the following on the command line:
 
 You can also see all existing registrations with the following command:
 
-    ntsh http show urlacl
+    netsh http show urlacl
 
 ## IISReset
 


### PR DESCRIPTION
I copy pasted from here the other day trying to diagnose a problem on someone's local raven installation and discovered the command was spelled incorrectly.
