### PR TITLE
RDoc-2367 [Node.js] Client API > Operations > Maintenance > Indexes >Get index & Get indexes 

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
@@ -6,6 +6,13 @@
 
 * Use `GetIndexOperation` to retrieve an index definition from the database.
 
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definition returned is taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.
+
+* To get the index state on the local node use [get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats).
+
 * In this page:
     * [Get index example](../../../../client-api/operations/maintenance/indexes/get-index#get-index-example)
     * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index#syntax)
@@ -53,3 +60,4 @@
 - [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
 - [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
 - [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)
+- [Get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
@@ -1,0 +1,55 @@
+# Get Index Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexOperation` to retrieve an index definition from the database.
+
+* In this page:
+    * [Get index example](../../../../todo..)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/stop-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_index@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TAB:csharp:Async get_index_async@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_index_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| __indexName__ | string | Name of index to get |
+
+| Return value of `store.Maintenance.Send(getIndexOp)` | |
+|- | - |
+| `IndexDefinition` | An instance of class [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.java.markdown
@@ -1,0 +1,36 @@
+# Get Index Operation
+
+**GetIndexOperation** is used to retrieve an index definition from a database.
+
+### Syntax
+
+{CODE:java get_1_0@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | name of an index |
+
+| Return Value | |
+| ------------- | ----- |
+| `IndexDefinition` | Instance of IndexDefinition representing index. |
+
+### Example
+
+{CODE:java get_1_1@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
@@ -16,22 +16,19 @@
 
 {PANEL: Get index example}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync get_index@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
-{CODE-TAB:csharp:Async get_index_async@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
-{CODE-TABS/}
+{CODE:nodejs get_index@ClientApi\Operations\Maintenance\Indexes\getIndex.js /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE get_index_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE:nodejs get_index_syntax@ClientApi\Operations\Maintenance\Indexes\getIndex.js /}
 
 | Parameters | Type | Description |
 | - | - | - |
 | __indexName__ | string | Name of index to get |
 
-| Return value of `store.Maintenance.Send(getIndexOp)` | |
+| Return value of `store.maintenance.send(getIndexOp)` | |
 |- | - |
 | `IndexDefinition` | An instance of class [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
@@ -4,7 +4,14 @@
 
 {NOTE: }
 
-* Use `GetIndexOperation` to retrieve an index definition from the database.
+* Use `GetIndexOperation` to retrieve the __index definition__ from the database.
+
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definition returned is taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.  
+
+* To get the index state on the local node use [get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats).
 
 * In this page:
     * [Get index example](../../../../client-api/operations/maintenance/indexes/get-index#get-index-example)
@@ -50,3 +57,4 @@
 - [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
 - [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
 - [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)
+- [Get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
@@ -34,7 +34,7 @@
 
 | Return value of `store.Maintenance.Send(getIndexesOp)` | |
 | - | - |
-| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) <br> ordered alphabetically by index name |
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
@@ -4,7 +4,14 @@
 
 {NOTE: }
 
-* Use `GetIndexesOperation` to retrieve multiple index definitions from the database.
+* Use `GetIndexesOperation` to retrieve multiple __index definitions__ from the database.
+
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definitions returned are taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.
+
+* To get a specific index state on a local node use [get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats).
 
 * In this page:
     * [Get indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
@@ -34,7 +41,7 @@
 
 | Return value of `store.Maintenance.Send(getIndexesOp)` | |
 | - | - |
-| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) <br> ordered alphabetically by index name |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition), <br> ordered alphabetically by index name. |
 
 {PANEL/}
 
@@ -54,3 +61,4 @@
 - [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)
 - [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
 - [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)
+- [Get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
@@ -1,0 +1,56 @@
+# Get Indexes Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexesOperation` to retrieve multiple index definitions from the database.
+
+* In this page:
+    * [Get indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-indexes#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get indexes example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_indexes@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TAB:csharp:Async get_indexes_async@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_indexes_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| __start__ | int | Number of indexes to skip |
+| __pageSize__ | int | Number of indexes to retrieve |
+
+| Return value of `store.Maintenance.Send(getIndexesOp)` | |
+| - | - |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.java.markdown
@@ -1,0 +1,37 @@
+# Get Indexes Operation
+
+**GetIndexesOperation** is used to retrieve multiple index definitions from a database.
+
+### Syntax
+
+{CODE:java get_2_0@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **start** | int | Number of indexes that should be skipped |
+| **pageSize** | int | Maximum number of indexes that will be retrieved  |
+
+| Return Value | |
+| ------------- | ----- |
+| `IndexDefinition` | Instance of IndexDefinition representing index. |
+
+### Example
+
+{CODE:java get_2_1@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
@@ -31,7 +31,7 @@
 
 | Return value of `store.maintenance.send(getIndexesOp)` | |
 | - | - |
-| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) <br> ordered alphabetically by index name |
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
@@ -26,8 +26,8 @@
 
 | Parameters | Type | Description |
 | - | - | - |
-| __start__ | int | Number of indexes to skip |
-| __pageSize__ | int | Number of indexes to retrieve |
+| __start__ | number | Number of indexes to skip |
+| __pageSize__ | number | Number of indexes to retrieve |
 
 | Return value of `store.maintenance.send(getIndexesOp)` | |
 | - | - |

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
@@ -16,23 +16,20 @@
 
 {PANEL: Get indexes example}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync get_indexes@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
-{CODE-TAB:csharp:Async get_indexes_async@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
-{CODE-TABS/}
+{CODE:nodejs get_indexes@ClientApi\Operations\Maintenance\Indexes\getIndex.js /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE get_indexes_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE:nodejs get_indexes_syntax@ClientApi\Operations\Maintenance\Indexes\getIndex.js /}
 
 | Parameters | Type | Description |
 | - | - | - |
 | __start__ | int | Number of indexes to skip |
 | __pageSize__ | int | Number of indexes to retrieve |
 
-| Return value of `store.Maintenance.Send(getIndexesOp)` | |
+| Return value of `store.maintenance.send(getIndexesOp)` | |
 | - | - |
 | `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
@@ -4,7 +4,14 @@
 
 {NOTE: }
 
-* Use `GetIndexesOperation` to retrieve multiple index definitions from the database.
+* Use `GetIndexesOperation` to retrieve multiple __index definitions__ from the database.
+
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definitions returned are taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.
+
+* To get a specific index state on a local node use [get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats).
 
 * In this page:
     * [Get indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
@@ -31,7 +38,7 @@
 
 | Return value of `store.maintenance.send(getIndexesOp)` | |
 | - | - |
-| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) <br> ordered alphabetically by index name |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition), <br>ordered alphabetically by index name. |
 
 {PANEL/}
 
@@ -51,3 +58,4 @@
 - [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)
 - [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
 - [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)
+- [Get index stats](../../../../client-api/operations/maintenance/indexes/get-index-stats)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.dotnet.markdown
@@ -87,7 +87,7 @@ Using `PutIndexesOperation` with an IndexDefinition created from an __IndexDefin
 | - |- | - |
 | **indexesToAdd** | `params IndexDefinition[]` | Definitions of indexes to deploy |
 
-[//]: # (__The IndexDefinition class__)
+<a id="indexDefinition" />
 
 | `IndexDefinition` | | |
 | - | - | - |

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.js.markdown
@@ -65,6 +65,8 @@ Using `PutIndexesOperation` with __IndexDefinition__ allows the following:
 | - |- | - |
 | **indexesToAdd** | `...IndexDefinition[]` | Definitions of indexes to deploy |
 
+<a id="indexDefinition" />
+
 | `IndexDefinition` | | |
 | - | - | - |
 | name | string | Name of the index, a unique identifier |

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
@@ -38,7 +38,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 // Execute the operation by passing it to Maintenance.Send
                 IndexDefinition[] indexes = store.Maintenance.Send(getIndexesOp);
                 
-                // Access an index definition
+                // Access an index definition from the resulting list
                 var name = indexes[0].Name;
                 var state = indexes[0].State;
                 var lockMode = indexes[0].LockMode;
@@ -77,7 +77,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 // Execute the operation by passing it to Maintenance.SendAsync
                 IndexDefinition[] indexes = await store.Maintenance.SendAsync(getIndexesOp);
                 
-                // Access an index definition
+                // Access an index definition from the resulting list
                 var name = indexes[0].Name;
                 var state = indexes[0].State;
                 var lockMode = indexes[0].LockMode;

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
@@ -39,7 +39,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 IndexDefinition[] indexes = store.Maintenance.Send(getIndexesOp);
                 
                 // indexes will contain the first 10 indexes, alphabetically ordered by index name
-                // Access an index definition from the resulting list
+                // Access an index definition from the resulting list:
                 var name = indexes[0].Name;
                 var state = indexes[0].State;
                 var lockMode = indexes[0].LockMode;
@@ -79,7 +79,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 IndexDefinition[] indexes = await store.Maintenance.SendAsync(getIndexesOp);
                 
                 // indexes will contain the first 10 indexes, alphabetically ordered by index name
-                // Access an index definition from the resulting list
+                // Access an index definition from the resulting list:
                 var name = indexes[0].Name;
                 var state = indexes[0].State;
                 var lockMode = indexes[0].LockMode;

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
@@ -1,0 +1,105 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class GetIndex
+    {
+        public GetIndex()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index
+
+                // Define the get index operation, pass the index name
+                var getIndexOp = new GetIndexOperation("Orders/Totals");
+
+                // Execute the operation by passing it to Maintenance.Send
+                IndexDefinition index = store.Maintenance.Send(getIndexOp);
+
+                // Access the index definition
+                var state = index.State;
+                var lockMode = index.LockMode;
+                var deploymentMode = index.DeploymentMode;
+                // etc.
+
+                #endregion
+            }
+            
+            using (var store = new DocumentStore()) 
+            {
+                #region get_indexes
+                // Define the get indexes operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexesOp = new GetIndexesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                IndexDefinition[] indexes = store.Maintenance.Send(getIndexesOp);
+                
+                // Access an index definition
+                var name = indexes[0].Name;
+                var state = indexes[0].State;
+                var lockMode = indexes[0].LockMode;
+                var deploymentMode = indexes[0].DeploymentMode;
+                // etc.
+                #endregion
+            }
+        }
+        
+        public async Task GetIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_async
+                // Define the get index operation, pass the index name
+                var getIndexOp = new GetIndexOperation("Orders/Totals");
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                IndexDefinition index = await store.Maintenance.SendAsync(getIndexOp);
+
+                // Access the index definition
+                var state = index.State;
+                var lockMode = index.LockMode;
+                var deploymentMode = index.DeploymentMode;
+                // etc.
+                #endregion
+            }
+            
+            using (var store = new DocumentStore()) 
+            {
+                #region get_indexes_async
+                // Define the get indexes operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexesOp = new GetIndexesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                IndexDefinition[] indexes = await store.Maintenance.SendAsync(getIndexesOp);
+                
+                // Access an index definition
+                var name = indexes[0].Name;
+                var state = indexes[0].State;
+                var lockMode = indexes[0].LockMode;
+                var deploymentMode = indexes[0].DeploymentMode;
+                // etc.
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region get_index_syntax
+            public GetIndexOperation(string indexName)
+            #endregion
+            */
+
+            /*
+            #region get_indexes_syntax
+            public GetIndexesOperation(int start, int pageSize)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
@@ -38,6 +38,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 // Execute the operation by passing it to Maintenance.Send
                 IndexDefinition[] indexes = store.Maintenance.Send(getIndexesOp);
                 
+                // indexes will contain the first 10 indexes, alphabetically ordered by index name
                 // Access an index definition from the resulting list
                 var name = indexes[0].Name;
                 var state = indexes[0].State;
@@ -77,6 +78,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 // Execute the operation by passing it to Maintenance.SendAsync
                 IndexDefinition[] indexes = await store.Maintenance.SendAsync(getIndexesOp);
                 
+                // indexes will contain the first 10 indexes, alphabetically ordered by index name
                 // Access an index definition from the resulting list
                 var name = indexes[0].Name;
                 var state = indexes[0].State;

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/Get.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/Get.java
@@ -1,0 +1,50 @@
+package net.ravendb.ClientApi.Operations.Indexes;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexDefinition;
+import net.ravendb.client.documents.operations.indexes.GetIndexNamesOperation;
+import net.ravendb.client.documents.operations.indexes.GetIndexOperation;
+import net.ravendb.client.documents.operations.indexes.GetIndexesOperation;
+
+public class Get {
+
+    private interface IFoo {
+        /*
+        //region get_1_0
+        public GetIndexOperation(String indexName)
+        //endregion
+
+        //region get_2_0
+        public GetIndexesOperation(int start, int pageSize)
+        //endregion
+
+        //region get_3_0
+        public GetIndexNamesOperation(int start, int pageSize)
+        //endregion
+        */
+    }
+
+    public Get() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region get_1_1
+            IndexDefinition index
+                = store.maintenance()
+                    .send(new GetIndexOperation("Orders/Totals"));
+
+            //endregion
+
+            //region get_2_1
+            IndexDefinition[] indexes
+                = store.maintenance()
+                    .send(new GetIndexesOperation(0, 10));
+            //endregion
+
+            //region get_3_1
+            String[] indexNames
+                = store.maintenance()
+                    .send(new GetIndexNamesOperation(0, 10));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
@@ -27,7 +27,7 @@ async function getIndex() {
         // Execute the operation by passing it to maintenance.send
         const indexes = await store.maintenance.send(getIndexesOp);
 
-        // Access an index definition
+        // Access an index definition from the resulting list
         const name = indexes[0].name;
         const state = indexes[0].state;
         const lockMode = indexes[0].lockMode;

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
@@ -27,6 +27,7 @@ async function getIndex() {
         // Execute the operation by passing it to maintenance.send
         const indexes = await store.maintenance.send(getIndexesOp);
 
+        // indexes will contain the first 10 indexes, alphabetically ordered by index name
         // Access an index definition from the resulting list
         const name = indexes[0].name;
         const state = indexes[0].state;

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
@@ -1,0 +1,48 @@
+﻿import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+
+async function getIndex() {
+    {
+        //region get_index
+        // Define the get index operation, pass the index name
+        const getIndexOp = new GetIndexOperation("Orders/Totals");
+
+        // Execute the operation by passing it to maintenance.send
+        const indexDefinition = await store.maintenance.send(getIndexOp);
+
+        // Access the index definition
+        const state = indexDefinition.state;
+        const lockMode = indexDefinition.lockMode;
+        const deploymentMode = indexDefinition.deploymentMode;
+        // etc.
+        //endregion
+
+        //region get_indexes
+        // Define the get indexes operation
+        // Pass number of indexes to skip & number of indexes to retrieve
+        const getIndexesOp = new GetIndexesOperation(0, 10);
+
+        // Execute the operation by passing it to maintenance.send
+        const indexes = await store.maintenance.send(getIndexesOp);
+
+        // Access an index definition
+        const name = indexes[0].name;
+        const state = indexes[0].state;
+        const lockMode = indexes[0].lockMode;
+        const deploymentMode = indexes[0].deploymentMode;
+        // etc.
+        //endregion
+    }
+}
+
+{
+    //region get_index_syntax
+    const getIndexOp = new GetIndexOperation(indexName);
+    //endregion
+
+    //region get_indexes_syntax
+    const getIndexesOp = new GetIndexesOperation(start, pageSize);
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
@@ -28,7 +28,7 @@ async function getIndex() {
         const indexes = await store.maintenance.send(getIndexesOp);
 
         // indexes will contain the first 10 indexes, alphabetically ordered by index name
-        // Access an index definition from the resulting list
+        // Access an index definition from the resulting list:
         const name = indexes[0].name;
         const state = indexes[0].state;
         const lockMode = indexes[0].lockMode;


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2367/Node.js-Client-API-Operations-Maintenance-Indexes-Get-index-Get-indexes

@ml054
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndex.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling
