### PR TITLE
Fixed code errors

### DIFF
--- a/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/Raven.Documentation.Samples.csproj
+++ b/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/Raven.Documentation.Samples.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.0.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.0.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.0.4-nightly-20201110-0401" />
     <PackageReference Include="RavenDB.Embedded" Version="5.0.0" />
     <PackageReference Include="RavenDB.TestDriver" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Counters/IndexingCounters.cs
+++ b/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Counters/IndexingCounters.cs
@@ -6,7 +6,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Counters;
 using Raven.Documentation.Samples.Orders;
 
-namespace Raven.Documentation.Samples.Indexes
+namespace Raven.Documentation.Samples.DocumentExtensions
 {
     public class IndexingCounters
     {

--- a/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Analyzers.cs
+++ b/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/Indexes/Analyzers.cs
@@ -108,6 +108,13 @@ namespace Raven.Documentation.Samples.Indexes
         }
     }
 
+    public class BlogPost
+    {
+        public string[] Tags { get; set; }
+        public string Content { get; set; }
+        public string Title { get; internal set; }
+    }
+
     /*
     #region analyzers_6
     public class MyAnalyzer : Lucene.Net.Analysis.Analyzer


### PR DESCRIPTION
-for errors in Analyzers.cs created a class BlogPosts
-in OpeningSession.cs in 5.0, the convention ShouldIgnoreEntityChanges was not recognized because the client version was 5.0.0, updated to a 5.0.4 nightly
- DocumentExtensions/Counters/IndexingCounters.cs is a copy of Indexes/IndexingCounters.cs, down to the same namespace, so I changed the namespace