### PR TITLE
Update authorization.markdown

### DIFF
--- a/Documentation/3.0/Raven.Documentation.Pages/server/bundles/authorization.markdown
+++ b/Documentation/3.0/Raven.Documentation.Pages/server/bundles/authorization.markdown
@@ -88,7 +88,6 @@ To install the Auth Bundle on the server side, simply place the Raven.Bundles.Au
 
 To use the Auth Bundle on the client side, you need to reference the following:
 
-* Raven.Bundles.Authorization.dll
 * Raven.Client.Authorization.dll
 
 and import the "Raven.Client.Authorization" namespace to include the authorization extension methods.


### PR DESCRIPTION
Removed the instruction to reference Raven.Bundles.Authorization.dll since referencing both the client and the server version of the bundle gives a compile error. Also this brings this file in line with http://ravendb.net/docs/article-page/3.0/csharp/client-api/bundles/how-to-work-with-authorization-bundle.
