### PR TITLE
RDoc-1697 java index query code samples

### DIFF
--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/indexing-attachments.dotnet.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/indexing-attachments.dotnet.markdown
@@ -1,21 +1,19 @@
 # Indexes: Indexing Attachments
 
-To address the need of indexing (and searching for) the [attachments](../client-api/session/attachments/what-are-attachments) we have introduced the `AttachmentsFor` method that can be used in indexing functions. This method will return a list of attachments in given document with basic information like `Name` or `Size` about every one of them.
-
-## Creating Indexes
-
-The `AttachmentsFor` method available in `AbstractIndexCreationTask` returns all of the attachments for a document passed as the first argument.
+The `AttachmentsFor` method returns a list of [attachments](../client-api/session/attachments/what-are-attachments) in a given document as well as basic information like `Name` or `Size` about each of them.
 
 {CODE-TABS}
 {CODE-TAB:csharp:AttachmentsFor syntax@Indexes\IndexingAttachments.cs /}
 {CODE-TAB:csharp:AttachmentName result@Indexes\IndexingAttachments.cs /}
 {CODE-TABS/}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Index index@Indexes\IndexingAttachments.cs /}
-{CODE-TABS/}
+## Creating an index using `AttachmentsFor()`
 
-## Example
+The `AttachmentsFor` method is available in `AbstractIndexCreationTask`.
+
+{CODE:csharp index@Indexes\IndexingAttachments.cs /}
+
+## Querying the index
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync query1@Indexes\IndexingAttachments.cs /}

--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/indexing-attachments.java.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/indexing-attachments.java.markdown
@@ -1,19 +1,17 @@
 # Indexes: Indexing Attachments
 
-To address the need of indexing (and searching for) the [attachments](../client-api/session/attachments/what-are-attachments) we have introduced the `AttachmentsFor` method that can be used in indexing functions. This method will return a list of attachments in given document with basic information like `Name` or `Size` about every one of them.
-
-## Creating Indexes
-
-The `AttachmentsFor` method returns all of the attachments for a document passed as the first argument.
+The `AttachmentsFor` method returns a list of [attachments](../client-api/session/attachments/what-are-attachments) in a given document as well as basic information like `Name` or `Size` about each of them.
 
 {CODE-TABS}
 {CODE-TAB:java:AttachmentsFor syntax@Indexes\IndexingAttachments.java /}
 {CODE-TAB:java:AttachmentName result@Indexes\IndexingAttachments.java /}
 {CODE-TABS/}
 
+## Creating an index using `AttachmentsFor()`
+
 {CODE:java index@Indexes\IndexingAttachments.java /}
 
-## Example
+## Querying the index
 
 {CODE:java query1@Indexes\IndexingAttachments.java /}
 

--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/map-indexes.java.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/map-indexes.java.markdown
@@ -32,7 +32,7 @@ Let's create an index that will help us search for `Employees` by their `FirstNa
 {CODE-TABS}
 {CODE-TAB:java indexes_2@Indexes/Map.java /}
 {CODE-TAB:java:JavaScript-syntax javaScriptindexes_2@Indexes/JavaScript.java /}
-{CODE-TABS}
+{CODE-TABS/}
 
 - The final step is to [deploy it](../indexes/creating-and-deploying) to the server and issue a query using the session [Query](../client-api/session/querying/how-to-query) method:
 

--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/map-reduce-indexes.java.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/map-reduce-indexes.java.markdown
@@ -21,7 +21,7 @@ Let's assume that we want to count the number of products for each category. To 
 {CODE-TABS}
 {CODE-TAB:java:LINQ map_reduce_0_0@Indexes\MapReduceIndexes.java /}
 {CODE-TAB:java:JavaScript map_reduce_0_0@Indexes\JavaScript.java /}
-{CODE-TABS}
+{CODE-TABS/}
 
 and issue the query:
 
@@ -63,7 +63,7 @@ We want to know how many times each product was ordered and how much we earned f
 {CODE-TABS}
 {CODE-TAB:java:LINQ map_reduce_2_0@Indexes\MapReduceIndexes.java /}
 {CODE-TAB:java:JavaScript map_reduce_2_0@Indexes\JavaScript.java /}}
-{CODE-TABS}
+{CODE-TABS/}
 
 and send the query:
 

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/FanoutIndexes.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/FanoutIndexes.cs
@@ -39,7 +39,7 @@ namespace Raven.Documentation.Samples.Indexes
 			{
 				Map = orders => from order in orders
 					from line in order.Lines
-					select new
+					select new Result
 					{
 						Product = line.Product,
 						Count = 1,

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingAttachments.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingAttachments.cs
@@ -42,7 +42,7 @@ namespace Raven.Documentation.Samples.Indexes
             {
                 Map = employees => from e in employees
                                    let attachments = AttachmentsFor(e)
-                                   select new
+                                   select new Result
                                    {
                                        AttachmentNames = attachments.Select(x => x.Name).ToArray()
                                    };
@@ -57,7 +57,7 @@ namespace Raven.Documentation.Samples.Indexes
                 using (var session = store.OpenSession())
                 {
                     #region query1
-                    // return all employees that have CV attached
+                    //return all employees that have an attachment called "cv.pdf"
                     List<Employee> employees = session
                         .Query<Employees_ByAttachmentNames.Result, Employees_ByAttachmentNames>()
                         .Where(x => x.AttachmentNames.Contains("cv.pdf"))
@@ -69,7 +69,7 @@ namespace Raven.Documentation.Samples.Indexes
                 using (var asyncSession = store.OpenAsyncSession())
                 {
                     #region query2
-                    // return all employees that have CV attached
+                    //return all employees that have an attachment called "cv.pdf"
                     List<Employee> employees = await asyncSession
                         .Query<Employees_ByAttachmentNames.Result, Employees_ByAttachmentNames>()
                         .Where(x => x.AttachmentNames.Contains("cv.pdf"))
@@ -81,7 +81,7 @@ namespace Raven.Documentation.Samples.Indexes
                 using (var session = store.OpenSession())
                 {
                     #region query3
-                    // return all employees that have CV attached
+                    //return all employees that have an attachment called "cv.pdf"
                     List<Employee> employees = session
                         .Advanced
                         .DocumentQuery<Employee, Employees_ByAttachmentNames>()

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingCounters.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingCounters.cs
@@ -28,7 +28,7 @@ namespace Raven.Documentation.Samples.Indexes
             {
                 Map = employees => from e in employees
                                    let counterNames = CounterNamesFor(e)
-                                   select new
+                                   select new Result
                                    {
                                        CounterNames = counterNames.ToArray()
                                    };

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingHierarchicalData.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingHierarchicalData.cs
@@ -35,13 +35,13 @@ namespace Raven.Documentation.Samples.Indexes
         {
             public class Result
             {
-                public string[] Authors { get; set; }
+                public IEnumerable<string> Authors { get; set; }
             }
 
             public BlogPosts_ByCommentAuthor()
             {
                 Map = posts => from post in posts
-                               select new
+                               select new Result
                                {
                                    Authors = Recurse(post, x => x.Comments).Select(x => x.Author)
                                };

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingRelatedDocuments.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/IndexingRelatedDocuments.cs
@@ -40,7 +40,7 @@ namespace Raven.Documentation.Samples.Indexes
             public Products_ByCategoryName()
             {
                 Map = products => from product in products
-                                  select new
+                                  select new Result
                                   {
                                       CategoryName = LoadDocument<Category>(product.Category).Name
                                   };
@@ -55,13 +55,13 @@ namespace Raven.Documentation.Samples.Indexes
             {
                 public string Name { get; set; }
 
-                public IList<string> Books { get; set; }
+                public IEnumerable<string> Books { get; set; }
             }
 
             public Authors_ByNameAndBooks()
             {
                 Map = authors => from author in authors
-                                 select new
+                                 select new Result
                                  {
                                      Name = author.Name,
                                      Books = author.BookIds.Select(x => LoadDocument<Book>(x).Name)

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Map.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Map.cs
@@ -123,7 +123,7 @@ namespace Raven.Documentation.Samples.Indexes
             public Employees_ByFullName()
             {
                 Map = employees => from employee in employees
-                                   select new
+                                   select new Result
                                    {
                                        FullName = employee.FirstName + " " + employee.LastName
                                    };
@@ -164,7 +164,7 @@ namespace Raven.Documentation.Samples.Indexes
             public Employees_ByYearOfBirth()
             {
                 Map = employees => from employee in employees
-                                   select new
+                                   select new Result
                                    {
                                        YearOfBirth = employee.Birthday.Year
                                    };
@@ -207,7 +207,7 @@ namespace Raven.Documentation.Samples.Indexes
             public Employees_ByBirthday()
             {
                 Map = employees => from employee in employees
-                                   select new
+                                   select new Result
                                    {
                                        Birthday = employee.Birthday
                                    };
@@ -249,7 +249,7 @@ namespace Raven.Documentation.Samples.Indexes
             public Employees_ByCountry()
             {
                 Map = employees => from employee in employees
-                                   select new
+                                   select new Result
                                    {
                                        Country = employee.Address.Country
                                    };
@@ -291,7 +291,7 @@ namespace Raven.Documentation.Samples.Indexes
             public Employees_Query()
             {
                 Map = employees => from employee in employees
-                                   select new
+                                   select new Result
                                    {
                                        Query = new[]
                                         {

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/MultiMap.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/MultiMap.cs
@@ -69,9 +69,9 @@ namespace Raven.Documentation.Samples.Indexes
 
                 public string DisplayName { get; set; }
 
-                public string Collection { get; set; }
+                public object Collection { get; set; }
 
-                public string Content { get; set; }
+                public string[] Content { get; set; }
             }
 
             public class Projection
@@ -86,9 +86,9 @@ namespace Raven.Documentation.Samples.Indexes
             public Smart_Search()
             {
                 AddMap<Company>(companies => from c in companies
-                    select new
+                    select new Result
                     {
-                        c.Id,
+                        Id = c.Id,
                         Content = new[]
                         {
                             c.Name
@@ -98,9 +98,9 @@ namespace Raven.Documentation.Samples.Indexes
                     });
 
                 AddMap<Product>(products => from p in products
-                    select new
+                    select new Result
                     {
-                        p.Id,
+                        Id = p.Id,
                         Content = new[]
                         {
                             p.Name
@@ -110,9 +110,9 @@ namespace Raven.Documentation.Samples.Indexes
                     });
 
                 AddMap<Employee>(employees => from e in employees
-                    select new
+                    select new Result
                     {
-                        e.Id,
+                        Id = e.Id,
                         Content = new[]
                         {
                             e.FirstName,

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Filtering.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Filtering.cs
@@ -49,7 +49,7 @@ namespace Raven.Documentation.Samples.Indexes.Querying
             public Orders_ByTotalPrice()
             {
                 Map = orders => from order in orders
-                                select new
+                                select new Result
                                 {
                                     TotalPrice = order.Lines.Sum(x => (x.Quantity * x.PricePerUnit) * (1 - x.Discount))
                                 };

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Highlights.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Highlights.cs
@@ -21,9 +21,9 @@ namespace Raven.Documentation.Samples.Indexes.Querying
             public BlogPosts_ByContent()
             {
                 Map = posts => from post in posts
-                               select new
+                               select new Result
                                {
-                                   post.Content
+                                   Content = post.Content
                                };
 
                 Index(x => x.Content, FieldIndexing.Search);
@@ -46,10 +46,10 @@ namespace Raven.Documentation.Samples.Indexes.Querying
             public BlogPosts_ByCategory_Content()
             {
                 Map = posts => from post in posts
-                               select new
+                               select new Result
                                {
-                                   post.Category,
-                                   post.Content
+                                   Category = post.Category,
+                                   Content = post.Content
                                };
 
                 Reduce = results => from result in results

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Searching.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Searching.cs
@@ -29,13 +29,13 @@ namespace Raven.Documentation.Samples.Indexes.Querying
         {
             public class Result
             {
-                public string Query;
+                public object Query;
             }
 
             public Users_Search()
             {
                 Map = users => from user in users
-                               select new
+                               select new Result
                                {
                                    Query = new object[]
                                    {

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Sorting.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Sorting.cs
@@ -69,7 +69,7 @@ namespace Raven.Documentation.Samples.Indexes.Querying
             public Products_ByName_Search()
             {
                 Map = products => from product in products
-                                  select new
+                                  select new Result
                                   {
                                       Name = product.Name,
                                       NameForSorting = product.Name

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/DynamicFields.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/DynamicFields.java
@@ -56,27 +56,6 @@ public class DynamicFields {
 
     //region dynamic_fields_2
     public static class Products_ByAttribute extends AbstractIndexCreationTask {
-        public static class Result {
-            private String color;
-            private String size;
-
-            public String getColor() {
-                return color;
-            }
-
-            public void setColor(String color) {
-                this.color = color;
-            }
-
-            public String getSize() {
-                return size;
-            }
-
-            public void setSize(String size) {
-                this.size = size;
-            }
-        }
-
         public Products_ByAttribute() {
             map = "docs.Products.Select(p => new { " +
                 "    _ = p.Attributes.Select(attribute => this.CreateField(attribute.name, attribute.value, false, true)) " +
@@ -90,9 +69,8 @@ public class DynamicFields {
             try (IDocumentSession session = store.openSession()) {
                 //region dynamic_fields_4
                 List<Product> results = session
-                    .query(Products_ByAttribute.Result.class, Products_ByAttribute.class)
+                    .query(Product.class, Products_ByAttribute.class)
                     .whereEquals("color", "red")
-                    .ofType(Product.class)
                     .toList();
                 //endregion
             }

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/FanoutIndexes.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/FanoutIndexes.java
@@ -21,36 +21,6 @@ public class FanoutIndexes {
 
     //region fanout_index_def_2
     public static class Product_Sales extends AbstractIndexCreationTask {
-        public static class Result {
-            private String product;
-            private int count;
-            private double total;
-
-            public String getProduct() {
-                return product;
-            }
-
-            public void setProduct(String product) {
-                this.product = product;
-            }
-
-            public int getCount() {
-                return count;
-            }
-
-            public void setCount(int count) {
-                this.count = count;
-            }
-
-            public double getTotal() {
-                return total;
-            }
-
-            public void setTotal(double total) {
-                this.total = total;
-            }
-        }
-
         public Product_Sales() {
             map = "docs.Orders.SelectMany(order => order.Lines, (order, line) => new { " +
                 "    Product = line.Product, " +

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingAttachments.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingAttachments.java
@@ -61,18 +61,6 @@ public class IndexingAttachments {
 
     //region index
     public static class Employees_ByAttachmentNames extends AbstractIndexCreationTask {
-        public static class Result {
-            private String[] attachmentNames;
-
-            public String[] getAttachmentNames() {
-                return attachmentNames;
-            }
-
-            public void setAttachmentNames(String[] attachmentNames) {
-                this.attachmentNames = attachmentNames;
-            }
-        }
-
         public Employees_ByAttachmentNames() {
             map = "from e in docs.Employees\n" +
                 "let attachments = AttachmentsFor(e)\n" +
@@ -89,8 +77,8 @@ public class IndexingAttachments {
 
             try (IDocumentSession session = store.openSession()) {
                 //region query1
-                //return all employees that have CV attached
-                session.query(Employees_ByAttachmentNames.Result.class, Employees_ByAttachmentNames.class)
+                //return all employees that have an attachment called "cv.pdf"
+                List<Employee> employees = session.query(Employee.class, Employees_ByAttachmentNames.class)
                     .containsAny("attachmentNames", Lists.newArrayList("cv.pdf"))
                     .toList();
                 //endregion

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingCounters.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingCounters.java
@@ -18,18 +18,6 @@ public class IndexingCounters {
 
     //region index
     public static class Companies_ByCounterNames extends AbstractIndexCreationTask {
-        public static class Result {
-            private String[] counterNames;
-
-            public String[] getCounterNames() {
-                return counterNames;
-            }
-
-            public void setCounterNames(String[] counterNames) {
-                this.counterNames = counterNames;
-            }
-        }
-
         public Companies_ByCounterNames() {
             map = "from e in docs.Employees\n" +
                 "let counterNames = CounterNamesFor(e)\n" +

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingHierarchicalData.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingHierarchicalData.java
@@ -85,18 +85,6 @@ public class IndexingHierarchicalData {
 
     //region indexes_2
     public static class BlogPosts_ByCommentAuthor extends AbstractIndexCreationTask {
-        public static class Result {
-            private String[] authors;
-
-            public String[] getAuthors() {
-                return authors;
-            }
-
-            public void setAuthors(String[] authors) {
-                this.authors = authors;
-            }
-        }
-
         public BlogPosts_ByCommentAuthor() {
             map = "docs.BlogPosts.Select(post => new { " +
                 "    authors = this.Recurse(post, x => x.comments).Select(x0 => x0.author) " +
@@ -128,9 +116,8 @@ public class IndexingHierarchicalData {
             try (IDocumentSession session = store.openSession()) {
                 //region indexes_4
                 List<BlogPost> results = session
-                    .query(BlogPosts_ByCommentAuthor.Result.class, BlogPosts_ByCommentAuthor.class)
+                    .query(BlogPost.class, BlogPosts_ByCommentAuthor.class)
                     .whereEquals("authors", "Ayende Rahien")
-                    .ofType(BlogPost.class)
                     .toList();
                 //endregion
             }

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingRelatedDocuments.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/IndexingRelatedDocuments.java
@@ -71,18 +71,6 @@ public class IndexingRelatedDocuments {
 
     //region indexing_related_documents_2
     public static class Products_ByCategoryName extends AbstractIndexCreationTask {
-        public static class Result {
-            private String categoryName;
-
-            public String getCategoryName() {
-                return categoryName;
-            }
-
-            public void setCategoryName(String categoryName) {
-                this.categoryName = categoryName;
-            }
-        }
-
         public Products_ByCategoryName() {
             map = "docs.Products.Select(product => new { " +
                 "    CategoryName = (this.LoadDocument(product.Category, \"Categories\")).Name " +
@@ -93,27 +81,6 @@ public class IndexingRelatedDocuments {
 
     //region indexing_related_documents_5
     public static class Authors_ByNameAndBooks extends AbstractIndexCreationTask {
-        public static class Result {
-            private String name;
-            private List<String> books;
-
-            public String getName() {
-                return name;
-            }
-
-            public void setName(String name) {
-                this.name = name;
-            }
-
-            public List<String> getBooks() {
-                return books;
-            }
-
-            public void setBooks(List<String> books) {
-                this.books = books;
-            }
-        }
-
         public Authors_ByNameAndBooks() {
             map = "docs.Authors.Select(author => new { " +
                 "    name = author.name, " +
@@ -141,9 +108,8 @@ public class IndexingRelatedDocuments {
             try (IDocumentSession session = store.openSession()) {
                 //region indexing_related_documents_7
                 List<Product> results = session
-                    .query(Products_ByCategoryName.Result.class, Products_ByCategoryName.class)
+                    .query(Product.class, Products_ByCategoryName.class)
                     .whereEquals("CategoryName", "Beverages")
-                    .ofType(Product.class)
                     .toList();
                 //endregion
             }
@@ -165,10 +131,9 @@ public class IndexingRelatedDocuments {
             try (IDocumentSession session = store.openSession()) {
                 //region indexing_related_documents_8
                 List<Author> results = session
-                    .query(Authors_ByNameAndBooks.Result.class, Authors_ByNameAndBooks.class)
+                    .query(Author.class, Authors_ByNameAndBooks.class)
                     .whereEquals("name", "Andrzej Sapkowski")
                     .whereEquals("books", "The Witcher")
-                    .ofType(Author.class)
                     .toList();
                 //endregion
             }

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/JavaScript.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/JavaScript.java
@@ -47,18 +47,6 @@ public class JavaScript {
 
     //region javaScriptindexes_7
     public static class Employees_ByFullName extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String fullName;
-
-            public String getFullName() {
-                return fullName;
-            }
-
-            public void setFullName(String fullName) {
-                this.fullName = fullName;
-            }
-        }
-
         public Employees_ByFullName() {
             setMaps(Sets.newHashSet("map('Employees', function (employee){\n" +
                 "            return {\n" +
@@ -72,18 +60,6 @@ public class JavaScript {
 
     //region javaScriptindexes_1_0
     public static class Employees_ByYearOfBirth extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private int yearOfBirth;
-
-            public int getYearOfBirth() {
-                return yearOfBirth;
-            }
-
-            public void setYearOfBirth(int yearOfBirth) {
-                this.yearOfBirth = yearOfBirth;
-            }
-        }
-
         public Employees_ByYearOfBirth() {
             setMaps(Sets.newHashSet("map('Employees', function (employee){\n" +
                 "            return {\n" +
@@ -92,21 +68,10 @@ public class JavaScript {
                 "        })"));
         }
     }
+    //endregion
 
     //region javaScriptindexes_1_2
     public static class Employees_ByBirthday extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private Date birthday;
-
-            public Date getBirthday() {
-                return birthday;
-            }
-
-            public void setBirthday(Date birthday) {
-                this.birthday = birthday;
-            }
-        }
-
         public Employees_ByBirthday() {
             setMaps(Sets.newHashSet("map('Employees', function (employee){\n" +
                 "            return {\n" +
@@ -119,18 +84,6 @@ public class JavaScript {
 
     //region javaScriptindexes_1_4
     public static class Employees_ByCountry extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String country;
-
-            public String getCountry() {
-                return country;
-            }
-
-            public void setCountry(String country) {
-                this.country = country;
-            }
-        }
-
         public Employees_ByCountry() {
             setMaps(Sets.newHashSet("map('Employees', function (employee){\n" +
                 "            return {\n" +
@@ -143,18 +96,6 @@ public class JavaScript {
 
     //region javaScriptindexes_1_6
     public static class Employees_Query extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String[] query;
-
-            public String[] getQuery() {
-                return query;
-            }
-
-            public void setQuery(String[] query) {
-                this.query = query;
-            }
-        }
-
         public Employees_Query() {
             setMaps(Sets.newHashSet("map('Employees', function (employee) {\n" +
                 "            return {\n" +
@@ -185,11 +126,6 @@ public class JavaScript {
 
     //region map_reduce_0_0
     public static class Products_ByCategory extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String category;
-            private int count;
-        }
-
         public Products_ByCategory() {
             setMaps(Sets.newHashSet("map('products', function(p){\n" +
                 "            return {\n" +
@@ -211,45 +147,6 @@ public class JavaScript {
 
     //region map_reduce_1_0
     public static class Product_Average_ByCategory extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String category;
-            private double priceSum;
-            private double priceAverage;
-            private int productCount;
-
-            public String getCategory() {
-                return category;
-            }
-
-            public void setCategory(String category) {
-                this.category = category;
-            }
-
-            public double getPriceSum() {
-                return priceSum;
-            }
-
-            public void setPriceSum(double priceSum) {
-                this.priceSum = priceSum;
-            }
-
-            public double getPriceAverage() {
-                return priceAverage;
-            }
-
-            public void setPriceAverage(double priceAverage) {
-                this.priceAverage = priceAverage;
-            }
-
-            public int getProductCount() {
-                return productCount;
-            }
-
-            public void setProductCount(int productCount) {
-                this.productCount = productCount;
-            }
-        }
-
         public Product_Average_ByCategory() {
             setMaps(Sets.newHashSet("map('products', function(product){\n" +
                 "    return {\n" +
@@ -277,36 +174,6 @@ public class JavaScript {
 
     //region map_reduce_2_0
     public static class Product_Sales extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String product;
-            private int count;
-            private double total;
-
-            public String getProduct() {
-                return product;
-            }
-
-            public void setProduct(String product) {
-                this.product = product;
-            }
-
-            public int getCount() {
-                return count;
-            }
-
-            public void setCount(int count) {
-                this.count = count;
-            }
-
-            public double getTotal() {
-                return total;
-            }
-
-            public void setTotal(double total) {
-                this.total = total;
-            }
-        }
-
         public Product_Sales() {
             setMaps(Sets.newHashSet("map('orders', function(order){\n" +
                 "            var res = [];\n" +
@@ -334,45 +201,6 @@ public class JavaScript {
 
     //region map_reduce_3_0
     public static class Product_Sales_ByMonth extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String product;
-            private Date month;
-            private int count;
-            private double total;
-
-            public String getProduct() {
-                return product;
-            }
-
-            public void setProduct(String product) {
-                this.product = product;
-            }
-
-            public Date getMonth() {
-                return month;
-            }
-
-            public void setMonth(Date month) {
-                this.month = month;
-            }
-
-            public int getCount() {
-                return count;
-            }
-
-            public void setCount(int count) {
-                this.count = count;
-            }
-
-            public double getTotal() {
-                return total;
-            }
-
-            public void setTotal(double total) {
-                this.total = total;
-            }
-        }
-
         public Product_Sales_ByMonth() {
             setMaps(Sets.newHashSet("map('orders', function(order){\n" +
                 "            var res = [];\n" +
@@ -421,18 +249,6 @@ public class JavaScript {
 
     //region static_sorting2
     private static class Products_ByName extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String analyzedName;
-
-            public String getAnalyzedName() {
-                return analyzedName;
-            }
-
-            public void setAnalyzedName(String analyzedName) {
-                this.analyzedName = analyzedName;
-            }
-        }
-
         public Products_ByName() {
             setMaps(Sets.newHashSet("map('products', function (u){\n" +
                 "    return {\n" +
@@ -455,18 +271,6 @@ public class JavaScript {
 
     //region indexing_related_documents_2
     public static class Products_ByCategoryName extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String categoryName;
-
-            public String getCategoryName() {
-                return categoryName;
-            }
-
-            public void setCategoryName(String categoryName) {
-                this.categoryName = categoryName;
-            }
-        }
-
         public Products_ByCategoryName() {
             setMaps(Sets.newHashSet("map('products', function(product ){\n" +
                 "            return {\n" +
@@ -479,27 +283,6 @@ public class JavaScript {
 
     //region indexing_related_documents_5
     public static class Authors_ByNameAndBookNames extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String name;
-            private List<String> books;
-
-            public String getName() {
-                return name;
-            }
-
-            public void setName(String name) {
-                this.name = name;
-            }
-
-            public List<String> getBooks() {
-                return books;
-            }
-
-            public void setBooks(List<String> books) {
-                this.books = books;
-            }
-        }
-
         public Authors_ByNameAndBookNames() {
             setMaps(Sets.newHashSet("map('author', function(a){\n" +
                 "            return {\n" +
@@ -513,18 +296,6 @@ public class JavaScript {
 
     //region indexes_2
     public static class BlogPosts_ByCommentAuthor extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String[] authors;
-
-            public String[] getAuthors() {
-                return authors;
-            }
-
-            public void setAuthors(String[] authors) {
-                this.authors = authors;
-            }
-        }
-
         public BlogPosts_ByCommentAuthor() {
             setMaps(Sets.newHashSet("map('BlogPosts', function(b){\n" +
                 "            var names = [];\n" +

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Map.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Map.java
@@ -43,18 +43,6 @@ public class Map {
 
     //region indexes_7
     public static class Employees_ByFullName extends AbstractIndexCreationTask {
-        public static class Result {
-            private String fullName;
-
-            public String getFullName() {
-                return fullName;
-            }
-
-            public void setFullName(String fullName) {
-                this.fullName = fullName;
-            }
-        }
-
         public Employees_ByFullName() {
             map = "docs.Employees.Select(employee => new { " +
                 "    FullName = (employee.FirstName + \" \") + employee.LastName " +
@@ -65,18 +53,6 @@ public class Map {
 
     //region indexes_1_0
     public static class Employees_ByYearOfBirth extends AbstractIndexCreationTask {
-        public static class Result {
-            private int yearOfBirth;
-
-            public int getYearOfBirth() {
-                return yearOfBirth;
-            }
-
-            public void setYearOfBirth(int yearOfBirth) {
-                this.yearOfBirth = yearOfBirth;
-            }
-        }
-
         public Employees_ByYearOfBirth() {
             map = "docs.Employees.Select(employee => new { " +
                 "    YearOfBirth = employee.Birthday.Year " +
@@ -87,18 +63,6 @@ public class Map {
 
     //region indexes_1_2
     public static class Employees_ByBirthday extends AbstractIndexCreationTask {
-        public static class Result {
-            private Date birthday;
-
-            public Date getBirthday() {
-                return birthday;
-            }
-
-            public void setBirthday(Date birthday) {
-                this.birthday = birthday;
-            }
-        }
-
         public Employees_ByBirthday() {
             map = "docs.Employees.Select(employee => new { " +
                 "    Birthday = employee.Birthday " +
@@ -109,18 +73,6 @@ public class Map {
 
     //region indexes_1_4
     public static class Employees_ByCountry extends AbstractIndexCreationTask {
-        public static class Result {
-            private String country;
-
-            public String getCountry() {
-                return country;
-            }
-
-            public void setCountry(String country) {
-                this.country = country;
-            }
-        }
-
         public Employees_ByCountry() {
             map = "docs.Employees.Select(employee => new { " +
                 "    Country = employee.Address.Country " +
@@ -131,18 +83,6 @@ public class Map {
 
     //region indexes_1_6
     public static class Employees_Query extends AbstractIndexCreationTask {
-        public static class Result {
-            private String[] query;
-
-            public String[] getQuery() {
-                return query;
-            }
-
-            public void setQuery(String[] query) {
-                this.query = query;
-            }
-        }
-
         public Employees_Query() {
             map = "docs.Employees.Select(employee => new { " +
                 "    Query = new [] { employee.FirstName, employee.LastName, employee.Title, employee.Address.City } " +
@@ -176,9 +116,8 @@ public class Map {
                 // by marking result type in 'query' as 'Employees_ByFullName.Result'
                 // and changing type using 'ofType' before sending query to server
                 List<Employee> employees = session
-                    .query(Employees_ByFullName.Result.class, Employees_ByFullName.class)
+                    .query(Employee.class, Employees_ByFullName.class)
                     .whereEquals("FullName", "Robert King")
-                    .ofType(Employee.class)
                     .toList();
                 //endregion
             }
@@ -196,9 +135,8 @@ public class Map {
             try (IDocumentSession session = store.openSession()) {
                 //region indexes_6_1
                 List<Employee> employees = session
-                    .query(Employees_ByYearOfBirth.Result.class, Employees_ByYearOfBirth.class)
+                    .query(Employee.class, Employees_ByYearOfBirth.class)
                     .whereEquals("YearOfBirth", 1963)
-                    .ofType(Employee.class)
                     .toList();
                 //endregion
             }
@@ -208,9 +146,8 @@ public class Map {
                 LocalDate startDate = LocalDate.of(1963, 1, 1);
                 LocalDate endDate = startDate.plusYears(1).minus(1, ChronoUnit.MILLIS);
                 List<Employee> employees = session
-                    .query(Employees_ByBirthday.Result.class, Employees_ByBirthday.class)
+                    .query(Employee.class, Employees_ByBirthday.class)
                     .whereBetween("Birthday", startDate, endDate)
-                    .ofType(Employee.class)
                     .toList();
                 //endregion
             }
@@ -218,9 +155,8 @@ public class Map {
             try (IDocumentSession session = store.openSession()) {
                 //region indexes_7_1
                 List<Employee> employees = session
-                    .query(Employees_ByCountry.Result.class, Employees_ByCountry.class)
+                    .query(Employee.class, Employees_ByCountry.class)
                     .whereEquals("Country", "USA")
-                    .ofType(Employee.class)
                     .toList();
                 //endregion
             }
@@ -228,9 +164,8 @@ public class Map {
             try (IDocumentSession session = store.openSession()) {
                 //region indexes_1_7
                 List<Employee> employees = session
-                    .query(Employees_Query.Result.class, Employees_Query.class)
+                    .query(Employee.class, Employees_Query.class)
                     .search("Query", "John Doe")
-                    .ofType(Employee.class)
                     .toList();
                 //endregion
             }

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Filtering.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Filtering.java
@@ -45,17 +45,6 @@ public class Filtering {
 
     //region filtering_7_4
     public static class Orders_ByTotalPrice extends AbstractIndexCreationTask {
-        public static class Result {
-            private double totalPrice;
-
-            public double getTotalPrice() {
-                return totalPrice;
-            }
-
-            public void setTotalPrice(double totalPrice) {
-                this.totalPrice = totalPrice;
-            }
-        }
         public Orders_ByTotalPrice() {
             map = "docs.Orders.Select(order => new {" +
                 "    TotalPrice = Enumerable.Sum(order.Lines, x => ((decimal)((((decimal) x.Quantity) * x.PricePerUnit) * (1M - x.Discount))))" +
@@ -120,9 +109,8 @@ public class Filtering {
             try (IDocumentSession session = store.openSession()) {
                 //region filtering_7_1
                 List<Order> results = session
-                    .query(Orders_ByTotalPrice.Result.class, Orders_ByTotalPrice.class)
+                    .query(Order.class, Orders_ByTotalPrice.class)
                     .whereGreaterThan("TotalPrice", 50)
-                    .ofType(Order.class)
                     .toList();
                 //endregion
             }

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Highlights.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Highlights.java
@@ -18,7 +18,7 @@ public class Highlights {
 
     //region highlights_1
     public static class BlogPosts_ByContent extends AbstractIndexCreationTask {
-        public static class Result {
+        public static class Projection {
             private String content;
 
             public String getContent() {
@@ -41,27 +41,6 @@ public class Highlights {
 
     //region highlights_7
     public static class BlogPosts_ByCategory_Content extends AbstractIndexCreationTask {
-        public static class Result {
-            private String category;
-            private String content;
-
-            public String getCategory() {
-                return category;
-            }
-
-            public void setCategory(String category) {
-                this.category = category;
-            }
-
-            public String getContent() {
-                return content;
-            }
-
-            public void setContent(String content) {
-                this.content = content;
-            }
-        }
-
         public BlogPosts_ByCategory_Content() {
             map = "docs.Posts.Select(post => new { post.category, post.content })";
 
@@ -110,11 +89,11 @@ public class Highlights {
                 HighlightingOptions highlightingOptions = new HighlightingOptions();
                 highlightingOptions.setPreTags(new String[] { "**" });
                 highlightingOptions.setPostTags(new String[] { "**" });
-                List<BlogPosts_ByContent.Result> results = session
-                    .query(BlogPosts_ByContent.class, BlogPosts_ByContent.class)
+                List<BlogPosts_ByContent.Projection> results = session
+                    .query(BlogPost.class, BlogPosts_ByContent.class)
                     .highlight("content", 128, 1, highlightingOptions, highlightsRef)
                     .search("content", "raven")
-                    .selectFields(BlogPosts_ByContent.Result.class)
+                    .selectFields(BlogPosts_ByContent.Projection.class)
                     .toList();
                 //endregion
             }
@@ -127,9 +106,9 @@ public class Highlights {
                 highlightingOptions.setPreTags(new String[] { "**" });
                 highlightingOptions.setPostTags(new String[] { "**" });
                 highlightingOptions.setGroupKey("category");
-                List<BlogPosts_ByCategory_Content.Result> results = session
+                List<BlogPost> results = session
                     .advanced()
-                    .documentQuery(BlogPosts_ByCategory_Content.Result.class, BlogPosts_ByCategory_Content.class)
+                    .documentQuery(BlogPost.class, BlogPosts_ByCategory_Content.class)
                     .highlight("content", 128, 1, highlightingOptions, highlightsRef)
                     .search("content", "raven")
                     .toList();

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Highlights.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Highlights.java
@@ -18,7 +18,7 @@ public class Highlights {
 
     //region highlights_1
     public static class BlogPosts_ByContent extends AbstractIndexCreationTask {
-        public static class Projection {
+        public static class Result {
             private String content;
 
             public String getContent() {
@@ -41,6 +41,27 @@ public class Highlights {
 
     //region highlights_7
     public static class BlogPosts_ByCategory_Content extends AbstractIndexCreationTask {
+        public static class Result {
+            private String category;
+            private String content;
+
+            public String getCategory() {
+                return category;
+            }
+
+            public void setCategory(String category) {
+                this.category = category;
+            }
+
+            public String getContent() {
+                return content;
+            }
+
+            public void setContent(String content) {
+                this.content = content;
+            }
+        }
+
         public BlogPosts_ByCategory_Content() {
             map = "docs.Posts.Select(post => new { post.category, post.content })";
 
@@ -89,11 +110,11 @@ public class Highlights {
                 HighlightingOptions highlightingOptions = new HighlightingOptions();
                 highlightingOptions.setPreTags(new String[] { "**" });
                 highlightingOptions.setPostTags(new String[] { "**" });
-                List<BlogPosts_ByContent.Projection> results = session
-                    .query(BlogPost.class, BlogPosts_ByContent.class)
+                List<BlogPosts_ByContent.Result> results = session
+                    .query(BlogPosts_ByContent.class, BlogPosts_ByContent.class)
                     .highlight("content", 128, 1, highlightingOptions, highlightsRef)
                     .search("content", "raven")
-                    .selectFields(BlogPosts_ByContent.Projection.class)
+                    .selectFields(BlogPosts_ByContent.Result.class)
                     .toList();
                 //endregion
             }
@@ -106,9 +127,9 @@ public class Highlights {
                 highlightingOptions.setPreTags(new String[] { "**" });
                 highlightingOptions.setPostTags(new String[] { "**" });
                 highlightingOptions.setGroupKey("category");
-                List<BlogPost> results = session
+                List<BlogPosts_ByCategory_Content.Result> results = session
                     .advanced()
-                    .documentQuery(BlogPost.class, BlogPosts_ByCategory_Content.class)
+                    .documentQuery(BlogPosts_ByCategory_Content.Result.class, BlogPosts_ByCategory_Content.class)
                     .highlight("content", 128, 1, highlightingOptions, highlightsRef)
                     .search("content", "raven")
                     .toList();

--- a/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Sorting.java
+++ b/Documentation/4.1/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Sorting.java
@@ -48,27 +48,6 @@ public class Sorting {
 
     //region sorting_6_4
     public static class Products_ByName_Search extends AbstractIndexCreationTask {
-        public static class Result {
-            private String name;
-            private String nameForSorting;
-
-            public String getName() {
-                return name;
-            }
-
-            public void setName(String name) {
-                this.name = name;
-            }
-
-            public String getNameForSorting() {
-                return nameForSorting;
-            }
-
-            public void setNameForSorting(String nameForSorting) {
-                this.nameForSorting = nameForSorting;
-            }
-        }
-
         public Products_ByName_Search() {
             map = "docs.Products.Select(product => new {" +
                 "    Name = product.Name," +

--- a/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/Indexes/Creating.cs
+++ b/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/Indexes/Creating.cs
@@ -28,10 +28,10 @@ namespace Raven.Documentation.Samples.Indexes
                 public Orders_Totals()
                 {
                     Map = orders => from order in orders
-                                    select new
+                                    select new Result
                                     {
-                                        order.Employee,
-                                        order.Company,
+                                        Employee = order.Employee,
+                                        Company = order.Company,
                                         Total = order.Lines.Sum(l => (l.Quantity * l.PricePerUnit) * (1 - l.Discount))
                                     };
                 }

--- a/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Searching.cs
+++ b/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Searching.cs
@@ -29,13 +29,13 @@ namespace Raven.Documentation.Samples.Indexes.Querying
         {
             public class Result
             {
-                public string Query;
+                public object Query;
             }
 
             public Users_Search()
             {
                 Map = users => from user in users
-                               select new
+                               select new Result
                                {
                                    Query = new object[]
                                    {

--- a/Documentation/4.2/Samples/java/src/test/java/net/ravendb/Indexes/JavaScript.java
+++ b/Documentation/4.2/Samples/java/src/test/java/net/ravendb/Indexes/JavaScript.java
@@ -72,18 +72,6 @@ public class JavaScript {
 
     //region javaScriptindexes_1_0
     public static class Employees_ByYearOfBirth extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private int yearOfBirth;
-
-            public int getYearOfBirth() {
-                return yearOfBirth;
-            }
-
-            public void setYearOfBirth(int yearOfBirth) {
-                this.yearOfBirth = yearOfBirth;
-            }
-        }
-
         public Employees_ByYearOfBirth() {
             setMaps(Sets.newHashSet("map('Employees', function (employee){\n" +
                 "            return {\n" +
@@ -92,21 +80,10 @@ public class JavaScript {
                 "        })"));
         }
     }
+    //endregion
 
     //region javaScriptindexes_1_2
     public static class Employees_ByBirthday extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private Date birthday;
-
-            public Date getBirthday() {
-                return birthday;
-            }
-
-            public void setBirthday(Date birthday) {
-                this.birthday = birthday;
-            }
-        }
-
         public Employees_ByBirthday() {
             setMaps(Sets.newHashSet("map('Employees', function (employee){\n" +
                 "            return {\n" +
@@ -119,18 +96,6 @@ public class JavaScript {
 
     //region javaScriptindexes_1_4
     public static class Employees_ByCountry extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String country;
-
-            public String getCountry() {
-                return country;
-            }
-
-            public void setCountry(String country) {
-                this.country = country;
-            }
-        }
-
         public Employees_ByCountry() {
             setMaps(Sets.newHashSet("map('Employees', function (employee){\n" +
                 "            return {\n" +
@@ -143,18 +108,6 @@ public class JavaScript {
 
     //region javaScriptindexes_1_6
     public static class Employees_Query extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String[] query;
-
-            public String[] getQuery() {
-                return query;
-            }
-
-            public void setQuery(String[] query) {
-                this.query = query;
-            }
-        }
-
         public Employees_Query() {
             setMaps(Sets.newHashSet("map('Employees', function (employee) {\n" +
                 "            return {\n" +
@@ -185,11 +138,6 @@ public class JavaScript {
 
     //region map_reduce_0_0
     public static class Products_ByCategory extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String category;
-            private int count;
-        }
-
         public Products_ByCategory() {
             setMaps(Sets.newHashSet("map('products', function(p){\n" +
                 "            return {\n" +
@@ -211,45 +159,6 @@ public class JavaScript {
 
     //region map_reduce_1_0
     public static class Product_Average_ByCategory extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String category;
-            private double priceSum;
-            private double priceAverage;
-            private int productCount;
-
-            public String getCategory() {
-                return category;
-            }
-
-            public void setCategory(String category) {
-                this.category = category;
-            }
-
-            public double getPriceSum() {
-                return priceSum;
-            }
-
-            public void setPriceSum(double priceSum) {
-                this.priceSum = priceSum;
-            }
-
-            public double getPriceAverage() {
-                return priceAverage;
-            }
-
-            public void setPriceAverage(double priceAverage) {
-                this.priceAverage = priceAverage;
-            }
-
-            public int getProductCount() {
-                return productCount;
-            }
-
-            public void setProductCount(int productCount) {
-                this.productCount = productCount;
-            }
-        }
-
         public Product_Average_ByCategory() {
             setMaps(Sets.newHashSet("map('products', function(product){\n" +
                 "    return {\n" +
@@ -277,36 +186,6 @@ public class JavaScript {
 
     //region map_reduce_2_0
     public static class Product_Sales extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String product;
-            private int count;
-            private double total;
-
-            public String getProduct() {
-                return product;
-            }
-
-            public void setProduct(String product) {
-                this.product = product;
-            }
-
-            public int getCount() {
-                return count;
-            }
-
-            public void setCount(int count) {
-                this.count = count;
-            }
-
-            public double getTotal() {
-                return total;
-            }
-
-            public void setTotal(double total) {
-                this.total = total;
-            }
-        }
-
         public Product_Sales() {
             setMaps(Sets.newHashSet("map('orders', function(order){\n" +
                 "            var res = [];\n" +
@@ -334,45 +213,6 @@ public class JavaScript {
 
     //region map_reduce_3_0
     public static class Product_Sales_ByMonth extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String product;
-            private Date month;
-            private int count;
-            private double total;
-
-            public String getProduct() {
-                return product;
-            }
-
-            public void setProduct(String product) {
-                this.product = product;
-            }
-
-            public Date getMonth() {
-                return month;
-            }
-
-            public void setMonth(Date month) {
-                this.month = month;
-            }
-
-            public int getCount() {
-                return count;
-            }
-
-            public void setCount(int count) {
-                this.count = count;
-            }
-
-            public double getTotal() {
-                return total;
-            }
-
-            public void setTotal(double total) {
-                this.total = total;
-            }
-        }
-
         public Product_Sales_ByMonth() {
             setMaps(Sets.newHashSet("map('orders', function(order){\n" +
                 "            var res = [];\n" +
@@ -421,18 +261,6 @@ public class JavaScript {
 
     //region static_sorting2
     private static class Products_ByName extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String analyzedName;
-
-            public String getAnalyzedName() {
-                return analyzedName;
-            }
-
-            public void setAnalyzedName(String analyzedName) {
-                this.analyzedName = analyzedName;
-            }
-        }
-
         public Products_ByName() {
             setMaps(Sets.newHashSet("map('products', function (u){\n" +
                 "    return {\n" +
@@ -455,18 +283,6 @@ public class JavaScript {
 
     //region indexing_related_documents_2
     public static class Products_ByCategoryName extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String categoryName;
-
-            public String getCategoryName() {
-                return categoryName;
-            }
-
-            public void setCategoryName(String categoryName) {
-                this.categoryName = categoryName;
-            }
-        }
-
         public Products_ByCategoryName() {
             setMaps(Sets.newHashSet("map('products', function(product ){\n" +
                 "            return {\n" +
@@ -479,27 +295,6 @@ public class JavaScript {
 
     //region indexing_related_documents_5
     public static class Authors_ByNameAndBookNames extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String name;
-            private List<String> books;
-
-            public String getName() {
-                return name;
-            }
-
-            public void setName(String name) {
-                this.name = name;
-            }
-
-            public List<String> getBooks() {
-                return books;
-            }
-
-            public void setBooks(List<String> books) {
-                this.books = books;
-            }
-        }
-
         public Authors_ByNameAndBookNames() {
             setMaps(Sets.newHashSet("map('author', function(a){\n" +
                 "            return {\n" +
@@ -513,18 +308,6 @@ public class JavaScript {
 
     //region indexes_2
     public static class BlogPosts_ByCommentAuthor extends AbstractJavaScriptIndexCreationTask {
-        public static class Result {
-            private String[] authors;
-
-            public String[] getAuthors() {
-                return authors;
-            }
-
-            public void setAuthors(String[] authors) {
-                this.authors = authors;
-            }
-        }
-
         public BlogPosts_ByCommentAuthor() {
             setMaps(Sets.newHashSet("map('BlogPosts', function(b){\n" +
                 "            var names = [];\n" +


### PR DESCRIPTION
In both Java and Csharp, there were problems in the code samples for index definitions:
- Java indexes had nested `Result` classes that were not necessary (they were probably copied from the Csharp code where they are necessary)
- Csharp indexes did not use the Result class in the map function