### PR TITLE
Update enabling-ssl.markdown to include information about the prerequisites to run the SSL install script.

### DIFF
--- a/version_3/docs/server/configuration/enabling-ssl.markdown
+++ b/version_3/docs/server/configuration/enabling-ssl.markdown
@@ -1,6 +1,7 @@
 # Configuration : Enabling SSL
 
-{INFO SSL can only be enabled when RavenDB is running as a Windows Service /}
+{INFO SSL can only be enabled when RavenDB is running as a Windows Service.
+The certificate has to be installed in the local certificate repository [Certificates - Local Computer\Personal\Certificates] and include the private key (.pfx file), otherwise the following will not work. /}
 
 By default, secure connectivity is disabled. To enable the SSL in RavenDB, you need to do the following:
 


### PR DESCRIPTION
Had some troubles setting up SSL for RavenDB - I was mainly fooled by the script to install SSL in RavenDB, as it did not output error messages from netsh. I think this note can help others to identify what might be wrong if they encounter any troubles. Of course letting the install script emit errors from netsh would be nice, but that must be another pull request.
