### PR TITLE
RDocs-1720-RDB-Client-Version

### DIFF
--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/querying/sorting.dotnet.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/querying/sorting.dotnet.markdown
@@ -145,21 +145,6 @@ order by spatial.distance(spatial.point(Latitude, Longitude), spatial.point(32.1
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 
-## Creating a Custom Sorter
-
-Lucene also allows you to create your own custom sorters. Create a sorter that inherits from the Lucene class 
-[FieldComparator](https://lucene.apache.org/core/3_0_3/api/core/org/apache/lucene/search/FieldComparator.html), and send it to the 
-server using a `PutSortersOperation`:  
-
-{CODE-TABS}
-{CODE-TAB:csharp:PutSortersOperation custom_1@Indexes/Querying/Sorting.cs/}
-{CODE-TAB:csharp:SorterDefinition custom_2@Indexes/Querying/Sorting.cs/}
-{CODE-TABS/}
-<br/>
-### Example
-
-{CODE:csharp custom_3@Indexes/Querying/Sorting.cs/}
-
 ## Related Articles
 
 ### Indexes

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Sorting.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Sorting.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.Sorters;
-using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.Documents.Session;
 using Raven.Documentation.Samples.Orders;
 using Sparrow.Json.Parsing;
@@ -323,38 +321,6 @@ namespace Raven.Documentation.Samples.Indexes.Querying
                         .ToList();
                     #endregion
                 }
-            }
-
-            using (var documentStore = new DocumentStore())
-            {
-                /*
-                #region custom_1
-                PutSortersOperation(params SorterDefinition[] sortersToAdd)
-                #endregion
-
-                #region custom_2
-                public class SorterDefinition
-                {
-                    public string Name { get; set; }
-                    public string Code { get; set; }
-                }
-                #endregion
-                */
-
-                #region custom_3
-                //Assign the code of your new sorter as a `string`
-                var sorterCode = "<code of custom sorter>";
-
-                //Create one or more `SorterDefinition` objects
-                var customSorterDefinition = new SorterDefinition
-                {
-                    Name = "MySorter",
-                    Code = sorterCode
-                };
-
-                //Send the new sorters to the server
-                documentStore.Maintenance.Send(new PutSortersOperation(customSorterDefinition));
-                #endregion
             }
         }
     }

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Raven.Documentation.Samples.csproj
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/Raven.Documentation.Samples.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.7" />
-    <PackageReference Include="RavenDB.Client" Version="4.2.0" />
+    <PackageReference Include="RavenDB.Client" Version="4.1.10" />
     <PackageReference Include="RavenDB.Embedded" Version="4.1.10" />
     <PackageReference Include="RavenDB.TestDriver" Version="4.1.10" />
     <PackageReference Include="System.Reactive.Core" Version="4.3.2" />

--- a/Documentation/4.2/Raven.Documentation.Pages/indexes/querying/sorting.dotnet.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/indexes/querying/sorting.dotnet.markdown
@@ -1,0 +1,175 @@
+# Querying: Sorting
+
+## Basics
+
+Starting from RavenDB 4.0, the server will determine possible sorting capabilities automatically from the indexed value, but sorting will **not be applied** until you request it by using the appropriate methods. The following queries will not return ordered results:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_1_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_1_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_1_4@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+To start sorting, we need to request to order by some specified index field. In our case we will order by `UnitsInStock` in descending order:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_2_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_2_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_1_4@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by UnitsInStock as long desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO:Forcing ordering type}
+
+By default, `OrderBy` methods will determine `OrderingType` from the property path expression (e.g. `x => x.UnitsInStock` will result in `OrderingType.Long` because property type is an integer), but a different ordering can be forced by passing `OrderingType` explicitly to one of the `OrderBy` methods.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_8_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_8_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_1_4@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by UnitsInStock desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO/}
+
+## Ordering by Score
+
+When a query is issued, each index entry is scored by Lucene (you can read more about Lucene scoring [here](http://lucene.apache.org/core/3_3_0/scoring.html)).  
+This value is available in metadata information of the resulting query documents under `@index-score` (the higher the value, the better the match).  
+To order by this value you can use the `OrderByScore` or the `OrderByScoreDescending` methods:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_4_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_4_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_1_4@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by score()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Chaining Orderings
+
+It is also possible to chain multiple orderings of the query results. 
+You can sort the query results first by some specified index field (or by the `@index-score`), then sort all the equal entries by some different index field (or the `@index-score`).  
+This can be achived by using the `ThenBy` (`ThenByDescending`) and `ThenByScore` (`ThenByScoreDescending`) methods.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_4_3@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_1_5@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStockAndName' 
+where UnitsInStock > 10
+order by UnitsInStock, score(), Name desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Random Ordering
+
+If you want to randomize the order of your results each time the query is executed, use the `RandomOrdering` method (API reference [here](../../client-api/session/querying/how-to-customize-query#randomordering)):
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_3_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_3_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_1_4@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by random()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Ordering When a Field is Searchable
+
+When sorting must be done on field that is [Searchable](../../indexes/using-analyzers), due to [Lucene](https://lucene.apache.org/) limitations sorting on such a field is not supported. To overcome this, create another field that is not searchable and sort by it.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_6_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_6_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_6_4@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByName/Search' 
+where search(Name, 'Louisiana')
+order by NameForSorting desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## AlphaNumeric Ordering
+
+Sometimes when ordering strings, it doesn't make sense to use the default lexicographic ordering.    
+
+For example, "Abc9" will come after "Abc10" because if treated as single characters, 9 is greater than 1.   
+
+If you want digit characters in a string to be treated as numbers and not as text, you should use alphanumeric ordering. In that case, when comparing "Abc10" to "Abc9", the digits 1 and 0 will be treated as the number 10 which will be considered greater than 9.
+
+To order in this mode you can pass the `OrderingType.AlphaNumeric` type into `OrderBy` or `OrderByDescending`:   
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_7_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_7_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_1_4@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock ' 
+where UnitsInStock > 10
+order by Name as alphanumeric
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Spatial Ordering
+
+If your data contains geographical locations, you might want to sort the query result by distance from a given point.
+
+This can be achieved by using the `OrderByDistance` and `OrderByDistanceDescending` methods (API reference [here](../../client-api/session/querying/how-to-query-a-spatial-index#orderbydistance)):
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sorting_9_1@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:DocumentQuery sorting_9_2@Indexes\Querying\Sorting.cs /}
+{CODE-TAB:csharp:Index sorting_9_3@Indexes\Querying\Sorting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Events/ByCoordinates'
+where spatial.within(Coordinates, spatial.circle(500, 30, 30))
+order by spatial.distance(spatial.point(Latitude, Longitude), spatial.point(32.1234, 23.4321))
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Creating a Custom Sorter
+
+Lucene also allows you to create your own custom sorters. Create a sorter that inherits from the Lucene class 
+[FieldComparator](https://lucene.apache.org/core/3_0_3/api/core/org/apache/lucene/search/FieldComparator.html), and send it to the 
+server using a `PutSortersOperation`:  
+
+{CODE-TABS}
+{CODE-TAB:csharp:PutSortersOperation custom_1@Indexes/Querying/Sorting.cs/}
+{CODE-TAB:csharp:SorterDefinition custom_2@Indexes/Querying/Sorting.cs/}
+{CODE-TABS/}
+<br/>
+### Example
+
+{CODE:csharp custom_3@Indexes/Querying/Sorting.cs/}
+
+## Related Articles
+
+### Indexes
+
+- [Indexing Basics](../../indexes/indexing-basics)
+- [Sorting & Collation](../../indexes/sorting-and-collation)
+
+### Querying
+
+- [Basics](../../indexes/querying/basics)
+- [Filtering](../../indexes/querying/filtering)
+- [Paging](../../indexes/querying/paging)
+- [Spatial](../../indexes/querying/spatial)

--- a/Documentation/4.2/Raven.Documentation.Pages/indexes/querying/sorting.java.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/indexes/querying/sorting.java.markdown
@@ -1,0 +1,152 @@
+# Querying: Sorting
+
+## Basics
+
+Starting from RavenDB 4.0, the server will determine possible sorting capabilities automatically from the indexed value, but sorting will **not be applied** until you request it by using the appropriate methods. The following queries will not return ordered results:
+
+{CODE-TABS}
+{CODE-TAB:java:Java sorting_1_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_1_4@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+To start sorting, we need to request to order by some specified index field. In our case we will order by `UnitsInStock` in descending order:
+
+{CODE-TABS}
+{CODE-TAB:java:Java sorting_2_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_1_4@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by UnitsInStock as long desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO:Forcing ordering type}
+
+By default, `orderBy` methods will determine `orderingType` from the property path expression (e.g. `x => x.unitsInStock` will result in `OrderingType.LONG` because property type is an integer), but a different ordering can be forced by passing `OrderingType` explicitly to one of the `orderBy` methods.
+
+{CODE-TABS}
+{CODE-TAB:java:Java sorting_8_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_1_4@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by UnitsInStock desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO/}
+
+## Ordering by Score
+
+When a query is issued, each index entry is scored by Lucene (you can read more about Lucene scoring [here](http://lucene.apache.org/core/3_3_0/scoring.html)).  
+This value is available in metadata information of the resulting query documents under `@index-score` (the higher the value, the better the match).  
+To order by this value you can use the `orderByScore` or the `orderByScoreDescending` methods:
+
+{CODE-TABS}
+{CODE-TAB:java:Java sorting_4_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_1_4@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by score()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Chaining Orderings
+
+It is also possible to chain multiple orderings of the query results. 
+You can sort the query results first by some specified index field (or by the `@index-score`), then sort all the equal entries by some different index field (or the `@index-score`).  
+This can be achieved by using the `thenBy` (`thenByDescending`) and `thenByScore` (`thenByScoreDescending`) methods.
+
+{CODE-TABS}
+{CODE-TAB:java:Query sorting_4_3@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_1_5@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStockAndName' 
+where UnitsInStock > 10
+order by UnitsInStock, score(), Name desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Random Ordering
+
+If you want to randomize the order of your results each time the query is executed, use the `randomOrdering` method (API reference [here](../../client-api/session/querying/how-to-customize-query#randomordering)):
+
+{CODE-TABS}
+{CODE-TAB:java:Java sorting_3_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_1_4@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock' 
+where UnitsInStock > 10
+order by random()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Ordering When a Field is Searchable
+
+When sorting must be done on field that is [Searchable](../../indexes/using-analyzers), due to [Lucene](https://lucene.apache.org/) limitations sorting on such a field is not supported. To overcome this, create another field that is not searchable, and sort by it.
+
+{CODE-TABS}
+{CODE-TAB:java:Java sorting_6_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_6_4@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByName/Search' 
+where search(Name, 'Louisiana')
+order by NameForSorting desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## AlphaNumeric Ordering
+
+Sometimes when ordering strings, it doesn't make sense to use the default lexicographic ordering.    
+
+For example, "Abc9" will come after "Abc10" because if treated as single characters, 9 is greater than 1.   
+
+If you want digit characters in a string to be treated as numbers and not as text, you should use alphanumeric ordering. In that case, when comparing "Abc10" to "Abc9", the digits 1 and 0 will be treated as the number 10 which will be considered greater than 9.
+
+To order in this mode you can pass the `OrderingType.ALPHA_NUMERIC` type into `orderBy` or `orderByDescending`:   
+
+{CODE-TABS}
+{CODE-TAB:java:Java sorting_7_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_1_4@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Products/ByUnitsInStock ' 
+where UnitsInStock > 10
+order by Name as alphanumeric
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Spatial Ordering
+
+If your data contains geographical locations, you might want to sort the query result by distance from a given point.
+
+This can be achived by using the `orderByDistance` and `orderByDistanceDescending` methods (API reference [here](../../client-api/session/querying/how-to-query-a-spatial-index#orderbydistance)):
+
+{CODE-TABS}
+{CODE-TAB:java:Query sorting_9_1@Indexes\Querying\Sorting.java /}
+{CODE-TAB:java:Index sorting_9_3@Indexes\Querying\Sorting.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Events/ByCoordinates'
+where spatial.within(Coordinates, spatial.circle(500, 30, 30))
+order by spatial.distance(spatial.point(Latitude, Longitude), spatial.point(32.1234, 23.4321))
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Related Articles
+
+### Indexes
+
+- [Indexing Basics](../../indexes/indexing-basics)
+- [Sorting & Collation](../../indexes/sorting-and-collation)
+
+### Querying
+
+- [Basics](../../indexes/querying/basics)
+- [Filtering](../../indexes/querying/filtering)
+- [Paging](../../indexes/querying/paging)
+- [Spatial](../../indexes/querying/spatial)

--- a/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Sorting.cs
+++ b/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Sorting.cs
@@ -1,0 +1,361 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Sorters;
+using Raven.Client.Documents.Queries.Sorting;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Documentation.Samples.Indexes.Querying
+{
+    public class Sorting
+    {
+        #region sorting_5_6
+        public class Employee_ByFirstName : AbstractIndexCreationTask<Employee>
+        {
+            public Employee_ByFirstName()
+            {
+                Map = employees => from employee in employees
+                                   select new
+                                   {
+                                       employee.FirstName
+                                   };
+
+                Store(x => x.FirstName, FieldStorage.Yes);
+            }
+        }
+        #endregion
+
+        #region sorting_1_4
+        public class Products_ByUnitsInStock : AbstractIndexCreationTask<Product>
+        {
+            public Products_ByUnitsInStock()
+            {
+                Map = products => from product in products
+                                  select new
+                                  {
+                                      product.UnitsInStock
+                                  };
+            }
+        }
+        #endregion
+
+        #region sorting_1_5
+        public class Products_ByUnitsInStockAndName : AbstractIndexCreationTask<Product>
+        {
+            public Products_ByUnitsInStockAndName()
+            {
+                Map = products => from product in products
+                                  select new
+                                  {
+                                      product.UnitsInStock,
+                                      product.Name
+                                  };
+            }
+        }
+        #endregion
+
+        #region sorting_6_4
+        public class Products_ByName_Search : AbstractIndexCreationTask<Product>
+        {
+            public class Result
+            {
+                public string Name { get; set; }
+
+                public string NameForSorting { get; set; }
+            }
+
+            public Products_ByName_Search()
+            {
+                Map = products => from product in products
+                                  select new
+                                  {
+                                      Name = product.Name,
+                                      NameForSorting = product.Name
+                                  };
+
+                Indexes.Add(x => x.Name, FieldIndexing.Search);
+            }
+        }
+        #endregion
+
+        #region sorting_9_3
+        public class Events_ByCoordinates : AbstractIndexCreationTask<Event>
+        {
+            public Events_ByCoordinates()
+            {
+                Map = events => from e in events
+                                select new
+                                {
+                                    Coordinates = CreateSpatialField(e.Latitude, e.Longitude)
+                                };
+            }
+        }
+        #endregion
+
+        public Sorting()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_1_1
+                    IList<Product> results = session
+                        .Query<Product, Products_ByUnitsInStock>()
+                        .Where(x => x.UnitsInStock > 10)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_1_2
+                    IList<Product> results = session
+                        .Advanced
+                        .DocumentQuery<Product, Products_ByUnitsInStock>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_2_1
+                    IList<Product> results = session
+                        .Query<Product, Products_ByUnitsInStock>()
+                        .Where(x => x.UnitsInStock > 10)
+                        .OrderByDescending(x => x.UnitsInStock)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_2_2
+                    IList<Product> results = session
+                        .Advanced
+                        .DocumentQuery<Product, Products_ByUnitsInStock>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                        .OrderByDescending(x => x.UnitsInStock)
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_8_1
+                    IList<Product> results = session
+                        .Query<Product, Products_ByUnitsInStock>()
+                        .Where(x => x.UnitsInStock > 10)
+                        .OrderByDescending(x => x.UnitsInStock, OrderingType.String)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_8_2
+                    IList<Product> results = session
+                        .Advanced
+                        .DocumentQuery<Product, Products_ByUnitsInStock>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                        .OrderByDescending("UnitsInStock", OrderingType.String)
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_3_1
+                    IList<Product> results = session
+                        .Query<Product, Products_ByUnitsInStock>()
+                        .Customize(x => x.RandomOrdering())
+                        .Where(x => x.UnitsInStock > 10)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_3_2
+                    IList<Product> results = session
+                        .Advanced
+                        .DocumentQuery<Product, Products_ByUnitsInStock>()
+                        .RandomOrdering()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_4_1
+                    IList<Product> results = session
+                        .Query<Product, Products_ByUnitsInStock>()
+                        .Where(x => x.UnitsInStock > 10)
+                        .OrderByScore()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_4_2
+                    IList<Product> results = session
+                        .Advanced
+                        .DocumentQuery<Product, Products_ByUnitsInStock>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                        .OrderByScore()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_4_3
+                    IList<Product> results = session
+                        .Query<Product, Products_ByUnitsInStockAndName>()
+                        .Where(x => x.UnitsInStock > 10)
+                        .OrderBy(x => x.UnitsInStock)
+                        .ThenByScore()
+                        .ThenByDescending(x => x.Name)
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_6_1
+                    IList<Product> results = session
+                        .Query<Products_ByName_Search.Result, Products_ByName_Search>()
+                        .Search(x => x.Name, "Louisiana")
+                        .OrderByDescending(x => x.NameForSorting)
+                        .OfType<Product>()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_6_2
+                    IList<Product> results = session
+                        .Advanced
+                        .DocumentQuery<Product, Products_ByName_Search>()
+                        .Search("Name", "Louisiana")
+                        .OrderByDescending("NameForSorting")
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_7_1
+                    IList<Product> results = session
+                        .Query<Product, Products_ByUnitsInStock>()
+                        .Where(x => x.UnitsInStock > 10)
+                        .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_7_2
+                    IList<Product> results = session
+                        .Advanced
+                        .DocumentQuery<Product, Products_ByUnitsInStock>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                        .OrderBy("Name", OrderingType.AlphaNumeric)
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_9_1
+                    List<Event> results = session
+                        .Query<Event, Events_ByCoordinates>()
+                        .Spatial(
+                            "Coordinates",
+                            criteria => criteria.WithinRadius(500, 30, 30))
+                        .OrderByDistance(
+                            factory => factory.Point(x => x.Latitude, x => x.Longitude), 32.1234, 23.4321)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region sorting_9_2
+                    List<Event> results = session
+                        .Advanced
+                        .DocumentQuery<Event, Events_ByCoordinates>()
+                        .Spatial(
+                            "Coordinates",
+                            criteria => criteria.WithinRadius(500, 30, 30))
+                        .OrderByDistance(
+                            factory => factory.Point(x => x.Latitude, x => x.Longitude), 32.1234, 23.4321)
+                        .ToList();
+                    #endregion
+                }
+            }
+
+            using (var documentStore = new DocumentStore())
+            {
+                /*
+                #region custom_1
+                PutSortersOperation(params SorterDefinition[] sortersToAdd)
+                #endregion
+
+                #region custom_2
+                public class SorterDefinition
+                {
+                    public string Name { get; set; }
+                    public string Code { get; set; }
+                }
+                #endregion
+                */
+
+                #region custom_3
+                //Assign the code of your new sorter as a `string`
+                var sorterCode = "<code of custom sorter>";
+
+                //Create one or more `SorterDefinition` objects
+                var customSorterDefinition = new SorterDefinition
+                {
+                    Name = "MySorter",
+                    Code = sorterCode
+                };
+
+                //Send the new sorters to the server
+                documentStore.Maintenance.Send(new PutSortersOperation(customSorterDefinition));
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/4.2/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Sorting.java
+++ b/Documentation/4.2/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Sorting.java
@@ -1,0 +1,199 @@
+package net.ravendb.Indexes.Querying;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.FieldIndexing;
+import net.ravendb.client.documents.indexes.FieldStorage;
+import net.ravendb.client.documents.queries.spatial.PointField;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.client.documents.session.OrderingType;
+
+import java.util.List;
+
+public class Sorting {
+
+    //region sorting_5_6
+    public static class Employee_ByFirstName extends AbstractIndexCreationTask {
+        public Employee_ByFirstName() {
+            map = "docs.Employees.Select(employee => new {" +
+                "    FirstName = employee.FirstName" +
+                "})";
+
+            store("FirstName", FieldStorage.YES);
+        }
+    }
+    //endregion
+
+    //region sorting_1_4
+    public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
+        public Products_ByUnitsInStock() {
+            map = "docs.Products.Select(product => new {" +
+                "    UnitsInStock = product.UnitsInStock" +
+                "})";
+        }
+    }
+    //endregion
+
+    //region sorting_1_5
+    public static class Products_ByUnitsInStockAndName extends AbstractIndexCreationTask {
+        public Products_ByUnitsInStockAndName() {
+            map = "docs.Products.Select(product => new {" +
+                "    UnitsInStock = product.UnitsInStock" +
+                "    Name = product.Name" +
+                "})";
+        }
+    }
+    //endregion
+
+    //region sorting_6_4
+    public static class Products_ByName_Search extends AbstractIndexCreationTask {
+        public static class Result {
+            private String name;
+            private String nameForSorting;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getNameForSorting() {
+                return nameForSorting;
+            }
+
+            public void setNameForSorting(String nameForSorting) {
+                this.nameForSorting = nameForSorting;
+            }
+        }
+
+        public Products_ByName_Search() {
+            map = "docs.Products.Select(product => new {" +
+                "    Name = product.Name," +
+                "    NameForSorting = product.Name" +
+                "})";
+
+            index("Name", FieldIndexing.SEARCH);
+        }
+    }
+    //endregion
+
+    //region sorting_9_3
+    public static class Events_ByCoordinates extends AbstractIndexCreationTask {
+        public Events_ByCoordinates() {
+            map = "docs.Events.Select(e => new {" +
+                "   Coordinates = this.CreateSpatialField(e.Latitude, e.Longitude)" +
+                "})";
+        }
+    }
+    //endregion
+
+    public static class Products_ByName extends AbstractIndexCreationTask {
+
+    }
+
+    private static class Product {
+
+    }
+
+    public Sorting() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_1_1
+                List<Product> results = session
+                    .query(Product.class, Products_ByUnitsInStock.class)
+                    .whereGreaterThan("UnitsInStock", 10)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_2_1
+                List<Product> results = session
+                    .query(Product.class, Products_ByUnitsInStock.class)
+                    .whereGreaterThan("UnitsInStock", 10)
+                    .orderByDescending("UnitsInStock")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_8_1
+                List<Product> results = session
+                    .query(Product.class, Products_ByUnitsInStock.class)
+                    .whereGreaterThan("UnitsInStock", 10)
+                    .orderByDescending("UnitsInStock", OrderingType.STRING)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_3_1
+                List<Product> results = session
+                    .query(Product.class, Products_ByUnitsInStock.class)
+                    .randomOrdering()
+                    .whereGreaterThan("UnitsInStock", 10)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_4_1
+                List<Product> results = session
+                    .query(Product.class, Products_ByUnitsInStock.class)
+                    .whereGreaterThan("UnitsInStock", 10)
+                    .orderByScore()
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_4_3
+                List<Product> results = session
+                    .query(Product.class, Products_ByUnitsInStockAndName.class)
+                    .whereGreaterThan("UnitsInStock", 10)
+                    .orderBy("UnitsInStock")
+                    .orderByScore()
+                    .orderByDescending("Name")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_6_1
+                List<Product> results = session
+                    .query(Product.class, Products_ByName_Search.class)
+                    .search("Name", "Louisiana")
+                    .orderByDescending("NameForSorting")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_7_1
+                List<Product> results = session
+                    .query(Product.class, Products_ByUnitsInStock.class)
+                    .whereGreaterThan("UnitsInStock", 10)
+                    .orderBy("Name", OrderingType.ALPHA_NUMERIC)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region sorting_9_1
+                List<Events> results = session
+                    .query(Events.class, Events_ByCoordinates.class)
+                    .spatial("Coordinates", criteria -> criteria.withinRadius(500, 30, 30))
+                    .orderByDistance(new PointField("Latitude", "Longitude"), 32.1234, 23.4321)
+                    .toList();
+                //endregion
+            }
+        }
+    }
+
+    public static class Events {
+
+    }
+}


### PR DESCRIPTION
- Changed the 4.1 docs' .NET client version to 4.1.10 instead of 4.2.0 (using NuGet
- Fixed a mistake I made in RDoc-1616-custom-sorter - I documented the PutSortersOperation in 4.1 instead of 4.2. This caused an exception in the Sorting.cs code sample when I updated the client version (which is why I'm fixing it here). The mistake was in this pull request: https://github.com/ravendb/docs/pull/1133 which is already merged.
    - Copied sorting.dotnet.markdown and Sorting.cs from 4.1 to 4.2, including the documentation for PutSortersOperation. No additional changes made
    - Removed PutSorterOperation from sorting.dotnet.markdown and Sorting.cs in 4.1
    - Added sorting.java.markdown and Sorting.java from 4.1 to 4.2 for good measure