### PR TITLE
Fix example for PublicTcpServerUrl

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/server/configuration/server-core-configuration.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/configuration/server-core-configuration.markdown
@@ -86,7 +86,7 @@ Set the public TCP address of the server. Used for inter-node communication and 
 
 #Example:
 ```
-PublicServerUrl=tcp://example.com:38888
+PublicTcpServerUrl=tcp://example.com:38888
 ```
 
 <br><br>


### PR DESCRIPTION
Parameter name is wrong for PublicTcpServerUrl setting inside example.