### PR TITLE
RDoc-2324 [Node.js] Client API > Operations > Maintenance > Get statistics

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,44 +1,55 @@
 [
-  {
-    "Path": "get-collection-statistics.markdown",
-    "Name": "Get Collection Statistics",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
-  {
-    "Path": "get-statistics.markdown",
-    "Name": "Get Statistics",
-    "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "client-api/commands/how-to/get-database-and-server-statistics"
-      }
-    ]
-  },
-  {
-    "Path": "/configuration",
-    "Name": "Configuration",
-    "Mappings": []
-  },
-  {
-    "Path": "/identities",
-    "Name": "Identities",
-    "Mappings": []
-  },
-  {
-    "Path": "/indexes",
-    "Name": "Indexes",
-    "Mappings": []
-  },
-  {
-    "Path": "/etl",
-    "Name": "ETL",
-    "Mappings": []
-  },
-  {
-    "Path": "/backup",
-    "Name": "Backup",
-    "Mappings": []
-  }
+    {
+        "Path": "get-collection-statistics.markdown",
+        "Name": "Get Collection Statistics",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": [
+            {
+                "Version": 5.2,
+                "Key": "client-api/operations/maintenance/get-stats"
+            }
+        ],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-statistics.markdown",
+        "Name": "Get Statistics",
+        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+            },
+            {
+                "Version": 5.2,
+                "Key": "client-api/operations/maintenance/get-stats"
+            }
+        ],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "/configuration",
+        "Name": "Configuration",
+        "Mappings": []
+    },
+    {
+        "Path": "/identities",
+        "Name": "Identities",
+        "Mappings": []
+    },
+    {
+        "Path": "/indexes",
+        "Name": "Indexes",
+        "Mappings": []
+    },
+    {
+        "Path": "/backup",
+        "Name": "Backup",
+        "Mappings": []
+    },
+    {
+        "Path": "/etl",
+        "Name": "ETL",
+        "Mappings": []
+    }
 ]

--- a/Documentation/4.1/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/4.1/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,55 +1,63 @@
 [
-  {
-    "Path": "get-collection-statistics.markdown",
-    "Name": "Get Collection Statistics",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
-  {
-    "Path": "get-statistics.markdown",
-    "Name": "Get Statistics",
-    "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "client-api/commands/how-to/get-database-and-server-statistics"
-      }
-    ]
-  },
-  {
-    "Path": "get-detailed-statistics.markdown",
-    "Name": "Get Detailed Statistics",
-    "DiscussionId": "fdcda5ce-8793-4b3c-a008-5ec906e7c234",
-    "Mappings": []
-  },
-  {
-    "Path": "/configuration",
-    "Name": "Configuration",
-    "Mappings": []
-  },
-  {
-    "Path": "/identities",
-    "Name": "Identities",
-    "Mappings": []
-  },
-  {
-    "Path": "/indexes",
-    "Name": "Indexes",
-    "Mappings": []
-  },
-  {
-    "Path": "/etl",
-    "Name": "ETL",
-    "Mappings": []
-  },
-  {
-    "Path": "/connection-strings",
-    "Name": "Connection strings",
-    "Mappings": []
-  },
-  {
-    "Path": "/backup",
-    "Name": "Backup",
-    "Mappings": []
-  }
+    {
+        "Path": "get-collection-statistics.markdown",
+        "Name": "Get Collection Statistics",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": [],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-statistics.markdown",
+        "Name": "Get Statistics",
+        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+            }
+        ],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-detailed-statistics.markdown",
+        "Name": "Get Detailed Statistics",
+        "DiscussionId": "fdcda5ce-8793-4b3c-a008-5ec906e7c234",
+        "Mappings": [
+            {
+                "Version": 5.2,
+                "Key": "client-api/operations/maintenance/get-stats"
+            }
+        ],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "/configuration",
+        "Name": "Configuration",
+        "Mappings": []
+    },
+    {
+        "Path": "/identities",
+        "Name": "Identities",
+        "Mappings": []
+    },
+    {
+        "Path": "/indexes",
+        "Name": "Indexes",
+        "Mappings": []
+    },
+    {
+        "Path": "/backup",
+        "Name": "Backup",
+        "Mappings": []
+    },
+    {
+        "Path": "/etl",
+        "Name": "ETL",
+        "Mappings": []
+    },
+    {
+        "Path": "/connection-strings",
+        "Name": "Connection strings",
+        "Mappings": []
+    }
 ]

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,50 +1,64 @@
 [
-  {
-    "Path": "get-collection-statistics.markdown",
-    "Name": "Get Collection Statistics",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
-  {
-    "Path": "get-statistics.markdown",
-    "Name": "Get Statistics",
-    "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "client-api/commands/how-to/get-database-and-server-statistics"
-      }
-    ]
-  },
-  {
-    "Path": "/configuration",
-    "Name": "Configuration",
-    "Mappings": []
-  },
-  {
-    "Path": "/identities",
-    "Name": "Identities",
-    "Mappings": []
-  },
-  {
-    "Path": "/indexes",
-    "Name": "Indexes",
-    "Mappings": []
-  },
-  {
-    "Path": "/etl",
-    "Name": "ETL",
-    "Mappings": []
-  },
+    {
+        "Path": "get-collection-statistics.markdown",
+        "Name": "Get Collection Statistics",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": [],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-statistics.markdown",
+        "Name": "Get Statistics",
+        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+            }
+        ],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-detailed-statistics.markdown",
+        "Name": "Get Detailed Statistics",
+        "DiscussionId": "fdcda5ce-8793-4b3c-a008-5ec906e7c234",
+        "Mappings": [],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "clean-change-vector.markdown",
+        "Name": "Clean Change Vector",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": []
+    },
+    {
+        "Path": "/configuration",
+        "Name": "Configuration",
+        "Mappings": []
+    },
+    {
+        "Path": "/identities",
+        "Name": "Identities",
+        "Mappings": []
+    },
+    {
+        "Path": "/indexes",
+        "Name": "Indexes",
+        "Mappings": []
+    },
     {
         "Path": "/backup",
         "Name": "Backup",
         "Mappings": []
     },
-      {
-    "Path": "clean-change-vector.markdown",
-    "Name": "Clean Change Vector",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
+    {
+        "Path": "/etl",
+        "Name": "ETL",
+        "Mappings": []
+    },
+    {
+        "Path": "/connection-strings",
+        "Name": "Connection strings",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/5.0/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,50 +1,64 @@
 [
-  {
-    "Path": "get-collection-statistics.markdown",
-    "Name": "Get Collection Statistics",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
-  {
-    "Path": "get-statistics.markdown",
-    "Name": "Get Statistics",
-    "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "client-api/commands/how-to/get-database-and-server-statistics"
-      }
-    ]
-  },
-  {
-    "Path": "/configuration",
-    "Name": "Configuration",
-    "Mappings": []
-  },
-  {
-    "Path": "/identities",
-    "Name": "Identities",
-    "Mappings": []
-  },
-  {
-    "Path": "/indexes",
-    "Name": "Indexes",
-    "Mappings": []
-  },
-  {
-    "Path": "/etl",
-    "Name": "ETL",
-    "Mappings": []
-  },
+    {
+        "Path": "get-collection-statistics.markdown",
+        "Name": "Get Collection Statistics",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": [],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-statistics.markdown",
+        "Name": "Get Statistics",
+        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+            }
+        ],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-detailed-statistics.markdown",
+        "Name": "Get Detailed Statistics",
+        "DiscussionId": "fdcda5ce-8793-4b3c-a008-5ec906e7c234",
+        "Mappings": [],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "clean-change-vector.markdown",
+        "Name": "Clean Change Vector",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": []
+    },
+    {
+        "Path": "/configuration",
+        "Name": "Configuration",
+        "Mappings": []
+    },
+    {
+        "Path": "/identities",
+        "Name": "Identities",
+        "Mappings": []
+    },
+    {
+        "Path": "/indexes",
+        "Name": "Indexes",
+        "Mappings": []
+    },
     {
         "Path": "/backup",
         "Name": "Backup",
         "Mappings": []
     },
-      {
-    "Path": "clean-change-vector.markdown",
-    "Name": "Clean Change Vector",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
+    {
+        "Path": "/etl",
+        "Name": "ETL",
+        "Mappings": []
+    },
+    {
+        "Path": "/connection-strings",
+        "Name": "Connection strings",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,50 +1,64 @@
 [
-  {
-    "Path": "get-collection-statistics.markdown",
-    "Name": "Get Collection Statistics",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
-  {
-    "Path": "get-statistics.markdown",
-    "Name": "Get Statistics",
-    "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "client-api/commands/how-to/get-database-and-server-statistics"
-      }
-    ]
-  },
-  {
-    "Path": "/configuration",
-    "Name": "Configuration",
-    "Mappings": []
-  },
-  {
-    "Path": "/identities",
-    "Name": "Identities",
-    "Mappings": []
-  },
-  {
-    "Path": "/indexes",
-    "Name": "Indexes",
-    "Mappings": []
-  },
-  {
-    "Path": "/etl",
-    "Name": "ETL",
-    "Mappings": []
-  },
+    {
+        "Path": "get-collection-statistics.markdown",
+        "Name": "Get Collection Statistics",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": [],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-statistics.markdown",
+        "Name": "Get Statistics",
+        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+            }
+        ],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "get-detailed-statistics.markdown",
+        "Name": "Get Detailed Statistics",
+        "DiscussionId": "fdcda5ce-8793-4b3c-a008-5ec906e7c234",
+        "Mappings": [],
+        "LastSupportedVersion": "5.1"
+    },
+    {
+        "Path": "clean-change-vector.markdown",
+        "Name": "Clean Change Vector",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": []
+    },
+    {
+        "Path": "/configuration",
+        "Name": "Configuration",
+        "Mappings": []
+    },
+    {
+        "Path": "/identities",
+        "Name": "Identities",
+        "Mappings": []
+    },
+    {
+        "Path": "/indexes",
+        "Name": "Indexes",
+        "Mappings": []
+    },
     {
         "Path": "/backup",
         "Name": "Backup",
         "Mappings": []
     },
-      {
-    "Path": "clean-change-vector.markdown",
-    "Name": "Clean Change Vector",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
+    {
+        "Path": "/etl",
+        "Name": "ETL",
+        "Mappings": []
+    },
+    {
+        "Path": "/connection-strings",
+        "Name": "Connection strings",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,20 +1,20 @@
 [
     {
-        "Path": "get-collection-statistics.markdown",
-        "Name": "Get Collection Statistics",
-        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-        "Mappings": []
-    },
-    {
-        "Path": "get-statistics.markdown",
+        "Path": "get-stats.markdown",
         "Name": "Get Statistics",
-        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
         "Mappings": [
             {
-                "Version": 3.5,
-                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+                "Version": 4.0,
+                "Key": "client-api/operations/maintenance/get-statistics"
             }
         ]
+    },
+    {
+        "Path": "clean-change-vector.markdown",
+        "Name": "Clean Change Vector",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": []
     },
     {
         "Path": "/configuration",
@@ -32,26 +32,18 @@
         "Mappings": []
     },
     {
-        "Path": "/etl",
-        "Name": "ETL",
-        "Mappings": []
-    },
-
-    {
-        "Path": "/connection-strings",
-        "Name": "Connection strings",
-        "Mappings": []
-    },
-
-    {
         "Path": "/backup",
         "Name": "Backup",
         "Mappings": []
     },
     {
-        "Path": "clean-change-vector.markdown",
-        "Name": "Clean Change Vector",
-        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Path": "/etl",
+        "Name": "ETL",
+        "Mappings": []
+    },
+    {
+        "Path": "/connection-strings",
+        "Name": "Connection strings",
         "Mappings": []
     }
 ]

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
@@ -6,11 +6,15 @@
 
 * Statistics about your database and collections can be retrieved.  
 
+* By default, you get stats for the database defined in your Document Store.   
+  To get database and collection stats for another database use [ForDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).  
+
 * In this page:
     * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
     * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
     * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
     * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+    * [Get stats for another database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database)
 {NOTE/}
 
 ---
@@ -59,11 +63,24 @@ Stats are returned in the `DetailedDatabaseStatistics` object.
 {NOTE/}
 {PANEL/}
 
+{PANEL: Get stats for another database}
+{NOTE: }
+
+* By default, you get stats for the database defined in your Document Store.  
+* Use `ForDatabase` to get database & collection stats for another database.  
+* 'ForDatabase' can be used with __any__ of the above stats options.
+
+{CODE stats_5@ClientApi\Operations\Maintenance\GetStats.cs /}
+
+{NOTE/}
+{PANEL/}
+
 ## Related Articles
 
 ### Operations
 
 - [What are Operations](../../../client-api/operations/what-are-operations)
+- [Switch operation to another database](../../../client-api/operations/how-to/switch-operations-to-a-different-database)
 
 ### FAQ
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
@@ -1,0 +1,70 @@
+# Get Statistics
+
+---
+
+{NOTE: }
+
+* Statistics about your database and collections can be retrieved.  
+
+* In this page:
+    * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
+    * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+    * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
+    * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+{NOTE/}
+
+---
+
+{PANEL: Get collection stats}
+{NOTE: }
+Use `GetCollectionStatisticsOperation` to get __collection stats__.
+{CODE stats_1@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `CollectionStatistics` object.
+{CODE stats_1_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed collection stats}
+{NOTE: }
+Use `GetDetailedCollectionStatisticsOperation` to get __detailed collection stats__.
+{CODE stats_2@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedCollectionStatistics` object.
+{CODE stats_2_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get database stats}
+{NOTE: }
+Use `GetStatisticsOperation` to get __database stats__.
+{CODE stats_3@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DatabaseStatistics` object.
+{CODE stats_3_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed database stats}
+{NOTE: }
+Use `GetDetailedStatisticsOperation` to get __detailed database stats__.
+{CODE stats_4@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedDatabaseStatistics` object.
+{CODE stats_4_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+
+### FAQ
+
+- [What is a Collection](../../../client-api/faq/what-is-a-collection)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
@@ -72,6 +72,8 @@ Stats are returned in the `DetailedDatabaseStatistics` object.
 
 {CODE stats_5@ClientApi\Operations\Maintenance\GetStats.cs /}
 
+* Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
+
 {NOTE/}
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
@@ -1,0 +1,70 @@
+# Get Statistics
+
+---
+
+{NOTE: }
+
+* Statistics about your database and collections can be retrieved.
+
+* In this page:
+    * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
+    * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+    * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
+    * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+{NOTE/}
+
+---
+
+{PANEL: Get collection stats}
+{NOTE: }
+Use `GetCollectionStatisticsOperation` to get __collection stats__.
+{CODE:java stats_1@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `CollectionStatistics` object.
+{CODE:java stats_1_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed collection stats}
+{NOTE: }
+Use `GetDetailedCollectionStatisticsOperation` to get __detailed collection stats__.
+{CODE:java stats_2@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedCollectionStatistics` object.
+{CODE:java stats_2_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get database stats}
+{NOTE: }
+Use `GetStatisticsOperation` to get __database stats__.
+{CODE:java stats_3@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DatabaseStatistics` object.
+{CODE:java stats_3_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed database stats}
+{NOTE: }
+Use `GetDetailedStatisticsOperation` to get __detailed database stats__.
+{CODE:java stats_4@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedDatabaseStatistics` object.
+{CODE:java stats_4_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+
+### FAQ
+
+- [What is a Collection](../../../client-api/faq/what-is-a-collection)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
@@ -6,11 +6,15 @@
 
 * Statistics about your database and collections can be retrieved.
 
+* By default, you get stats for the database defined in your Document Store.   
+  To get database and collection stats for another database use [forDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).
+
 * In this page:
     * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
     * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
     * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
     * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+    * [Get stats for another database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database)
 {NOTE/}
 
 ---
@@ -59,11 +63,24 @@ Stats are returned in the `DetailedDatabaseStatistics` object.
 {NOTE/}
 {PANEL/}
 
+{PANEL: Get stats for another database}
+{NOTE: }
+
+* By default, you get stats for the database defined in your Document Store.
+* Use `forDatabase` to get database & collection stats for another database.
+* 'ForDatabase' can be used with __any__ of the above stats options.
+ 
+{CODE:java stats_5@ClientApi\Operations\Maintenance\GetStats.java /}
+
+{NOTE/}
+{PANEL/}
+
 ## Related Articles
 
 ### Operations
 
 - [What are Operations](../../../client-api/operations/what-are-operations)
+- [Switch operation to another database](../../../client-api/operations/how-to/switch-operations-to-a-different-database)
 
 ### FAQ
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
@@ -72,6 +72,8 @@ Stats are returned in the `DetailedDatabaseStatistics` object.
  
 {CODE:java stats_5@ClientApi\Operations\Maintenance\GetStats.java /}
 
+* Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
+
 {NOTE/}
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
@@ -25,7 +25,7 @@ Use `GetCollectionStatisticsOperation` to get __collection stats__.
 {CODE:nodejs stats_1@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {NOTE: }
-Stats are returned in the `CollectionStatistics` object.
+Collection stats results:
 {CODE:nodejs stats_1_results@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {PANEL/}
@@ -36,7 +36,7 @@ Use `GetDetailedCollectionStatisticsOperation` to get __detailed collection stat
 {CODE:nodejs stats_2@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {NOTE: }
-Stats are returned in the `DetailedCollectionStatistics` object.
+Detailed collection stats results:
 {CODE:nodejs stats_2_results@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {PANEL/}
@@ -47,7 +47,7 @@ Use `GetStatisticsOperation` to get __database stats__.
 {CODE:nodejs stats_3@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {NOTE: }
-Stats are returned in the `DatabaseStatistics` object.
+Database stats results:
 {CODE:nodejs stats_3_results@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {PANEL/}
@@ -58,7 +58,7 @@ Use `GetDetailedStatisticsOperation` to get __detailed database stats__.
 {CODE:nodejs stats_4@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {NOTE: }
-Stats are returned in the `DetailedDatabaseStatistics` object.
+Detailed database stats results:
 {CODE:nodejs stats_4_results@ClientApi\Operations\Maintenance\getStats.js /}
 {NOTE/}
 {PANEL/}
@@ -68,9 +68,11 @@ Stats are returned in the `DetailedDatabaseStatistics` object.
 
 * By default, you get stats for the database defined in your Document Store.
 * Use `forDatabase` to get database & collection stats for another database.
-* 'ForDatabase' can be used with __any__ of the above stats options.
+* 'forDatabase' can be used with __any__ of the above stats options.
  
 {CODE:nodejs stats_5@ClientApi\Operations\Maintenance\getStats.js /}
+
+* Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
 
 {NOTE/}
 {PANEL/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
@@ -4,13 +4,17 @@
 
 {NOTE: }
 
-* Statistics about your database and collections can be retrieved.  
+* Statistics about your database and collections can be retrieved.
+
+* By default, you get stats for the database defined in your Document Store.   
+  To get database and collection stats for another database use [forDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).
 
 * In this page:
     * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
     * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
     * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
     * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+    * [Get stats for another database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database)
 {NOTE/}
 
 ---
@@ -59,11 +63,24 @@ Stats are returned in the `DetailedDatabaseStatistics` object.
 {NOTE/}
 {PANEL/}
 
+{PANEL: Get stats for another database}
+{NOTE: }
+
+* By default, you get stats for the database defined in your Document Store.
+* Use `forDatabase` to get database & collection stats for another database.
+* 'ForDatabase' can be used with __any__ of the above stats options.
+ 
+{CODE:nodejs stats_5@ClientApi\Operations\Maintenance\getStats.js /}
+
+{NOTE/}
+{PANEL/}
+
 ## Related Articles
 
 ### Operations
 
 - [What are Operations](../../../client-api/operations/what-are-operations)
+- [Switch operation to another database](../../../client-api/operations/how-to/switch-operations-to-a-different-database)
 
 ### FAQ
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
@@ -1,0 +1,70 @@
+# Get Statistics
+
+---
+
+{NOTE: }
+
+* Statistics about your database and collections can be retrieved.  
+
+* In this page:
+    * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
+    * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+    * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
+    * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+{NOTE/}
+
+---
+
+{PANEL: Get collection stats}
+{NOTE: }
+Use `GetCollectionStatisticsOperation` to get __collection stats__.
+{CODE:nodejs stats_1@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `CollectionStatistics` object.
+{CODE:nodejs stats_1_results@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed collection stats}
+{NOTE: }
+Use `GetDetailedCollectionStatisticsOperation` to get __detailed collection stats__.
+{CODE:nodejs stats_2@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedCollectionStatistics` object.
+{CODE:nodejs stats_2_results@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get database stats}
+{NOTE: }
+Use `GetStatisticsOperation` to get __database stats__.
+{CODE:nodejs stats_3@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DatabaseStatistics` object.
+{CODE:nodejs stats_3_results@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed database stats}
+{NOTE: }
+Use `GetDetailedStatisticsOperation` to get __detailed database stats__.
+{CODE:nodejs stats_4@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedDatabaseStatistics` object.
+{CODE:nodejs stats_4_results@ClientApi\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+
+### FAQ
+
+- [What is a Collection](../../../client-api/faq/what-is-a-collection)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.markdown
@@ -87,7 +87,7 @@ only new or modified documents will be compressed.
 **Database**
 
 - [How to create database?](../../../client-api/operations/server-wide/create-database) 
-- [How to get database statistics](../../../client-api/operations/maintenance/get-statistics)
+- [How to get database statistics](../../../client-api/operations/maintenance/get-stats)
 - [How to restore a database from backup](../../../client-api/operations/server-wide/restore-backup)
 
 **Compression**

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
@@ -42,6 +42,15 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance
                     store.Maintenance.Send(new GetDetailedStatisticsOperation());
                 #endregion
             }
+            
+            using (var store = new DocumentStore())
+            {
+                #region stats_5
+                // Get stats for 'AnotherDatabase':
+                DatabaseStatistics stats =
+                    store.Maintenance.ForDatabase("AnotherDatabase").Send(new GetStatisticsOperation());
+                #endregion
+            }
         }
     }
   

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
@@ -113,7 +113,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance
         public string DatabaseChangeVector { get; set; } // Global change vector of the database
         public string DatabaseId { get; set; }           // Database identifier
         public bool Is64Bit { get; set; }                // Indicates if process is 64-bit
-        public string Pager { get; set; }
+        public string Pager { get; set; }                // Component handling the memory-mapped files
         public DateTime? LastIndexingTime { get; set; }  // Last time of indexing an item
         public Size SizeOnDisk { get; set; }             // Database size on disk
         public Size TempBuffersSizeOnDisk { get; set; }  // Temp buffers size on disk

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
@@ -47,6 +47,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance
   
     /*
     #region stats_1_results
+    // Collection stats results:
     public class CollectionStatistics
     {
         // Total # of documents in all collections
@@ -97,24 +98,25 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance
         public long CountOfDocuments { get; set; }  // Total # of documents in database
         public long CountOfRevisionDocuments { get; set; }  // Total # of revision documents in database
         public long CountOfDocumentsConflicts { get; set; } // Total # of documents conflicts in database
-        public long CountOfTombstones { get; set; }  // Total # of tombstones in database
-        public long CountOfConflicts { get; set; }   // Total # of conflicts in database
-        public long CountOfAttachments { get; set; } // Total # of attachments in database
+        public long CountOfTombstones { get; set; }         // Total # of tombstones in database
+        public long CountOfConflicts { get; set; }          // Total # of conflicts in database
+        public long CountOfAttachments { get; set; }        // Total # of attachments in database
         public long CountOfUniqueAttachments { get; set; }  // Total # of unique attachments in database
         public long CountOfCounterEntries { get; set; }     // Total # of counter-group entries in database
         public long CountOfTimeSeriesSegments { get; set; } // Total # of time-series segments in database
         
         // List of stale index names in database
         public string[] StaleIndexes => Indexes?.Where(x => x.IsStale).Select(x => x.Name).ToArray();
-        public IndexInformation[] Indexes { get; set; }  // Statistics for each index in database
+        // Statistics for each index in database
+        public IndexInformation[] Indexes { get; set; }
         
         public string DatabaseChangeVector { get; set; } // Global change vector of the database
-        public string DatabaseId { get; set; } // Database identifier
-        public bool Is64Bit { get; set; }      // Indicates if process is 64-bit
+        public string DatabaseId { get; set; }           // Database identifier
+        public bool Is64Bit { get; set; }                // Indicates if process is 64-bit
         public string Pager { get; set; }
-        public DateTime? LastIndexingTime { get; set; } // Last time of indexing an item
-        public Size SizeOnDisk { get; set; }            // Database size on disk
-        public Size TempBuffersSizeOnDisk { get; set; } // Temp buffers size on disk
+        public DateTime? LastIndexingTime { get; set; }  // Last time of indexing an item
+        public Size SizeOnDisk { get; set; }             // Database size on disk
+        public Size TempBuffersSizeOnDisk { get; set; }  // Temp buffers size on disk
         public int NumberOfTransactionMergerQueueOperations { get; set; }
     }
     #endregion

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
@@ -113,8 +113,8 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance
         public bool Is64Bit { get; set; }      // Indicates if process is 64-bit
         public string Pager { get; set; }
         public DateTime? LastIndexingTime { get; set; } // Last time of indexing an item
-        public Size SizeOnDisk { get; set; }            // Database size 
-        public Size TempBuffersSizeOnDisk { get; set; } // Temp buffers size
+        public Size SizeOnDisk { get; set; }            // Database size on disk
+        public Size TempBuffersSizeOnDisk { get; set; } // Temp buffers size on disk
         public int NumberOfTransactionMergerQueueOperations { get; set; }
     }
     #endregion

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
@@ -1,0 +1,139 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance
+{
+    public class GetStats
+    {
+        public GetStats()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region stats_1
+                // Pass an instance of class `GetCollectionStatisticsOperation` to the store 
+                CollectionStatistics stats =
+                    store.Maintenance.Send(new GetCollectionStatisticsOperation());
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region stats_2
+                // Pass an instance of class `GetDetailedCollectionStatisticsOperation` to the store 
+                DetailedCollectionStatistics stats =
+                    store.Maintenance.Send(new GetDetailedCollectionStatisticsOperation());
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region stats_3
+                // Pass an instance of class `GetStatisticsOperation` to the store 
+                DatabaseStatistics stats =
+                    store.Maintenance.Send(new GetStatisticsOperation());
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region stats_4
+                // Pass an instance of class `GetDetailedStatisticsOperation` to the store 
+                DetailedDatabaseStatistics stats =
+                    store.Maintenance.Send(new GetDetailedStatisticsOperation());
+                #endregion
+            }
+        }
+    }
+  
+    /*
+    #region stats_1_results
+    public class CollectionStatistics
+    {
+        // Total # of documents in all collections
+        public int CountOfDocuments { get; set; }
+        // Total # of conflicts
+        public int CountOfConflicts { get; set; }
+        // Total # of documents per collection
+        public Dictionary<string, long> Collections { get; set; }
+    }
+    #endregion
+    */
+    
+    /*
+    #region stats_2_results
+    // Detailed collection stats results:
+    public class DetailedCollectionStatistics
+    {
+        // Total # of documents in all collections
+        public long CountOfDocuments { get; set; }
+        // Total # of conflicts
+        public long CountOfConflicts { get; set; }
+        // Collection details per collection
+        public Dictionary<string, CollectionDetails> Collections { get; set; }
+    }
+    
+    // Details per collection
+    public class CollectionDetails
+    {        
+        public string Name { get; set; }
+        public long CountOfDocuments { get; set; }
+        public Size Size { get; set; }
+        public Size DocumentsSize { get; set; }
+        public Size TombstonesSize { get; set; }
+        public Size RevisionsSize { get; set; }
+    }
+    #endregion
+    */
+    
+    /*
+    #region stats_3_results
+    // Database stats results:
+    public class DatabaseStatistics
+    {
+        public long? LastDocEtag { get; set; }      // Last document etag in database
+        public long? LastDatabaseEtag { get; set; } // Last database etag
+        
+        public int CountOfIndexes { get; set; }     // Total # of indexes in database
+        public long CountOfDocuments { get; set; }  // Total # of documents in database
+        public long CountOfRevisionDocuments { get; set; }  // Total # of revision documents in database
+        public long CountOfDocumentsConflicts { get; set; } // Total # of documents conflicts in database
+        public long CountOfTombstones { get; set; }  // Total # of tombstones in database
+        public long CountOfConflicts { get; set; }   // Total # of conflicts in database
+        public long CountOfAttachments { get; set; } // Total # of attachments in database
+        public long CountOfUniqueAttachments { get; set; }  // Total # of unique attachments in database
+        public long CountOfCounterEntries { get; set; }     // Total # of counter-group entries in database
+        public long CountOfTimeSeriesSegments { get; set; } // Total # of time-series segments in database
+        
+        // List of stale index names in database
+        public string[] StaleIndexes => Indexes?.Where(x => x.IsStale).Select(x => x.Name).ToArray();
+        public IndexInformation[] Indexes { get; set; }  // Statistics for each index in database
+        
+        public string DatabaseChangeVector { get; set; } // Global change vector of the database
+        public string DatabaseId { get; set; } // Database identifier
+        public bool Is64Bit { get; set; }      // Indicates if process is 64-bit
+        public string Pager { get; set; }
+        public DateTime? LastIndexingTime { get; set; } // Last time of indexing an item
+        public Size SizeOnDisk { get; set; }            // Database size 
+        public Size TempBuffersSizeOnDisk { get; set; } // Temp buffers size
+        public int NumberOfTransactionMergerQueueOperations { get; set; }
+    }
+    #endregion
+    */
+    
+    /*
+    #region stats_4_results
+    // Detailed database stats results:
+    public class DetailedDatabaseStatistics : DatabaseStatistics
+    {
+        // Total # of identities in database
+        public long CountOfIdentities { get; set; }
+        // Total # of compare-exchange items in database
+        public long CountOfCompareExchange { get; set; }
+        // Total # of cmpXchg tombstones in database
+        public long CountOfCompareExchangeTombstones { get; set; }
+        // Total # of TS deleted ranges values in database
+        public long CountOfTimeSeriesDeletedRanges { get; set; }
+    }
+    #endregion
+    */
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
@@ -21,6 +21,7 @@ public class GetStats {
     
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_1
+            // Pass an instance of class `GetCollectionStatisticsOperation` to the store 
             CollectionStatistics stats
                 = store.maintenance().send(new GetCollectionStatisticsOperation());
             //endregion
@@ -28,6 +29,7 @@ public class GetStats {
         
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_2
+            // Pass an instance of class `GetDetailedCollectionStatisticsOperation` to the store 
             DetailedCollectionStatistics stats
                 = store.maintenance().send(new GetDetailedCollectionStatisticsOperation());
             //endregion
@@ -35,6 +37,7 @@ public class GetStats {
         
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_3
+            // Pass an instance of class `GetStatisticsOperation` to the store 
             DatabaseStatistics stats
                 = store.maintenance().send(new GetStatisticsOperation());
             //endregion
@@ -42,6 +45,7 @@ public class GetStats {
     
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_4
+            // Pass an instance of class `GetDetailedStatisticsOperation` to the store 
             DetailedDatabaseStatistics stats
                 = store.maintenance().send(new GetDetailedStatisticsOperation());
             //endregion
@@ -51,6 +55,7 @@ public class GetStats {
     /*
     //region stats_1_results
     public class CollectionStatistics {
+    // Collection stats results:
         // Total # of documents in all collections
         int CountOfDocuments;
         // Total # of conflicts
@@ -63,6 +68,7 @@ public class GetStats {
     
     /*
     //region stats_2_results
+    // Detailed collection stats results:
     public class DetailedCollectionStatistics  {
         // Total # of documents in all collections
         long CountOfDocuments;
@@ -86,6 +92,7 @@ public class GetStats {
     
     /*
     //region stats_3_results
+    // Database stats results:
     public class DatabaseStatistics {
         Long LastDocEtag;       // Last document etag in database
         Long LastDatabaseEtag;  // Last database etag
@@ -117,6 +124,7 @@ public class GetStats {
     
     /*
     //region stats_4_results
+    // Detailed database stats results:
     public class DetailedDatabaseStatistics extends DatabaseStatistics {
         // Total # of identities in database
         long CountOfIdentities;

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
@@ -113,7 +113,7 @@ public class GetStats {
         String DatabaseChangeVector;    // Global change vector of the database
         String DatabaseId;              // Database identifier
         boolean Is64Bit;                // Indicates if process is 64-bit
-        String Pager;
+        String Pager;                   // Component handling the memory-mapped files
         Date LastIndexingTime;          // Last time of indexing an item
         Size SizeOnDisk;                // Database size on disk
         Size TempBuffersSizeOnDisk;     // Temp buffers size on disk

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
@@ -1,0 +1,132 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+
+import net.ravendb.client.documents.operations.CollectionStatistics;
+import net.ravendb.client.documents.operations.GetCollectionStatisticsOperation;
+
+import net.ravendb.client.documents.operations.DetailedCollectionStatistics;
+import net.ravendb.client.documents.operations.GetDetailedCollectionStatisticsOperation;
+
+import net.ravendb.client.documents.operations.DatabaseStatistics;
+import net.ravendb.client.documents.operations.GetStatisticsOperation;
+
+import net.ravendb.client.documents.operations.DetailedDatabaseStatistics;
+import net.ravendb.client.documents.operations.GetDetailedStatisticsOperation;
+
+public class GetStats {
+
+    public DetailedStatistics() {
+    
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_1
+            CollectionStatistics stats
+                = store.maintenance().send(new GetCollectionStatisticsOperation());
+            //endregion
+        }
+        
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_2
+            DetailedCollectionStatistics stats
+                = store.maintenance().send(new GetDetailedCollectionStatisticsOperation());
+            //endregion
+        }
+        
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_3
+            DatabaseStatistics stats
+                = store.maintenance().send(new GetStatisticsOperation());
+            //endregion
+        }
+    
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_4
+            DetailedDatabaseStatistics stats
+                = store.maintenance().send(new GetDetailedStatisticsOperation());
+            //endregion
+        }
+    }
+    
+    /*
+    //region stats_1_results
+    public class CollectionStatistics {
+        // Total # of documents in all collections
+        int CountOfDocuments;
+        // Total # of conflicts
+        int CountOfConflicts;
+        // Total # of documents per collection
+        Map<String, Long> Collections;
+    }
+    //endregion
+    */
+    
+    /*
+    //region stats_2_results
+    public class DetailedCollectionStatistics  {
+        // Total # of documents in all collections
+        long CountOfDocuments;
+        // Total # of conflicts
+        long CountOfConflicts;
+        // Collection details per collection
+        Map<String, CollectionDetails> Collections;
+    }
+    
+    // Details per collection
+    public class CollectionDetails {
+        String Name;
+        long CountOfDocuments;
+        Size Size;
+        Size DocumentsSize;
+        Size TombstonesSize;
+        Size RevisionsSize;
+    }
+    //endregion
+    */
+    
+    /*
+    //region stats_3_results
+    public class DatabaseStatistics {
+        Long LastDocEtag;       // Last document etag in database
+        Long LastDatabaseEtag;  // Last database etag
+        
+        int CountOfIndexes;     // Total # of indexes in database
+        long CountOfDocuments;  // Total # of documents in database
+        long CountOfRevisionDocuments;  // Total # of revision documents in database
+        long CountOfDocumentsConflicts; // Total # of documents conflicts in database
+        long CountOfTombstones;         // Total # of tombstones in database
+        long CountOfConflicts;          // Total # of conflicts in database
+        long CountOfAttachments;        // Total # of attachments in database
+        long CountOfUniqueAttachments;  // Total # of unique attachments in database
+        long CountOfCounterEntries;     // Total # of counter-group entries in database
+        long CountOfTimeSeriesSegments; // Total # of time-series segments in database
+    
+        IndexInformation[] Indexes;     // Statistics for each index in database
+    
+        String DatabaseChangeVector;    // Global change vector of the database
+        String DatabaseId;              // Database identifier
+        boolean Is64Bit;                // Indicates if process is 64-bit
+        String Pager;
+        Date LastIndexingTime;          // Last time of indexing an item
+        Size SizeOnDisk;                // Database size on disk
+        Size TempBuffersSizeOnDisk;     // Temp buffers size on disk
+        int NumberOfTransactionMergerQueueOperations;
+    }
+    //endregion
+    */
+    
+    /*
+    //region stats_4_results
+    public class DetailedDatabaseStatistics extends DatabaseStatistics {
+        // Total # of identities in database
+        long CountOfIdentities;
+        // Total # of compare-exchange items in database
+        long CountOfCompareExchange;
+        // Total # of cmpXchg tombstones in database
+        long CountOfCompareExchangeTombstones;
+        // Total # of TS deleted ranges values in database
+        long CountOfTimeSeriesDeletedRanges;
+    }
+    //endregion
+    */
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
@@ -22,32 +22,40 @@ public class GetStats {
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_1
             // Pass an instance of class `GetCollectionStatisticsOperation` to the store 
-            CollectionStatistics stats
-                = store.maintenance().send(new GetCollectionStatisticsOperation());
+            CollectionStatistics stats =
+                store.maintenance().send(new GetCollectionStatisticsOperation());
             //endregion
         }
         
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_2
             // Pass an instance of class `GetDetailedCollectionStatisticsOperation` to the store 
-            DetailedCollectionStatistics stats
-                = store.maintenance().send(new GetDetailedCollectionStatisticsOperation());
+            DetailedCollectionStatistics stats =
+                store.maintenance().send(new GetDetailedCollectionStatisticsOperation());
             //endregion
         }
         
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_3
             // Pass an instance of class `GetStatisticsOperation` to the store 
-            DatabaseStatistics stats
-                = store.maintenance().send(new GetStatisticsOperation());
+            DatabaseStatistics stats =
+                store.maintenance().send(new GetStatisticsOperation());
             //endregion
         }
     
         try (IDocumentStore store = new DocumentStore()) {
             //region stats_4
             // Pass an instance of class `GetDetailedStatisticsOperation` to the store 
-            DetailedDatabaseStatistics stats
-                = store.maintenance().send(new GetDetailedStatisticsOperation());
+            DetailedDatabaseStatistics stats =
+                store.maintenance().send(new GetDetailedStatisticsOperation());
+            //endregion
+        }
+        
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_5
+            // Get stats for 'AnotherDatabase':
+            DatabaseStatistics stats =
+                store.maintenance().forDatabase("AnotherDatabase").send(new GetStatisticsOperation());
             //endregion
         }
     }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
@@ -28,6 +28,13 @@ async function getStats() {
         const stats = await store.maintenance.send(new GetDetailedStatisticsOperation());
         //endregion
     }
+    {
+        //region stats_5
+        // Get stats for 'AnotherDatabase':
+        const stats = 
+            await store.maintenance.forDatabase("AnotherDatabase").send(new GetStatisticsOperation());
+        //endregion
+    }
 }
 
 //region stats_1_results

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
@@ -86,7 +86,7 @@ interface DatabaseStatistics {
     databaseChangeVector;  // Global change vector of the database
     databaseId;            // Database identifier
     is64Bit;               // Indicates if process is 64-bit 
-    pager;                
+    pager;                 // Component handling the memory-mapped files
     lastIndexingTime;      // Last time of indexing an item
     sizeOnDisk;            // Database size on disk
     tempBuffersSizeOnDisk; // Temp buffers size on disk

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
@@ -38,79 +38,79 @@ async function getStats() {
 }
 
 //region stats_1_results
-// Collection stats results:
-interface CollectionStatistics {
+// Object with following props is returned:
+{
     // Total # of documents in all collections
-    countOfDocuments;
+    countOfDocuments,
     // Total # of conflicts
-    countOfConflicts;
+    countOfConflicts,
     // Dictionary with total # of documents per collection
-    collections;
+    collections
 }
 //endregion
 
 //region stats_2_results
-// Detailed collection stats results:
-interface DetailedCollectionStatistics {
+// Object with following props is returned:
+{
     // Total # of documents in all collections
-    countOfDocuments;
+    countOfDocuments,
     // Total # of conflicts
-    countOfConflicts;
-    // Dictionary with collection details per collection
-    collections;
+    countOfConflicts,
+    // Dictionary with 'collection details per collection'
+    collections,
 }
 
-// Details per collection
-interface CollectionDetails {
-    name;
-    countOfDocuments;
-    size;
-    documentsSize;
-    tombstonesSize;
-    revisionsSize;
+// 'Collection details per collection' object props:
+{
+    name,
+    countOfDocuments,
+    size,
+    documentsSize,
+    tombstonesSize,
+    revisionsSize
 }
 //endregion
 
 //region stats_3_results
-// Database stats results:
-interface DatabaseStatistics {
-    lastDocEtag;      // Last document etag in database
-    lastDatabaseEtag; // Last database etag
+// Object with following props is returned:
+{
+    lastDocEtag,      // Last document etag in database
+    lastDatabaseEtag, // Last database etag
     
-    countOfIndexes;            // Total # of indexes in database
-    countOfDocuments;          // Total # of documents in database
-    countOfRevisionDocuments;  // Total # of revision documents in database
-    countOfDocumentsConflicts; // Total # of documents conflicts in database 
-    countOfTombstones;         // Total # of tombstones in database
-    countOfConflicts;          // Total # of conflicts in database
-    countOfAttachments;        // Total # of attachments in database
-    countOfUniqueAttachments;  // Total # of unique attachments in database
-    countOfCounterEntries;     // Total # of counter-group entries in database
-    countOfTimeSeriesSegments; // Total # of time-series segments in database
+    countOfIndexes,            // Total # of indexes in database
+    countOfDocuments,          // Total # of documents in database
+    countOfRevisionDocuments,  // Total # of revision documents in database
+    countOfDocumentsConflicts, // Total # of documents conflicts in database 
+    countOfTombstones,         // Total # of tombstones in database
+    countOfConflicts,          // Total # of conflicts in database
+    countOfAttachments,        // Total # of attachments in database
+    countOfUniqueAttachments,  // Total # of unique attachments in database
+    countOfCounterEntries,     // Total # of counter-group entries in database
+    countOfTimeSeriesSegments, // Total # of time-series segments in database
     
-    indexes; // Statistics for each index in database (array of IndexInformation) 
+    indexes, // Statistics for each index in database (array of IndexInformation) 
 
-    databaseChangeVector;  // Global change vector of the database
-    databaseId;            // Database identifier
-    is64Bit;               // Indicates if process is 64-bit 
-    pager;                 // Component handling the memory-mapped files
-    lastIndexingTime;      // Last time of indexing an item
-    sizeOnDisk;            // Database size on disk
-    tempBuffersSizeOnDisk; // Temp buffers size on disk
-    numberOfTransactionMergerQueueOperations;
+    databaseChangeVector,  // Global change vector of the database
+    databaseId,            // Database identifier
+    is64Bit,               // Indicates if process is 64-bit 
+    pager,                 // Component handling the memory-mapped files
+    lastIndexingTime,      // Last time of indexing an item
+    sizeOnDisk,            // Database size on disk
+    tempBuffersSizeOnDisk, // Temp buffers size on disk
+    numberOfTransactionMergerQueueOperations
 }
 //endregion
 
 //region stats_4_results
-// Detailed database stats results:
-interface DetailedDatabaseStatistics extends DatabaseStatistics {
+// Resulting object contains all database stats props from above and the following in addition:
+{
     // Total # of identities in database
-    countOfIdentities;
+    countOfIdentities,
     // Total # of compare-exchange items in database
-    countOfCompareExchange;
+    countOfCompareExchange,
     // Total # of cmpXchg tombstones in database
-    countOfCompareExchangeTombstones;
+    countOfCompareExchangeTombstones,
     // Total # of TS deleted ranges values in database
-    countOfTimeSeriesDeletedRanges;
+    countOfTimeSeriesDeletedRanges
 }
 //endregion

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
@@ -1,0 +1,109 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function getStats() {
+    {
+        //region stats_1
+        // Pass an instance of class `GetCollectionStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetCollectionStatisticsOperation());
+        //endregion
+    }
+    {
+        //region stats_2
+        // Pass an instance of class `GetDetailedCollectionStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetDetailedCollectionStatisticsOperation());
+        //endregion
+    }
+    {
+        //region stats_3
+        // Pass an instance of class `GetStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetStatisticsOperation());
+        //endregion
+    }
+    {
+        //region stats_4
+        // Pass an instance of class `GetDetailedStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetDetailedStatisticsOperation());
+        //endregion
+    }
+}
+
+//region stats_1_results
+// Collection stats results:
+interface CollectionStatistics {
+    // Total # of documents in all collections
+    countOfDocuments;
+    // Total # of conflicts
+    countOfConflicts;
+    // Dictionary with total # of documents per collection
+    collections;
+}
+//endregion
+
+//region stats_2_results
+// Detailed collection stats results:
+interface DetailedCollectionStatistics {
+    // Total # of documents in all collections
+    countOfDocuments;
+    // Total # of conflicts
+    countOfConflicts;
+    // Dictionary with collection details per collection
+    collections;
+}
+
+// Details per collection
+interface CollectionDetails {
+    name;
+    countOfDocuments;
+    size;
+    documentsSize;
+    tombstonesSize;
+    revisionsSize;
+}
+//endregion
+
+//region stats_3_results
+// Database stats results:
+interface DatabaseStatistics {
+    lastDocEtag;      // Last document etag in database
+    lastDatabaseEtag; // Last database etag
+    
+    countOfIndexes;            // Total # of indexes in database
+    countOfDocuments;          // Total # of documents in database
+    countOfRevisionDocuments;  // Total # of revision documents in database
+    countOfDocumentsConflicts; // Total # of documents conflicts in database 
+    countOfTombstones;         // Total # of tombstones in database
+    countOfConflicts;          // Total # of conflicts in database
+    countOfAttachments;        // Total # of attachments in database
+    countOfUniqueAttachments;  // Total # of unique attachments in database
+    countOfCounterEntries;     // Total # of counter-group entries in database
+    countOfTimeSeriesSegments; // Total # of time-series segments in database
+    
+    indexes; // Statistics for each index in database (array of IndexInformation) 
+
+    databaseChangeVector;  // Global change vector of the database
+    databaseId;            // Database identifier
+    is64Bit;               // Indicates if process is 64-bit 
+    pager;                
+    lastIndexingTime;      // Last time of indexing an item
+    sizeOnDisk;            // Database size on disk
+    tempBuffersSizeOnDisk; // Temp buffers size on disk
+    numberOfTransactionMergerQueueOperations;
+}
+//endregion
+
+//region stats_4_results
+// Detailed database stats results:
+interface DetailedDatabaseStatistics extends DatabaseStatistics {
+    // Total # of identities in database
+    countOfIdentities;
+    // Total # of compare-exchange items in database
+    countOfCompareExchange;
+    // Total # of cmpXchg tombstones in database
+    countOfCompareExchangeTombstones;
+    // Total # of TS deleted ranges values in database
+    countOfTimeSeriesDeletedRanges;
+}
+//endregion

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,20 +1,20 @@
 [
     {
-        "Path": "get-collection-statistics.markdown",
-        "Name": "Get Collection Statistics",
-        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-        "Mappings": []
-    },
-    {
-        "Path": "get-statistics.markdown",
+        "Path": "get-stats.markdown",
         "Name": "Get Statistics",
-        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
         "Mappings": [
             {
-                "Version": 3.5,
-                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+                "Version": 4.0,
+                "Key": "client-api/operations/maintenance/get-statistics"
             }
         ]
+    },
+    {
+        "Path": "clean-change-vector.markdown",
+        "Name": "Clean Change Vector",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": []
     },
     {
         "Path": "/configuration",
@@ -32,6 +32,11 @@
         "Mappings": []
     },
     {
+        "Path": "/backup",
+        "Name": "Backup",
+        "Mappings": []
+    },
+    {
         "Path": "/etl",
         "Name": "ETL",
         "Mappings": []
@@ -39,17 +44,6 @@
     {
         "Path": "/connection-strings",
         "Name": "Connection strings",
-        "Mappings": []
-    },
-    {
-        "Path": "/backup",
-        "Name": "Backup",
-        "Mappings": []
-    },
-    {
-        "Path": "clean-change-vector.markdown",
-        "Name": "Clean Change Vector",
-        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
         "Mappings": []
     }
 ]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,20 +1,20 @@
 [
     {
-        "Path": "get-collection-statistics.markdown",
-        "Name": "Get Collection Statistics",
+        "Path": "get-stats.markdown",
+        "Name": "Get Statistic",
         "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-        "Mappings": []
-    },
-    {
-        "Path": "get-statistics.markdown",
-        "Name": "Get Statistics",
-        "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
         "Mappings": [
             {
-                "Version": 3.5,
-                "Key": "client-api/commands/how-to/get-database-and-server-statistics"
+                "Version": 4.0,
+                "Key": "client-api/operations/maintenance/get-statistics"
             }
         ]
+    },
+    {
+        "Path": "clean-change-vector.markdown",
+        "Name": "Clean Change Vector",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": []
     },
     {
         "Path": "/configuration",
@@ -32,6 +32,11 @@
         "Mappings": []
     },
     {
+        "Path": "/backup",
+        "Name": "Backup",
+        "Mappings": []
+    },
+    {
         "Path": "/etl",
         "Name": "ETL",
         "Mappings": []
@@ -39,17 +44,6 @@
     {
         "Path": "/connection-strings",
         "Name": "Connection strings",
-        "Mappings": []
-    },
-    {
-        "Path": "/backup",
-        "Name": "Backup",
-        "Mappings": []
-    },
-    {
-        "Path": "clean-change-vector.markdown",
-        "Name": "Clean Change Vector",
-        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
         "Mappings": []
     }
 ]

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/maintenance/.docs.json
@@ -1,50 +1,49 @@
 [
-  {
-    "Path": "get-collection-statistics.markdown",
-    "Name": "Get Collection Statistics",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
-  {
-    "Path": "get-statistics.markdown",
-    "Name": "Get Statistics",
-    "DiscussionId": "eca4335e-f435-4687-91db-43a41ea08aab",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "client-api/commands/how-to/get-database-and-server-statistics"
-      }
-    ]
-  },
-  {
-    "Path": "/configuration",
-    "Name": "Configuration",
-    "Mappings": []
-  },
-  {
-    "Path": "/identities",
-    "Name": "Identities",
-    "Mappings": []
-  },
-  {
-    "Path": "/indexes",
-    "Name": "Indexes",
-    "Mappings": []
-  },
-  {
-    "Path": "/etl",
-    "Name": "ETL",
-    "Mappings": []
-  },
+    {
+        "Path": "get-stats.markdown",
+        "Name": "Get Statistics",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": [
+            {
+                "Version": 4.0,
+                "Key": "client-api/operations/maintenance/get-statistics"
+            }
+        ]
+    },
+    {
+        "Path": "clean-change-vector.markdown",
+        "Name": "Clean Change Vector",
+        "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
+        "Mappings": []
+    },
+    {
+        "Path": "/configuration",
+        "Name": "Configuration",
+        "Mappings": []
+    },
+    {
+        "Path": "/identities",
+        "Name": "Identities",
+        "Mappings": []
+    },
+    {
+        "Path": "/indexes",
+        "Name": "Indexes",
+        "Mappings": []
+    },
     {
         "Path": "/backup",
         "Name": "Backup",
         "Mappings": []
     },
-      {
-    "Path": "clean-change-vector.markdown",
-    "Name": "Clean Change Vector",
-    "DiscussionId": "43588db5-317b-4d2c-afb6-5db073dca55c",
-    "Mappings": []
-  },
+    {
+        "Path": "/etl",
+        "Name": "ETL",
+        "Mappings": []
+    },
+    {
+        "Path": "/connection-strings",
+        "Name": "Connection strings",
+        "Mappings": []
+    }
 ]


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2324/Node.js-Client-API-Operations-Maintenance-Get-statistics

@ml054 
For Node.js - the files to be reviewed are:

```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/getStats.js
```

Organized the Jave files in a similar way, may want to look at that as well:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
```

