### PR TITLE
[RDoc-1223] fix Table of Contents ordering

### DIFF
--- a/Raven.Documentation.Parser/Compilation/ToC/TocConverter.cs
+++ b/Raven.Documentation.Parser/Compilation/ToC/TocConverter.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Documentation.Parser.Data;
+
+namespace Raven.Documentation.Parser.Compilation.ToC
+{
+    internal class TocConverter
+    {
+        public TableOfContents ConvertToTableOfContents(List<TableOfContentsCompiler.CompilationResult> compilationResults, string version, Category category)
+        {
+            var tocItems = ConvertToTableOfContentItems(compilationResults).ToList();
+
+            var tableOfContents = new TableOfContents
+            {
+                Version = version,
+                Category = category,
+                Items = tocItems
+            };
+            return tableOfContents;
+        }
+
+        public IEnumerable<TableOfContents.TableOfContentsItem> ConvertToTableOfContentItems(IEnumerable<TableOfContentsCompiler.CompilationResult> compilationResults)
+        {
+            foreach (var compilationResult in compilationResults)
+            {
+                var tocItem = ConvertToTableOfContentsItem(compilationResult);
+                tocItem.Items = ConvertToTableOfContentItems(compilationResult.Items).ToList();
+
+                yield return tocItem;
+            }
+        }
+
+        public TableOfContents.TableOfContentsItem ConvertToTableOfContentsItem(TableOfContentsCompiler.CompilationResult compilationResult)
+        {
+            var tocItem = new TableOfContents.TableOfContentsItem
+            {
+                Key = compilationResult.Key,
+                Title = compilationResult.Title,
+                SourceVersion = compilationResult.SourceVersion,
+                IsFolder = compilationResult.IsFolder,
+                Languages = compilationResult.Languages
+            };
+            return tocItem;
+        }
+    }
+}

--- a/Raven.Documentation.Parser/Data/DocumentationFile.cs
+++ b/Raven.Documentation.Parser/Data/DocumentationFile.cs
@@ -16,6 +16,8 @@ namespace Raven.Documentation.Parser.Data
 
         public List<string> SupportedVersions { get; set; }
 
+        public bool IsPlaceholder { get; set; }
+
         public Dictionary<string, string> Metadata { get; set; }
 
         public Dictionary<string, string> SeoMetaProperties { get; set; }

--- a/Raven.Documentation.Parser/Data/FolderItem.cs
+++ b/Raven.Documentation.Parser/Data/FolderItem.cs
@@ -22,6 +22,8 @@ namespace Raven.Documentation.Parser.Data
 
         public bool IsFolder { get; private set; }
 
+        public bool IsPlaceholder { get; set; }
+
         public string Name { get; set; }
 
         public string Description { get; set; }

--- a/Raven.Documentation.Parser/Data/TableOfContents.cs
+++ b/Raven.Documentation.Parser/Data/TableOfContents.cs
@@ -29,8 +29,6 @@
 
             public string SourceVersion { get; set; }
 
-            public string SourcePath { get; set; }
-
 			public bool IsFolder { get; set; }
 
 			public List<TableOfContentsItem> Items { get; set; }

--- a/Raven.Documentation.Parser/DocumentationParser.cs
+++ b/Raven.Documentation.Parser/DocumentationParser.cs
@@ -43,13 +43,13 @@ namespace Raven.Documentation.Parser
 
             var documentationDirectories = Directory.GetDirectories(Options.PathToDocumentationDirectory);
 
-            var tableOfContents = documentationDirectories
+            var compiledTocs = documentationDirectories
                 .Select(documentationDirectory => new DirectoryInfo(documentationDirectory))
-                .SelectMany(directory => _tableOfContentsCompiler.GenerateTableOfContents(directory, compilationContext))
+                .Select(directory => _tableOfContentsCompiler.Compile(directory, compilationContext))
                 .ToList();
 
-            TableOfContentsMerger.Merge(tableOfContents);
-            return tableOfContents;
+            var mergedTocs = TableOfContentsMerger.Merge(compiledTocs);
+            return mergedTocs;
         }
 
         private IEnumerable<DocumentationPage> GenerateDocumentationPages(IEnumerable<TableOfContents> tocs)

--- a/Raven.Documentation.Parser/Helpers/DocumentationFileHelper.cs
+++ b/Raven.Documentation.Parser/Helpers/DocumentationFileHelper.cs
@@ -34,6 +34,7 @@ namespace Raven.Documentation.Parser.Helpers
                     Description = name,
                     Name = isFolder ? path.Substring(1, path.Length - 1) : path.Substring(0, path.Length - Constants.MarkdownFileExtension.Length),
                     SupportedVersions = file.SupportedVersions,
+                    IsPlaceholder = file.IsPlaceholder,
                     Mappings = file.Mappings,
                     Metadata = file.Metadata,
                     SeoMetaProperties = file.SeoMetaProperties


### PR DESCRIPTION
Also, added optional "IsPlaceholder" field to .docs.json entries. The field indicates that an entry should be present in the 4.1 Table of Contents but its contents will be provided by a lower version (4.0).