### PR TITLE
RDoc-2071_GetRevisionCount

### DIFF
--- a/Documentation/5.0/Raven.Documentation.Pages/server/kb/document-identifier-generation.markdown
+++ b/Documentation/5.0/Raven.Documentation.Pages/server/kb/document-identifier-generation.markdown
@@ -33,7 +33,7 @@
 By default, document IDs created by the server use the character / to separate their components. 
 This separator can be changed to any other character except | in the 
 [Document Store Conventions](../../client-api/configuration/conventions#changing-the-identity-separator).  
-{NOTE/}
+{INFO/}
 
 * In this page:  
   * [Semantic ID](../../server/kb/document-identifier-generation#semantic-id)  

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/revisions/.docs.json
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/revisions/.docs.json
@@ -1,0 +1,26 @@
+[
+  {
+    "Path": "what-are-revisions.markdown",
+    "Name": "What are Revisions",
+    "DiscussionId": "88bfd5cd-b5d9-4e31-b38a-21c6506a90e8",
+    "Mappings": []
+  },
+  {
+    "Path": "loading.markdown",
+    "Name": "Loading",
+    "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
+    "Mappings": []
+  },
+  {
+    "Path": "counting.markdown",
+    "Name": "Counting",
+    "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
+    "Mappings": []
+  },
+  {
+    "Path": "counter-revisions.markdown",
+    "Name": "Counter Revisions",
+    "DiscussionId": "68e60b2c-83a2-42dd-b464-9deb18c90e7a",
+    "Mappings": []
+  }
+]

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/revisions/counting.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/revisions/counting.markdown
@@ -1,0 +1,49 @@
+# Revisions: Counting Revisions
+
+---
+
+{NOTE: }
+A document's revisions can be counted using the `session.Advanced.Revisions.GetCountFor` method.  
+
+* In this page:  
+   * [Syntax](../../../client-api/session/revisions/counting#syntax)  
+   * [Example](../../../client-api/session/revisions/counting#example)  
+
+{NOTE/}
+
+---
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\Revisions\Counting.cs /}
+
+* **`GetCountFor` Parameters**  
+
+    | Parameter | Type | Description |
+    | ------------- | ------------- | ------------- |
+    | **id** | string | ID of the document whose revisions are counted |
+
+* **Return Value**: `long`  
+  The number of revisions for this document.  
+
+{PANEL/}
+
+{PANEL: Example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync example_sync@ClientApi\Session\Revisions\Counting.cs /}
+{CODE-TAB:csharp:Async example_async@ClientApi\Session\Revisions\Counting.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [What are Revisions](../../../client-api/session/revisions/what-are-revisions)  
+- [Loading Revisions](../../../client-api/session/revisions/loading)  
+
+### Server
+
+- [Revisions](../../../server/extensions/revisions)

--- a/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Revisions/Counting.cs
+++ b/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Revisions/Counting.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Json;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Revisions
+{
+    public class Loading
+    {
+        private interface IFoo
+        {
+            #region syntax
+            long GetCountFor(string id);
+            #endregion
+        }
+
+        public async Task Samples()
+        {
+            using (var store = new DocumentStore())
+            {
+                var CompanyProfile = new Company { Name = "Persian Rugs" };
+                using (var session = store.OpenSession())
+                {
+                    #region example_sync
+                    var RevisionsCount = session.Advanced.Revisions.GetCountFor(CompanyProfile.Id);
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region example_async
+                    var RevisionsCount = await asyncSession.Advanced.Revisions.GetCountForAsync(CompanyProfile.Id);
+                    #endregion
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 - new "Counting" page under session\Revisions for GetCountFor
 - errors fixed in the introduction to the the Document Identifier Generation article