### PR TITLE
RDoc-1762-review-comment-cmpxchg-metadata-expiration

### DIFF
--- a/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/compare-exchange/.docs.json
+++ b/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/compare-exchange/.docs.json
@@ -35,9 +35,15 @@
     "Mappings": []
   },
   {
-    "Path": "compare-exchange-expiration-metadata.markdown",
-    "Name": "Compare Exchange Expiration and Metadata",
+    "Path": "compare-exchange-expiration.markdown",
+    "Name": "Compare Exchange Expiration",
     "DiscussionId": "14b18c8c-28fc-4c97-b435-b4176d4e1a26",
+    "Mappings": []
+  },
+  {
+    "Path": "compare-exchange-metadata.markdown",
+    "Name": "Compare Exchange Metadata",
+    "DiscussionId": "42e13e99-2dfb-4f8c-9cde-f0a2cbfccfe0",
     "Mappings": []
   }
 ]

--- a/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/compare-exchange/compare-exchange-expiration.dotnet.markdown
+++ b/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/compare-exchange/compare-exchange-expiration.dotnet.markdown
@@ -1,16 +1,15 @@
-﻿# Compare Exchange Expiration and Metadata
+﻿# Compare Exchange Expiration
 ---
 
 {NOTE: }
 
-* RavenDB 5.0 added metadata to compare exchange values.  
+* Compare exchange value expiration works very similar to [document expiration](../../../server/extensions/expiration).  
 
-* Use the `@expires` field in the metadata to schedule an expiration for a 
-compare exchange value. This works very similar to [document expiration](../../../server/extensions/expiration).  
+* Use the `@expires` field in a [compare exchange value's metadata](../../../client-api/operations/compare-exchange/compare-exchange-metadata) to schedule its expiration.  
 
 * In this page:
-  * [syntax](../../../client-api/operations/compare-exchange/compare-exchange-expiration-metadata#syntax)
-  * [examples](../../../client-api/operations/compare-exchange/compare-exchange-expiration-metadata#examples)
+  * [Syntax](../../../client-api/operations/compare-exchange/compare-exchange-expiration#syntax)
+  * [Examples](../../../client-api/operations/compare-exchange/compare-exchange-expiration#examples)
 
 {NOTE/}
 
@@ -24,11 +23,7 @@ deletion by the expiration feature. The _exact_ time this happens depends
 on the expiration frequency and other 
 [expiration configurations](../../../server/extensions/expiration#configuring-the-expiration-feature).  
 
-Editing compare exchange metadata works much the same as editing a 
-[document's metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata) 
-- it is a root property of the compare exchange value object.  
-
-To set a compare exchange value to expire, simple put a `DateTime` value 
+To set a compare exchange value to expire, simply put a `DateTime` value 
 (in UTC format) in the `@expires` field, then to send it to the server.  
 
 {PANEL/}
@@ -50,6 +45,7 @@ Updating an existing key with `PutCompareExchangeValueOperation<T>`:
 ### Client API
 - [Session: How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
 - [Compare Exchange: Overview](../../../client-api/operations/compare-exchange/overview)
+- [Compare Exchange Metadata](../../../client-api/operations/compare-exchange/compare-exchange-metadata)
 
 ### Server
 - [Document Expiration](../../../server/extensions/expiration)

--- a/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/compare-exchange/compare-exchange-metadata.dotnet.markdown
+++ b/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/compare-exchange/compare-exchange-metadata.dotnet.markdown
@@ -1,0 +1,36 @@
+﻿# Compare Exchange Metadata
+---
+
+{NOTE: }
+
+* RavenDB 5.0 added metadata to compare exchange values.  
+
+* In this page:  
+  * [Syntax](../../../client-api/operations/compare-exchange/compare-exchange-metadata#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Syntax}
+
+A compare exchange value's metadata is very similar to a 
+[document's metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata).  
+
+The metadata can be used to set [compare exchange expiration](../../../client-api/operations/compare-exchange/compare-exchange-expiration).  
+
+The metadata is accessible as a root property of the compare exchange value object:  
+
+{CODE:csharp metadata_0@ClientApi/CompareExchange.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API  
+- [Session: How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)  
+- [Compare Exchange: Overview](../../../client-api/operations/compare-exchange/overview)  
+- [Compare Exchange Expiration](../../../client-api/operations/compare-exchange/compare-exchange-expiration)  
+
+### Server  
+- [Document Expiration](../../../server/extensions/expiration)  

--- a/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/CompareExchange.cs
+++ b/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/CompareExchange.cs
@@ -190,6 +190,21 @@ namespace Raven.Documentation.Samples.ClientApi.Operations
                                 cmpxchgValue.Index));
                     #endregion
                 }
+
+                using (IAsyncDocumentSession session = store.OpenAsyncSession())
+                {
+                    #region metadata_0
+                    // Create a new compare exchange value
+                    var cmpxchgValue = session.Advanced.ClusterTransaction.CreateCompareExchangeValue("key", "value");
+
+                    // Add a field to the metadata
+                    // with a value of type string
+                    cmpxchgValue.Metadata["Field name"] = "some value";
+
+                    // Retrieve metadata as a dictionary
+                    IDictionary<string, object> cmpxchgMetadata = cmpxchgValue.Metadata;
+                    #endregion
+                }
             }
         }
 


### PR DESCRIPTION
- following previous PR [https://github.com/ravendb/docs/pull/1189](https://github.com/ravendb/docs/pull/1189) the single page "Compare Exchange Expiration & Metadata" has been split into two smaller pages
- the content is almost the same as in the original page
- added a code example for accessing cmpxchg metadata