### PR TITLE
RDoc-2331 [Node.js] Client API > Operations > How to > Switch operation to diff database

### DIFF
--- a/Documentation/4.1/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
@@ -36,7 +36,7 @@
 
 * **Databases temporary files**  
   By default, all databases' temporary files are written to the `Temp` folder under each Database directory.  
-  Customize the files path by setting configuration option [Storage.TempPath](../..//server/configuration/storage-configuration#storage.temppath) in your _settings.json_ file.  
+  Customize the files path by setting configuration option [Storage.TempPath](../../server/configuration/storage-configuration#storage.temppath) in your _settings.json_ file.  
 
 * **Indexes temporary files**  
   By default, all indexes' temporary files are written to the `Temp` folder under each Index directory.  

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/.docs.json
@@ -1,8 +1,14 @@
 [
-  {
-    "Path": "switch-operations-to-a-different-database.markdown",
-    "Name": "...switch operations to different database",
-    "DiscussionId": "9e232ccc-1683-4e5c-993d-c6948a2a5f51",
-    "Mappings": []
-  }
+    {
+        "Path": "switch-operations-to-a-different-database.markdown",
+        "Name": "Switch operations to different database",
+        "DiscussionId": "9e232ccc-1683-4e5c-993d-c6948a2a5f51",
+        "Mappings": []
+    },
+    {
+        "Path": "switch-operations-to-different-node.markdown",
+        "Name": "Switch operations to different node",
+        "DiscussionId": "9e232ccc-1683-4e5c-993d-c6948a2a5f51",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/.docs.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Path": "switch-operations-to-a-different-database.markdown",
+    "Name": "...switch operations to different database",
+    "DiscussionId": "9e232ccc-1683-4e5c-993d-c6948a2a5f51",
+    "Mappings": []
+  }
+]

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
@@ -18,6 +18,8 @@
 
 {PANEL: Common operations - ForDatabase}
 
+* For reference, all common operations are listed [here](../../../client-api/operations/what-are-operations#the-following-operations-are-available).
+
 {CODE for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
 
 __Syntax__:
@@ -26,7 +28,7 @@ __Syntax__:
 
 | Parameters | Type | Description |
 | - | - | - |
-| **databaseName** | string | Name of a database to operate on |
+| **databaseName** | string | Name of the database to operate on |
 
 | Return Value | |
 | - | - |
@@ -36,6 +38,8 @@ __Syntax__:
 
 {PANEL: Maintenance operations - ForDatabase}
 
+* For reference, all maintenance operations are listed [here](../../../client-api/operations/what-are-operations#the-following-maintenance-operations-are-available).
+
 {CODE for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
 
 __Syntax__:
@@ -44,7 +48,7 @@ __Syntax__:
 
 | Parameters | Type | Description |
 | - | - | - |
-| **databaseName** | string | Name of a database to operate on |
+| **databaseName** | string | Name of the database to operate on |
 
 | Return Value | |
 | - | - |

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
@@ -6,17 +6,17 @@
 
 * By default, all operations work on the default database defined in the [Document Store](../../../client-api/creating-document-store).
 
-* To operate on a different database, use the `ForDatabase` method.  
+* __To operate on a different database__, use the `ForDatabase` method.  
   (An exception is thrown if that database doesn't exist on the server).
 
 * In this page:
-    * [Common operations](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operations)
-    * [Maintenance operations](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operations)
+    * [Common operations - ForDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operations---fordatabase)
+    * [Maintenance operations - ForDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operations---fordatabase)
 {NOTE/}
 
 ---
 
-{PANEL: Common operations}
+{PANEL: Common operations - ForDatabase}
 
 {CODE for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
 
@@ -34,7 +34,7 @@ __Syntax__:
 
 {PANEL/}
 
-{PANEL: Maintenance operations}
+{PANEL: Maintenance operations - ForDatabase}
 
 {CODE for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
@@ -1,0 +1,59 @@
+# Switch Operations to a Different Database
+
+---
+
+{NOTE: }
+
+* By default, all operations work on the default database defined in the [Document Store](../../../client-api/creating-document-store).
+
+* To operate on a different database, use the `ForDatabase` method.  
+  (An exception is thrown if that database doesn't exist on the server).
+
+* In this page:
+    * [Common operations](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operations)
+    * [Maintenance operations](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operations)
+{NOTE/}
+
+---
+
+{PANEL: Common operations}
+
+{CODE for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+__Syntax__:
+
+{CODE syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | string | Name of a database to operate on |
+
+| Return Value | |
+| - | - |
+| `OperationExecutor` | New instance of Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+{PANEL: Maintenance operations}
+
+{CODE for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+__Syntax__:
+
+{CODE syntax_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | string | Name of a database to operate on |
+
+| Return Value | |
+| - | - |
+| `MaintenanceOperationExecutor` | New instance of Maintenance Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.java.markdown
@@ -1,0 +1,49 @@
+# Switch Operations to a Different Database
+
+By default, the operations available directly in store are working on a default database that was setup for that store. To switch operations to a different database that is available on that server use the **forDatabase** method.
+
+{PANEL:Operations.forDatabase}
+
+{CODE:java for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **databaseName** | String | Name of a database for which you want to get new Operations |
+
+| Return Value | |
+| ------------- | ----- |
+| OperationExecutor | New instance of Operations that is scoped to the requested database |
+
+### Example
+
+{CODE:java for_database_3@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+{PANEL/}
+
+## How to Switch Maintenance Operations to a Different Database
+
+As with `operations`, by default the `maintenance` operations available directly in store are working on a default database that was setup for that store. To switch maintenance operations to a different database use the **forDatabase** method.
+
+{PANEL:Maintenance.forDatabase}
+
+{CODE:java for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **databaseName** | String | Name of a database for which you want to get new maintenance operations |
+
+| Return Value | |
+| ------------- | ----- |
+| MaintenanceOperationExecutor | New instance of maintenance that is scoped to the requested database |
+
+### Example
+
+{CODE:java for_database_4@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
@@ -18,6 +18,8 @@
 
 {PANEL: Common operations - forDatabase}
 
+* For reference, all common operations are listed [here](../../../client-api/operations/what-are-operations#the-following-operations-are-available).
+
 {CODE:nodejs for_database_1@ClientApi\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
 
 __Syntax__:
@@ -26,7 +28,7 @@ __Syntax__:
 
 | Parameters | Type | Description |
 | - | - | - |
-| **databaseName** | string | Name of a database to operate on |
+| **databaseName** | string | Name of the database to operate on |
 
 | Return Value | |
 | - | - |
@@ -36,6 +38,8 @@ __Syntax__:
 
 {PANEL: Maintenance operations - forDatabase}
 
+* For reference, all maintenance operations are listed [here](../../../client-api/operations/what-are-operations#the-following-maintenance-operations-are-available).
+
 {CODE:nodejs for_database_2@ClientApi\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
 
 __Syntax__:
@@ -44,7 +48,7 @@ __Syntax__:
 
 | Parameters | Type | Description |
 | - | - | - |
-| **databaseName** | string | Name of a database to operate on |
+| **databaseName** | string | Name of the database to operate on |
 
 | Return Value | |
 | - | - |

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
@@ -1,0 +1,59 @@
+# Switch Operations to a Different Database
+
+---
+
+{NOTE: }
+
+* By default, all operations work on the default database defined in the [document store](../../../client-api/creating-document-store).
+
+* __To operate on a different database__, use the `forDatabase` method.  
+  (An exception is thrown if that database doesn't exist on the server).
+
+* In this page:
+    * [Common operations - forDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operations---fordatabase)
+    * [Maintenance operations - forDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operations---fordatabase)
+{NOTE/}
+
+---
+
+{PANEL: Common operations - forDatabase}
+
+{CODE:nodejs for_database_1@ClientApi\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+__Syntax__:
+
+{CODE:nodejs syntax_1@ClientApi\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | string | Name of a database to operate on |
+
+| Return Value | |
+| - | - |
+| `OperationExecutor` | New instance of Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+{PANEL: Maintenance operations - forDatabase}
+
+{CODE:nodejs for_database_2@ClientApi\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+__Syntax__:
+
+{CODE:nodejs syntax_2@ClientApi\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | string | Name of a database to operate on |
+
+| Return Value | |
+| - | - |
+| `MaintenanceOperationExecutor` | New instance of Maintenance Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-different-node.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-different-node.dotnet.markdown
@@ -1,0 +1,44 @@
+# Switch Operations to a Different Node
+
+---
+
+{NOTE: }
+
+* By default, when working with multiple nodes,  
+  all client requests will access the server node that is defined by the client configuration.  
+  (Learn more in: [ReadBalanceBehavior](../../../client-api/configuration/load-balance-and-failover) & [LoadBalanceBehavior](../../../client-api/session/configuration/use-session-context-for-load-balancing)).
+
+* __Maintenance server operations__ can be executed on a specific node by using the `ForNode` method.  
+  (An exception is thrown if that node is not available).
+
+* In this page:
+    * [Maintenance server operations - ForNode](../../../client-api/operations/how-to/switch-operations-to-different-node#maintenance-server-operations---fornode)
+{NOTE/}
+
+---
+
+{PANEL: Maintenance server operations - ForNode}
+
+* For reference, all maintenance server operations are listed [here](../../../client-api/operations/what-are-operations#the-following-server-wide-operations-are-available).
+
+{CODE for_node_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentNode.cs /}
+
+__Syntax__:
+
+{CODE syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentNode.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **nodeTag** | string | The tag of the node to operate on |
+
+| Return Value | |
+| - | - |
+| `ServerOperationExecutor` | New instance of Server Operation Executor that is scoped to the requested node |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-different-node.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-different-node.js.markdown
@@ -1,0 +1,44 @@
+# Switch Operations to a Different Node
+
+---
+
+{NOTE: }
+
+* By default, when working with multiple nodes,  
+  all client requests will access the server node that is defined by the client configuration.  
+  (Learn more in: [readBalanceBehavior](../../../client-api/configuration/load-balance-and-failover) & [loadBalanceBehavior](../../../client-api/session/configuration/use-session-context-for-load-balancing)).
+
+* __Maintenance server operations__ can be executed on a specific node by using the `forNode` method.  
+  (An exception is thrown if that node is not available).
+
+* In this page:
+    * [Maintenance server operations - forNode](../../../client-api/operations/how-to/switch-operations-to-different-node#maintenance-server-operations---fornode)
+{NOTE/}
+
+---
+
+{PANEL: Maintenance server operations - forNode}
+
+* For reference, all maintenance server operations are listed [here](../../../client-api/operations/what-are-operations#the-following-server-wide-operations-are-available).
+
+{CODE:nodejs for_node_1@ClientApi\Operations\HowTo\switchOperationsToDifferentNode.js /}
+
+__Syntax__:
+
+{CODE:nodejs syntax_1@ClientApi\Operations\HowTo\switchOperationsToDifferentNode.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **nodeTag** | string | The tag of the node to operate on |
+
+| Return Value | |
+| - | - |
+| `Promise<ServerOperationExecutor>` | A promise that returns a new instance of Server Operation Executor<br>scoped to the requested node |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
@@ -24,14 +24,16 @@ namespace Raven.Documentation.Samples.ClientApi.Operations
         public void SwitchOperationToDifferentDatabase()
         {
             #region for_database_1
+            // Define default database on the store
             var documentStore = new DocumentStore
             {
-                Database = "DefaultDB" // Define default database on the store
+                Urls = new[] { "yourServerURL" },
+                Database = "DefaultDB"
             }.Initialize();
             
             using (documentStore)
             {
-                // Get operation executor for another database
+                // Use 'ForDatabase', get operation executor for another database
                 OperationExecutor opExecutor = documentStore.Operations.ForDatabase("AnotherDB");
                 
                 // Send the operation, e.g. 'GetRevisionsOperation' will be executed on "AnotherDB"
@@ -48,17 +50,19 @@ namespace Raven.Documentation.Samples.ClientApi.Operations
         public void SwitchMaintenanceOperationToDifferentDatabase()
         {
             #region for_database_2
+            // Define default database on the store
             var documentStore = new DocumentStore
             {
-                Database = "DefaultDB" // Define default database on the store
+                Urls = new[] { "yourServerURL" },
+                Database = "DefaultDB"
             }.Initialize();
             
             using (documentStore = new DocumentStore())
             {
-                // Get maintenance operation executor for another database
+                // Use 'ForDatabase', get maintenance operation executor for another database
                 MaintenanceOperationExecutor opExecutor = documentStore.Maintenance.ForDatabase("AnotherDB");
                 
-                // Send the operation, e.g. get database stats for "AnotherDB"
+                // Send the maintenance operation, e.g. get database stats for "AnotherDB"
                 var statsForAnotherDB =
                     opExecutor.Send(new GetStatisticsOperation());
                 

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
@@ -1,0 +1,72 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations
+{
+    public class SwitchOperationsToDifferentDatabase
+    {
+        private interface OperationsForDatabaseSyntax
+        {
+            #region syntax_1
+            OperationExecutor ForDatabase(string databaseName);
+            #endregion
+        }
+        
+        private interface MaintenanceForDatabaseSyntax
+        {
+            #region syntax_2
+            MaintenanceOperationExecutor ForDatabase(string databaseName);
+            #endregion
+        }
+
+        public void SwitchOperationToDifferentDatabase()
+        {
+            #region for_database_1
+            var documentStore = new DocumentStore
+            {
+                Database = "DefaultDB" // Define default database on the store
+            }.Initialize();
+            
+            using (documentStore)
+            {
+                // Get operation executor for another database
+                OperationExecutor opExecutor = documentStore.Operations.ForDatabase("AnotherDB");
+                
+                // Send the operation, e.g. 'GetRevisionsOperation' will be executed on "AnotherDB"
+                var revisionsInAnotherDB = 
+                    opExecutor.Send(new GetRevisionsOperation<Order>("Orders/1-A"));
+             
+                // Without 'ForDatabase', the operation is executed "DefaultDB"
+                var revisionsInDefaultDB =
+                    documentStore.Operations.Send(new GetRevisionsOperation<Company>("Company/1-A"));
+            }
+            #endregion
+        }
+        
+        public void SwitchMaintenanceOperationToDifferentDatabase()
+        {
+            #region for_database_2
+            var documentStore = new DocumentStore
+            {
+                Database = "DefaultDB" // Define default database on the store
+            }.Initialize();
+            
+            using (documentStore = new DocumentStore())
+            {
+                // Get maintenance operation executor for another database
+                MaintenanceOperationExecutor opExecutor = documentStore.Maintenance.ForDatabase("AnotherDB");
+                
+                // Send the operation, e.g. get database stats for "AnotherDB"
+                var statsForAnotherDB =
+                    opExecutor.Send(new GetStatisticsOperation());
+                
+                // Without 'ForDatabase', the stats are retrieved for "DefaultDB"
+                var statsForDefaultDB =
+                    documentStore.Maintenance.Send(new GetStatisticsOperation());
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
@@ -3,7 +3,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Documentation.Samples.Orders;
 
-namespace Raven.Documentation.Samples.ClientApi.Operations
+namespace Raven.Documentation.Samples.ClientApi.Operations.HowTo
 {
     public class SwitchOperationsToDifferentDatabase
     {

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentNode.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentNode.cs
@@ -1,0 +1,45 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.HowTo
+{
+    public class SwitchOperationsToDifferentNode
+    {
+        private interface OperationsForDatabaseSyntax
+        {
+            #region syntax_1
+            ServerOperationExecutor ForNode(string nodeTag);
+            #endregion
+        }
+
+        public void SwitchOperationToDifferentNode()
+        {
+            #region for_node_1
+            // Default node access can be defined on the store
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "ServerURL_1", "ServerURL_2", "..." },
+                Database = "DefaultDB",
+                Conventions = new DocumentConventions
+                {
+                    // For example:
+                    // With ReadBalanceBehavior set to: 'FastestNode':
+                    // Client READ requests will address the fastest node
+                    // Client WRITE requests will address the preferred node
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                }
+            }.Initialize();
+            
+            using (documentStore)
+            {
+                // Use 'ForNode' to override the default node configuration
+                // The Maintenance.Server operation will be executed on the specified node
+                var dbNames = documentStore.Maintenance.Server.ForNode("C")
+                    .Send(new GetDatabaseNamesOperation(0, 25));
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.java
@@ -1,0 +1,32 @@
+package net.ravendb.ClientApi.Operations.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.MaintenanceOperationExecutor;
+import net.ravendb.client.documents.operations.OperationExecutor;
+
+public class SwitchOperationsToDifferentDatabase {
+    private interface ForDatabase1 {
+        //region for_database_1
+        OperationExecutor forDatabase(String databaseName);
+        //endregion
+    }
+
+    private interface ForDatabase2 {
+        //region for_database_2
+        MaintenanceOperationExecutor forDatabase(String databaseName);
+        //endregion
+    }
+
+    public SwitchOperationsToDifferentDatabase() {
+        try (IDocumentStore documentStore = new DocumentStore()) {
+            //region for_database_3
+            OperationExecutor operations = documentStore.operations().forDatabase("otherDatabase");
+            //endregion
+
+            //region for_database_4
+            MaintenanceOperationExecutor maintenanceOperations = documentStore.maintenance().forDatabase("otherDatabase");
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentDatabase.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentDatabase.js
@@ -32,11 +32,11 @@ async function addDatabaseNode() {
 
         // Send the maintenance operation, e.g. get database stats for "AnotherDB"
         const statsForAnotherDB =
-            opExecutor.send(new GetStatisticsOperation());
+            await opExecutor.send(new GetStatisticsOperation());
 
         // Without 'forDatabase', the stats are retrieved for "DefaultDB"
         const statsForDefaultDB =
-            documentStore.maintenance.send(new GetStatisticsOperation());
+            await documentStore.maintenance.send(new GetStatisticsOperation());
         //endregion
     }
 }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentDatabase.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentDatabase.js
@@ -1,0 +1,53 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function addDatabaseNode() {
+    {
+        //region for_database_1
+        // Define default database on the store
+        const documentStore = new DocumentStore("yourServerURL", "DefaultDB");
+        documentStore.initialize();
+
+        // Use 'forDatabase', get operation executor for another database
+         const opExecutor = documentStore.operations.forDatabase("AnotherDB");
+
+        // Send the operation, e.g. 'GetRevisionsOperation' will be executed on "AnotherDB"
+        const revisionsInAnotherDB =
+            await opExecutor.send(new GetRevisionsOperation("Orders/1-A"));
+
+        // Without 'forDatabase', the operation is executed "DefaultDB"
+        const revisionsInDefaultDB =
+           await documentStore.operations.send(new GetRevisionsOperation("Company/1-A"));
+        //endregion
+    }
+    {
+        //region for_database_2
+        // Define default database on the store
+        const documentStore = new DocumentStore("yourServerURL", "DefaultDB");
+        documentStore.initialize();
+
+        // Use 'forDatabase', get maintenance operation executor for another database
+        const opExecutor = documentStore.maintenance.forDatabase("AnotherDB");
+
+        // Send the maintenance operation, e.g. get database stats for "AnotherDB"
+        const statsForAnotherDB =
+            opExecutor.send(new GetStatisticsOperation());
+
+        // Without 'forDatabase', the stats are retrieved for "DefaultDB"
+        const statsForDefaultDB =
+            documentStore.maintenance.send(new GetStatisticsOperation());
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    store.operations.forDatabase(databaseName);
+    //endregion
+}
+{
+    //region syntax_2
+    store.maintenance.forDatabase(databaseName);
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentNode.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentNode.js
@@ -1,0 +1,32 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function addDatabaseNode() {
+    {
+        //region for_node_1
+        // Default node access can be defined on the store        
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+        
+        // For example:
+        // With readBalanceBehavior set to: 'FastestNode':
+        // Client READ requests will address the fastest node
+        // Client WRITE requests will address the preferred node
+        documentStore.conventions.readBalanceBehavior = "FastestNode";
+        documentStore.initialize();
+        
+        // Use 'forNode' to override the default node configuration 
+        // Get a server operation executor for a specific node
+        const serverOpExecutor = await documentStore.maintenance.server.forNode("C");
+
+        // The maintenance.server operation will be executed on the specified node 'C'
+        const dbNames = await serverOpExecutor.send(new GetDatabaseNamesOperation(0, 25));
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    await store.maintenance.server.forNode(nodeTag);
+    //endregion
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2331/Node.js-Client-API-Operations-How-to-Switch-operation-to-diff-database

@ml054 
For Node.js - files to be reviewed:

**Switch Database:**
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentDatabase.js
```
**Switch Node:**
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-different-node.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/HowTo/switchOperationsToDifferentNode.js
```



**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling.