### PR TITLE
RDoc-1743-RQL-links

### DIFF
--- a/Documentation/5.0/Raven.Documentation.Pages/indexes/querying/what-is-rql.markdown
+++ b/Documentation/5.0/Raven.Documentation.Pages/indexes/querying/what-is-rql.markdown
@@ -319,6 +319,8 @@ The following keywords and methods are available in RQL:
   - sum()
   - count()
   - [facet()](../../indexes/querying/faceted-search)
+  - [timeseries()](../../document-extensions/timeseries/querying/overview-and-syntax#syntax)
+  - [counter()](../../document-extensions/counters/counters-and-other-features#counters-and-queries)
 - [UPDATE](../../indexes/querying/what-is-rql#update)
 - [INCLUDE](../../indexes/querying/what-is-rql#include)
 


### PR DESCRIPTION
- added `timeseries()` and `counter()` methods to the list of methods that follow `select`
- links to pages/sections of querying timeseries and counters