### PR TITLE
RDoc-2009 and RDoc-2010 - Edited Data Subscription articles

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.dotnet.markdown
@@ -51,9 +51,11 @@ Documents are always sent in Etag order which means that data that already been 
 
 3. In case of subscription failover (`Enterprise feature`), when there is a chance that documents will be processed again, because it's not always possible to find the same starting point on a different machine.
 
-A subscription worker will retry processing documents from the last acknowledged and processed document (by tracking its Change Vector).
-
-* If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+{NOTE: }
+If the database has Revisions defined, the subscription can be configured to process pairs 
+of subsequent document revisions.  
+Read more here: [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning)
+{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.java.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.java.markdown
@@ -51,9 +51,11 @@ Documents are always sent in Etag order which means that data that already been 
 
 3. In case of subscription failover (`Enterprise feature`), when there is a chance that documents will be processed again, because it's not always possible to find the same starting point on a different machine.
 
-A subscription worker will retry processing documents from the last acknowledged and processed document (by tracking its Change Vector).
-
-* If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+{NOTE: }
+If the database has Revisions defined, the subscription can be configured to process pairs 
+of subsequent document revisions.  
+Read more here: [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning)
+{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.js.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.js.markdown
@@ -51,9 +51,11 @@ Documents are always sent in Etag order which means that data that already been 
 
 3. In case of subscription failover (`Enterprise feature`), when there is a chance that documents will be processed again, because it's not always possible to find the same starting point on a different machine.
 
-A subscription worker will retry processing documents from the last acknowledged and processed document (by tracking its Change Vector).
-
-* If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+{NOTE: }
+If the database has Revisions defined, the subscription can be configured to process pairs 
+of subsequent document revisions.  
+Read more here: [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning)
+{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/4.1/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.dotnet.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.dotnet.markdown
@@ -83,15 +83,17 @@ The `Run` function receives the client-side code as a delegate that will process
 | **OpenAsyncSession()** | `IDocumentSession` | New asynchronous document session, that tracks all items and included items of the current batch. |
 
 
-{NOTE:Subscription Session characteristics}
-Session will be created by the same document store that created the worker, therefore will receive the same configurations as any other session created by the store.  
-However, in order to maintain consistency, the session will address the same server that the batch was received from.  
-It won't try to fail over to another server. It might also fail if the subscription worker changes the node it communicates with.  
-Such event could happen if the subscription worker starts again to address its original node after a fallback occurrence.  
-If such failure occurs, the subscription processing will be stopped, and will have to be restarted, as shown [here](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
+{NOTE:Subscription Worker Connectivity}
+
+As long as there is no exception, the worker will continue addressing the same 
+server that the first batch was received from.  
+If the worker fails to reach that node, it will try to 
+[failover](../../../client-api/configuration/load-balance-and-failover#readbalancebehavior-options) to another node 
+from the session's topology list.  
+The node that the worker succeeded connecting to, will inform the worker which 
+node is currently responsible for data subscriptions.  
+
 {NOTE/}
-
-
 
 {INFO:SubscriptionBatch&lt;T&gt;.Item}
 

--- a/Documentation/4.1/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.java.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.java.markdown
@@ -80,14 +80,17 @@ The `run` function receives the client-side code as a consumer that will process
 | **openSession()** | `IDocumentSession` | New document session, that tracks all items and included items of the current batch. |
 
 
-{NOTE:Subscription Session characteristics}
-Session will be created by the same document store that created the worker, therefore will receive the same configurations as any other session created by the store.  
-However, in order to maintain consistency, the session will address the same server that the batch was received from.  
-It won't try to fail over to another server. It might also fail if the subscription worker changes the node it communicates with.  
-Such event could happen if the subscription worker starts again to address its original node after a fallback occurrence.  
-If such failure occurs, the subscription processing will be stopped, and will have to be restarted, as shown [here](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
-{NOTE/}
+{NOTE:Subscription Worker Connectivity}
 
+As long as there is no exception, the worker will continue addressing the same 
+server that the first batch was received from.  
+If the worker fails to reach that node, it will try to 
+[failover](../../../client-api/configuration/load-balance-and-failover#readbalancebehavior-options) to another node 
+from the session's topology list.  
+The node that the worker succeeded connecting to, will inform the worker which 
+node is currently responsible for data subscriptions.  
+
+{NOTE/}
 
 {INFO:SubscriptionBatch&lt;T&gt;.Item}
 

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.dotnet.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.dotnet.markdown
@@ -85,15 +85,17 @@ The `Run` function receives the client-side code as a delegate that will process
 | **OpenAsyncSession()** | `IDocumentSession` | New asynchronous document session, that tracks all items and included items of the current batch. |
 
 
-{NOTE:Subscription Session characteristics}
-Session will be created by the same document store that created the worker, therefore will receive the same configurations as any other session created by the store.  
-However, in order to maintain consistency, the session will address the same server that the batch was received from.  
-It won't try to fail over to another server. It might also fail if the subscription worker changes the node it communicates with.  
-Such event could happen if the subscription worker starts again to address its original node after a fallback occurrence.  
-If such failure occurs, the subscription processing will be stopped, and will have to be restarted, as shown [here](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
+{NOTE:Subscription Worker Connectivity}
+
+As long as there is no exception, the worker will continue addressing the same 
+server that the first batch was received from.  
+If the worker fails to reach that node, it will try to 
+[failover](../../../client-api/configuration/load-balance-and-failover#readbalancebehavior-options) to another node 
+from the session's topology list.  
+The node that the worker succeeded connecting to, will inform the worker which 
+node is currently responsible for data subscriptions.  
+
 {NOTE/}
-
-
 
 {INFO:SubscriptionBatch&lt;T&gt;.Item}
 

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.java.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.java.markdown
@@ -82,14 +82,17 @@ The `run` function receives the client-side code as a consumer that will process
 | **openSession()** | `IDocumentSession` | New document session, that tracks all items and included items of the current batch. |
 
 
-{NOTE:Subscription Session characteristics}
-Session will be created by the same document store that created the worker, therefore will receive the same configurations as any other session created by the store.  
-However, in order to maintain consistency, the session will address the same server that the batch was received from.  
-It won't try to fail over to another server. It might also fail if the subscription worker changes the node it communicates with.  
-Such event could happen if the subscription worker starts again to address its original node after a fallback occurrence.  
-If such failure occurs, the subscription processing will be stopped, and will have to be restarted, as shown [here](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
-{NOTE/}
+{NOTE:Subscription Worker Connectivity}
 
+As long as there is no exception, the worker will continue addressing the same 
+server that the first batch was received from.  
+If the worker fails to reach that node, it will try to 
+[failover](../../../client-api/configuration/load-balance-and-failover#readbalancebehavior-options) to another node 
+from the session's topology list.  
+The node that the worker succeeded connecting to, will inform the worker which 
+node is currently responsible for data subscriptions.  
+
+{NOTE/}
 
 {INFO:SubscriptionBatch&lt;T&gt;.Item}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.dotnet.markdown
@@ -85,12 +85,16 @@ The `Run` function receives the client-side code as a delegate that will process
 | **OpenAsyncSession()** | `IDocumentSession` | New asynchronous document session, that tracks all items and included items of the current batch. |
 
 
-{NOTE:Subscription Session characteristics}
-Session will be created by the same document store that created the worker, therefore will receive the same configurations as any other session created by the store.  
-However, in order to maintain consistency, the session will address the same server that the batch was received from.  
-It won't try to failover to another server. It might also fail if the subscription worker changes the node it communicates with.  
-Such event could happen if the subscription worker starts again to address its original node after a fallback occurrence.  
-If such failure occurs, the subscription processing will be stopped, and will have to be restarted, as shown [here](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
+{NOTE:Subscription Worker Connectivity}
+
+As long as there is no exception, the worker will continue addressing the same 
+server that the first batch was received from.  
+If the worker fails to reach that node, it will try to 
+[failover](../../../client-api/configuration/load-balance-and-failover#readbalancebehavior-options) to another node 
+from the session's topology list.  
+The node that the worker succeeded connecting to, will inform the worker which 
+node is currently responsible for data subscriptions.  
+
 {NOTE/}
 
 

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.java.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/api-overview.java.markdown
@@ -82,12 +82,16 @@ The `run` function receives the client-side code as a consumer that will process
 | **openSession()** | `IDocumentSession` | New document session, that tracks all items and included items of the current batch. |
 
 
-{NOTE:Subscription Session characteristics}
-Session will be created by the same document store that created the worker, therefore will receive the same configurations as any other session created by the store.  
-However, in order to maintain consistency, the session will address the same server that the batch was received from.  
-It won't try to fail over to another server. It might also fail if the subscription worker changes the node it communicates with.  
-Such event could happen if the subscription worker starts again to address its original node after a fallback occurrence.  
-If such failure occurs, the subscription processing will be stopped, and will have to be restarted, as shown [here](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
+{NOTE:Subscription Worker Connectivity}
+
+As long as there is no exception, the worker will continue addressing the same 
+server that the first batch was received from.  
+If the worker fails to reach that node, it will try to 
+[failover](../../../client-api/configuration/load-balance-and-failover#readbalancebehavior-options) to another node 
+from the session's topology list.  
+The node that the worker succeeded connecting to, will inform the worker which 
+node is currently responsible for data subscriptions.  
+
 {NOTE/}
 
 

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.dotnet.markdown
@@ -54,9 +54,9 @@ Documents are always sent in Etag order which means that data that has already b
 
 3. In case of subscription failover (`Enterprise feature`), when there is a chance that documents will be processed again, because it's not always possible to find the same starting point on a different machine.
 
-A subscription worker will retry processing documents from the last acknowledged and processed document (by tracking its Change Vector).
-
-* If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+{NOTE: }
+If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+{NOTE/}
 
 {PANEL/}
 
@@ -68,7 +68,7 @@ A subscription worker will retry processing documents from the last acknowledged
   presence of failure, whether it's client-side related, communication, or any other disaster.  
 * Subscriptions progress is stored in the cluster level, in the `Enterprise edition`.  
   In the case of a node failure, the processing can be automatically failed over to another node.  
-* The usage of Change Vectors allows us to continue from a point that is close to 
+* The usage of **Change Vectors** allows us to continue from a point that is close to 
   the last point reached before failure rather than starting the process from scratch.  
 {PANEL/}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.dotnet.markdown
@@ -55,7 +55,9 @@ Documents are always sent in Etag order which means that data that has already b
 3. In case of subscription failover (`Enterprise feature`), when there is a chance that documents will be processed again, because it's not always possible to find the same starting point on a different machine.
 
 {NOTE: }
-If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+If the database has Revisions defined, the subscription can be configured to process pairs 
+of subsequent document revisions.  
+Read more here: [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning)
 {NOTE/}
 
 {PANEL/}

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.java.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.java.markdown
@@ -51,9 +51,11 @@ Documents are always sent in Etag order which means that data that already been 
 
 3. In case of subscription failover (`Enterprise feature`), when there is a chance that documents will be processed again, because it's not always possible to find the same starting point on a different machine.
 
-A subscription worker will retry processing documents from the last acknowledged and processed document (by tracking its Change Vector).
-
-* If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+{NOTE: }
+If the database has Revisions defined, the subscription can be configured to process pairs 
+of subsequent document revisions.  
+Read more here: [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning)
+{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.js.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/what-are-data-subscriptions.js.markdown
@@ -51,9 +51,11 @@ Documents are always sent in Etag order which means that data that already been 
 
 3. In case of subscription failover (`Enterprise feature`), when there is a chance that documents will be processed again, because it's not always possible to find the same starting point on a different machine.
 
-A subscription worker will retry processing documents from the last acknowledged and processed document (by tracking its Change Vector).
-
-* If the database has Revisions defined, the subscription can be configured to process pairs of subsequent document revisions. Read more in [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning).
+{NOTE: }
+If the database has Revisions defined, the subscription can be configured to process pairs 
+of subsequent document revisions.  
+Read more here: [revisions support](../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning)
+{NOTE/}
 
 {PANEL/}
 


### PR DESCRIPTION
RDoc-2009 (Clarify failover subscriptions text in API Overview)
RDoc-2010 (Clarify documents processing text under Data Subscriptions)