### PR TITLE
:wrench: Fix PatchRequest type when adding a new Property

### DIFF
--- a/Documentation/3.5/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Patches/PatchRequests.cs
+++ b/Documentation/3.5/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Patches/PatchRequests.cs
@@ -92,7 +92,7 @@ namespace Raven.Documentation.Samples.ClientApi.Commands.Patches
 						{
 							new PatchRequest
 								{
-									Type = PatchCommandType.Add, 
+									Type = PatchCommandType.Set, 
 									Name = "Age", 
 									Value = 30
 								}


### PR DESCRIPTION
- Was incorrectly suggesting to use the `PatchCommandType.Add` type when trying to add a simple primitive value to an existing document. This is used for adding items to a collection.

![](https://media.giphy.com/media/imRu0Oqh6kzdK/giphy.gif)