### PR TITLE
RDoc-1904-fix-comp-errors To fix compilation errors:

### DIFF
--- a/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/Blog.cs
+++ b/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/Blog.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Raven.Documentation.Samples
+{
+	#region blog_post
+	public class BlogPost
+	{
+		public string Id { get; set; }
+
+		public string Title { get; set; }
+
+		public string Category { get; set; }
+
+		public string Content { get; set; }
+
+		public DateTime PublishedAt { get; set; }
+
+		public string[] Tags { get; set; }
+
+		public BlogComment[] Comments { get; set; }
+	}
+	#endregion
+
+	#region blog_comment
+	public class BlogComment
+	{
+		public string Title { get; set; }
+
+		public string Content { get; set; }
+	}
+	#endregion
+}

--- a/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/Raven.Documentation.Samples.csproj
+++ b/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/Raven.Documentation.Samples.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.0.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.1.0-nightly-20201031-0731" />
+    <PackageReference Include="RavenDB.Client" Version="5.1.5" />
     <PackageReference Include="RavenDB.Embedded" Version="5.1.0-nightly-20200929-0713" />
     <PackageReference Include="RavenDB.TestDriver" Version="5.1.0-nightly-20200929-0713" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
-copied Blog.cs from 4.2 to 5.0
-updated the 5.1 docs' client version from a 5.1.0 nightly to version 5.1.5