### PR TITLE
RDoc -1944 IsLoaded returns true when document doesn't exist

### DIFF
--- a/Documentation/3.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/3.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -183,7 +183,9 @@ Entities can be streamed from server using one of the following `Stream` methods
 
 {PANEL:IsLoaded}
 
-To check if entity is attached to session, e.g. has been loaded previously, use `IsLoaded` method from `Advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/3.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/3.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -160,7 +160,9 @@ Entities can be streamed from server using one of the following `stream` methods
 
 {PANEL:IsLoaded}
 
-To check if entity is attached to session, e.g. has been loaded previously, use `isLoaded` method from `advanced()` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/3.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/3.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -160,9 +160,9 @@ Entities can be streamed from server using one of the following `stream` methods
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -195,7 +195,9 @@ StreamDocs using the SimpleTransformer defined above and one supplied parameter:
 
 {PANEL:IsLoaded}
 
-To check if entity is attached to session, e.g. it has been loaded previously, use the `IsLoaded` method from `Advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -195,9 +195,11 @@ StreamDocs using the SimpleTransformer defined above and one supplied parameter:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the **Advanced** session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+`IsLoaded` checks if you've already tried to load a document during the current session.  
+If you try to load a document that no longer exists with the `Load` method (perhaps it has been deleted),  
+`IsLoaded` will then return `true` because `IsLoaded` shows that you've already tried to load the non-existent document.  
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -160,7 +160,9 @@ Entities can be streamed from server using one of the following `stream` methods
 
 {PANEL:IsLoaded}
 
-To check if entity is attached to session, e.g. has been loaded previously, use `isLoaded` method from `advanced()` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/3.5/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -160,9 +160,9 @@ Entities can be streamed from server using one of the following `stream` methods
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -183,7 +183,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -183,10 +183,11 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the **Advanced** session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
-
+`IsLoaded` checks if you've already tried to load a document during the current session.  
+If you try to load a document that no longer exists with the `Load` method (perhaps it has been deleted),  
+`IsLoaded` will then return `true` because `IsLoaded` shows that you've already tried to load the non-existent document.  
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 
 | Parameters | | |

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -136,8 +136,8 @@ To load multiple entities that contain a common prefix, use the `LoadStartingWit
 
 Entities can be streamed from the server using one of the following `Stream` methods from the `Advanced` session operations.
 
-Streaming query results does not support the [`include` feature](../../../client-api/how-to/handle-document-relationships#includes). 
-Learn more in [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results).  
+Streaming query results does not support the [`include` feature](../../client-api/how-to/handle-document-relationships#includes). 
+Learn more in [How to Stream Query Results](../../client-api/session/querying/how-to-stream-query-results).  
 
 {INFO Entities loaded using `Stream` will be transient (not attached to session). /}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -141,7 +141,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -141,9 +141,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
@@ -153,7 +153,9 @@ Fetch documents for a ID prefix directly into a writable stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded()` method from the `advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:nodejs loading_entities_6_0@client-api\session\loadingEntities.js /}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
@@ -153,9 +153,9 @@ Fetch documents for a ID prefix directly into a writable stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:nodejs loading_entities_6_0@client-api\session\loadingEntities.js /}
 

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -234,7 +234,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -148,15 +148,15 @@ To load multiple entities that contain a common prefix, use the `LoadStartingWit
 
 {PANEL: ConditionalLoad}
 
+This method can be used to check whether a document has been modified 
+since the last time its change vector was recorded, so that the cost of loading it 
+can be saved if it has not been modified.  
+
 The `ConditionalLoad` method takes a document's [change vector](../../server/clustering/replication/change-vector). 
 If the entity is tracked by the session, this method returns the entity. If the entity 
 is not tracked, it checks if the provided change vector matches the document's 
 current change vector on the server side. If they match, the entity is not loaded. 
 If the change vectors _do not_ match, the document is loaded.  
-
-In other words, this method can be used to check whether a document has been modified 
-since the last time its change vector was recorded, so that the cost of loading it 
-can be saved if it has not been modified.  
 
 The method is accessible from the `session.Advanced` operations.  
 
@@ -187,8 +187,8 @@ The method is accessible from the `session.Advanced` operations.
 
 Entities can be streamed from the server using one of the following `Stream` methods from the `Advanced` session operations.
 
-Streaming query results does not support the [`include` feature](../../../client-api/how-to/handle-document-relationships#includes). 
-Learn more in [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results).  
+Streaming query results does not support the [`include` feature](../../client-api/how-to/handle-document-relationships#includes). 
+Learn more in [How to Stream Query Results](../../client-api/session/querying/how-to-stream-query-results).  
 
 {INFO Entities loaded using `Stream` will be transient (not attached to session). /}
 

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -141,7 +141,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -141,9 +141,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -234,10 +234,11 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the **Advanced** session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
-
+`IsLoaded` checks if you've already tried to load a document during the current session.  
+If you try to load a document that no longer exists with the `Load` method (perhaps it has been deleted),  
+`IsLoaded` will then return `true` because `IsLoaded` shows that you've already tried to load the non-existent document.  
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -234,7 +234,10 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -148,15 +148,15 @@ To load multiple entities that contain a common prefix, use the `LoadStartingWit
 
 {PANEL: ConditionalLoad}
 
+This method can be used to check whether a document has been modified 
+since the last time its change vector was recorded, so that the cost of loading it 
+can be saved if it has not been modified.  
+
 The `ConditionalLoad` method takes a document's [change vector](../../server/clustering/replication/change-vector). 
 If the entity is tracked by the session, this method returns the entity. If the entity 
 is not tracked, it checks if the provided change vector matches the document's 
 current change vector on the server side. If they match, the entity is not loaded. 
 If the change vectors _do not_ match, the document is loaded.  
-
-In other words, this method can be used to check whether a document has been modified 
-since the last time its change vector was recorded, so that the cost of loading it 
-can be saved if it has not been modified.  
 
 The method is accessible from the `session.Advanced` operations.  
 
@@ -187,8 +187,8 @@ The method is accessible from the `session.Advanced` operations.
 
 Entities can be streamed from the server using one of the following `Stream` methods from the `Advanced` session operations.
 
-Streaming query results does not support the [`include` feature](../../../client-api/how-to/handle-document-relationships#includes). 
-Learn more in [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results).  
+Streaming query results does not support the [`include` feature](../../client-api/how-to/handle-document-relationships#includes). 
+Learn more in [How to Stream Query Results](../../client-api/session/querying/how-to-stream-query-results).  
 
 {INFO Entities loaded using `Stream` will be transient (not attached to session). /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -188,9 +188,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -188,7 +188,9 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
@@ -185,9 +185,9 @@ Fetch documents for a ID prefix directly into a writable stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
   
-If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:nodejs loading_entities_6_0@ClientApi\Session\loadingEntities.js /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
@@ -185,7 +185,9 @@ Fetch documents for a ID prefix directly into a writable stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded()` method from the `advanced` session operations.
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the `Advanced` session operations.  
+  
+If you try to load a document that does not exist with the `Load` method, `IsLoaded` will return `true` because that document load has already been attempted.  
 
 {CODE:nodejs loading_entities_6_0@ClientApi\Session\loadingEntities.js /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
@@ -113,18 +113,17 @@ To load multiple entities that contain a common prefix, use the `loadStartingWit
 
 {PANEL: ConditionalLoad}
 
+This method can be used to check whether a document has been modified 
+since the last time its change vector was recorded, so that the cost of loading it 
+can be saved if it has not been modified.  
+
 The `conditionalLoad` method takes a document's [change vector](../../server/clustering/replication/change-vector). 
 If the entity is tracked by the session, this method returns the entity. If the entity 
 is not tracked, it checks if the provided change vector matches the document's 
 current change vector on the server side. If they match, the entity is not loaded. 
 If the change vectors _do not_ match, the document is loaded.  
 
-In other words, this method can be used to check whether a document has been modified 
-since the last time its change vector was recorded, so that the cost of loading it 
-can be saved if it has not been modified.  
-
-The method is accessible from the `session.advanced` operations.  
-
+The method is accessible from the `session.Advanced` operations.  
 {CODE:nodejs loading_entities_7_0@ClientApi\Session\loadingEntities.js /}
 
 | Parameter | Type | Description |


### PR DESCRIPTION
Added sentence to clarify why `IsLoaded` returns `true` in C#, Java, and JS from versions 3.0 till 5.2