### PR TITLE
RDoc-1997_SubscriptionsEdits

### DIFF
--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/examples.dotnet.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/examples.dotnet.markdown
@@ -6,6 +6,7 @@
 
 In this page:  
 
+[Subscription workers with failover on other nodes](../../../client-api/data-subscriptions/consumption/examples#subscription-workers-with-failover-on-other-nodes)  
 [Worker with a specified batch size](../../../client-api/data-subscriptions/consumption/examples#worker-with-a-specified-batch-size)  
 [Client with full exception handling and processing retries](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
 [Subscription that ends when no documents left](../../../client-api/data-subscriptions/consumption/examples#subscription-that-ends-when-no-documents-left)  
@@ -13,11 +14,20 @@ In this page:
 [Subscription that works with a session](../../../client-api/data-subscriptions/consumption/examples#subscription-that-works-with-a-session)  
 [Subscription that uses included documents](../../../client-api/data-subscriptions/consumption/examples#subscription-that-uses-included-documents)  
 [Subscription that works with lowest level API](../../../client-api/data-subscriptions/consumption/examples#subscription-that-works-with-lowest-level-api)  
-[Two subscription workers that are waiting for each other](../../../client-api/data-subscriptions/consumption/examples#two-subscription-workers-that-are-waiting-for-each-other)  
+[Subscription workers with a primary and a secondary node](../../../client-api/data-subscriptions/consumption/examples#subscription-workers-with-a-primary-and-a-secondary-node)  
 
 {NOTE/}
 
 ---
+
+{PANEL:Subscription workers with failover on other nodes}
+
+In this configuration, any available node will create a worker.  
+If the worker fails, another available node will take over.
+
+{CODE waitforfree@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+
+{PANEL/}
 
 {PANEL:Worker with a specified batch size}
 
@@ -81,18 +91,17 @@ but it may be dangerous due to the direct usage of unmanaged memory.
 
 {PANEL/}
 
-{PANEL:Two subscription workers that are waiting for each other}
+{PANEL:Subscription workers with a primary and a secondary node}
 
 Here we create two workers:  
-* The main worker with the `TakeOver` strategy that will take over the other one and will take the lead  
-* The secondary worker that will wait for the first one fail (due to machine failure etc.)
 
-The main worker:
+* The primary worker, set with a `TakeOver` strategy, will take the lead over the secondary worker.  
+* The secondary worker, set with a `WaitForFree` strategy, will take over if the primary worker fails (e.g. due to a machine failure).  
 
+The primary worker:  
 {CODE waiting_subscription_1@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
 
-The secondary worker:
-
+The secondary worker:  
 {CODE waiting_subscription_2@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
 
 {PANEL/}

--- a/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
+++ b/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
@@ -761,10 +761,21 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
         }
 
 
+        public async Task WaitForFreeSubscription(DocumentStore store, string subscriptionName)
+        {
+            #region waitforfree
+            var worker = store.Subscriptions.GetSubscriptionWorker<Order>
+                    (new SubscriptionWorkerOptions(subscriptionName)
+                    {
+                        Strategy = SubscriptionOpeningStrategy.WaitForFree
+                    });
+            #endregion
+        }
+
         public async Task TwoSubscriptions(DocumentStore store, string subscriptionName)
         {
             #region waiting_subscription_1
-            var worker = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
+            var primaryWorker = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
             {
                 Strategy = SubscriptionOpeningStrategy.TakeOver
             });
@@ -773,7 +784,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             {
                 try
                 {
-                    await worker.Run(x =>
+                    await primaryWorker.Run(x =>
                     {
                         // your logic
                     });
@@ -786,7 +797,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             #endregion
 
             #region waiting_subscription_2
-            var worker2 = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
+            var secondaryWorker = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
             {
                 Strategy = SubscriptionOpeningStrategy.WaitForFree
             });
@@ -795,7 +806,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             {
                 try
                 {
-                    await worker.Run(x =>
+                    await secondaryWorker.Run(x =>
                     {
                         // your logic
                     });

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/examples.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/data-subscriptions/consumption/examples.dotnet.markdown
@@ -6,6 +6,7 @@
 
 In this page:  
 
+[Subscription workers with failover on other nodes](../../../client-api/data-subscriptions/consumption/examples#subscription-workers-with-failover-on-other-nodes)  
 [Worker with a specified batch size](../../../client-api/data-subscriptions/consumption/examples#worker-with-a-specified-batch-size)  
 [Client with full exception handling and processing retries](../../../client-api/data-subscriptions/consumption/examples#client-with-full-exception-handling-and-processing-retries)  
 [Subscription that ends when no documents are left](../../../client-api/data-subscriptions/consumption/examples#subscription-that-ends-when-no-documents-are-left)  
@@ -13,11 +14,20 @@ In this page:
 [Subscription that works with a session](../../../client-api/data-subscriptions/consumption/examples#subscription-that-works-with-a-session)  
 [Subscription that uses included documents](../../../client-api/data-subscriptions/consumption/examples#subscription-that-uses-included-documents)  
 [Subscription that works with lowest level API](../../../client-api/data-subscriptions/consumption/examples#subscription-that-works-with-lowest-level-api)  
-[Two subscription workers that are waiting for each other](../../../client-api/data-subscriptions/consumption/examples#two-subscription-workers-that-are-waiting-for-each-other)  
+[Subscription workers with a primary and a secondary node](../../../client-api/data-subscriptions/consumption/examples#subscription-workers-with-a-primary-and-a-secondary-node)  
 
 {NOTE/}
 
 ---
+
+{PANEL:Subscription workers with failover on other nodes}
+
+In this configuration, any available node will create a worker.  
+If the worker fails, another available node will take over.
+
+{CODE waitforfree@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+
+{PANEL/}
 
 {PANEL:Worker with a specified batch size}
 
@@ -81,18 +91,17 @@ but it may be dangerous due to the direct usage of unmanaged memory.
 
 {PANEL/}
 
-{PANEL:Two subscription workers that are waiting for each other}
+{PANEL:Subscription workers with a primary and a secondary node}
 
 Here we create two workers:  
-* The main worker with the `TakeOver` strategy that will take over the other worker and take the lead  
-* The secondary worker that will wait for the first worker to fail (due to machine failure etc.)
 
-The main worker:
+* The primary worker, set with a `TakeOver` strategy, will take the lead over the secondary worker.  
+* The secondary worker, set with a `WaitForFree` strategy, will take over if the primary worker fails (e.g. due to a machine failure).  
 
+The primary worker:  
 {CODE waiting_subscription_1@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
 
-The secondary worker:
-
+The secondary worker:  
 {CODE waiting_subscription_2@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
 
 {PANEL/}

--- a/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
+++ b/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
@@ -855,10 +855,21 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
         }
 
 
+        public async Task WaitForFreeSubscription(DocumentStore store, string subscriptionName)
+        {
+            #region waitforfree
+            var worker = store.Subscriptions.GetSubscriptionWorker<Order>
+                    (new SubscriptionWorkerOptions(subscriptionName)
+            {
+                Strategy = SubscriptionOpeningStrategy.WaitForFree
+            });
+            #endregion
+        }
+
         public async Task TwoSubscriptions(DocumentStore store, string subscriptionName)
         {
             #region waiting_subscription_1
-            var worker = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
+            var primaryWorker = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
             {
                 Strategy = SubscriptionOpeningStrategy.TakeOver
             });
@@ -867,7 +878,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             {
                 try
                 {
-                    await worker.Run(x =>
+                    await primaryWorker.Run(x =>
                     {
                         // your logic
                     });
@@ -880,7 +891,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             #endregion
 
             #region waiting_subscription_2
-            var worker2 = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
+            var secondaryWorker = store.Subscriptions.GetSubscriptionWorker<Order>(new SubscriptionWorkerOptions(subscriptionName)
             {
                 Strategy = SubscriptionOpeningStrategy.WaitForFree
             });
@@ -889,7 +900,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             {
                 try
                 {
-                    await worker.Run(x =>
+                    await secondaryWorker.Run(x =>
                     {
                         // your logic
                     });


### PR DESCRIPTION
edited subscription examples markdown & samples for 4.2 and 5.3
note regarding the suggested changes (https://github.com/ravendb/docs/pull/1370#issuecomment-902494864) - 

* changes suggested in `consumption\examples.dotnet.markdown`:
  edited c# markdowns and samples for versions 4.2, 5.3 as suggested
  suggested java fixes use the c# sample (which is wrong), created a new issue to catch the java pages up 
  with the c# version.
* changes suggested in `consumption/how-to-consume-data-subscription.dotnet.markdown`:
  this page was redesigned in any case for version 5.3, and all the suggested fixes are taken care of by this edit.