### PR TITLE
RDoc-1874-REST-metadataOnly

### DIFF
--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/rest-api/document-commands/get-all-documents.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/rest-api/document-commands/get-all-documents.markdown
@@ -98,7 +98,7 @@ This is the general format of a cURL request that uses all query string paramete
 curl -X GET "<server URL>/databases/<database name>/docs?
             &start=<integer>
             &pageSize=<integer>
-            &metadata=<boolean>"
+            &metadataOnly=<boolean>"
 --header "If-None-Match: <hash>"
 {CODE-BLOCK/}
 Linebreaks are added for clarity.  
@@ -181,7 +181,7 @@ Skip first 1,057 documents, and retrieve the rest (our version of Northwind cont
 cURL request:  
 
 {CODE-BLOCK: bash}
-curl -X GET "http://live-test.ravendb.net/databases/Example/docs?start=1056"
+curl -X GET "http://live-test.ravendb.net/databases/Example/docs?start=1057"
 {CODE-BLOCK/}
 
 Response:  

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/rest-api/document-commands/get-documents-by-prefix.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/rest-api/document-commands/get-documents-by-prefix.markdown
@@ -96,7 +96,7 @@ curl -X GET "<server URL>/databases/<database name>/docs?
             &startAfter=<document ID>
             &start=<integer>
             &pageSize=<integer>
-            &metadata=<boolean>"
+            &metadataOnly=<boolean>"
 --header "If-None-Match: <hash>"
 {CODE-BLOCK/}
 Linebreaks are added for clarity.  

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/rest-api/queries/query-the-database.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/rest-api/queries/query-the-database.markdown
@@ -99,7 +99,7 @@ This is the general format of a cURL request that uses all query string paramete
 
 {CODE-BLOCK: batch}
 curl -X POST "<server URL>/databases/<database name>/queries?
-            metadata=<boolean>
+            metadataOnly=<boolean>
             &includeServerSideQuery=<boolean>
             &debug=<debug>"
 --header "If-None-Match: <long>"


### PR DESCRIPTION
Fixed instances of the query parameter `metadataOnly`
- `metadata` => `metadataOnly`
- In get-all-documents.markdown a query example did not match its description
    "?start=1056" => "?start=1057"