### PR TITLE
Backward compatibility for V4

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/faq/backward-compatibility.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/faq/backward-compatibility.markdown
@@ -1,0 +1,32 @@
+# Backward compatibility
+
+When it comes to client server compatibility in RavenDB there are two valid rules. Either:
+
+ * The server version is within the same Major and Minor range as the client version
+
+**OR**
+
+ * The server version is greater than the client version
+ 
+**HOWEVER**
+
+ * RavenDB 4.0 contains significant breaking changes, so a 4.0 client is needed to connect to it.
+
+Some examples:
+
+ * `4.0` client will work with `4.0` server since client and server are in the same Major and Minor range.
+ * `3.0`/`3.5` client will **NOT** work with `4.0` server due to the breaking changes in 4.0.
+ * For versions prior to 4.0:
+   * `3.0` client will work with `3.5` server since server is greater than client
+   * `3.5` client will work with `3.5` server since client and server are in the same Major and Minor range
+   * `3.5.3785` client will work with `3.5.3528` server since client and server are in the same Major and Minor range
+   * `3.5` client will **NOT** work with `3.0` server since client is greater than server
+   * `3.0` client will **NOT** work with `2.5` server since client is greater than server
+
+## Upgrading
+
+To properly upgrade your applications and server, we advise you to upgrade the server first, then the clients. This way your applications will keep working as before, and you can update them one-by-one if needed.
+
+## Related articles
+
+- [Server : Upgrading to a new version](../../server/installation/upgrading-to-new-version)


### PR DESCRIPTION
I got stung by the 3.5 client not being able to connect to 4.0 database. Only documentation I could find on this was a [small mention in one of Oren's blog posts](https://ayende.com/blog/176385/ravendb-4-0-alpha-is-out) so figured something canonical was needed.