### PR TITLE
Let's not show moved article in old location in 4.2 docs - studio/ser…

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/studio/server/cluster/.docs.json
+++ b/Documentation/4.0/Raven.Documentation.Pages/studio/server/cluster/.docs.json
@@ -12,6 +12,12 @@
     {
         "Path": "cluster-observer.markdown",
         "Name": "Cluster Observer",
-        "Mappings": []
+        "Mappings": [
+            {
+                "Version": 4.2,
+                "Key": "studio/server/debug/advanced/cluster-observer"
+            }
+        ],
+        "LastSupportedVersion": "4.1"
     }
 ]


### PR DESCRIPTION
…ver/cluster/cluster-observer article has been moved to studio/server/debug/advanced/cluster-observer