### PR TITLE
typo

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/migration/client-api/indexes.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/migration/client-api/indexes.markdown
@@ -22,7 +22,7 @@ There is no need to explicitly define sorting in definitions of static indexes a
 
 ### Constants.AllFields
 
-`Constants.AllFields` constant has been removed to `Constants.Documents.Indexing.Fields.AllFields`
+`Constants.AllFields` constant has been moved to `Constants.Documents.Indexing.Fields.AllFields`
 
 ### FieldIndexing.Analyzed
 


### PR DESCRIPTION
removed to => moved to