### PR TITLE
RDoc-2371 [Node.js] Client API > Operations > Maintenance > Indexes >Delete index

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.dotnet.markdown
@@ -1,0 +1,50 @@
+# Delete Index Operation
+
+---
+
+{NOTE: }
+
+* Use `DeleteIndexOperation` to remove an index from the database.
+
+* In this page:
+    * [Delete index example](../../../../client-api/operations/maintenance/indexes/delete-index#delete-index-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/delete-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Delete index example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync delete_index@ClientApi\Operations\Maintenance\Indexes\DeleteIndex.cs /}
+{CODE-TAB:csharp:Async delete_index_async@ClientApi\Operations\Maintenance\Indexes\DeleteIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Operations\Maintenance\Indexes\DeleteIndex.cs /}
+
+| Parameters    | Type | Description |
+|- | - | - |
+| __indexName__ | string | Name of index to delete |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.java.markdown
@@ -1,0 +1,31 @@
+# Delete Index Operation
+
+**DeleteIndexOperation** is used to remove an index from a database.
+
+## Syntax
+
+{CODE:java delete_1@ClientApi\Operations\Maintenance\Indexes\DeleteIndex.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | name of an index to delete |
+
+## Example
+
+{CODE:java delete_2@ClientApi\Operations\Maintenance\Indexes\DeleteIndex.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.js.markdown
@@ -1,0 +1,47 @@
+# Delete Index Operation
+
+---
+
+{NOTE: }
+
+* Use `DeleteIndexOperation` to remove an index from the database.
+
+* In this page:
+    * [Delete index example](../../../../client-api/operations/maintenance/indexes/delete-index#delete-index-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/delete-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Delete index example}
+
+{CODE:nodejs delete_index@ClientApi\Operations\Maintenance\Indexes\deleteIndex.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Operations\Maintenance\Indexes\deleteIndex.js /}
+
+| Parameters    | Type | Description |
+|- | - | - |
+| __indexName__ | string | Name of index to delete |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/DeleteIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/DeleteIndex.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class DeleteIndex
+    {
+        public DeleteIndex()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region delete_index
+                // Define the delete index operation, specify the index name
+                var deleteIndexOp = new DeleteIndexOperation("Orders/Totals");
+                
+                // Execute the operation by passing it to Maintenance.Send
+                store.Maintenance.Send(deleteIndexOp);
+                #endregion
+            }
+        }
+        
+        public async Task DeleteIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region delete_index_async
+                    // Define the delete index errors operation, specify the index name
+                    var deleteIndexOp = new DeleteIndexOperation("Orders/Totals");
+                
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    await store.Maintenance.SendAsync(deleteIndexOp);
+                    #endregion
+                }
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public DeleteIndexOperation(string indexName)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/DeleteIndex.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/DeleteIndex.java
@@ -1,0 +1,23 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.indexes.DeleteIndexOperation;
+
+public class DeleteIndex {
+    private interface IFoo {
+        /*
+        //region delete_1
+        public DeleteIndexOperation(String indexName)
+        //endregion
+         */
+    }
+
+    public DeleteIndex() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region delete_2
+            store.maintenance().send(new DeleteIndexOperation("Orders/Totals"));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/deleteIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/deleteIndex.js
@@ -1,0 +1,21 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function deleteIndex() {
+    {
+        //region delete_index
+        // Define the delete index operation, specify the index name
+        const deleteIndexOp = new DeleteIndexOperation("Orders/Totals");
+
+        // Execute the operation by passing it to maintenance.send
+        await store.maintenance.send(deleteIndexOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const deleteIndexOp = new DeleteIndexOperation(indexName);
+    //endregion
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2371/Node.js-Client-API-Operations-Maintenance-Indexes-Delete-index

@ml054
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/deleteIndex.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling