### PR TITLE
RDoc-578 delete PutIndexAsyncWithOperation from whats-new.markdown

### DIFF
--- a/Documentation/3.0/Raven.Documentation.Pages/start/whats-new.markdown
+++ b/Documentation/3.0/Raven.Documentation.Pages/start/whats-new.markdown
@@ -104,8 +104,7 @@
 - Fixed filtering of ignored headers,
 - Optimized memory usage when streaming documents with missing properties according to a given type,
 - Optimized usage of HttpClient cache,
-- Fixed reconnection issue in Changes API,
-- Added `PutIndexAsyncWithOperation` command method
+- Fixed reconnection issue in Changes API
 
 <hr />
 


### PR DESCRIPTION
This is the only thing I had to change for this issue 
http://issues.hibernatingrhinos.com/issue/RavenDB-4838
