### PR TITLE
RDoc-2183-AlternativeToCmpxchg - Added section about cluster boundaries

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -142,7 +142,7 @@ so that conflicts are prevented.
 {PANEL: Why Compare-Exchange Items are Not Replicated to External Clusters }
 
 [To prevent consistency conflicts between clusters](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system) 
-and model an efficient global system, each cluster should have sole ownership of documents created in it.  
+and model an efficient multi-cluster system, each cluster should have sole ownership of documents created in it.  
 
 In geo-distributed systems, to avoid latency problems, a new cluster is usually set up in each region.  
 But to achieve strong consistency in a distributed system, each transaction must achieve a majority consensus amongst the
@@ -228,7 +228,7 @@ Updating a compare exchange key can be divided into 2 phases:
 * Compare Exchange can be used to maintain the uniqueness of a value **inside a single cluster**.  
   [Compare-Exchange items are not replicated to other clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters)
   because each cluster should be solely responsible for the documents created by it.
-   * To establish uniqueness in a globally distributed system, see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-with-reference-documents).
+   * To establish uniqueness in a multi-clustered distributed system, see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-with-reference-documents).
 
 {NOTE/}
 
@@ -266,7 +266,7 @@ If the email is successfully reserved, then we save the new user account documen
 * Compare Exchange can be used to reserve a shared resource **inside a single cluster**.  
   [Compare-Exchange items are not replicated to other clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters)
   because each cluster should be solely responsible for the documents created by it.
-   * To reserve a resource in a globally distributed system, see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-with-reference-documents).
+   * To reserve a resource in a multi-clustered distributed system, see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-with-reference-documents).
 
 {NOTE/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -11,8 +11,9 @@
     when compared to non-cluster-wide transactions. 
     They prioritize consistency over performance to ensure ACIDity across the cluster.  
 
-* To [maintain consistency between globally distributed clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-an-external-cluster), 
+* To [maintain consistency between globally distributed clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters), 
   documents created in each cluster should be owned and operated only by that cluster. 
+  Thus, because they are associated with documents, compare-exchange items are not replicated externally to other clusters.
 
 * Each compare-exchange item contains: 
   * A key - A unique string across the cluster.  
@@ -30,7 +31,7 @@
 * In this page:  
  * [Using Compare-Exchange Items](../../../client-api/operations/compare-exchange/overview#using-compare-exchange-items)  
  * [When to use cluster-wide sessions or node-local sessions](../../../client-api/operations/compare-exchange/overview#when-to-use-cluster-wide-sessions-or-node-local-sessions)  
- * [Why Compare-Exchange Items are Not Replicated to an External Cluster](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-an-external-cluster)  
+ * [Why Compare-Exchange Items are Not Replicated to External Clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters)  
  * [Transaction Scope for Compare-Exchange Operations](../../../client-api/operations/compare-exchange/overview#transaction-scope-for-compare-exchange-operations)  
  * [Creating a Key](../../../client-api/operations/compare-exchange/overview#creating-a-key)  
  * [Updating a Key](../../../client-api/operations/compare-exchange/overview#updating-a-key)  
@@ -110,7 +111,7 @@ guarantee ACID transactions via Atomic Guards and their Raft consensus checks.
 Your business logic can run both types of sessions as the situation requires.  
 {NOTE/}
 
-* **Node-local sessions** have a default setting that one node is responsible for all reads/writes on a particular database. 
+* **Node-local sessions** are significantly faster and have a default setting that one node is responsible for all reads/writes on a particular database. 
   Node-local transactions are almost always consistent, though if the primary node has to failover, there is a chance of a conflict occurring.  
    * Many situations can handle conflicts and you can program [conflict resolution](../../../server/clustering/replication/replication-conflicts) 
      scripts or use other conflict resolution strategies via Studio and also [in the client](../../../client-api/cluster/document-conflicts-in-client-side#modifying-conflict-resolution-from-the-client-side).
@@ -130,7 +131,7 @@ so that conflicts are prevented.
 
 {PANEL/}
 
-{PANEL: Why Compare-Exchange Items are Not Replicated to an External Cluster }
+{PANEL: Why Compare-Exchange Items are Not Replicated to External Clusters }
 
 To [prevent consistency conflicts between clusters and model an efficient global system](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system), 
 each cluster should have sole ownership of documents created in it.  
@@ -140,12 +141,18 @@ But to achieve strong consistency in a distributed system, each transaction must
 involved servers.  Trying to achieve consensus on each transaction between different clusters is usually unrealistic, 
 especially considering geographic latency.  
 
+{WARNING: }
+If multiple clusters are set to modify the same document and then replicate it to each other, 
+there will likely be frequent conflicts.
+{WARNING/}
+
 One way to ensure consistency between clusters is if [documents created in each cluster are owned and operated only by that cluster](../../../server/ongoing-tasks/external-replication#maintaining-consistency-boundaries-between-clusters). 
 This means that different clusters should not share compare-exchange items because they don't manage the same documents.  
 For example, "NYC-Orders123-B" is a different document than "LDN-Orders123-B". To prevent conflicts and model an efficient system, 
-each document should only be written on by the cluster that made it. 
+each document should only be modified by the cluster that made it.  
 You can replicate or ETL to another cluster for record-keeping or data analysis.  
-The rule of thumb for documents created by another cluster - you can look, but don't touch.
+
+**The rule of thumb for documents created by another cluster - you can look, but don't touch.**
 
 
 {PANEL/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -218,7 +218,8 @@ Updating a compare exchange key can be divided into 2 phases:
   in [cluster-wide transactions](../../../client-api/session/cluster-transaction).  
   There is no need to manually create or maintain Compare-Exchange items to ensure consistency across your cluster.
 
-* [Compare-Exchange items are not replicated to other clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-an-external-cluster) to preserve consistency between clusters.  
+* [Compare-Exchange items are not replicated to other clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters)
+  to preserve consistency between clusters.  
   In documents where immediate consistency is important, each cluster should be solely responsible for the documents created by it.
 
 {NOTE/}
@@ -254,7 +255,8 @@ from Users as s where id() == cmpxchg("emails/ayende@ayende.com")
   in [cluster-wide transactions](../../../client-api/session/cluster-transaction).  
   There is no need to manually create or maintain Compare-Exchange items to ensure consistency across your cluster.
 
-* [Compare-Exchange items are not replicated to other clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-an-external-cluster) to preserve consistency between clusters.  
+* [Compare-Exchange items are not replicated to other clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters)
+  to preserve consistency between clusters.  
   In documents where immediate consistency is important, each cluster should be solely responsible for the documents created by it.
 
 {NOTE/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -103,14 +103,14 @@ only for documents where immediate consistency is crucial AND you want every nod
 Local-node sessions have a default setting that one node is responsible for all reads/writes on a particular database. 
 This ensures consistency. The data is replicated to the other nodes in the database group for failover purposes, 
 but only the primary node will modify documents.  
-If the primary node is down, another node will automatically be selected by the [cluster observer](../../../server/clustering/distribution/cluster-observer). 
+If the primary node is down, another node will automatically be selected to read and write by the [cluster observer](../../../server/clustering/distribution/cluster-observer). 
 
 If you are running on a [distributed cluster](https://ravendb.net/learn/inside-ravendb-book/reader/4.0/6-ravendb-clusters#transaction-atomicity-and-replication) 
 and have to support ACID transactions where all nodes must have read/write permission, 
 you should use cluster-wide transactions. Be aware that doing so will prioritize consistency over performance.
 
 {NOTE: }
-You have the flexibility to program different sessions on the same document store so that you can run cluster-wide or node-local as needed.  
+You have the flexibility to program different sessions on the same document store so that you can run cluster-wide or node-local sessions as needed.  
 There are also tools that provide flexibility such as [revisions](../../../document-extensions/revisions/overview) 
 and the ability to [model your documents](https://ravendb.net/learn/inside-ravendb-book/reader/4.0/3-document-modeling) 
 so that conflicts are prevented.
@@ -121,14 +121,15 @@ so that conflicts are prevented.
 {PANEL: Why Compare-Exchange Items are Not Replicated to an External Cluster }
 
 To [prevent consistency conflicts between clusters and model an efficient global system](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system), 
-each cluster should have sole ownership of documents created by clients that connect to it.  
+each cluster should have sole ownership of documents created in it.  
 
-In geo-distributed systems, to avoid latency problems, a new cluster must be set up in each region.  
-But to achieve consistency, each transaction must achieve a majority consensus amongst the
-involved servers.  Trying to achieve consensus on each transaction between different clusters is unrealistic, 
+In geo-distributed systems, to avoid latency problems, a new cluster is usually set up in each region.  
+But to achieve strong consistency in a distributed system, each transaction must achieve a majority consensus amongst the
+involved servers.  Trying to achieve consensus on each transaction between different clusters is usually unrealistic, 
 especially considering geographic latency.  
 
 One way to ensure consistency between clusters is if [documents created in each cluster are owned and operated only by that cluster](../../../server/ongoing-tasks/external-replication#maintaining-consistency-boundaries-between-clusters). 
+This means that different clusters should not share compare-exchange items.  
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -180,7 +180,7 @@ The following example shows how to use compare-exchange to create documents with
 The scope is within the database group on a single cluster. 
 
 Compare-exchange items are not externally replicated to other databases.  
-To establish uniqueness without using compare-exchange see [example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange).
+To establish uniqueness without using compare-exchange see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange).
 
 {CODE email@Server\CompareExchange.cs /}  
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -6,11 +6,11 @@
 * Compare Exchange items are key/value pairs where the key serves a unique value across your database. 
 
 * Compare-exchange operations require cluster consensus to ensure consistency across all nodes.  
-  Once a consensus is reached, the compare-exchange items are distributed through the Raft algorithm to all nodes in the database group
+  Once a consensus is reached, the compare-exchange items are distributed through the Raft algorithm to all nodes in the database group.
 
 * When creating documents using a cluster-wide session RavenDB automatically creates [Atomic Guards](../../../client-api/operations/compare-exchange/atomic-guards),  
    which are compare-exchange items that guarantee ACID transactions.  
-   Cluster-wide transactions prioritize consistency over performance -  
+   Cluster-wide transactions prioritize consistency over performance.  
 
 * Compare-exchange items are [not replicated externally](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-databases) to other databases.
 
@@ -18,7 +18,6 @@
  * [What Compare Exchange Items Are](../../../client-api/operations/compare-exchange/overview#what-compare-exchange-items-are)  
  * [How to Create and Manage Compare-Exchange Items](../../../client-api/operations/compare-exchange/overview#how-to-create-and-manage-compare-exchange-items)  
  * [Using Compare-Exchange Items](../../../client-api/operations/compare-exchange/overview#using-compare-exchange-items)  
- * [When to Use Cluster-Wide Sessions or Node-Local Sessions](../../../client-api/operations/compare-exchange/overview#when-to-use-cluster-wide-sessions-or-node-local-sessions)  
  * [Why Compare-Exchange Items are Not Replicated to External Databases](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-databases)  
  * [Example I - Email Address Reservation](../../../client-api/operations/compare-exchange/overview#example-i---email-address-reservation)  
  * [Example II - Reserve a Shared Resource](../../../client-api/operations/compare-exchange/overview#example-ii---reserve-a-shared-resource)  
@@ -36,7 +35,8 @@ Compare Exchange items are key/value pairs where the key servers a unique value 
   * **A key** - A unique string across the cluster.  
   * **A value** - Can be numbers, strings, arrays, or objects.  
     Any value that can be represented as JSON is valid.
-  * **Metadata**  
+  * **Metadata** - Like document metadata, it is written in JSON format where the key is prefixed with the `@` character.  
+    eg. "@expires": "2021-02-26T13:09:37.4040256Z" 
   * **Raft index** - A version number that is modified on each change.  
     Any change to the value or metadata changes the Raft index.  
 
@@ -56,12 +56,10 @@ Compare exchange items are created and managed with any of the following approac
 * **Document Store Operations**  
   You can manage a compare-exchange item as an [Operation on the document store](../../../client-api/operations/compare-exchange/put-compare-exchange-value).  
   This can be done within or outside of a session (cluster-wide or single-node session).
-   * When inside a Cluster-wide session:  
-     If the session fails, the item is not created on any of the nodes.
-   * When inside a Single-node session:  
-     If the session fails the compare-exchange operation can still succeed  
+   * When inside a session:
+     If the session fails, the compare-exchange operation can still succeed
      because store Operations do not rely on the success of the session.  
-     You will need to delete the compare-exchange item explicitly if you don't want it to persist.
+     You will need to delete the compare-exchange item explicitly upon session failure if you don't want the compare-exchange item to persist.
 
 * **Cluster-Wide Sessions**  
   You can manage a compare-exchange item from inside a [Cluster-Wide session](../../../client-api/session/cluster-transaction).  
@@ -84,9 +82,6 @@ Compare exchange items are created and managed with any of the following approac
    * [Example I - Email Address Reservation](../../../client-api/operations/compare-exchange/overview#example-i---email-address-reservation)  
    * [Example II - Reserve a Shared Resource](../../../client-api/operations/compare-exchange/overview#example-ii---reserve-a-shared-resource)  
 
-* If you create a compare-exchange item, you can decide what actions to implement when the compare-exchange [value changes](../client-api/operations/compare-exchange/put-compare-exchange-value#example-ii---update-an-existing-key).  
-  
-
 ---
 
 #### How Atomic Guard items work when protecting shared documents in cluster-wide sessions
@@ -100,60 +95,6 @@ Compare exchange items are created and managed with any of the following approac
   To ensure [atomicity](https://en.wikipedia.org/wiki/ACID#Atomicity), if even one action within a session fails, the entire [session will roll back](../../../client-api/session/what-is-a-session-and-how-does-it-work#batching).  
   Be sure that your business logic is written so that if a concurrency exception is thrown, your code will re-execute the entire session.  
 
-
-{INFO: }
-#### Performance cost of cluster-wide sessions  
-
-Cluster-wide transactions are more expensive than node-local transactions due to Raft consensus checks. 
-People prefer a cluster-wide transaction when they prioritize consistency over performance and availability.  
-It ensures ACIDity across the cluster.  
-
-* One way to protect transactions **without** using cluster-wide sessions is to ensure that one node 
-  is responsible for writing on a specific database. Conflicts can occur rarely, but performance is greatly improved. 
-    * RavenDB single-node transactions are usually ACID on the local node, but if two nodes were to write concurrently on the same document, [conflicts](../../../server/clustering/replication/replication-conflicts)
-      can occur. 
-    * By default to prevent conflicts, one primary node is responsible for all reads and writes.  
-      You can configure [load balancing](../../../client-api/session/configuration/use-session-context-for-load-balancing)
-      to fine-tune the settings to your needs.  
-    * To distribute work, you can set different nodes to be responsible for different sets of data.  
-      Learn more in the article [Scaling Distributed Work in RavenDB](https://ravendb.net/learn/inside-ravendb-book/reader/4.0/7-scaling-distributed-work-in-ravendb). 
-{INFO/}
-
-{PANEL/}
-
-{PANEL: When to Use Cluster-Wide Sessions or Node-Local Sessions}
-
-[Node-local (non-cluster-wide) sessions](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
-are much faster and less expensive than cluster-wide sessions.  
-
-**If conflict-free, safe ACID transactions are a must**, [cluster-wide sessions](../../../client-api/session/cluster-transaction) 
-guarantee ACID transactions via Atomic Guards and their Raft consensus checks.
-
-{NOTE: }
-Your business logic can run both types of sessions as the situation requires.  
-{NOTE/}
-
-* **Node-local sessions** are significantly faster and have a default setting that one node is responsible for all reads/writes on a particular database. 
-  Node-local transactions are almost always consistent, though if the primary node has to failover, there is a chance of a conflict occurring.  
-   * Many situations can handle conflicts and you can program [conflict resolution](../../../server/clustering/replication/replication-conflicts) 
-     scripts or use other conflict resolution strategies via [Studio](../../../studio/database/settings/conflict-resolution) 
-     and also [in the client](../../../client-api/cluster/document-conflicts-in-client-side#modifying-conflict-resolution-from-the-client-side).
-   * Because of the higher performance and lower cost of node-local sessions, we recommend using them in situations where 
-     occasional conflicts, and the conflict resolution process, are acceptable.  
-
-* **Cluster-wide sessions** have ACID guarantees for conflict-free transactions.
-   * Because of the performance cost of raft consensus checks, we recommend using cluster-wide sessions  
-     for transactions where immediate consistency is crucial.  
-   * You can also set the session transaction mode to cluster-wide if you need every node to be able to read and write on the same database, 
-     instead of the primary node handling all reads and writes in node-local sessions. 
-
-{NOTE: }
-There are also tools that provide flexibility such as [revisions](../../../document-extensions/revisions/client-api/operations/conflict-revisions-configuration) 
-and the ability to [model your documents](https://ravendb.net/learn/inside-ravendb-book/reader/4.0/3-document-modeling) 
-so that conflicts are prevented.
-{NOTE/}
-
-{PANEL/}
 
 {PANEL: Why Compare-Exchange Items are Not Replicated to External Databases }
 
@@ -188,12 +129,12 @@ To establish uniqueness without using compare-exchange see [Example III](../../.
 
 * The `User` object is saved as a document, hence it can be indexed, queried, etc.  
 
-* This compare-exchange item was [created as an operation](../../../client-api/operations/compare-exchange/overview#how-to-create-and-manage-compare-exchange-items)
+* This compare-exchange item was [created as an operation](../../../client-api/operations/compare-exchange/put-compare-exchange-value)
   rather than with a [cluster-wide session](../../../client-api/session/cluster-transaction).  
   Thus, if `session.SaveChanges` fails, then the email reservation is _not_ rolled back automatically.  
   It is your responsibility to do so.  
 
-* The compare-exchange value that was saved can be accessed in a query using CmpXchg:  
+* The compare-exchange value that was saved can be accessed in a query using `CmpXchg`:  
     {CODE-TABS}
     {CODE-TAB:csharp:Query-LINQ query_cmpxchg@Server\CompareExchange.cs /}  
     {CODE-TAB:csharp:Document-Query document_query_cmpxchg@Server\CompareExchange.cs /}  

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -109,10 +109,12 @@ If you are running on a [distributed cluster](https://ravendb.net/learn/inside-r
 and have to support ACID transactions where all nodes must have read/write permission, 
 you should use cluster-wide transactions. Be aware that doing so will prioritize consistency over performance.
 
+{NOTE: }
 You have the flexibility to program different sessions on the same document store so that you can run cluster-wide or node-local as needed.  
 There are also tools that provide flexibility such as [revisions](../../../document-extensions/revisions/overview) 
 and the ability to [model your documents](https://ravendb.net/learn/inside-ravendb-book/reader/4.0/3-document-modeling) 
 so that conflicts are prevented.
+{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -42,7 +42,7 @@ Compare Exchange items are key/value pairs that allow you to perform cluster-wid
 
 * Creating and modifying a compare-exchange item is an atomic, thread-safe [compare-and-swap](https://en.wikipedia.org/wiki/Compare-and-swap) interlocked 
   compare-exchange operation.
-  * The compare-exchange item is distributed to all nodes in a [cluster-wide transaction](../../../server/clustering/cluster-transactions)
+  * The compare-exchange item is distributed to all nodes through the [Raft algorithm](../../../glossary/raft-algorithm)
     so that a consistent, unique key is guaranteed cluster-wide.  
 
 {PANEL/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -11,9 +11,26 @@
     when compared to non-cluster-wide transactions. 
     They prioritize consistency over performance to ensure ACIDity across the cluster.  
 
-* To [maintain consistency between globally distributed clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters), 
-  documents created in each cluster should be owned and operated only by that cluster. 
-  Thus, because they are associated with documents, compare-exchange items are not replicated externally to other clusters.
+* Compare-exchange items are [not replicated externally](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters) to other clusters.
+
+* In this page:  
+ * [What Compare Exchange Items Are](../../../client-api/operations/compare-exchange/overview#what-compare-exchange-items-are)  
+ * [Using Compare-Exchange Items](../../../client-api/operations/compare-exchange/overview#using-compare-exchange-items)  
+ * [When to Use Cluster-Wide Sessions or Node-Local Sessions](../../../client-api/operations/compare-exchange/overview#when-to-use-cluster-wide-sessions-or-node-local-sessions)  
+ * [Why Compare-Exchange Items are Not Replicated to External Clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters)  
+ * [Transaction Scope for Compare-Exchange Operations](../../../client-api/operations/compare-exchange/overview#transaction-scope-for-compare-exchange-operations)  
+ * [Creating a Key](../../../client-api/operations/compare-exchange/overview#creating-a-key)  
+ * [Updating a Key](../../../client-api/operations/compare-exchange/overview#updating-a-key)  
+ * [Example I - Email Address Reservation](../../../client-api/operations/compare-exchange/overview#example-i---email-address-reservation)  
+ * [Example II- Reserve a Shared Resource](../../../client-api/operations/compare-exchange/overview#example-ii---reserve-a-shared-resource)  
+
+{NOTE/}
+
+---
+
+{PANEL: What Compare Exchange Items Are}
+
+Compare Exchange items are key/value pairs that allow you to perform cluster-wide interlocked distributed operations.
 
 * Each compare-exchange item contains: 
   * A key - A unique string across the cluster.  
@@ -28,19 +45,7 @@
   * The compare-exchange item is distributed to all nodes in a [cluster-wide transaction](../../../server/clustering/cluster-transactions)
     so that a consistent, unique key is guaranteed cluster-wide.  
 
-* In this page:  
- * [Using Compare-Exchange Items](../../../client-api/operations/compare-exchange/overview#using-compare-exchange-items)  
- * [When to use cluster-wide sessions or node-local sessions](../../../client-api/operations/compare-exchange/overview#when-to-use-cluster-wide-sessions-or-node-local-sessions)  
- * [Why Compare-Exchange Items are Not Replicated to External Clusters](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-clusters)  
- * [Transaction Scope for Compare-Exchange Operations](../../../client-api/operations/compare-exchange/overview#transaction-scope-for-compare-exchange-operations)  
- * [Creating a Key](../../../client-api/operations/compare-exchange/overview#creating-a-key)  
- * [Updating a Key](../../../client-api/operations/compare-exchange/overview#updating-a-key)  
- * [Example I - Email Address Reservation](../../../client-api/operations/compare-exchange/overview#example-i---email-address-reservation)  
- * [Example II- Reserve a Shared Resource](../../../client-api/operations/compare-exchange/overview#example-ii---reserve-a-shared-resource)  
-
-{NOTE/}
-
----
+{PANEL/}
 
 {PANEL: Using Compare-Exchange Items}
 
@@ -99,7 +104,7 @@ It ensures ACIDity across the cluster.
 
 ---
 
-#### When to use cluster-wide sessions or node-local sessions
+#### When to Use Cluster-Wide Sessions or Node-Local Sessions
 
 [Node-local (non-cluster-wide) sessions](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
 are much faster and less expensive than cluster-wide sessions.  
@@ -120,8 +125,9 @@ Your business logic can run both types of sessions as the situation requires.
 
 * **Cluster-wide sessions** have ACID guarantees for conflict-free transactions.
    * Because of the performance cost of raft consensus checks, we recommend using cluster-wide sessions  
-     for transactions where immediate consistency is crucial  
-     or if you need every node to be able to read/write on the same database.  
+     for transactions where immediate consistency is crucial.  
+   * You can also set the session transaction mode to cluster-wide if you need every node to be able to read and write on the same database, 
+     instead of the primary node handling all reads and writes in node-local sessions. 
 
 {NOTE: }
 There are also tools that provide flexibility such as [revisions](../../../document-extensions/revisions/client-api/operations/conflict-revisions-configuration) 
@@ -133,8 +139,8 @@ so that conflicts are prevented.
 
 {PANEL: Why Compare-Exchange Items are Not Replicated to External Clusters }
 
-To [prevent consistency conflicts between clusters and model an efficient global system](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system), 
-each cluster should have sole ownership of documents created in it.  
+[To prevent consistency conflicts between clusters](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system) 
+and model an efficient global system, each cluster should have sole ownership of documents created in it.  
 
 In geo-distributed systems, to avoid latency problems, a new cluster is usually set up in each region.  
 But to achieve strong consistency in a distributed system, each transaction must achieve a majority consensus amongst the
@@ -146,14 +152,11 @@ If multiple clusters are set to modify the same document and then replicate it t
 there will likely be frequent conflicts.
 {WARNING/}
 
-One way to ensure consistency between clusters is if [documents created in each cluster are owned and operated only by that cluster](../../../server/ongoing-tasks/external-replication#maintaining-consistency-boundaries-between-clusters). 
-This means that different clusters should not share compare-exchange items because they don't manage the same documents.  
-For example, "NYC-Orders123-B" is a different document than "LDN-Orders123-B". To prevent conflicts and model an efficient system, 
-each document should only be modified by the cluster that made it.  
-You can replicate or ETL to another cluster for record-keeping or data analysis.  
+To ensure consistency between clusters, documents created in each cluster are owned and operated only by that cluster.  
+Learn how to protect document uniqueness and [local ownership in a global system](../../../server/ongoing-tasks/external-replication#maintaining-consistency-boundaries-between-clusters) 
+in our article on External Replication. 
 
 **The rule of thumb for documents created by another cluster - you can look, but don't touch.**
-
 
 {PANEL/}
 
@@ -185,6 +188,8 @@ This article is about non-session-specific compare-exchange operations.
 {PANEL: Creating a Key}
 
 Provide the following when saving a **key**:
+
+{CODE put_0@ClientApi\Operations\CompareExchange.cs /}
 
 | Parameter | Description |
 | ------------- | ---- |

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -35,8 +35,13 @@ Compare Exchange items are key/value pairs where the key servers a unique value 
   * **A key** - A unique string across the cluster.  
   * **A value** - Can be numbers, strings, arrays, or objects.  
     Any value that can be represented as JSON is valid.
-  * **Metadata** - Like document metadata, it is written in JSON format where the key is prefixed with the `@` character.  
-    eg. "@expires": "2021-02-26T13:09:37.4040256Z" 
+  * **Metadata** - Data that is associated with the item's value.  
+    Can be numbers, strings, arrays, or objects.  
+    Any value that can be represented as JSON is valid.  
+     * Similar to [Document Expiration](../../../server/extensions/expiration), 
+	   the metadata can be used to set the Compare Exchange item expiration.  
+       Set `@expires` field to schedule expiration.  
+       e.g. `{ "@expires": "2021-02-26T13:09:37.4040256Z" }`
   * **Raft index** - A version number that is modified on each change.  
     Any change to the value or metadata changes the Raft index.  
 
@@ -56,7 +61,7 @@ Compare exchange items are created and managed with any of the following approac
 * **Document Store Operations**  
   You can manage a compare-exchange item as an [Operation on the document store](../../../client-api/operations/compare-exchange/put-compare-exchange-value).  
   This can be done within or outside of a session (cluster-wide or single-node session).
-   * When inside a session:
+   * When inside a session:  
      If the session fails, the compare-exchange operation can still succeed
      because store Operations do not rely on the success of the session.  
      You will need to delete the compare-exchange item explicitly upon session failure if you don't want the compare-exchange item to persist.
@@ -95,6 +100,7 @@ Compare exchange items are created and managed with any of the following approac
   To ensure [atomicity](https://en.wikipedia.org/wiki/ACID#Atomicity), if even one action within a session fails, the entire [session will roll back](../../../client-api/session/what-is-a-session-and-how-does-it-work#batching).  
   Be sure that your business logic is written so that if a concurrency exception is thrown, your code will re-execute the entire session.  
 
+{PANEL/}
 
 {PANEL: Why Compare-Exchange Items are Not Replicated to External Databases }
 
@@ -110,8 +116,7 @@ Compare exchange items are created and managed with any of the following approac
   Change-Vector. Compare-exchange conflicts cannot be handled properly as they do not have a similar
   mechanism to resolve conflicts.
 
-* To ensure unique values between two databases without using compare-exchange items see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange) 
-  for similar functionality that can be externally replicated.
+* To ensure unique values between two databases without using compare-exchange items see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange).
 
 {PANEL/}
 

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
@@ -149,10 +149,9 @@ namespace Raven.Documentation.Samples.Server
         #endregion
 
         #region create_uniqueness_control_documents
-        // When you create documents that must contain a unique value such as a phone or email, etc,
+        // When you create documents that must contain a unique value such as a phone or email, etc.,
         // you can create reference documents that will have that unique value in their IDs.
-        // Then whenever you want know if a value already exists,
-        // all you need to do is check whether a reference document with such ID exists.
+        // To know if a value already exists, all you need to do is check whether a reference document with such ID exists.
 
         // The reference document class
         class UniquePhoneReference

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
@@ -145,9 +145,12 @@ namespace Raven.Documentation.Samples.Server
         #endregion
 
         #region create_uniqueness_control_documents
-        // When you create documents that must not duplicate another record
-        // you can create reference documents with a unique value such as phone or email as the IDs.
-        // Then you can check if that value is already part of another document.
+        // When you need documents that must contain a unique value such as a phone or email,
+        // you can create reference documents that will have that unique value in their IDs.
+        // Then whenever you want know if a value already exists,
+        // all you need to do is check whether a reference document with such ID exists.
+
+        // The reference document class
         class UniquePhoneReference
         {
             public class PhoneReference
@@ -185,6 +188,7 @@ namespace Raven.Documentation.Samples.Server
                         var msg = $"Phone '{newCompany.Phone}' already exists in ID: {phoneRefDocument.CompanyId}";
                         throw new ConcurrencyException(msg);
                     }
+
                     // If the new phone number doesn't already exist, store the new entity
                     session.Store(newCompany);
                     // Store a new reference document with the new phone value in its ID for future checks.

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
@@ -149,7 +149,7 @@ namespace Raven.Documentation.Samples.Server
         #endregion
 
         #region create_uniqueness_control_documents
-        // When you need documents that must contain a unique value such as a phone or email, etc,
+        // When you create documents that must contain a unique value such as a phone or email, etc,
         // you can create reference documents that will have that unique value in their IDs.
         // Then whenever you want know if a value already exists,
         // all you need to do is check whether a reference document with such ID exists.

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
@@ -150,7 +150,7 @@ namespace Raven.Documentation.Samples.Server
         // Then you can check if that value is already part of another document.
         class UniquePhoneReference
         {
-            public class CompanyReference
+            public class PhoneReference
             {
                 public string Id;
                 public string CompanyId;
@@ -177,18 +177,18 @@ namespace Raven.Documentation.Samples.Server
                             new SessionOptions { TransactionMode = TransactionMode.ClusterWide }
                         );
 
-                    // Check whether the new company phone is already in use by another company
-                    // by checking if there is already a reference document that has the new phone in its ID
-                    var phoneReferenceDocument = session.Load<CompanyReference>("phones/" + newCompany.Phone);
-                    if (phoneReferenceDocument != null)
+                    // Check whether the new company phone already exists
+                    // by checking if there is already a reference document that has the new phone in its ID.
+                    var phoneRefDocument = session.Load<PhoneReference>("phones/" + newCompany.Phone);
+                    if (phoneRefDocument != null)
                     {
-                        var msg = $"Phone '{newCompany.Phone}' already exists in ID: {phoneReferenceDocument.CompanyId}";
+                        var msg = $"Phone '{newCompany.Phone}' already exists in ID: {phoneRefDocument.CompanyId}";
                         throw new ConcurrencyException(msg);
                     }
                     // If the new phone number doesn't already exist, store the new entity
                     session.Store(newCompany);
                     // Store a new reference document with the new phone value in its ID for future checks.
-                    session.Store(new CompanyReference { CompanyId = newCompany.Id }, "phones/" + newCompany.Phone);
+                    session.Store(new PhoneReference { CompanyId = newCompany.Id }, "phones/" + newCompany.Phone);
 
                     // May fail if called concurrently with the same phone number
                     session.SaveChanges();

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
@@ -57,18 +57,22 @@ namespace Raven.Documentation.Samples.Server
                 }
                 #endregion
 
-                #region query_cmpxchg
+
                 using (IDocumentSession session = store.OpenSession())
                 {
+                    #region query_cmpxchg
                     var query = from u in session.Query<User>()
                                 where u.Id == RavenQuery.CmpXchg<string>("emails/ayende@ayende.com")
                                 select u;
+                    #endregion
 
+                    #region document_query_cmpxchg
                     var q = session.Advanced
                         .DocumentQuery<User>()
                         .WhereEquals("Id", CmpXchg.Value("emails/ayende@ayende.com"));
+                    #endregion
                 }
-                #endregion
+
             }
         }
 
@@ -145,7 +149,7 @@ namespace Raven.Documentation.Samples.Server
         #endregion
 
         #region create_uniqueness_control_documents
-        // When you need documents that must contain a unique value such as a phone or email,
+        // When you need documents that must contain a unique value such as a phone or email, etc,
         // you can create reference documents that will have that unique value in their IDs.
         // Then whenever you want know if a value already exists,
         // all you need to do is check whether a reference document with such ID exists.


### PR DESCRIPTION
The link to external replication will work when the new edits to that doc will be merged. [RDoc-2178](https://issues.hibernatingrhinos.com/issue/RDoc-2178) 

Also, I included the note about atomic guards before both code samples, in case a reader skips the first one.