### PR TITLE
Use quotes for JSON field names in RQL

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-work-with-suggestions.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-work-with-suggestions.dotnet.markdown
@@ -41,7 +41,7 @@ The `Suggestion` feature is available through query extension methods. It gives 
 {CODE-TAB:csharp:Async suggest_6@ClientApi\Session\Querying\HowToWorkWithSuggestions.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
 from index 'Employees/ByFullName' 
-select suggest('FullName', 'johne', '{ Accuracy : 0.4, PageSize : 5, Distance : "JaroWinkler", SortMode : "Popularity" }')
+select suggest('FullName', 'johne', '{ "Accuracy" : 0.4, "PageSize" : 5, "Distance" : "JaroWinkler", "SortMode" : "Popularity" }')
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-work-with-suggestions.java.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-work-with-suggestions.java.markdown
@@ -39,7 +39,7 @@ The `suggestion` feature is available through query extension methods. It gives 
 {CODE-TAB:java:Java suggest_5@ClientApi\Session\Querying\HowToWorkWithSuggestions.java /}
 {CODE-TAB-BLOCK:sql:RQL}
 from index 'Employees/ByFullName' 
-select suggest('fullName', 'johne', '{ Accuracy : 0.4, PageSize : 5, Distance : "JaroWinkler", SortMode : "Popularity" }')
+select suggest('fullName', 'johne', '{ "Accuracy" : 0.4, "PageSize" : 5, "Distance" : "JaroWinkler", "SortMode" : "Popularity" }')
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 


### PR DESCRIPTION
Original version fails with: System.IO.InvalidDataException: Cannot have a 'A' in this position at  (1,4) around: { Accuracy: 0.4, PageSize: 5, Distance: "JaroWinkler", SortMode: "Popularity" }
