### PR TITLE
fixed incorrect indentation

### DIFF
--- a/Documentation/2.5/Samples/csharp/Raven.Documentation.Samples/ClientApi/Querying/LazyOperations.cs
+++ b/Documentation/2.5/Samples/csharp/Raven.Documentation.Samples/ClientApi/Querying/LazyOperations.cs
@@ -154,7 +154,7 @@
 								   };
 
 					session.Store(user);
-                    session.Store(city);
+					session.Store(city);
 					session.SaveChanges();
 				}
 


### PR DESCRIPTION
The previous commit was using spaces instead of tabs, which I think is what caused the incorrect indentation in the website