### PR TITLE
Rdbc 349 compact database operation

### DIFF
--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
@@ -24,9 +24,23 @@ To compact database, please use **CompactDatabaseOperation**. You can choose wha
 {CODE compact_4@ClientApi\Operations\Server\Compact.cs /}
 
 
+## Example III
+
+* CompactDatabaseOperation automatically runs **on the store's database**.  
+  If we try to compact **a different database**, the process will succeed only if the database 
+  resides **on the cluster's first online node**.  
+  Trying to compact a non-default database on a different node will fail with an error such as -  
+  **_"500 Internal Server Error : 
+  System.InvalidOperationException , 
+  Cannot compact database 'name' on node A, because it doesn't reside on this node."_**  
+  
+* To solve this, we can explicitly identify the database we want to compact by 
+  providing its name to a private CompactDatabaseOperation method.  
+  {CODE compact_5@ClientApi\Operations\Server\Compact.cs /}
+
 ## Remarks
 
-The compacting operation is executed **asynchronously** and during this operation the **database** will be **offline**.
+* The compacting operation is executed **asynchronously**, and during this operation **the database will be offline**.
 
 ## Related Articles
 

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
@@ -1,0 +1,36 @@
+# Operations: Server: How to Compact a Database
+
+To compact database, please use **CompactDatabaseOperation**. You can choose what should be compacted: documents and/or listed indexes.
+
+## Syntax
+
+{CODE compact_1@ClientApi\Operations\Server\Compact.cs /}
+
+{CODE compact_2@ClientApi\Operations\Server\Compact.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **DatabaseName** | string | Name of a database to compact |
+| **Documents** | bool | Indicates if documents should be compacted |
+| **Indexes** | string[] | List of index names to compact |
+
+## Example I
+
+{CODE compact_3@ClientApi\Operations\Server\Compact.cs /}
+
+
+## Example II
+
+{CODE compact_4@ClientApi\Operations\Server\Compact.cs /}
+
+
+## Remarks
+
+The compacting operation is executed **asynchronously** and during this operation the **database** will be **offline**.
+
+## Related Articles
+
+- [How to **create** database?](../../../client-api/operations/server-wide/create-database) 
+- [How to get database **statistics**?](../../../client-api/operations/maintenance/get-statistics)
+- [How to start **restore** operation?](../../../client-api/operations/server-wide/restore-backup)
+

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
@@ -34,8 +34,8 @@ To compact database, please use **CompactDatabaseOperation**. You can choose wha
   System.InvalidOperationException , 
   Cannot compact database 'name' on node A, because it doesn't reside on this node."_**  
   
-* To solve this, we can explicitly identify the database we want to compact by 
-  providing its name to a private CompactDatabaseOperation method.  
+* To solve this, we can explicitly identify the database we want to compact by providing 
+  its name to CompactDatabaseOperation as in the following example.  
   {CODE compact_5@ClientApi\Operations\Server\Compact.cs /}
 
 ## Remarks

--- a/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/Compact.cs
+++ b/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/Compact.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+
+    public class Compact
+    {
+        private interface IFoo
+        {
+            /*
+            #region compact_1
+            public CompactDatabaseOperation(CompactSettings compactSettings)
+            #endregion
+            */
+        }
+
+        private class Foo
+        {
+            #region compact_2
+            public class CompactSettings
+            {
+                public string DatabaseName { get; set; }
+
+                public bool Documents { get; set; }
+
+                public string[] Indexes { get; set; }
+            }
+            #endregion
+        }
+
+        public Compact()
+        {
+
+            using (var store = new DocumentStore())
+            {
+                #region compact_3
+                CompactSettings settings = new CompactSettings
+                {
+                    DatabaseName = "Northwind",
+                    Documents = true,
+                    Indexes = new[] { "Orders/Totals", "Orders/ByCompany" }
+                };
+                Operation operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(settings));
+                operation.WaitForCompletion();
+                #endregion
+            }
+            using (var store = new DocumentStore())
+            {
+                #region compact_4
+                // get all index names
+                string[] indexNames = store.Maintenance.Send(new GetIndexNamesOperation(0, int.MaxValue));
+
+                CompactSettings settings = new CompactSettings
+                {
+                    DatabaseName = "Northwind",
+                    Documents = true,
+                    Indexes = indexNames
+                };
+                // compact entire database: documents + all indexes
+                Operation operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(settings));
+                operation.WaitForCompletion();
+                #endregion
+            }
+        }
+    }
+}


### PR DESCRIPTION
RDBC-349 - CompactDatabaseOperation

Documentation of -
* The issue: an error while trying to compact a database that resides on a node other than the first online node.
* A temporary solution: explicitly identifying the database we want to compact.