### PR TITLE
RDoc-2319 [Node.js] Client API > Session > Configuration > Disable tr…

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -1,0 +1,174 @@
+# Conventions
+
+Conventions give you the ability to customize the Client API behavior. They are accessible from the `DocumentStore` object:
+
+{CODE conventions_1@ClientApi\Configuration\Conventions.cs /}
+
+You will find many settings to overwrite, allowing you to adjust the client according to your needs. The conventions apply to many different client behaviors. Some of them are grouped and described in the separate articles of this section.
+
+{INFO All customizations need to be set before `DocumentStore.Initialize()` is called. /}
+
+##MaxHttpCacheSize
+
+If you need to modify the maximum http cache size, you can use the following setting:
+
+{CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE: Default size}
+
+The default value of this setting is configured as follows:
+
+* running on 64 bits:
+  * if usable memory is lower than or equal to 3GB: 64MB,
+  * if usable memory is greater than 3GB and lower than or equal to 6GB: 128MB,
+  * if usable memory is greater than 6GB: 512MB,
+
+* running on 32 bits: 32MB.
+
+The cache is created per database you use.
+
+{NOTE/}
+
+{NOTE: Disable caching} 
+
+To disable the caching globally, you can set the `MaxHttpCacheSize` value to zero:
+
+{CODE disable_cache@ClientApi\Configuration\Conventions.cs /}
+
+**In this scenario, all the requests will be sent to the server to fetch the data.**
+
+{NOTE/}
+
+## MaxNumberOfRequestsPerSession
+
+Gets or sets maximum number of GET requests per session. Default: `30`.
+
+{CODE MaxNumberOfRequestsPerSession@ClientApi\Configuration\Conventions.cs /}
+
+##UseOptimisticConcurrency
+
+Controls whether optimistic concurrency is set to true by default for all future sessions. Default: `false`.
+
+{CODE UseOptimisticConcurrency@ClientApi\Configuration\Conventions.cs /}
+
+##RequestTimeout
+
+It allows you to define the global request timeout value for all `RequestExecutors` created per database. Default: `null`.
+
+{CODE RequestTimeout@ClientApi\Configuration\Conventions.cs /}
+
+##DisableTopologyUpdates
+
+Forces you to disable updates of database topology. Default: `false`.
+
+{CODE DisableTopologyUpdates@ClientApi\Configuration\Conventions.cs /}
+
+##SaveEnumsAsIntegers
+
+It determines if C# `enum` types should be saved as integers or strings and instructs the LINQ provider to query enums as integer values. Default: `false`.
+
+{CODE SaveEnumsAsIntegers@ClientApi\Configuration\Conventions.cs /}
+
+##UseCompression
+
+It determines if the client will send headers to the server indicating that it allows compression to be used. Default: `true`.
+
+{CODE UseCompression@ClientApi\Configuration\Conventions.cs /}
+
+## OperationStatusFetchMode
+
+Changes the way the operation is fetching the operation status when waiting for completion. By default, the value is set to `ChangesApi` which underneath is using WebSocket protocol when connection is established with the server. On some older systems e.g. Windows 7, the WebSocket protocol might not be available due to the OS and .NET Framework limitations. For that reason, the value can be changed to `Polling` to bypass this issue.
+
+{CODE OperationStatusFetchMode@ClientApi\Configuration\Conventions.cs /}
+
+## Changing fields/properties naming convention 
+
+By default whatever casing convention you use in your entities' fields will be reflected server-side.
+
+If following language-specific field casing conventions RavenDB clients use different field/properties naming conventions:
+
+| Language | Default convention | Example |
+| ------------- | ----- | --- |
+| C# | PascalCase | OrderLines |
+| Java | camelCase | orderLines |
+| JavaScript | camelCase | orderLines |
+
+This can be configured to allow inter-language operability e.g. store data PascalCase, but keep fields in the application code camelCase.
+
+### Using camelCase in C# client
+
+You have to customize *JsonSerializer* and *PropertyNameConverter*.  
+
+{CODE FirstChar@ClientApi\Configuration\Conventions.cs /}
+
+{CODE PropertyCasing@ClientApi\Configuration\Conventions.cs /}
+
+### Changing the Identity Separator
+
+Changes the default **separator** for automatically generated document IDs. Can be any `char` 
+except `|` (pipe). Default: `/` (forward slash).  
+
+This affects these ID generation strategies:  
+
+* [Server-Side ID](../../server/kb/document-identifier-generation#server-side-id)
+* [Identity](../../server/kb/document-identifier-generation#identity)
+* [HiLo Algorithm](../../server/kb/document-identifier-generation#hilo-algorithm)
+
+{CODE IdentityPartsSeparator@ClientApi\Configuration\Conventions.cs /}
+
+## TopologyCacheLocation
+
+Changes the location of topology cache files. Setting this value will check directory existance and write permissions. By default it is set to the application base directory (`AppContext.BaseDirectory`).
+
+{CODE TopologyCacheLocation@ClientApi\Configuration\Conventions.cs /}
+
+## AddIdFieldToDynamicObjects
+
+Determines whether an Id field is automatically added to dynamic objects. Default: `true`.
+
+{CODE AddIdFieldToDynamicObjects@ClientApi\Configuration\Conventions.cs /}
+
+## ShouldIgnoreEntityChanges
+
+This function can be configured to disable entity tracking for certain entities.  
+Learn more in [Customize tracking in conventions](../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions).
+
+## WaitForIndexesAfterSaveChangesTimeout
+
+Sets the default timeout for DocumentSession.Advanced.WaitForIndexesAfterSaveChanges method.  
+
+Default: 15 Seconds.  
+
+{CODE WaitForIndexesAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+
+## WaitForReplicationAfterSaveChangesTimeout
+
+Sets the default timeout for DocumentSession.Advanced.WaitForReplicationAfterSaveChanges method.
+Default: 15 Seconds.
+
+{CODE WaitForReplicationAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+
+## WaitForNonStaleResultsTimeout
+
+Sets the default timeout WaitForNonStaleResults methods used when querying. 
+Default: 15 Seconds.
+
+{CODE WaitForNonStaleResultsTimeout@ClientApi\Configuration\Conventions.cs /}
+
+## Related Articles
+
+### Conventions
+
+- [Querying](../../client-api/configuration/querying)
+- [Serialization](../../client-api/configuration/serialization)
+- [Load Balance & Failover](../../client-api/configuration/load-balance-and-failover)
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../client-api/configuration/identifier-generation/type-specific)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
@@ -36,7 +36,7 @@
     },
     {
         "Path": "how-to-disable-tracking.markdown",
-        "Name": "How to Disable Tracking",
+        "Name": "Disable Tracking",
         "DiscussionId": "be9f91c8-eb29-43a3-a331-39ae78fc974a",
         "Mappings": []
     },

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
@@ -10,6 +10,7 @@
 * __Tracking can be disabled__ by any of the following:  
     * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
     * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
     * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
 {NOTE/}
 
@@ -44,11 +45,24 @@ __Syntax__
 * Tracking can be disabled for all entities in the session's options.  
 * When tracking is disabled for the session:  
   * Method `Store` will Not be available (an exception will be thrown if used).
-  * Calling `Load` will generate a call to the server and create a new entity instance.  
+  * Calling `Load` or `Query` will generate a call to the server and create new entities instances.  
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.cs /}
 {CODE-TAB:csharp:Async disable_tracking_2_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Disable tracking query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query-Sync disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Query-Async disable_tracking_3_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:DocumentQuery-Sync disable_tracking_3_documentQuery@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:DocumentQuery-Async disable_tracking_3_documentQuery_async@ClientApi\Session\Configuration\DisableTracking.cs /}
 {CODE-TABS/}
 
 {PANEL/}
@@ -61,7 +75,7 @@ __Syntax__
 
 __Example__
 
-{CODE:csharp disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE:csharp disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.cs /}
 
 __Syntax__
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
@@ -1,0 +1,95 @@
+# Disable Entity Tracking
+
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `SaveChanges` is called.  
+
+* __Tracking can be disabled__ by any of the following:  
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking a specific entity in session}
+
+* Tracking can be disabled for a specific entity in the session.  
+* Once tracking is disabled for the entity then:
+  * Any changes made to this entity will be ignored for `SaveChanges`.  
+  * Performing another `Load` for this entity will Not generate another call to the server.
+  
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_1_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+__Syntax__
+
+{CODE syntax_1@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking all entities in session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Methods `Store` & `SaveChanges` will Not be available (an exception will be thrown if used).  
+  * Calling `Load` will generate a call to the server and create a new entity instance.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_2_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+
+__Example__
+
+{CODE:csharp disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+__Syntax__
+
+{CODE syntax_2@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+| Parameter | Description |
+| - | - |
+| `InMemoryDocumentSessionOperations` | The session for which tracking is to be disabled |
+| `object` | The entity for which tracking is to be disabled |
+| `string` | The entity's document ID |
+
+| Return Type | Description |
+| - | - |
+| `bool` | `true` - Entity will Not be tracked<br>`false` - Entity will be tracked |
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
@@ -43,7 +43,7 @@ __Syntax__
 
 * Tracking can be disabled for all entities in the session's options.  
 * When tracking is disabled for the session:  
-  * Methods `Store` & `SaveChanges` will Not be available (an exception will be thrown if used).  
+  * Method `Store` will Not be available (an exception will be thrown if used).
   * Calling `Load` will generate a call to the server and create a new entity instance.  
 
 {CODE-TABS}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
@@ -1,0 +1,89 @@
+# Disable Entity Tracking
+
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `saveChanges` is called.  
+
+* __Tracking can be disabled__ by any of the following:  
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking a specific entity in session}
+
+* Tracking can be disabled for a specific entity in the session.  
+* Once tracking is disabled for the entity then:
+  * Any changes made to this entity will be ignored for `saveChanges`.  
+  * Performing another `load` for this entity will Not generate another call to the server.
+  
+__Example__
+
+{CODE:nodejs disable_tracking_1@ClientApi\Session\Configuration\disableTracking.js /}
+
+__Syntax__
+
+{CODE:nodejs syntax_1@ClientApi\Session\Configuration\disableTracking.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking all entities in session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Methods `store` & `saveChanges` will Not be available (an exception will be thrown if used).
+  * Calling `load` will generate a call to the server and create a new entity instance.
+
+{CODE:nodejs disable_tracking_2@ClientApi\Session\Configuration\disableTracking.js /}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+
+__Example__
+
+{CODE:nodejs disable_tracking_3@ClientApi\Session\Configuration\disableTracking.js /}
+
+__Syntax__
+
+{CODE:nodejs syntax_2@ClientApi\Session\Configuration\disableTracking.js /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| sessionOperations | `InMemoryDocumentSessionOperations` | The session for which tracking is to be disabled |
+| entity | `object` | The entity for which tracking is to be disabled |
+| documentId | `string` | The entity's document ID |
+
+| Return Type | Description |
+| - | - |
+| `boolean` | `true` - Entity will Not be tracked<br>`false` - Entity will be tracked |
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
@@ -40,7 +40,7 @@ __Syntax__
 
 * Tracking can be disabled for all entities in the session's options.  
 * When tracking is disabled for the session:  
-  * Methods `store` & `saveChanges` will Not be available (an exception will be thrown if used).
+  * Method `store` will Not be available (an exception will be thrown if used).
   * Calling `load` will generate a call to the server and create a new entity instance.
 
 {CODE:nodejs disable_tracking_2@ClientApi\Session\Configuration\disableTracking.js /}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
@@ -59,7 +59,7 @@ __Syntax__
 {PANEL: Customize tracking in conventions}
 
 * You can further customize and fine-tune which entities will not be tracked  
-  by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
+  by configuring the `shouldIgnoreEntityChanges` convention method on the document store.
 * This customization rule will apply to all sessions opened for this document store.
 
 __Example__

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
@@ -10,6 +10,7 @@
 * __Tracking can be disabled__ by any of the following:  
     * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
     * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
     * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
 {NOTE/}
 
@@ -41,9 +42,17 @@ __Syntax__
 * Tracking can be disabled for all entities in the session's options.  
 * When tracking is disabled for the session:  
   * Method `store` will Not be available (an exception will be thrown if used).
-  * Calling `load` will generate a call to the server and create a new entity instance.
+  * Calling `load` or `query` will generate a call to the server and create new entities instances.
 
 {CODE:nodejs disable_tracking_2@ClientApi\Session\Configuration\disableTracking.js /}
+
+{PANEL/}
+
+{PANEL: Disable tracking query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE:nodejs disable_tracking_3@ClientApi\Session\Configuration\disableTracking.js /}
 
 {PANEL/}
 
@@ -55,7 +64,7 @@ __Syntax__
 
 __Example__
 
-{CODE:nodejs disable_tracking_3@ClientApi\Session\Configuration\disableTracking.js /}
+{CODE:nodejs disable_tracking_4@ClientApi\Session\Configuration\disableTracking.js /}
 
 __Syntax__
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
@@ -12,6 +12,7 @@
 * Tracking can be disabled by any of the following:
     * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
     * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
     * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
 {NOTE/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
@@ -1,0 +1,28 @@
+# How to Ignore Entity Changes
+
+---
+
+{NOTE: }
+
+* By default, each session tracks the changes made to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `SaveChanges` is called.
+
+* Entity changes can be ignored for the `SaveChanges` by disabling entity tracking.  
+
+* Tracking can be disabled by any of the following:
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.java.markdown
@@ -1,0 +1,30 @@
+# Session: How to Ignore Entity Changes
+
+In order to mark an entity as one that should be ignored for change tracking purposes, use the `ignoreChangesFor` method from the `advanced` session operations.  
+
+Unlike the `evict` method, performing another `Load` of that entity won't create a call to the server.  
+
+The entity will still take part in the session, but will be ignored for `saveChanges`.  
+
+## Syntax
+
+{CODE:java ignore_changes_1@ClientApi\Session\HowTo\IgnoreChanges.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | Object | Instance of entity for which changes will be ignored. |
+
+
+## Example
+
+{CODE:java ignore_changes_2@ClientApi\Session\HowTo\IgnoreChanges.java /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
@@ -1,0 +1,28 @@
+# How to Ignore Entity Changes
+
+---
+
+{NOTE: }
+
+* By default, each session tracks the changes made to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `saveChanges` is called.
+
+* Entity changes can be ignored for the `saveChanges` by disabling entity tracking.
+
+* Tracking can be disabled by any of the following:
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
@@ -12,6 +12,7 @@
 * Tracking can be disabled by any of the following:
     * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
     * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
     * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
 {NOTE/}
 

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Sparrow;
+
+namespace Raven.Documentation.Samples.ClientApi.Configuration
+{
+    public class Conventions
+    {
+        public Conventions()
+        {
+            #region conventions_1
+            using (var store = new DocumentStore()
+            {
+                Conventions =
+                {
+                    // customizations go here
+                }
+            }.Initialize())
+            {
+
+            }
+            #endregion
+        }
+        
+        #region FirstChar
+        private string FirstCharToLower(string str) => $"{Char.ToLower(str[0])}{str.Substring(1)}";
+        #endregion
+
+        public void Examples()
+        {
+            var store = new DocumentStore()
+            {
+                Conventions =
+                {
+	                #region MaxHttpCacheSize
+	                MaxHttpCacheSize = new Size(256, SizeUnit.Megabytes)
+	                #endregion
+	                ,
+	                #region MaxNumberOfRequestsPerSession
+	                MaxNumberOfRequestsPerSession = 10
+	                #endregion
+	                ,
+	                #region UseOptimisticConcurrency
+	                UseOptimisticConcurrency = true
+	                #endregion
+	                ,
+	                #region DisableTopologyUpdates
+                    DisableTopologyUpdates = false
+	                #endregion
+                    ,
+	                #region SaveEnumsAsIntegers
+                    SaveEnumsAsIntegers = true
+	                #endregion
+                    ,
+                    #region RequestTimeout
+                    RequestTimeout = TimeSpan.FromSeconds(90)
+                    #endregion
+                    ,
+                    #region UseCompression
+                    UseCompression = true
+                    #endregion
+                    ,
+                    #region OperationStatusFetchMode
+                    OperationStatusFetchMode = OperationStatusFetchMode.ChangesApi
+                    #endregion
+                    ,
+                    #region TopologyCacheLocation
+                    TopologyCacheLocation = @"C:\RavenDB\TopologyCache"
+                    #endregion
+                    ,
+                    #region PropertyCasing
+                    Serialization = new NewtonsoftJsonSerializationConventions
+                    {
+                        CustomizeJsonSerializer = s => s.ContractResolver = new CamelCasePropertyNamesContractResolver()
+                    },
+                    PropertyNameConverter = mi => FirstCharToLower(mi.Name)
+                    #endregion
+                    ,
+                    #region AddIdFieldToDynamicObjects
+                    AddIdFieldToDynamicObjects = false
+                    #endregion
+                    ,
+                    #region IdentityPartsSeparator
+                    IdentityPartsSeparator = '~'
+                    #endregion
+                    ,
+                    #region WaitForIndexesAfterSaveChangesTimeout
+                    WaitForIndexesAfterSaveChangesTimeout = TimeSpan.FromSeconds(10)
+                    #endregion
+                    ,
+                    #region WaitForReplicationAfterSaveChangesTimeout
+                    WaitForReplicationAfterSaveChangesTimeout = TimeSpan.FromSeconds(10)
+                    #endregion
+                    ,
+                    #region WaitForNonStaleResultsTimeout
+                    WaitForNonStaleResultsTimeout = TimeSpan.FromSeconds(10)
+                    #endregion
+
+                }
+            };
+            
+            var stor2e = new DocumentStore()
+            {
+                Conventions =
+                {
+                    #region disable_cache
+                    MaxHttpCacheSize = new Size(0, SizeUnit.Megabytes)
+                    #endregion
+                }
+            };
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+using Xunit;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class DisableTracking
+    {
+        private interface IgnoreChangesEntity
+        {
+            #region syntax_1
+            void IgnoreChangesFor(object entity);
+            #endregion
+        }
+
+        private abstract class IgnoreChangesConvention
+        {
+            #region syntax_2
+            public Func<InMemoryDocumentSessionOperations, object, string, bool> ShouldIgnoreEntityChanges;
+            #endregion
+        }
+
+        public async Task DisableTrackingSamples()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region disable_tracking_1
+                    // Load a product entity, the session will track its changes
+                    Product product = session.Load<Product>("products/1-A");
+                    
+                    // Disable tracking for the loaded product entity
+                    session.Advanced.IgnoreChangesFor(product);
+                    
+                    // The following change will be ignored for SaveChanges
+                    product.UnitsInStock += 1;
+                    
+                    session.SaveChanges();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region disable_tracking_1_async
+                    // Load a product entity, the session will track its changes
+                    Product product = await asyncSession.LoadAsync<Product>("products/1-A");
+                    
+                    // Disable tracking for the loaded product entity
+                    asyncSession.Advanced.IgnoreChangesFor(product);
+                    
+                    // The following change will be ignored for SaveChanges
+                    product.UnitsInStock += 1;
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+                
+                #region disable_tracking_2
+                using (IDocumentSession session = store.OpenSession(new SessionOptions
+                {
+                    // Disable tracking for all entities in the session's options
+                    NoTracking = true
+                }))
+                {
+                    // Load any entity, it will Not be tracked by the session
+                    Employee employee1 = session.Load<Employee>("employees/1-A");
+                    
+                    // Loading again from same document will result in a new entity instance
+                    Employee employee2 = session.Load<Employee>("employees/1-A");
+                    
+                    // Entities instances are not the same
+                    Assert.NotEqual(employee1, employee2);
+                    
+                    // Calling SaveChanges will throw an exception
+                    session.SaveChanges();
+                }
+                #endregion
+
+                #region disable_tracking_2_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession(new SessionOptions
+                {
+                    // Disable tracking for all entities in the session's options
+                    NoTracking = true
+                }))
+                {
+                    // Load any entity, it will Not be tracked by the session
+                    Employee employee1 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+                    
+                    // Loading again from same document will result in a new entity instance
+                    Employee employee2 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+
+                    // Entities instances are not the same
+                    Assert.NotEqual(employee1, employee2);
+                    
+                    // Calling SaveChangesAsync will throw an exception
+                    asyncSession.SaveChangesAsync();
+                }
+                #endregion
+            }
+
+            #region disable_tracking_3
+            using (var store = new DocumentStore()
+            {
+                // Define the 'ignore' convention on your document store
+                Conventions =
+                {
+                    ShouldIgnoreEntityChanges =
+                        // Define for which entities tracking should be disabled 
+                        // Tracking will be disabled ONLY for entities of type Employee whose FirstName is Bob
+                        (session, entity, id) => (entity is Employee e) &&
+                                                 (e.FirstName == "Bob")
+                }
+            }.Initialize())
+            {
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    var employee1 = new Employee { Id = "employees/1", FirstName = "Alice" };
+                    var employee2 = new Employee { Id = "employees/2", FirstName = "Bob" };
+
+                    session.Store(employee1);      // This entity will be tracked
+                    session.Store(employee2);      // Changes to this entity will be ignored
+
+                    session.SaveChanges();         // Only employee1 will be persisted
+
+                    employee1.FirstName = "Bob";   // Changes to this entity will now be ignored
+                    employee2.FirstName = "Alice"; // This entity will now be tracked
+
+                    session.SaveChanges();         // Only employee2 is persisted
+                }
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
@@ -54,6 +56,7 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
                     
                     // The following change will be ignored for SaveChanges
                     product.UnitsInStock += 1;
+                    
                     await asyncSession.SaveChangesAsync();
                     #endregion
                 }
@@ -73,9 +76,6 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
                     
                     // Entities instances are not the same
                     Assert.NotEqual(employee1, employee2);
-                    
-                    // Calling SaveChanges will throw an exception
-                    session.SaveChanges();
                 }
                 #endregion
 
@@ -94,14 +94,87 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
 
                     // Entities instances are not the same
                     Assert.NotEqual(employee1, employee2);
+                }
+                #endregion
+                
+                #region disable_tracking_3
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = session.Query<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
                     
-                    // Calling SaveChangesAsync will throw an exception
-                    asyncSession.SaveChangesAsync();
+                    // Change to 'firstEmployee' will not be persisted
+                    session.SaveChanges();
+                }
+                #endregion
+
+                #region disable_tracking_3_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = asyncSession.Query<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    await asyncSession.SaveChangesAsync();
+                }
+                #endregion
+                
+                #region disable_tracking_3_documentQuery
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = session.Advanced.DocumentQuery<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .NoTracking()
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    session.SaveChanges();
+                }
+                #endregion
+                
+                #region disable_tracking_3_documentQuery_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = asyncSession.Advanced.AsyncDocumentQuery<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .NoTracking()
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    await asyncSession.SaveChangesAsync();
                 }
                 #endregion
             }
 
-            #region disable_tracking_3
+            #region disable_tracking_4
             using (var store = new DocumentStore()
             {
                 // Define the 'ignore' convention on your document store

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/IgnoreChanges.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/IgnoreChanges.java
@@ -1,0 +1,40 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class IgnoreChanges {
+
+    private class Product {
+        private int unitsInStock;
+
+        public int getUnitsInStock() {
+            return unitsInStock;
+        }
+
+        public void setUnitsInStock(int unitsInStock) {
+            this.unitsInStock = unitsInStock;
+        }
+    }
+
+    public IgnoreChanges() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region ignore_changes_2
+                Product product = session.load(Product.class, "products/1-A");
+                session.advanced().ignoreChangesFor(product);
+                product.unitsInStock++; //this will be ignored for SaveChanges
+                session.saveChanges();
+                //endregion
+            }
+        }
+    }
+
+    private interface IFoo {
+        //region ignore_changes_1
+        void ignoreChangesFor(Object entity);
+        //endregion
+    }
+
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/Configuration/disableTracking.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/Configuration/disableTracking.js
@@ -1,0 +1,91 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+async function whatIsSessionUsingAwait() {
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_1
+        const session = documentStore.openSession();        
+
+        // Load a product entity, the session will track its changes
+        const product = await session.load("products/1-A");
+
+        // Disable tracking for the loaded product entity
+        session.advanded.ignoreChangesFor(product);
+
+        // The following change will be ignored for saveChanges
+        product.unitsInStock += 1;
+        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_2
+        const session = documentStore.openSession({
+            // Disable tracking for all entities in the session's options
+            noTracking: true
+        });
+
+        // Load any entity, it will Not be tracked by the session
+        const employee1 = await session.load("employees/1-A");
+
+        // Loading again from same document will result in a new entity instance
+        const employee2 = await session.load("employees/1-A");
+
+        // Entities instances are not the same
+        assert.notStrictEqual(company1, company2);
+        
+        // Calling saveChanges will throw an exception
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region disable_tracking_3
+        const customStore = new DocumentStore();
+        
+        // Define the 'ignore' convention on your document store
+        customStore.conventions.shouldIgnoreEntityChanges =
+            (sessionOperations, entity, documentId) => {
+                // Define for which entities tracking should be disabled 
+                // Tracking will be disabled ONLY for entities of type Employee whose firstName is Bob
+                return entity instanceof Employee && entity.firstName === "Bob";
+            };
+        customStore.initialize();
+
+        const session = customStore.openSession();
+
+        let employee1 = new Employee();
+        employee1.firstName = "Alice";
+
+        let employee2 = new Employee();
+        employee2.firstName = "Bob";
+
+        await session.store(employee1, "employees/1-A"); // This entity will be tracked
+        await session.store(employee2, "employees/2-A"); // Changes to this entity will be ignored
+
+        await session.saveChanges();   // Only employee1 will be persisted
+
+        employee1.firstName = "Bob";   // Changes to this entity will now be ignored
+        employee2.firstName = "Alice"; // This entity will now be tracked
+
+        session.saveChanges();         // Only employee2 is persisted
+        //endregion
+    }
+    {
+        //region syntax_1
+        session.advanced.ignoreChangesFor(entity);
+        //endregion
+    }
+    {
+        //region syntax_2
+        store.conventions.shouldIgnoreEntityChanges = (sessionOperations, entity, documentId) => {
+            // Write your logic
+            // return value:
+            //     true - entity will not be tracked 
+            //     false - entity will be tracked
+        }
+        //endregion
+    }
+}
+

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/Configuration/disableTracking.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/Configuration/disableTracking.js
@@ -55,10 +55,10 @@ async function whatIsSessionUsingAwait() {
 
         const session = customStore.openSession();
 
-        let employee1 = new Employee();
+        const employee1 = new Employee();
         employee1.firstName = "Alice";
 
-        let employee2 = new Employee();
+        const employee2 = new Employee();
         employee2.firstName = "Bob";
 
         await session.store(employee1, "employees/1-A"); // This entity will be tracked

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/Configuration/disableTracking.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/Configuration/disableTracking.js
@@ -41,7 +41,27 @@ async function whatIsSessionUsingAwait() {
         //endregion
     }
     {
+        const documentStore = new DocumentStore();
         //region disable_tracking_3
+        const session = documentStore.openSession();
+
+        // Define a query
+        const employeesResults = await session.query({ collection: "employees" })
+            .whereEquals("FirstName", "Robert")
+             // Set noTracking, all resulting entities will not be tracked
+            .noTracking()
+            .all();
+
+        // The following modification will not be tracked for saveChanges
+        const firstEmployee = employeesResults[0];
+        firstEmployee.lastName = "NewName";
+
+        // Change to 'firstEmployee' will not be persisted
+        session.saveChanges();
+        //endregion
+    }
+    {
+        //region disable_tracking_4
         const customStore = new DocumentStore();
         
         // Define the 'ignore' convention on your document store

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
@@ -36,7 +36,7 @@
     },
     {
         "Path": "how-to-disable-tracking.markdown",
-        "Name": "How to Disable Tracking",
+        "Name": "Disable Tracking",
         "DiscussionId": "be9f91c8-eb29-43a3-a331-39ae78fc974a",
         "Mappings": []
     },

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
@@ -36,7 +36,7 @@
     },
     {
         "Path": "how-to-disable-tracking.markdown",
-        "Name": "How to Disable Tracking",
+        "Name": "Disable Tracking",
         "DiscussionId": "be9f91c8-eb29-43a3-a331-39ae78fc974a",
         "Mappings": []
     },

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
@@ -36,7 +36,7 @@
     },
     {
         "Path": "how-to-disable-tracking.markdown",
-        "Name": "How to Disable Tracking",
+        "Name": "Disable Tracking",
         "DiscussionId": "be9f91c8-eb29-43a3-a331-39ae78fc974a",
         "Mappings": []
     },


### PR DESCRIPTION
…acking

**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2319/Node.js-Client-API-Session-Configuration-Disable-tracking

@ml054 
For Node.js - the files to be reviewed are:

```
Documentation/5.2/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Session/Configuration/disableTracking.js
```

**Notes:**
1. Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling.
2. Files for `client-api > configuration > conventions` were copied to 5.2 only to apply the new link to disable tracking.
No other changes were made to those files.