### PR TITLE
RDoc-2368 [Node.js] Client API > Operations > Maintenance > Indexes > Get index names

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
@@ -34,7 +34,7 @@
 
 | Return Value of `store.Maintenance.Send(getIndexNamesOp)` | |
 | - | - |
-| `string[]` | A list of index names |
+| `string[]` | A list of index names alphabetically ordered |
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
@@ -1,0 +1,56 @@
+# Get Index Names Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexNamesOperation` to retrieve multiple __index names__ from the database.
+
+* In this page:
+    * [Get index names example](../../../../client-api/operations/maintenance/indexes/get-index-names#get-index-names-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index-names#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index names example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_index_names@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
+{CODE-TAB:csharp:Async get_index_names_async@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_index_names_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
+
+| Parameters | Type | Description |
+| - |- | - |
+| __start__ | int | Number of index names to skip |
+| __pageSize__ | int   | Number of index names to retrieve |
+
+| Return Value of `store.Maintenance.Send(getIndexNamesOp)` | |
+| - | - |
+| `string[]` | A list of index names |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.java.markdown
@@ -1,0 +1,38 @@
+# Get Index Names Operation
+
+**GetIndexNamesOperation** is used to retrieve multiple index names from a database.
+
+### Syntax
+
+{CODE:java get_3_0@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **start** | int | Number of index names that should be skipped |
+| **pageSize** | int | Maximum number of index names that will be retrieved |
+
+| Return Value | |
+| ------------- | ----- |
+| String[] | This method returns an array of index **name** as a result. |
+
+### Example
+
+{CODE:java get_3_1@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
@@ -31,7 +31,7 @@
 
 | Return Value of `store.maintenance.send(getIndexNamesOp)` | |
 | - | - |
-| `string[]` | A list of index names |
+| `string[]` | A list of index names alphabetically ordered |
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
@@ -1,0 +1,53 @@
+# Get Index Names Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexNamesOperation` to retrieve multiple __index names__ from the database.
+
+* In this page:
+    * [Get index names example](../../../../client-api/operations/maintenance/indexes/get-index-names#get-index-names-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index-names#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index names example}
+
+{CODE:nodejs get_index_names@ClientApi\Operations\Maintenance\Indexes\getIndexNames.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs get_index_names_syntax@ClientApi\Operations\Maintenance\Indexes\getIndexNames.js /}
+
+| Parameters | Type | Description |
+| - |- | - |
+| __start__ | number | Number of index names to skip |
+| __pageSize__ | number   | Number of index names to retrieve |
+
+| Return Value of `store.maintenance.send(getIndexNamesOp)` | |
+| - | - |
+| `string[]` | A list of index names |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -184,7 +184,7 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexesStatisticsOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexingStatusOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexStalenessOperation  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexNamesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexNamesOperation](../../client-api/operations/maintenance/indexes/get-index-names)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StartIndexOperation](../../client-api/operations/maintenance/indexes/start-index)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StartIndexingOperation](../../client-api/operations/maintenance/indexes/start-indexing)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StopIndexOperation](../../client-api/operations/maintenance/indexes/stop-index)   

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.cs
@@ -17,6 +17,8 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 
                 // Execute the operation by passing it to Maintenance.Send
                 string[] indexNames = store.Maintenance.Send(getIndexNamesOp);
+                
+                // indexNames will contain the first 10 indexes, alphabetically ordered
                 #endregion
             }
         }
@@ -32,6 +34,8 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 
                 // Execute the operation by passing it to Maintenance.SendAsync
                 string[] indexNames = await store.Maintenance.SendAsync(getIndexNamesOp);
+                
+                // indexNames will contain the first 10 indexes, alphabetically ordered
                 #endregion
             }
         }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class GetIndexNames
+    {
+        public GetIndexNames()
+        {
+            using (var store = new DocumentStore()) 
+            {
+                #region get_index_names
+                // Define the get index names operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexNamesOp = new GetIndexNamesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                string[] indexNames = store.Maintenance.Send(getIndexNamesOp);
+                #endregion
+            }
+        }
+        
+        public async Task GetIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_names_async
+                // Define the get index names operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexNamesOp = new GetIndexNamesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                string[] indexNames = await store.Maintenance.SendAsync(getIndexNamesOp);
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region get_index_names_syntax
+            public GetIndexNamesOperation(int start, int pageSize)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/Get.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/Get.java
@@ -1,0 +1,50 @@
+package net.ravendb.ClientApi.Operations.Indexes;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexDefinition;
+import net.ravendb.client.documents.operations.indexes.GetIndexNamesOperation;
+import net.ravendb.client.documents.operations.indexes.GetIndexOperation;
+import net.ravendb.client.documents.operations.indexes.GetIndexesOperation;
+
+public class Get {
+
+    private interface IFoo {
+        /*
+        //region get_1_0
+        public GetIndexOperation(String indexName)
+        //endregion
+
+        //region get_2_0
+        public GetIndexesOperation(int start, int pageSize)
+        //endregion
+
+        //region get_3_0
+        public GetIndexNamesOperation(int start, int pageSize)
+        //endregion
+        */
+    }
+
+    public Get() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region get_1_1
+            IndexDefinition index
+                = store.maintenance()
+                    .send(new GetIndexOperation("Orders/Totals"));
+
+            //endregion
+
+            //region get_2_1
+            IndexDefinition[] indexes
+                = store.maintenance()
+                    .send(new GetIndexesOperation(0, 10));
+            //endregion
+
+            //region get_3_1
+            String[] indexNames
+                = store.maintenance()
+                    .send(new GetIndexNamesOperation(0, 10));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexNames.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexNames.js
@@ -11,6 +11,8 @@ async function getIndexNames() {
 
         // Execute the operation by passing it to maintenance.send
         const indexNames = await store.maintenance.send(getIndexNamesOp);
+
+        // indexNames will contain the first 10 indexes, alphabetically ordered
         //endregion
     }
 }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexNames.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexNames.js
@@ -1,0 +1,22 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getIndexNames() {
+    {
+        //region get_index_names
+        // Define the get index names operation
+        // Pass number of indexes to skip & number of indexes to retrieve
+        const getIndexNamesOp = new GetIndexNamesOperation(0, 10);
+
+        // Execute the operation by passing it to maintenance.send
+        const indexNames = await store.maintenance.send(getIndexNamesOp);
+        //endregion
+    }
+}
+
+{
+    //region get_index_names_syntax
+    const getIndexNamesOp = new GetIndexNamesOperation(start, pageSize);
+    //endregion
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2368/Node.js-Client-API-Operations-Maintenance-Indexes-Get-index-names

@ml054
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexNames.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling