### PR TITLE
Update unbounded-results.markdown

### DIFF
--- a/version_2_5/docs/client-api/advanced/unbounded-results.markdown
+++ b/version_2_5/docs/client-api/advanced/unbounded-results.markdown
@@ -41,7 +41,7 @@ The first one accepts ETag of a document that you want to starts from:
 If you use the second one then you will have to provide a prefix key of the documents you want to stream and optionally a string value that
 should match the documet key after the specified prefix:
 
-
+{CODE doc_streaming_2@ClientApi\Advanced\UnboundedResults.cs /}
 
 The query above will return all documents where ID starts with _"users/"_ and the end matches the expression _"*Ra?en"_ (e.g. "users/Admins/Raven", "Users/Ragen").
 


### PR DESCRIPTION
It looks like the 2nd doc streaming example is missing
