### PR TITLE
RDoc-2344 [Node.js] Client API > Operations > Maintenance > Indexes >…

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.dotnet.markdown
@@ -1,0 +1,84 @@
+# Disable Index Operation
+
+ ---
+
+{NOTE: }
+
+* Use `DisableIndexOperation` to disable a specific index.  
+
+* The index can be disabled either:  
+  * On a single node, or  
+  * Cluster wide - on all database-group nodes.  
+
+* __When index is disabled__:  
+  * No indexing will take place, new data will not be indexed.  
+  * You can still query the index,  
+    but results may be stale when querying a node on which the index was disabled.  
+
+* Disabling an index is a __persistent operation__:
+    * The index will remain disabled even after restarting the server or after disabling/enabling the database.
+    * To enable back the index use [enable index operation](../../../../client-api/operations/maintenance/indexes/enable-index).
+    * To only pause indexing and resume after a restart go to: [stop index operation](../../../../client-api/operations/maintenance/indexes/stop-index).
+
+* Disabling/enabling an index can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio. 
+
+* In this page:
+    * [Disable index - single node](../../../../client-api/operations/maintenance/indexes/disable-index#disable-index---single-node)
+    * [Disable index - cluster wide](../../../../client-api/operations/maintenance/indexes/disable-index#disable-index---cluster-wide)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/disable-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Disable index - single node}
+
+* With this option, the index will be disabled on the [preferred node](../../../../client-api/configuration/load-balance-and-failover#preferred-node) only.  
+  The preferred node is simply the first node in the [database group topology](../../../../studio/database/settings/manage-database-group).
+
+* Note: When disabling an index from the [Studio](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions),  
+  you can disable it on the local node the browser is opened on, even if it is Not the preferred node.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_1@ClientApi\Operations\Maintenance\Indexes\DisableIndex.cs /}
+{CODE-TAB:csharp:Async disable_1_async@ClientApi\Operations\Maintenance\Indexes\DisableIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Disable index - cluster wide}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_2@ClientApi\Operations\Maintenance\Indexes\DisableIndex.cs /}
+{CODE-TAB:csharp:Async disable_2_async@ClientApi\Operations\Maintenance\Indexes\DisableIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:csharp syntax@ClientApi\Operations\Maintenance\Indexes\DisableIndex.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | string | Name of index to disable |
+| **clusterWide** | bool | `true` - Disable index on all database-group nodes<br>`false` - Disable index only on a single node (the preferred node) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [How to Enable Index](../../../../client-api/operations/maintenance/indexes/enable-index)
+- [How to Stop Index Until Restart](../../../../client-api/operations/maintenance/indexes/stop-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.java.markdown
@@ -1,0 +1,34 @@
+# Disable Index Operation
+
+The **DisableIndexOperation** is used to turn the indexing off for a given index. Querying a `disabled` index is allowed, but it may return stale results.
+
+{NOTE Unlike [StopIndex](../../../../client-api/operations/maintenance/indexes/stop-index) or [StopIndexing](../../../../client-api/operations/maintenance/indexes/stop-indexing) disable index is a persistent operation, so the index remains disabled even after a server restart. /}
+
+
+## Syntax
+
+{CODE:java disable_1@ClientApi\Operations\Maintenance\Indexes\DisableIndex.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | name of an index to disable indexing |
+
+## Example
+
+{CODE:java disable_2@ClientApi\Operations\Maintenance\Indexes\DisableIndex.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Enable Index](../../../../client-api/operations/maintenance/indexes/enable-index)
+- [How to Stop Index Until Restart](../../../../client-api/operations/maintenance/indexes/stop-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.js.markdown
@@ -1,0 +1,77 @@
+# Disable Index Operation
+
+ ---
+
+{NOTE: }
+
+* Use `DisableIndexOperation` to disable a specific index.  
+
+* The index can be disabled either:  
+  * On a single node, or  
+  * Cluster wide - on all database-group nodes.  
+
+* __When index is disabled__:  
+  * No indexing will take place, new data will not be indexed.  
+  * You can still query the index,  
+    but results may be stale when querying a node on which the index was disabled.  
+
+* Disabling an index is a __persistent operation__:  
+  * The index will remain disabled even after restarting the server or after disabling/enabling the database.  
+  * To enable back the index use [enable index operation](../../../../client-api/operations/maintenance/indexes/enable-index).  
+  * To only pause indexing and resume after a restart go to: [stop index operation](../../../../client-api/operations/maintenance/indexes/stop-index).   
+
+* Disabling/enabling an index can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio. 
+
+* In this page:
+    * [Disable index - single node](../../../../client-api/operations/maintenance/indexes/disable-index#disable-index---single-node)
+    * [Disable index - cluster wide](../../../../client-api/operations/maintenance/indexes/disable-index#disable-index---cluster-wide)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/disable-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Disable index - single node}
+
+* With this option, the index will be disabled on the [preferred node](../../../../client-api/configuration/load-balance-and-failover#preferred-node) only.  
+  The preferred node is simply the first node in the [database group topology](../../../../studio/database/settings/manage-database-group).
+
+* Note: When disabling an index from the [Studio](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions),  
+  you can disable it on the local node the browser is opened on, even if it is Not the preferred node.
+
+{CODE:nodejs disable_1@ClientApi\Operations\Maintenance\Indexes\disableIndex.js /}
+{PANEL/}
+
+{PANEL: Disable index - cluster wide}
+
+{CODE:nodejs disable_2@ClientApi\Operations\Maintenance\Indexes\disableIndex.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Operations\Maintenance\Indexes\disableIndex.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | string | Name of index to disable |
+| **clusterWide** | boolean | `true` - Disable index on all database-group nodes<br>`false` - Disable index only on a single node (the preferred node) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [How to Enable Index](../../../../client-api/operations/maintenance/indexes/enable-index)
+- [How to Stop Index Until Restart](../../../../client-api/operations/maintenance/indexes/stop-index)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/DisableIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/DisableIndex.cs
@@ -1,0 +1,82 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class DisableIndex
+    {
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            // Available overloads:
+            public DisableIndexOperation(string indexName)
+            public DisableIndexOperation(string indexName, bool clusterWide)
+            #endregion
+            */
+        }
+
+        public DisableIndex()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region disable_1
+                // Use this overload to disable on a single node
+                var disableIndexOp = new DisableIndexOperation("Orders/Totals");
+                
+                // Execute the operation by passing it to Maintenance.Send
+                store.Maintenance.Send(disableIndexOp);
+                
+                // At this point, the index is disabled only on the 'preferred node'
+                // New data will not be indexed on this node only
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region disable_2
+                // Pass 'true' to disable the index on all nodes in the database-group
+                var disableIndexOp = new DisableIndexOperation("Orders/Totals", true);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                store.Maintenance.Send(disableIndexOp);
+                
+                // At this point, the index is disabled on all nodes
+                // New data will not be indexed
+                #endregion
+            }
+        }
+        
+        public async Task DisableIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region disable_1_async
+                // Use this overload to disable on a single node
+                var disableIndexOp = new DisableIndexOperation("Orders/Totals");
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                await store.Maintenance.SendAsync(disableIndexOp);
+                
+                // At this point, the index is disabled only on the 'preferred node'
+                // New data will not be indexed on this node only
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region disable_2_async
+                // Pass 'true' to disable the index on all nodes in the database-group
+                var disableIndexOp = new DisableIndexOperation("Orders/Totals", true);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                await store.Maintenance.SendAsync(disableIndexOp);
+                
+                // At this point, the index is disabled on all nodes
+                // New data will not be indexed
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/DisableIndex.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/DisableIndex.java
@@ -1,0 +1,26 @@
+package net.ravendb.ClientApi.Operations.Indexes;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.indexes.DisableIndexOperation;
+
+public class DisableIndex {
+
+    private interface IFoo {
+        /*
+        //region disable_1
+        public DisableIndexOperation(String indexName)
+        //endregion
+        */
+    }
+
+    public DisableIndex() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region disable_2
+            store.maintenance().send(new DisableIndexOperation("Orders/Totals"));
+            // index is disabled at this point, new data won't be indexed
+            // but you can still query on this index
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/disableIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/disableIndex.js
@@ -1,0 +1,39 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getStats() {
+    {
+        //region disable_1
+        // Define the disable index operation
+        // Use this overload to disable on a single node
+        const disableIndexOp = new DisableIndexOperation("Orders/Totals");
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(disableIndexOp);
+
+        // At this point, the index is disabled only on the 'preferred node'
+        // New data will not be indexed on this node only
+        //endregion
+    }
+    {
+        //region disable_2
+        // Define the disable index operation
+        // Pass 'true' to disable the index on all nodes in the database-group
+        const disableIndexOp = new DisableIndexOperation("Orders/Totals", true);
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(disableIndexOp);
+
+        // At this point, the index is disabled on all nodes
+        // New data will not be indexed
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const disableIndexOp = new DisableIndexOperation(indexName, clusterWide = false);
+    //endregion
+
+}


### PR DESCRIPTION
… Disable index

**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2344/Node.js-Client-API-Operations-Maintenance-Indexes-Disable-index

@ml054 
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/disableIndex.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling.