### PR TITLE
RDoc-2317 [Node.js] Client API > Session > How to > Defer operations

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
@@ -19,7 +19,7 @@
     },
     {
         "Path": "defer-operations.markdown",
-        "Name": "...defer operations",
+        "Name": "...defer commands",
         "DiscussionId": "256c056b-c14c-4a09-94f4-e1ce8f710594",
         "Mappings": []
     },

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.dotnet.markdown
@@ -1,0 +1,67 @@
+# How to Defer Commands
+
+---
+
+{NOTE: }
+
+* `Defer` allows you to register server commands via the session.
+
+* All the deferred requests will be stored in the session and sent to the server in a single batch when SaveChanges is called,
+  along with any other changes/operations made on the session.  
+  Thus, all deferred commands are __executed as part of the session's SaveChanges transaction__.
+
+* When SaveChanges is done, the session state will be updated appropriately for all actions.
+
+* In this page:   
+    * [Defer commands example](../../../client-api/session/how-to/defer-operations#defer-commands-example)  
+    * [Commands that can be deferred](../../../client-api/session/how-to/defer-operations#commands-that-can-be-deferred)
+    * [Syntax](../../../client-api/session/how-to/defer-operations#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Defer commands example}
+
+{CODE defer_1@ClientApi\Session\HowTo\Defer.cs /}
+
+{PANEL/}
+
+{PANEL: Commands that can be deferred}
+
+The following commands implement the `ICommandData` interface and can be deferred:  
+
+  - [PutCommandData](../../../glossary/put-command-data)
+  - [DeleteCommandData](../../../glossary/delete-command-data)
+  - DeletePrefixedCommandData
+  - [PatchCommandData](../../../glossary/patch-command-data)
+  - BatchPatchCommandData
+  - PutAttachmentCommandData
+  - DeleteAttachmentCommandData
+  - [CopyAttachmentCommandData](../../../glossary/copy-attachment-command-data)
+  - [MoveAttachmentCommandData](../../../glossary/move-attachment-command-data)
+  - [CountersBatchCommandData](../../../glossary/counters-batch-command-data)
+  - PutCompareExchangeCommandData
+  - DeleteCompareExchangeCommandData
+  - CopyTimeSeriesCommandData
+  - TimeSeriesBatchCommandData
+  - ForceRevisionCommandData
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\HowTo\Defer.cs /}
+
+| Parameter | Type | Description |
+| - |-|-|
+| **command** | A command that implements the `ICommandData` interface | The command to be executed |
+| **commands** | `ICommandData[]` | Array of commands to be executed |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.dotnet.markdown
@@ -10,8 +10,6 @@
   along with any other changes/operations made on the session.  
   Thus, all deferred commands are __executed as part of the session's SaveChanges transaction__.
 
-* When SaveChanges is done, the session state will be updated appropriately for all actions.
-
 * In this page:   
     * [Defer commands example](../../../client-api/session/how-to/defer-operations#defer-commands-example)  
     * [Commands that can be deferred](../../../client-api/session/how-to/defer-operations#commands-that-can-be-deferred)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.java.markdown
@@ -1,0 +1,37 @@
+# Session: How to Defer Commands
+
+Commands can be deferred till `saveChanges` is called by using `defer` method in `advanced` session operations.  
+All of the operations will update teh session state appropriately after `saveChanges` is called.
+
+Types of commands that can be deferred:
+
+- [PutCommandData](../../../glossary/put-command-data)
+- [DeleteCommandData](../../../glossary/delete-command-data)
+- DeletePrefixedCommandData
+- [PatchCommandData](../../../glossary/patch-command-data)
+- PutAttachmentCommandData
+- DeleteAttachmentCommandData
+- [CopyAttachmentCommandData](../../../glossary/copy-attachment-command-data)
+- [MoveAttachmentCommandData](../../../glossary/move-attachment-command-data)
+- [CountersBatchCommandData](../../../glossary/counters-batch-command-data)
+
+## Syntax
+
+{CODE:java defer_1@ClientApi\Session\HowTo\Defer.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| `ICommandData` | Command to be executed. |
+| `ICommandData[]` | Array of commands implementing `ICommandData` interface. |
+
+## Example
+
+{CODE:java defer_2@ClientApi\Session\HowTo\Defer.java /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.js.markdown
@@ -29,9 +29,9 @@
 The following commands implement the `ICommandData` interface and can be deferred:
 
 - PutCommandDataBase
-- DeleteCommandData]
+- DeleteCommandData
 - DeletePrefixedCommandData
-- PatchCommandData]
+- PatchCommandData
 - BatchPatchCommandData
 - PutAttachmentCommandData
 - DeleteAttachmentCommandData

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.js.markdown
@@ -1,0 +1,64 @@
+# How to Defer Commands
+
+---
+
+{NOTE: }
+
+* `Defer` allows you to register server commands via the session.
+
+* All the deferred requests will be stored in the session and sent to the server in a single batch when saveChanges is called,
+  along with any other changes/operations made on the session.  
+  Thus, all deferred commands are __executed as part of the session's saveChanges transaction__.
+
+* In this page:
+    * [Defer commands example](../../../client-api/session/how-to/defer-operations#defer-commands-example)
+    * [Commands that can be deferred](../../../client-api/session/how-to/defer-operations#commands-that-can-be-deferred)
+    * [Syntax](../../../client-api/session/how-to/defer-operations#syntax)  
+      {NOTE/}
+
+---
+
+{PANEL: Defer commands example}
+
+{CODE:nodejs defer_1@ClientApi\Session\HowTo\defer.js /}
+
+{PANEL/}
+
+{PANEL: Commands that can be deferred}
+
+The following commands implement the `ICommandData` interface and can be deferred:
+
+- PutCommandDataBase
+- DeleteCommandData]
+- DeletePrefixedCommandData
+- PatchCommandData]
+- BatchPatchCommandData
+- PutAttachmentCommandData
+- DeleteAttachmentCommandData
+- CopyAttachmentCommandData
+- MoveAttachmentCommandData
+- CountersBatchCommandData
+- PutCompareExchangeCommandData
+- DeleteCompareExchangeCommandData
+- CopyTimeSeriesCommandData
+- TimeSeriesBatchCommandData
+- ForceRevisionCommandData
+  {PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Session\HowTo\defer.js /}
+
+| Parameter | Type | Description |
+| - |-|-|
+| **commands** | `ICommandData[]` | Commands to be executed |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Defer.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Defer.cs
@@ -33,7 +33,7 @@ namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
                         // Patch document
                         new PatchCommandData("products/999-A", null, new PatchRequest
                                 {
-                                    Script = $@"this.Supplier = 'suppliers/2-A';"
+                                    Script = "this.Supplier = 'suppliers/2-A';"
                                 },
                                 null),
                         

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Defer.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Defer.cs
@@ -1,0 +1,65 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Operations;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class Defer
+    {
+        public Defer()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region defer_1
+
+                    // Defer is available in the session's Advanced methods 
+                    session.Advanced.Defer(
+                        
+                        // Define commands to be executed:
+                        // i.e. Put a new document
+                        new PutCommandData("products/999-A", null, new DynamicJsonValue
+                            {
+                                ["Name"] = "My Product",
+                                ["Supplier"] = "suppliers/1-A",
+                                ["@metadata"] = new DynamicJsonValue
+                                {
+                                    ["@collection"] = "Products"
+                                }
+                            }),
+                        
+                        // Patch document
+                        new PatchCommandData("products/999-A", null, new PatchRequest
+                                {
+                                    Script = $@"this.Supplier = 'suppliers/2-A';"
+                                },
+                                null),
+                        
+                        // Force a revision to be created
+                        new ForceRevisionCommandData("products/999-A"),
+                        
+                        // Delete a document
+                        new DeleteCommandData("products/1-A", null)
+                    );
+                    
+                    // All deferred commands will be sent to the server upon calling SaveChanges
+                    session.SaveChanges();
+
+                    #endregion
+                }
+            }
+        }
+
+        private interface IFoo
+        {
+            #region syntax
+
+            void Defer(ICommandData command, params ICommandData[] commands);
+            void Defer(ICommandData[] commands);
+
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Defer.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Defer.java
@@ -1,0 +1,56 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.batches.DeleteCommandData;
+import net.ravendb.client.documents.commands.batches.ICommandData;
+import net.ravendb.client.documents.commands.batches.PutCommandDataWithJson;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Defer {
+    public Defer() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region defer_2
+
+                Map<String, Object> value1 = new HashMap<>();
+                value1.put("Name", "My Product");
+                value1.put("Supplier", "suppliers/999-A");
+                value1.put("@metadata", Collections.singletonMap("@collection", "Users"));
+
+                PutCommandDataWithJson putCommand1 =
+                    new PutCommandDataWithJson("products/999-A",
+                        null,
+                        store.getConventions().getEntityMapper().valueToTree(value1));
+
+                HashMap<String, Object> value2 = new HashMap<>();
+                value2.put("Name", "My Product");
+                value2.put("Supplier", "suppliers/999-A");
+                value2.put("@metadata", Collections.singletonMap("@collection", "Suppliers"));
+
+                PutCommandDataWithJson putCommand2 =
+                    new PutCommandDataWithJson("suppliers/999-A",
+                        null,
+                        store.getConventions().getEntityMapper().valueToTree(value2));
+
+                DeleteCommandData command3 = new DeleteCommandData("products/1-A", null);
+
+                session.advanced().defer(putCommand1, putCommand2, command3);
+                //endregion
+            }
+        }
+    }
+
+    private interface IFoo {
+        //region defer_1
+        void defer(ICommandData command, ICommandData... commands);
+
+        void defer(ICommandData[] commands);
+        //endregion
+    }
+
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/HowTo/defer.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/HowTo/defer.js
@@ -1,0 +1,45 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+{
+    //region syntax
+    session.advanced.defer(...commands);
+    //endregion
+}
+
+async function defer() {
+    //region defer_1
+    const session = documentStore.openSession();
+    
+    // Define a patchRequest object for the PatchCommandData used in the 'defer' below
+    const patchRequest = new PatchRequest();
+    patchRequest.script = "this.Supplier = 'suppliers/2-A';";
+
+    // 'defer' is available in the session's advanced methods 
+    session.advanced.defer(
+
+        // Define commands to be executed:
+        // i.e. Put a new document
+        new PutCommandDataBase("products/999-A", null, null, {
+            "Name": "My Product",
+            "Supplier": "suppliers/1-A"
+            "@metadata": { "@collection": "Products" }
+        }),
+        
+        // Patch document
+        new PatchCommandData("products/999-A", null, patchRequest, null),
+
+        // Force a revision to be created
+        new ForceRevisionCommandData("products/999-A"),
+
+        // Delete a document
+        new DeleteCommandData("products/1-A", null)
+    );
+
+    // All deferred commands will be sent to the server upon calling SaveChanges
+    await session.saveChanges();
+    
+    }
+    //endregion
+}

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
@@ -19,7 +19,7 @@
     },
     {
         "Path": "defer-operations.markdown",
-        "Name": "...defer operations",
+        "Name": "...defer commands",
         "DiscussionId": "256c056b-c14c-4a09-94f4-e1ce8f710594",
         "Mappings": []
     },

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
@@ -19,7 +19,7 @@
     },
     {
         "Path": "defer-operations.markdown",
-        "Name": "...defer operations",
+        "Name": "...defer commands",
         "DiscussionId": "256c056b-c14c-4a09-94f4-e1ce8f710594",
         "Mappings": []
     },

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/how-to/.docs.json
@@ -19,7 +19,7 @@
     },
     {
         "Path": "defer-operations.markdown",
-        "Name": "...defer operations",
+        "Name": "...defer commands",
         "DiscussionId": "256c056b-c14c-4a09-94f4-e1ce8f710594",
         "Mappings": []
     },


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2317/Node.js-Client-API-Session-How-to-Defer-operations

@ml054 
For Node.js - the files to be reviewed are:

```
Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Session/HowTo/defer.js
```

**Note:**
Java files in this PR are Not to be reviewed.
Only copied (with minor changes) to 5.2 since we have no file bubbling.