### PR TITLE
Use static EntityToBlittable for object conversion

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/commands/documents/put.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/commands/documents/put.dotnet.markdown
@@ -10,7 +10,7 @@
 | ------------- | ------------- | ----- |
 | **id** | string | unique ID under which document will be stored |
 | **changeVector** | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
-| **document** | BlittableJsonReaderObject | The document to store. You may use `session.Advanced.EntityToBlittable.ConvertEntityToBlittable` to convert your entity to a `BlittableJsonReaderObject` |
+| **document** | BlittableJsonReaderObject | The document to store. You may use `EntityToBlittable.ConvertEntityToBlittable` to convert your entity to a `BlittableJsonReaderObject` |
 
 ## Example
 


### PR DESCRIPTION
Code example does not work, refactor in client has moved `session.Advanced.EntityToBlittable` to a static class `EntityToBlittable`

Change was in 2017, for 4.0.
https://github.com/ravendb/ravendb/commit/63110d091b5609ff3e56abba08c4a883829250da

I have not checked the rest of the docs for the same issue (yet!).