### PR TITLE
RDoc-2347 [Node.js] Client API > Operations > Maintenance > Indexes >…

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.dotnet.markdown
@@ -1,0 +1,77 @@
+# Enable Index Operation
+
+ ---
+
+{NOTE: }
+
+* Use `EnableIndexOperation` to enable a specific index.  
+
+* The index can be enabled either:  
+    * On a single node, or  
+    * Cluster wide - on all database-group nodes.  
+
+* When index is enabled indexing will take place, new data will be indexed.  
+
+* To disable the index use [disable index operation](../../../../client-api/operations/maintenance/indexes/disable-index).  
+  Disabling/enabling an index can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.
+
+* In this page:
+    * [Enable index - single node](../../../../client-api/operations/maintenance/indexes/enable-index#enable-index---single-node)
+    * [Enable index - cluster wide](../../../../client-api/operations/maintenance/indexes/enable-index#enable-index---cluster-wide)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/enable-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Enable index - single node}
+
+* With this option, the index will be enabled on the [preferred node](../../../../client-api/configuration/load-balance-and-failover#preferred-node) only.  
+  The preferred node is simply the first node in the [database group topology](../../../../studio/database/settings/manage-database-group).
+
+* Note: When enabling an index from the [Studio](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions),  
+  you can enable it on the local node the browser is opened on, even if it is Not the preferred node.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync enable_1@ClientApi\Operations\Maintenance\Indexes\EnableIndex.cs /}
+{CODE-TAB:csharp:Async enable_1_async@ClientApi\Operations\Maintenance\Indexes\EnableIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Enable index - cluster wide}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync enable_2@ClientApi\Operations\Maintenance\Indexes\EnableIndex.cs /}
+{CODE-TAB:csharp:Async enable_2_async@ClientApi\Operations\Maintenance\Indexes\EnableIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:csharp syntax@ClientApi\Operations\Maintenance\Indexes\EnableIndex.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | string | Name of index to enable |
+| **clusterWide** | bool | `true` - Enable index on all database-group nodes<br>`false` - Enable index only on a single node (the preferred node) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [How to Disable Index](../../../../client-api/operations/maintenance/indexes/disable-index)
+- [How to Stop Index Until Restart](../../../../client-api/operations/maintenance/indexes/stop-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.java.markdown
@@ -1,0 +1,32 @@
+# Enable Index Operation
+
+The **EnableIndexOperation** is used to turn on the indexing for a given index.
+
+
+## Syntax
+
+{CODE:java enable_1@ClientApi\Operations\Maintenance\Indexes\EnableIndex.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | name of an index to enable indexing |
+
+## Example
+
+{CODE:java enable_2@ClientApi\Operations\Maintenance\Indexes\EnableIndex.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Disable Index](../../../../client-api/operations/maintenance/indexes/disable-index)
+- [How to Stop Index Until Restart](../../../../client-api/operations/maintenance/indexes/stop-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.js.markdown
@@ -1,0 +1,71 @@
+# Enable Index Operation
+
+ ---
+
+{NOTE: }
+
+* Use `EnableIndexOperation` to enable a specific index.
+
+* The index can be enabled either:
+    * On a single node, or
+    * Cluster wide - on all database-group nodes.
+
+* When index is enabled indexing will take place, new data will be indexed.
+
+* To disable the index use [disable index operation](../../../../client-api/operations/maintenance/indexes/disable-index).  
+  Disabling/enabling an index can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.
+
+* In this page:
+    * [Enable index - single node](../../../../client-api/operations/maintenance/indexes/enable-index#enable-index---single-node)
+    * [Enable index - cluster wide](../../../../client-api/operations/maintenance/indexes/enable-index#enable-index---cluster-wide)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/enable-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Enable index - single node}
+
+* With this option, the index will be enabled on the [preferred node](../../../../client-api/configuration/load-balance-and-failover#preferred-node) only.  
+  The preferred node is simply the first node in the [database group topology](../../../../studio/database/settings/manage-database-group).
+
+* Note: When enabling an index from the [Studio](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions),  
+  you can enable it on the local node the browser is opened on, even if it is Not the preferred node.
+
+{CODE:nodejs enable_1@ClientApi\Operations\Maintenance\Indexes\enableIndex.js /}
+
+{PANEL/}
+
+{PANEL: Enable index - cluster wide}
+
+{CODE:nodejs enable_2@ClientApi\Operations\Maintenance\Indexes\enableIndex.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Operations\Maintenance\Indexes\enableIndex.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | string | Name of index to enable |
+| **clusterWide** | bool | `true` - Enable index on all database-group nodes<br>`false` - Enable index only on a single node (the preferred node) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [How to Disable Index](../../../../client-api/operations/maintenance/indexes/disable-index)
+- [How to Stop Index Until Restart](../../../../client-api/operations/maintenance/indexes/stop-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/indexes-list-view.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/indexes-list-view.markdown
@@ -47,15 +47,19 @@
 * `Paused`  
    * New data is not being indexed.  
    * Queries will be stale as new data is not indexed.  
-   * The indexing process will resume upon setting _'Resume'_ or when the server is _restarted_.  
+   * The indexing process will resume upon either of the following:  
+     * Setting _'Resume indexing'_  
+     * Restarting the server  
+     * Reloading the database (by disabling-enabling the database).  
 
 * `Disabled`  
    * New data is not being indexed.  
    * Queries will be stale as new data is not indexed.  
-   * The indexing process will _not_ automatically resume upon a server restart, but only when setting _'Enable'_.  
+   * The indexing process will resume only when setting _'Enable indexing'_.  
+     It will _not_ automatically resume upon restarting the server or reloading the database.  
 
 * `Idle`  
-   * An auto-index becomes idle when the time difference between its last-query-time and
+   * An __auto-index__ becomes idle when the time difference between its last-query-time and
      the most recent time the database was queried on (with any other index) is greater than a configurable threshold (30 min by default).  
      This is done in order to avoid marking indexes as idle for databases that were offline for a long period of time -  
      not having new data to index and not queried in general, as well as for databases that were just restored from a snapshot or a backup.  
@@ -107,7 +111,7 @@
 #### 3. >
 
 * **State**  
-  _Disable_ index or set as _Paused_. See states explanation above (under the figure-1).  
+  _Disable_ index or set as _Paused_. See states explanation above (under Figure-1).  
 * **Priority**  
   Set the indexing-process thread priority as RavenDB prioritizes requests-processing over [Indexing](../../../server/administration/index-administration#priority) by default.  
 * **Mode**  

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/EnableIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/EnableIndex.cs
@@ -1,0 +1,82 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class EnableIndex
+    {
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            // Available overloads:
+            public EnableIndexOperation(string indexName)
+            public EnableIndexOperation(string indexName, bool clusterWide)
+            #endregion
+            */
+        }
+
+        public EnableIndex() 
+        {
+            using (var store = new DocumentStore())
+            {
+                #region enable_1
+                // Use this overload to enable on a single node
+                var enableIndexOp = new EnableIndexOperation("Orders/Totals");
+
+                // Execute the operation by passing it to Maintenance.Send
+                store.Maintenance.Send(enableIndexOp);
+
+                // At this point, the index is enabled on the 'preferred node'
+                // New data will be indexed on this node
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region enable_2
+                // Pass 'true' to enable the index on all nodes in the database-group
+                var enableIndexOp = new EnableIndexOperation("Orders/Totals", true);
+
+                // Execute the operation by passing it to Maintenance.Send
+                store.Maintenance.Send(enableIndexOp);
+
+                // At this point, the index is enabled on all nodes
+                // New data will be indexed
+                #endregion
+            }
+        }
+        
+        public async Task EnableIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region enable_1_async
+                // Use this overload to enable on a single node
+                var enableIndexOp = new EnableIndexOperation("Orders/Totals");
+
+                // Execute the operation by passing it to Maintenance.SendAsync
+                await store.Maintenance.SendAsync(enableIndexOp);
+
+                // At this point, the index is enabled on the 'preferred node'
+                // New data will be indexed on this node
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region enable_2_async
+                // Pass 'true' to enable the index on all nodes in the database-group
+                var enableIndexOp = new EnableIndexOperation("Orders/Totals", true);
+
+                // Execute the operation by passing it to Maintenance.SendAsync
+                await store.Maintenance.SendAsync(enableIndexOp);
+
+                // At this point, the index is enabled on all nodes
+                // New data will be indexed
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/EnableIndex.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/EnableIndex.java
@@ -1,0 +1,24 @@
+package net.ravendb.ClientApi.Operations.Indexes;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.indexes.EnableIndexOperation;
+
+public class EnableIndex {
+
+    private interface IFoo {
+        /*
+        //region enable_1
+        public EnableIndexOperation(String indexName)
+        //endregion
+        */
+    }
+
+    public EnableIndex() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region enable_2
+            store.maintenance().send(new EnableIndexOperation("Orders/Totals"));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/enableIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/enableIndex.js
@@ -1,0 +1,39 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getStats() {
+    {
+        //region enable_1
+        // Define the enable index operation
+        // Use this overload to enable on a single node
+        const enableIndexOp = new EnableIndexOperation("Orders/Totals");
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(enableIndexOp);
+
+        // At this point, the index is enabled on the 'preferred node'
+        // New data will be indexed on this node
+        //endregion
+    }
+    {
+        //region enable_2
+        // Define the enable index operation
+        // Pass 'true' to enable the index on all nodes in the database-group
+        const enableIndexOp = new EnableIndexOperation("Orders/Totals", true);
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(enableIndexOp);
+
+        // At this point, the index is enabled on all nodes
+        // New data will be indexed
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const enableIndexOp = new EnableIndexOperation(indexName, clusterWide = false);
+    //endregion
+
+}


### PR DESCRIPTION
… Enable index

**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2347/Node.js-Client-API-Operations-Maintenance-Indexes-Enable-index

@ml054 
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/enableIndex.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling.