### PR TITLE
RDoc-1778-indexing-null-field-and-empty-entries

### DIFF
--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/map-indexes.dotnet.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/map-indexes.dotnet.markdown
@@ -14,6 +14,7 @@ You can:
 - [index nested data](../indexes/map-indexes#indexing-nested-data)
 - [index fields from related documents](../indexes/indexing-related-documents)
 - [index fields from multiple collections](../indexes/indexing-polymorphic-data#multi-map-indexes)
+- [configure whether to index a document if the specified fields are `null`](../indexes/map-indexes#indexing-missing-fields)
 - ...and more. 
 
 ## Indexing Single Fields
@@ -222,6 +223,15 @@ If a document relationship is represented by the document's ID, you can use the 
 ## Indexing Multiple Collections
 
 Read the article dedicated to `Multi-Map` indexes [here](../indexes/indexing-polymorphic-data#multi-map-indexes).
+
+## Indexing Missing Fields
+
+By default, indexes will not index a document that contains none of the specified fields. This behavior can be changed 
+using the [Indexing.IndexEmptyEntries](../server/configuration/indexing-configuration#indexing.indexemptyentries) 
+configuration option.  
+
+The option [Indexing.IndexMissingFieldsAsNull](../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull) 
+determines whether missing fields in documents are indexed with the value `null`, or not indexed at all.  
 
 ## Related Articles
 

--- a/Documentation/4.2/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -214,6 +214,26 @@ Max time to wait in seconds when forcing the storage environment flush and sync 
 
 {PANEL/}
 
+{PANEL:Indexing.IndexMissingFieldsAsNull}
+
+Indicates if missing fields should be indexed same as 'null' values or not.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Indexing.IndexEmptyEntries}
+
+Indicates if empty index entries should be indexed by static indexes.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
 {PANEL:Indexing.MapBatchSize}
 
 Maximum number of documents to be processed by the index per indexing batch.


### PR DESCRIPTION
Documented indexing configuration options Indexing.IndexMissingFieldsAsNull and Indexing.IndexEmptyEntries