### PR TITLE
RDoc-1949-stream-query-include Documented that streaming does not sup…

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.dotnet.markdown
@@ -78,6 +78,9 @@ include CustomerId
 
 This works because RavenDB has two channels through which it can return information in response to a load request. The first is the Results channel, through which the root object retrieved by the `Load()` method call is returned. The second is the Includes channel, through which any included documents are sent back to the client. Client side, those included documents are not returned from the `Load()` method call, but they are added to the session unit of work, and subsequent requests to load them are served directly from the session cache, without requiring any additional queries to the server.
 
+{INFO Streaming query results does not support the includes feature. Learn more in 
+[How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results). /}
+
 ### One to Many Includes
 
 Include can be used with a many to one relationship. In the above classes, an `Order` has a property `SupplierIds` which contains an array of references to `Supplier` documents. The following code will cause the suppliers to be pre-loaded:

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.java.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.java.markdown
@@ -78,6 +78,9 @@ include CustomerId
 
 This works because RavenDB has two channels through which it can return information in response to a load request. The first is the Results channel, through which the root object retrieved by the `load()` method call is returned. The second is the Includes channel, through which any included documents are sent back to the client. Client side, those included documents are not returned from the `load()` method call, but they are added to the session unit of work, and subsequent requests to load them are served directly from the session cache, without requiring any additional queries to the server.
 
+{INFO Streaming query results does not support the includes feature. Learn more in 
+[How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results). /}
+
 ### One to Many Includes
 
 Include can be used with a many to one relationship. In the above classes, an `Order` has a field `SupplierIds` which contains an array of references to `Supplier` documents. The following code will cause the suppliers to be pre-loaded:

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -136,24 +136,29 @@ To load multiple entities that contain a common prefix, use the `LoadStartingWit
 
 Entities can be streamed from the server using one of the following `Stream` methods from the `Advanced` session operations.
 
+Streaming query results does not support the [`include` feature](../../../client-api/how-to/handle-document-relationships#includes). 
+Learn more in [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results).  
+
+{INFO Entities loaded using `Stream` will be transient (not attached to session). /}
+
 {CODE-TABS}
 {CODE-TAB:csharp:Sync loading_entities_5_0@ClientApi\Session\LoadingEntities.cs /}
 {CODE-TAB:csharp:Async loading_entities_5_0_async@ClientApi\Session\LoadingEntities.cs /}
 {CODE-TABS/}
 
-| Parameters | | |
+| Parameter | Type | Description |
 | ------------- | ------------- | ----- |
-| **startsWith** | string | prefix for which documents should be streamed |
-| **matches** | string | pipe ('&#124;') separated values for which document IDs should be matched ('?' any single character, '*' any characters) |
-| **start** | int | number of documents that should be skipped  |
-| **pageSize** | int | maximum number of documents that will be retrieved |
-| **skipAfter** | string | skip document fetching until a given ID is found and returns documents after that ID (default: `null`) |
-| streamQueryStats (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
+| **startsWith** | `string` | prefix for which documents should be streamed |
+| **matches** | `string` | pipe ('&#124;') separated values for which document IDs should be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped  |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+| **skipAfter** | `string` | skip document fetching until a given ID is found and returns documents after that ID (default: `null`) |
+| **StreamQueryStats** | `streamQueryStats` (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
 
-| Return Value | |
+| Return Type | Description |
 | ------------- | ----- |
-| IEnumerator<[StreamResult](../../glossary/stream-result)> | Enumerator with entities. |
-| streamQueryStats (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
+| `IEnumerator<`[StreamResult](../../glossary/stream-result)`>` | Enumerator with entities. |
+| `streamQueryStats` (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
 
 
 ### Example I
@@ -173,10 +178,6 @@ Fetch documents for a ID prefix directly into a stream:
 {CODE-TAB:csharp:Sync loading_entities_5_2@ClientApi\Session\LoadingEntities.cs /}
 {CODE-TAB:csharp:Async loading_entities_5_2_async@ClientApi\Session\LoadingEntities.cs /}
 {CODE-TABS/}
-
-### Remarks
-
-{INFO Entities loaded using `Stream` will be transient (not attached to session). /}
 
 {PANEL/}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.dotnet.markdown
@@ -2,6 +2,12 @@
 
 Query results can be streamed using the `Stream` method from the `Advanced` session operations. The query can be issued using either a static index, or it can be a dynamic one where it will be handled by an auto index.
 
+Streaming query results does not support the [`include` feature](../../../client-api/how-to/handle-document-relationships#includes). 
+Instead, the query should rely on the [`load` clause](../../../indexes/querying/what-is-rql#load). See 
+[example IV](../../../client-api/session/querying/how-to-stream-query-results#example-iv) below.  
+
+{INFO Entities loaded using `Stream` will be transient (not attached to session). /}
+
 ## Syntax
 
 {CODE stream_1@ClientApi\Session\Querying\HowToStream.cs /}
@@ -15,25 +21,58 @@ Query results can be streamed using the `Stream` method from the `Advanced` sess
 | ------------- | ----- |
 | IEnumerator<[StreamResult](../../../glossary/stream-result)> | Enumerator with entities. |
 
-## Example I - Using Static Index
+### Example I - Using Static Index
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync stream_2@ClientApi\Session\Querying\HowToStream.cs /}
 {CODE-TAB:csharp:Async stream_2_async@ClientApi\Session\Querying\HowToStream.cs /}
 {CODE-TABS/}
 
-## Example II - Dynamic Document Query
+### Example II - Dynamic Document Query
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync stream_3@ClientApi\Session\Querying\HowToStream.cs /}
 {CODE-TAB:csharp:Async stream_3_async@ClientApi\Session\Querying\HowToStream.cs /}
 {CODE-TABS/}
 
-## Example III - Dynamic Raw Query
+### Example III - Dynamic Raw Query
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync stream_4@ClientApi\Session\Querying\HowToStream.cs /}
 {CODE-TAB:csharp:Async stream_4_async@ClientApi\Session\Querying\HowToStream.cs /}
+{CODE-TABS/}
+
+## Alternative to Using Includes
+
+Streaming does not support the [`include` feature](../../../client-api/how-to/handle-document-relationships#includes). 
+An `include` clause in a query loads additional documents related to the primary target of the query. 
+These are stored in the session on the client side so that they can be accessed without an additional 
+query.  
+
+In a normal non-streamed query, included documents are sent at the end of results, after the 
+main targets and documents added with `load`. This does not mesh well with streaming, which is 
+designed to allow transferring massive amounts of data, possibly over a significant amount of time. 
+Instead of getting related documents at the end of the stream, it is better to get them interspersed 
+with the other results.  
+
+### Example IV
+
+To include related documents in your query, add them using `load`, then use `select` to 
+retrieve the documents.  
+
+Because we used `select`, the query results are now a [projection](../../../indexes/querying/projections) containing more than 
+one entity. So on the client side, you need a projection class that matches the query result.  
+
+In this example, we query the `Orders` collection and also load related `Company` and 
+`Employee` documents. With the select clause, we return all three objects. We have a class 
+called `MyProjection` that has the three entity types as properties. We use this class to 
+store the results.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync includes@ClientApi\Session\Querying\HowToStream.cs /}
+{CODE-TAB:csharp:Async includes_async@ClientApi\Session\Querying\HowToStream.cs /}
+{CODE-TAB:csharp:Class class@ClientApi\Session\Querying\HowToStream.cs /}
+
 {CODE-TABS/}
 
 ## Related Articles

--- a/Documentation/4.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToStream.cs
+++ b/Documentation/4.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToStream.cs
@@ -139,6 +139,54 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                     }
                     #endregion
                 }
+
+                using (var session = store.OpenSession())
+                {
+                    #region includes
+                    IRawDocumentQuery<MyProjection> query = session
+                        .Advanced
+                        .RawQuery<MyProjection>(@"from Orders as o 
+                                                where o.ShipTo.City = 'London'
+                                                load o.Company as c, o.Employee as e
+                                                select {
+                                                    order: o,
+                                                    company: c,
+                                                    employee: e
+                                                }");
+
+
+                    IEnumerator<StreamResult<MyProjection>> results = session.Advanced.Stream(query);
+
+                    while (results.MoveNext())
+                    {
+                        StreamResult<MyProjection> projection = results.Current;
+                    }
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region includes_async
+                    IAsyncRawDocumentQuery<MyProjection> query = asyncSession
+                        .Advanced
+                        .AsyncRawQuery<MyProjection>(@"from Orders as o 
+                                                       where o.ShipTo.City = 'London'
+                                                       load o.Company as c, o.Employee as e
+                                                       select {
+                                                           order: o,
+                                                           company: c,
+                                                           employee: e
+                                                       }");
+
+
+                    IAsyncEnumerator<StreamResult<MyProjection>> results = await asyncSession.Advanced.StreamAsync(query);
+
+                    while (await results.MoveNextAsync())
+                    {
+                        StreamResult<MyProjection> projection = results.Current;
+                    }
+                    #endregion
+                }
             }
         }
     }
@@ -154,4 +202,13 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                                };
         }
     }
+
+    #region class
+    public class MyProjection
+    {
+        public Order order { get; set; }
+        public Employee employee { get; set; }
+        public Company company { get; set; }
+    }
+    #endregion
 }

--- a/Documentation/4.1/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.dotnet.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.dotnet.markdown
@@ -85,6 +85,9 @@ include CustomerId,counters(o,'OrderUpdateCount')
 This works because RavenDB has two channels through which it can return information in response to a load request. The first is the Results channel, through which the root object retrieved by the `Load()` method call is returned. The second is the Includes channel, through which any included documents are sent back to the client. Client side, those included documents are not returned from the `Load()` method call, but they are added to the session unit of work, and subsequent requests to load them are served directly from the session cache, without requiring any additional queries to the server.
 
 {NOTE Embedded and builder variants of Include clause are essentially syntax sugar and are equivalent at the server side. /}
+
+{INFO Streaming query results does not support the includes feature. Learn more in 
+[How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results). /}
  
 ### One to Many Includes
 

--- a/Documentation/4.1/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.java.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.java.markdown
@@ -86,6 +86,9 @@ This works because RavenDB has two channels through which it can return informat
 
 {NOTE Embedded and builder variants of Include clause are essentially syntax sugar and are equivalent at the server side. /}
 
+{INFO Streaming query results does not support the includes feature. Learn more in 
+[How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results). /}
+
 ### One to Many Includes
 
 Include can be used with a many to one relationship. In the above classes, an `Order` has a field `SupplierIds` which contains an array of references to `Supplier` documents. The following code will cause the suppliers to be pre-loaded:

--- a/Documentation/5.0/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.dotnet.markdown
+++ b/Documentation/5.0/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.dotnet.markdown
@@ -85,6 +85,9 @@ include CustomerId,counters(o,'OrderUpdateCount')
 This works because RavenDB has two channels through which it can return information in response to a load request. The first is the Results channel, through which the root object retrieved by the `Load()` method call is returned. The second is the Includes channel, through which any included documents are sent back to the client. Client side, those included documents are not returned from the `Load()` method call, but they are added to the session unit of work, and subsequent requests to load them are served directly from the session cache, without requiring any additional queries to the server.
 
 {NOTE Embedded and builder variants of Include clause are essentially syntax sugar and are equivalent at the server side. /}
+
+{INFO Streaming query results does not support the includes feature. Learn more in 
+[How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results). /}
  
 ### One to Many Includes
 

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -187,6 +187,11 @@ The method is accessible from the `session.Advanced` operations.
 
 Entities can be streamed from the server using one of the following `Stream` methods from the `Advanced` session operations.
 
+Streaming query results does not support the [`include` feature](../../../client-api/how-to/handle-document-relationships#includes). 
+Learn more in [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results).  
+
+{INFO Entities loaded using `Stream` will be transient (not attached to session). /}
+
 {CODE-TABS}
 {CODE-TAB:csharp:Sync loading_entities_5_0@ClientApi\Session\LoadingEntities.cs /}
 {CODE-TAB:csharp:Async loading_entities_5_0_async@ClientApi\Session\LoadingEntities.cs /}
@@ -224,10 +229,6 @@ Fetch documents for a ID prefix directly into a stream:
 {CODE-TAB:csharp:Sync loading_entities_5_2@ClientApi\Session\LoadingEntities.cs /}
 {CODE-TAB:csharp:Async loading_entities_5_2_async@ClientApi\Session\LoadingEntities.cs /}
 {CODE-TABS/}
-
-### Remarks
-
-{INFO Entities loaded using `Stream` will be transient (not attached to session). /}
 
 {PANEL/}
 


### PR DESCRIPTION
…port includes

- In how-to-stream-query-results.dotnet.markdown / HowToStream.cs: explained why streaming does not support `include`, and what can be done instead.
- In other pages, linked to how-to-stream-query-results.dotnet.markdown
- In 4.0 version of loading-entities.dotnet.markdown, improved the formatting of the table in the Streaming section.
Specifically, I just copy pasted the improvements I had previously done in the 5.1 version of that page.