### PR TITLE
RDoc-2369 [Node.js] Client API > Operations > Maintenance > Indexes > Get terms

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -86,18 +86,6 @@
         "Mappings": []
     },
     {
-        "Path": "get-index-errors.markdown",
-        "Name": "Get Index Errors",
-        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
-        "Mappings": []
-    },
-    {
-        "Path": "get-index-names.markdown",
-        "Name": "Get Index Names",
-        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
-        "Mappings": []
-    },
-    {
         "Path": "get-index.markdown",
         "Name": "Get Index",
         "DiscussionId": "1832ba8f-4142-4637-979f-820681ddcd1c",
@@ -110,8 +98,20 @@
         "Mappings": []
     },
     {
+        "Path": "get-index-errors.markdown",
+        "Name": "Get Index Errors",
+        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
+        "Mappings": []
+    },
+    {
+        "Path": "get-index-names.markdown",
+        "Name": "Get Index Names",
+        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
+        "Mappings": []
+    },
+    {
         "Path": "get-terms.markdown",
-        "Name": "Get Terms",
+        "Name": "Get Index Terms",
         "DiscussionId": "2033ba99-3ba9-48fe-9751-a918cf9ab652",
         "Mappings": [
             {

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
@@ -1,0 +1,52 @@
+# Get Index Terms Operation
+
+---
+
+{NOTE: }
+
+* Use `GetTermsOperation` to retrieve the __terms of an index-field__.  
+
+* In this page:
+    * [Get index terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-index-terms-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-terms#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index terms example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_index_terms@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.cs /}
+{CODE-TAB:csharp:Async get_index_terms_async@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_index_terms_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | string | Name of an index to get terms for |
+| **field** | string | Name of index-field to get terms for |
+| **fromValue** | string | The starting term from which to return results.<br>This term is not included in the results.<br>`null` - start from first term. |
+| **pageSize** | int? | Number of terms to get.<br>`null` - return all terms.  |
+
+| Return value of `store.Maintenance.Send(getTermsOp)` | |
+| - |- |
+| string[] | List of terms for the requested index-field. <br> Alphabetically ordered. |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.java.markdown
@@ -1,0 +1,34 @@
+# Get Index Terms Operation
+
+The **GetTermsOperation** will retrieve stored terms for a field of an index.
+
+## Syntax
+
+{CODE:java get_terms1@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.java /}
+
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | Name of an index to get terms for |
+| **field** | String | Name of field to get terms for |
+| **fromValue** | String | The starting term from which to return results |
+| **pageSize** | Integer | Number of terms to get |
+
+| Return Value | |
+| ------------- | ----- |
+| String[] | List of terms for the requested index-field. <br> Alphabetically ordered. |
+
+## Example
+
+{CODE:java get_terms2@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
@@ -1,0 +1,49 @@
+# Get Index Terms Operation
+
+---
+
+{NOTE: }
+
+* Use `GetTermsOperation` to retrieve the __terms of an index-field__.
+
+* In this page:
+    * [Get index terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-index-terms-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-terms#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index terms example}
+
+{CODE:nodejs get_index_terms@ClientApi\Operations\Maintenance\Indexes\getIndexTerms.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs get_index_terms_syntax@ClientApi\Operations\Maintenance\Indexes\getIndexTerms.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | string | Name of an index to get terms for |
+| **field** | string | Name of index-field to get terms for |
+| **fromValue** | string | The starting term from which to return results.<br>This term is not included in the results.<br>`null` - start from first term. |
+| **pageSize** | number | Number of terms to get.<br>`undefined/null` - return all terms.  |
+
+| Return value of `store.maintenance.send(getTermsOp)` | |
+| - |- |
+| string[] | List of terms for the requested index-field. <br> Alphabetically ordered. |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.cs
@@ -1,0 +1,52 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class GetIndexTerms
+    {
+        public GetIndexTerms()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_terms
+                // Define the get terms operation
+                // Pass the requested index-name, index-field, start value & page size
+                var getTermsOp = new GetTermsOperation("Orders/Totals", "Employee", "employees/5-a", 10);
+
+                // Execute the operation by passing it to Maintenance.Send
+                string[] fieldTerms = store.Maintenance.Send(getTermsOp);
+
+                // fieldTerms will contain the all terms that come after term 'employees/5-a' for index-field 'Employee'
+                #endregion
+            }
+        }
+        
+        public async Task GetIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_terms_async
+                // Define the get terms operation
+                // Pass the requested index-name, index-field, start value & page size
+                var getTermsOp = new GetTermsOperation("Orders/Totals", "Employee", "employees/5-a", 10);
+
+                // Execute the operation by passing it to Maintenance.SendAsync
+                string[] fieldTerms = await store.Maintenance.SendAsync(getTermsOp);
+
+                // fieldTerms will contain the all terms that come after term 'employees/5-a' for index-field 'Employee'
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region get_index_terms_syntax
+            public GetTermsOperation(string indexName, string field, string fromValue, int? pageSize = null)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.java
@@ -1,0 +1,29 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.indexes.GetTermsOperation;
+
+public class GetIndexTerms {
+
+    private interface IFoo {
+        /*
+        //region get_terms1
+        public GetTermsOperation(String indexName, String field, String fromValue)
+
+        public GetTermsOperation(String indexName, String field, String fromValue, Integer pageSize)
+        //endregion
+        */
+    }
+
+    public GetIndexTerms() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region get_terms2
+            String[] terms = store
+                .maintenance()
+                .send(
+                    new GetTermsOperation("Orders/Totals", "Employee", null));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexTerms.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexTerms.js
@@ -1,0 +1,26 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getIndexTerms() {
+    {
+        //region get_index_terms
+        // Define the get terms operation
+        // Pass the requested index-name, index-field, start value & page size
+        const getTermsOp = new GetTermsOperation("Orders/Totals", "Employee", "employees/5-a", 10);
+
+        // Execute the operation by passing it to maintenance.send
+        const fieldTerms = await store.maintenance.send(getTermsOp);
+
+        // fieldTerms will contain the all terms that come after term 'employees/5-a' for index-field 'Employee'
+        //endregion
+    }
+}
+
+{
+    //region get_index_terms_syntax
+    // Available overloads:
+    const getTermsOp = new GetTermsOperation(indexName, field, fromValue);
+    const getTermsOp = new GetTermsOperation(indexName, field, fromValue, pageSize);
+    //endregion
+}

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -86,18 +86,6 @@
         "Mappings": []
     },
     {
-        "Path": "get-index-errors.markdown",
-        "Name": "Get Index Errors",
-        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
-        "Mappings": []
-    },
-    {
-        "Path": "get-index-names.markdown",
-        "Name": "Get Index Names",
-        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
-        "Mappings": []
-    },
-    {
         "Path": "get-index.markdown",
         "Name": "Get Index",
         "DiscussionId": "1832ba8f-4142-4637-979f-820681ddcd1c",
@@ -110,8 +98,20 @@
         "Mappings": []
     },
     {
+        "Path": "get-index-errors.markdown",
+        "Name": "Get Index Errors",
+        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
+        "Mappings": []
+    },
+    {
+        "Path": "get-index-names.markdown",
+        "Name": "Get Index Names",
+        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
+        "Mappings": []
+    },
+    {
         "Path": "get-terms.markdown",
-        "Name": "Get Terms",
+        "Name": "Get Index Terms",
         "DiscussionId": "2033ba99-3ba9-48fe-9751-a918cf9ab652",
         "Mappings": [
             {

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -86,18 +86,6 @@
         "Mappings": []
     },
     {
-        "Path": "get-index-errors.markdown",
-        "Name": "Get Index Errors",
-        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
-        "Mappings": []
-    },
-    {
-        "Path": "get-index-names.markdown",
-        "Name": "Get Index Names",
-        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
-        "Mappings": []
-    },
-    {
         "Path": "get-index.markdown",
         "Name": "Get Index",
         "DiscussionId": "1832ba8f-4142-4637-979f-820681ddcd1c",
@@ -110,8 +98,20 @@
         "Mappings": []
     },
     {
+        "Path": "get-index-errors.markdown",
+        "Name": "Get Index Errors",
+        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
+        "Mappings": []
+    },
+    {
+        "Path": "get-index-names.markdown",
+        "Name": "Get Index Names",
+        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
+        "Mappings": []
+    },
+    {
         "Path": "get-terms.markdown",
-        "Name": "Get Terms",
+        "Name": "Get Index Terms",
         "DiscussionId": "2033ba99-3ba9-48fe-9751-a918cf9ab652",
         "Mappings": [
             {

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -86,18 +86,6 @@
         "Mappings": []
     },
     {
-        "Path": "get-index-errors.markdown",
-        "Name": "Get Index Errors",
-        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
-        "Mappings": []
-    },
-    {
-        "Path": "get-index-names.markdown",
-        "Name": "Get Index Names",
-        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
-        "Mappings": []
-    },
-    {
         "Path": "get-index.markdown",
         "Name": "Get Index",
         "DiscussionId": "1832ba8f-4142-4637-979f-820681ddcd1c",
@@ -110,8 +98,20 @@
         "Mappings": []
     },
     {
+        "Path": "get-index-errors.markdown",
+        "Name": "Get Index Errors",
+        "DiscussionId": "b48cab12-31d7-4602-b324-03026545fa05",
+        "Mappings": []
+    },
+    {
+        "Path": "get-index-names.markdown",
+        "Name": "Get Index Names",
+        "DiscussionId": "d08a3764-4501-4db4-b1a6-5441ccc46754",
+        "Mappings": []
+    },
+    {
         "Path": "get-terms.markdown",
-        "Name": "Get Terms",
+        "Name": "Get Index Terms",
         "DiscussionId": "2033ba99-3ba9-48fe-9751-a918cf9ab652",
         "Mappings": [
             {


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2369/Node.js-Client-API-Operations-Maintenance-Indexes-Get-terms

@ml054
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/getIndexTerms.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling