### PR TITLE
RDoc-2326 Client API > Operations > Server wide > Add database node

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.dotnet.markdown
@@ -1,0 +1,65 @@
+# Adding a Database Node
+
+---
+
+{NOTE: }
+
+* When creating a database, you specify the number of replicas for that database.  
+  This determines the number of database instances in the database-group.
+
+* __The number of replicas can be dynamically increased__ even after the database is up and running,  
+  by adding more nodes to the database-group.  
+
+* The nodes added must already exist in the [cluster topology](../../../server/clustering/rachis/cluster-topology).
+
+* Once the new node is added to the group,  
+  the cluster assigns a mentor node (from the existing database-group nodes) to update the new node.
+
+* In this page:
+    * [Add database node - random](../../../client-api/operations/server-wide/add-database-node#add-database-node---random)
+    * [Add database node - specific](../../../client-api/operations/server-wide/add-database-node#add-database-node---specific)
+    * [Syntax](../../../client-api/operations/server-wide/add-database-node#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Add database node - random}
+
+* Use `AddDatabaseNodeOperation` to add another database-instance to the database-group.
+* The node added will be a random node from the existing cluster nodes.   
+
+{CODE add_1@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+
+{PANEL/}
+
+{PANEL: Add database node - specific}
+
+* You can specify the node tag to add.  
+* This node must already exist in the cluster topology.
+
+{CODE add_2@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | string | Name of a database for which to add the node. |
+| **nodeTag** | string | Tag of node to add.<br>Default: a random node from the existing cluster topology will be added. |
+
+| Return Value<br>`DatabasePutResult` | | |
+| - | - | - |
+| RaftCommandIndex | long | Index of raft command that was executed |
+| Name | string | Database name |
+| Topology | `DatabaseTopology` | The database topology |
+| NodesAddedTo | List&lt;string&gt; | New nodes added to the cluster topology.<br>Will be 0 for this operation. |
+
+{PANEL/}
+
+
+
+
+

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.js.markdown
@@ -1,0 +1,65 @@
+# Adding a Database Node
+
+---
+
+{NOTE: }
+
+* When creating a database, you specify the number of replicas for that database.  
+  This determines the number of database instances in the database-group.
+
+* __The number of replicas can be dynamically increased__ even after the database is up and running,  
+  by adding more nodes to the database-group.  
+
+* The nodes added must already exist in the [cluster topology](../../../server/clustering/rachis/cluster-topology).
+
+* Once the new node is added to the group,  
+  the cluster assigns a mentor node (from the existing database-group nodes) to update the new node.
+
+* In this page:
+    * [Add database node - random](../../../client-api/operations/server-wide/add-database-node#add-database-node---random)
+    * [Add database node - specific](../../../client-api/operations/server-wide/add-database-node#add-database-node---specific)
+    * [Syntax](../../../client-api/operations/server-wide/add-database-node#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Add database node - random}
+
+* Use `AddDatabaseNodeOperation` to add another database-instance to the database-group.
+* The node added will be a random node from the existing cluster nodes.   
+
+{CODE:nodejs add_1@ClientApi\Operations\Server\addDatabaseNode.js /}
+
+{PANEL/}
+
+{PANEL: Add database node - specific}
+
+* You can specify the node tag to add.  
+* This node must already exist in the cluster topology.
+
+{CODE:nodejs add_2@ClientApi\Operations\Server\addDatabaseNode.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Operations\Server\addDatabaseNode.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | string | Name of a database for which to add the node. |
+| **nodeTag** | string | Tag of node to add.<br>Default: If not passed then a random node from the existing cluster topology will be added. |
+
+| Return Value<br>`DatabasePutResult` | | |
+| - | - | - |
+| raftCommandIndex | number | Index of raft command that was executed |
+| name | string | Database name |
+| topology | `DatabaseTopology` | The database topology |
+| nodesAddedTo | string[] | New nodes added to the cluster topology.<br>Will be 0 for this operation. |
+
+{PANEL/}
+
+
+
+
+

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/AddDatabaseNode.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/AddDatabaseNode.cs
@@ -17,24 +17,30 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
 
         public AddDatabaseNode()
         {
-
             using (var store = new DocumentStore())
             {
                 #region add_1
-                // Add random node to 'Northwind' database-group
-                DatabasePutResult result = store.Maintenance.Server.Send(new AddDatabaseNodeOperation("Northwind"));
+                // Create AddDatabaseNodeOperation
+                // Add a random node to 'Northwind' database-group
+                var addDatabaseNodeOperation = new AddDatabaseNodeOperation("Northwind");
+                
+                // Send operation to the store
+                DatabasePutResult result = store.Maintenance.Server.Send(addDatabaseNodeOperation);
                 
                 // Can access the new topology
                 var numberOfReplicas = result.Topology.AllNodes.Count();
-
                 #endregion
             }
             
             using (var store = new DocumentStore())
             {
                 #region add_2
+                // Create AddDatabaseNodeOperation
                 // Add node C to 'Northwind' database-group
-                DatabasePutResult result = store.Maintenance.Server.Send(new AddDatabaseNodeOperation("Northwind", "C"));
+                var addDatabaseNodeOperation = new AddDatabaseNodeOperation("Northwind", "C");
+                
+                // Send operation to the store
+                DatabasePutResult result = store.Maintenance.Server.Send(addDatabaseNodeOperation);
                 #endregion
             }
         }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/AddDatabaseNode.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/AddDatabaseNode.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+    public class AddDatabaseNode
+    {
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public AddDatabaseNodeOperation(string databaseName, string nodeTag = null)
+            #endregion
+            */
+        }
+
+        public AddDatabaseNode()
+        {
+
+            using (var store = new DocumentStore())
+            {
+                #region add_1
+                // Add random node to 'Northwind' database-group
+                DatabasePutResult result = store.Maintenance.Server.Send(new AddDatabaseNodeOperation("Northwind"));
+                
+                // Can access the new topology
+                var numberOfReplicas = result.Topology.AllNodes.Count();
+
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region add_2
+                // Add node C to 'Northwind' database-group
+                DatabasePutResult result = store.Maintenance.Server.Send(new AddDatabaseNodeOperation("Northwind", "C"));
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/addDatabaseNode.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/addDatabaseNode.js
@@ -1,0 +1,35 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function addDatabaseNode() {
+    {
+        //region add_1
+        // Create AddDatabaseNodeOperation
+        // Add a random node to 'Northwind' database-group
+        const addDatabaseNodeOperation = new AddDatabaseNodeOperation("Northwind");
+        
+        // Send operation to the store
+        const result = await documentStore.maintenance.server.send(addDatabaseNodeOperation);
+
+        // Can access the new topology
+        const numberOfReplicas = getAllNodesFromTopology(result.topology).length;
+        //endregion    
+    }
+    {
+        //region add_2
+        // Create AddDatabaseNodeOperation
+        // Add node C to 'Northwind' database-group
+        const addDatabaseNodeOperation = new AddDatabaseNodeOperation("Northwind", "C"));
+
+        // Send operation to the store
+        const result = await documentStore.maintenance.server.send(addDatabaseNodeOperation);
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const addDatabaseNodeOperation = new AddDatabaseNodeOperation(databaseName, nodeTag?);
+    //endregion
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2326/Client-API-Operations-Server-wide-Add-database-node

@ml054 
For Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/addDatabaseNode.js
```