### PR TITLE
TimeToSyncAfterFl*a*shInSec => TimeToSyncAfterFl*u*shInSec

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
@@ -32,9 +32,9 @@ Maximum concurrent flushes.
 
 {PANEL/}
 
-{PANEL:Storage.TimeToSyncAfterFlashInSec}
+{PANEL:Storage.TimeToSyncAfterFlushInSec}
 
-Time to sync after flash in seconds
+Time to sync after flush in seconds
 
 - **Type**: `int`
 - **Default**: `30`

--- a/Documentation/4.1/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
@@ -32,9 +32,9 @@ Maximum concurrent flushes.
 
 {PANEL/}
 
-{PANEL:Storage.TimeToSyncAfterFlashInSec}
+{PANEL:Storage.TimeToSyncAfterFlushInSec}
 
-Time to sync after flash in seconds
+Time to sync after flush in seconds
 
 - **Type**: `int`
 - **Default**: `30`

--- a/Documentation/4.2/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
@@ -32,9 +32,9 @@ Maximum concurrent flushes.
 
 {PANEL/}
 
-{PANEL:Storage.TimeToSyncAfterFlashInSec}
+{PANEL:Storage.TimeToSyncAfterFlushInSec}
 
-Time to sync after flash in seconds
+Time to sync after flush in seconds
 
 - **Type**: `int`
 - **Default**: `30`


### PR DESCRIPTION
Fixed typo in 4.0, 4.1 and 4.2 server>configuration>storage-configuration

TimeToSyncAfterFl*a*shInSec => TimeToSyncAfterFl*u*shInSec