### PR TITLE
RDoc-2372 [Node.js] Client API > Operations > Maintenance > Indexes > Set index lock

### DIFF
--- a/Documentation/3.5/Raven.Documentation.Pages/client-api/commands/indexes/how-to/.docs.json
+++ b/Documentation/3.5/Raven.Documentation.Pages/client-api/commands/indexes/how-to/.docs.json
@@ -1,38 +1,43 @@
 [
-  {
-    "Path": "reset-index.markdown",
-    "Name": "...reset index",
-    "DiscussionId": "dbb23a3e-c3e5-4497-832b-5bb1163254f2",
-    "Mappings": []
-  },
-  {
-    "Path": "get-index-terms.markdown",
-    "Name": "...get index terms",
-    "DiscussionId": "e51cf2de-616f-4cf3-9d34-c00fe66fd749",
-    "Mappings": []
-  },
-  {
-    "Path": "get-index-merge-suggestions.markdown",
-    "Name": "...get index merge suggestions",
-    "DiscussionId": "0d1479b0-d267-4d92-b43c-fec2dfd8358a",
-    "Mappings": []
-  },
-  {
-    "Path": "check-if-index-has-changed.markdown",
-    "Name": "...check if index has changed",
-    "DiscussionId": "c0871766-62c8-494b-9744-3cbf12122c36",
-    "Mappings": []
-  },
-  {
-    "Path": "change-index-lock-mode.markdown",
-    "Name": "...change index lock mode",
-    "DiscussionId": "3b1e76c4-d811-45d5-9f5e-46ff29b92d6d",
-    "Mappings": []
-  },
-  {
-    "Path": "change-index-priority.markdown",
-    "Name": "...change index priority",
-    "DiscussionId": "43b15382-30ae-4a30-8bf5-2cf69e287ac6",
-    "Mappings": []
-  }
+    {
+        "Path": "reset-index.markdown",
+        "Name": "...reset index",
+        "DiscussionId": "dbb23a3e-c3e5-4497-832b-5bb1163254f2",
+        "Mappings": []
+    },
+    {
+        "Path": "get-index-terms.markdown",
+        "Name": "...get index terms",
+        "DiscussionId": "e51cf2de-616f-4cf3-9d34-c00fe66fd749",
+        "Mappings": []
+    },
+    {
+        "Path": "get-index-merge-suggestions.markdown",
+        "Name": "...get index merge suggestions",
+        "DiscussionId": "0d1479b0-d267-4d92-b43c-fec2dfd8358a",
+        "Mappings": []
+    },
+    {
+        "Path": "check-if-index-has-changed.markdown",
+        "Name": "...check if index has changed",
+        "DiscussionId": "c0871766-62c8-494b-9744-3cbf12122c36",
+        "Mappings": []
+    },
+    {
+        "Path": "change-index-lock-mode.markdown",
+        "Name": "...change index lock mode",
+        "DiscussionId": "3b1e76c4-d811-45d5-9f5e-46ff29b92d6d",
+        "Mappings": [
+            {
+                "Version": 4.0,
+                "Key": "client-api/operations/maintenance/indexes/set-index-lock"
+            }
+        ]
+    },
+    {
+        "Path": "change-index-priority.markdown",
+        "Name": "...change index priority",
+        "DiscussionId": "43b15382-30ae-4a30-8bf5-2cf69e287ac6",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -7,7 +7,7 @@
     },
     {
         "Path": "set-index-lock.markdown",
-        "Name": "Set Index Lock",
+        "Name": "Set Index Lock Mode",
         "DiscussionId": "c1de9893-93fc-4326-8024-ce5512428123",
         "Mappings": [
             {

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.dotnet.markdown
@@ -1,0 +1,121 @@
+# Set Index Lock Mode Operation
+
+---
+
+{NOTE: }
+
+* The lock mode controls the behavior of index modifications.  
+  Use `SetIndexesLockOperation` to modify the __lock mode__ for a single index or multiple indexes.
+
+* __Indexes scope__:  
+  The lock mode can be set only for static-indexes, not for auto-indexes.
+
+* __Operation scope__:  
+  The lock mode will be updated on all nodes in the database group.
+
+* Setting the lock mode can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
+  Locking an index is not a security measure, the index can be unlocked at any time.  
+
+* In this page:
+    * [Lock modes](../../../../client-api/operations/maintenance/indexes/set-index-lock#lock-modes)
+    * [Sample usage flow](../../../../client-api/operations/maintenance/indexes/set-index-lock#sample-usage-flow)
+    * [Set lock mode - single index](../../../../client-api/operations/maintenance/indexes/set-index-lock#set-lock-mode---single-index)
+    * [Set lock mode - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-lock#set-lock-mode---multiple-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-lock#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Lock modes}
+
+* `Unlock` - when lock mode is set to _'Unlock'_:  
+  * Any change to the index definition will be applied.  
+  * If the new index definition differs from the one stored on the server,  
+    the index will be updated and the data will be re-indexed using the new index definition.  
+ 
+* `LockedIgnore` - when lock mode is set to _'LockedIgnore'_:  
+  * Index definition changes will Not be applied.  
+  * Modifying the index definition will return successfully and no error will be raised,  
+    however, no change will be made to the index definition on the server.
+ 
+* `LockedError` - when lock mode is set to _'LockedError'_:  
+  * Index definitions changes will Not be applied.  
+  * An exception will be thrown upon trying to modify the index.  
+
+{PANEL/}
+
+{PANEL: Sample usage flow}
+
+Consider the following scenario:
+
+* Your client application defines and [deploys a static-index](../../../../client-api/operations/maintenance/indexes/put-indexes) upon application startup.
+  
+* After the application has started, you make a change to your index definition and re-indexing occurs.   
+  However, if the index lock mode is _'Unlock'_, the next time your application will start,  
+  it will reset the index definition back to the original version.
+
+* Locking the index allows to make changes to the running index and prevents the application  
+  from setting it back to the previous definition upon startup. See the following steps:  
+<br>
+
+  1. Run your application  
+  2. Modify the index definition on the server (from Studio, or from another application),  
+     and then set this index lock mode to `LockedIgnore`.  
+  3. A side-by-side replacement index is created on the server.  
+     It will index your dataset according to the __new__ definition.  
+  4. At this point, if any instance of your original application is started,  
+     the code that defines and deploys the index upon startup will have no effect  
+     since the index is 'locked'.  
+  5. Once the replacement index is done indexing, it will replace the original index.  
+
+{PANEL/}
+
+{PANEL: Set lock mode - single index}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync set_lock_single@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
+{CODE-TAB:csharp:Async set_lock_single_async@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Set lock mode - multiple indexes}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync set_lock_multiple@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
+{CODE-TAB:csharp:Async set_lock_multiple_async@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
+
+| Parameters | Type | Description |
+|- | - | - |
+| __indexName__ | string | Index name for which to set lock mode |
+| __mode__ | `IndexLockMode` | Lock mode to set |
+| __parameters__ | `SetIndexesLockOperation.Parameters` | List of indexes + Lock mode to set |
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
+
+{CODE syntax_3@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Change Index Priority](../../../../client-api/operations/maintenance/indexes/set-index-priority)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.dotnet.markdown
@@ -10,7 +10,7 @@
 * __Indexes scope__:  
   The lock mode can be set only for static-indexes, not for auto-indexes.
 
-* __Operation scope__:  
+* __Nodes scope__:  
   The lock mode will be updated on all nodes in the database group.
 
 * Setting the lock mode can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
@@ -97,7 +97,7 @@ Consider the following scenario:
 |- | - | - |
 | __indexName__ | string | Index name for which to set lock mode |
 | __mode__ | `IndexLockMode` | Lock mode to set |
-| __parameters__ | `SetIndexesLockOperation.Parameters` | List of indexes + Lock mode to set |
+| __parameters__ | `SetIndexesLockOperation.Parameters` | List of indexes + Lock mode to set.<br>An exception is thrown if any of the specified indexes do not exist. |
 
 {CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\SetLockMode.cs /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.dotnet.markdown
@@ -29,17 +29,17 @@
 
 {PANEL: Lock modes}
 
-* `Unlock` - when lock mode is set to _'Unlock'_:  
+* __Unlocked__ - when lock mode is set to `Unlock`:  
   * Any change to the index definition will be applied.  
   * If the new index definition differs from the one stored on the server,  
     the index will be updated and the data will be re-indexed using the new index definition.  
  
-* `LockedIgnore` - when lock mode is set to _'LockedIgnore'_:  
+* __Locked (ignore)__ - when lock mode is set to `LockedIgnore`:  
   * Index definition changes will Not be applied.  
   * Modifying the index definition will return successfully and no error will be raised,  
     however, no change will be made to the index definition on the server.
  
-* `LockedError` - when lock mode is set to _'LockedError'_:  
+* __Locked (error)__ - when lock mode is set to `LockedError`:  
   * Index definitions changes will Not be applied.  
   * An exception will be thrown upon trying to modify the index.  
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.java.markdown
@@ -1,0 +1,40 @@
+# Set Index Lock Mode Operation
+
+**SetIndexesLockOperation**  allows you to change index lock mode for a given index or indexes.
+
+## Syntax
+
+{CODE:java set_lock_mode_1@ClientApi\Operations\Maintenance\Indexes\SetLockMode.java /}
+
+{CODE:java set_lock_mode_2@ClientApi\Operations\Maintenance\Indexes\SetLockMode.java /}
+
+{CODE:java set_lock_mode_3@ClientApi\Operations\Maintenance\Indexes\SetLockMode.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **name** | String | name of an index to change lock mode for |
+| **lockMode** | IndexLockMode | new index lock mode |
+| **parameters** | SetIndexesLockOperation.Parameters | list of indexes + new index lock mode |
+
+## Example I
+
+{CODE:java set_lock_mode_4@ClientApi\Operations\Maintenance\Indexes\SetLockMode.java /}
+
+## Example II
+
+{CODE:java set_lock_mode_5@ClientApi\Operations\Maintenance\Indexes\SetLockMode.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Change Index Priority](../../../../client-api/operations/maintenance/indexes/set-index-priority)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.js.markdown
@@ -10,7 +10,7 @@
 * __Indexes scope__:  
   The lock mode can be set only for static-indexes, not for auto-indexes.
 
-* __Operation scope__:  
+* __Nodes scope__:  
   The lock mode will be updated on all nodes in the database group.
 
 * Setting the lock mode can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
@@ -90,8 +90,8 @@ Consider the following scenario:
 | Parameters | Type | Description |
 |- | - | - |
 | __indexName__ | string | Index name for which to set lock mode |
-| __mode__ | `"Unlock"` / `"LockedIgnore"` / `"LockedError"` | Lock mode to set |
-| __parameters__ | parameters object | List of indexes + lock mode to set |
+| __mode__ | `"Unlock"` /<br> `"LockedIgnore"` /<br> `"LockedError"` | Lock mode to set |
+| __parameters__ | parameters object | List of indexes + lock mode to set.<br>An exception is thrown if any of the specified indexes do not exist. |
 
 {CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Indexes\setLockMode.js /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.js.markdown
@@ -29,17 +29,17 @@
 
 {PANEL: Lock modes}
 
-* `Unlock` - when lock mode is set to _'Unlock'_:  
+* __Unlocked__ - when lock mode is set to `Unlock`:  
   * Any change to the index definition will be applied.  
   * If the new index definition differs from the one stored on the server,  
     the index will be updated and the data will be re-indexed using the new index definition.  
  
-* `LockedIgnore` - when lock mode is set to _'LockedIgnore'_:  
+* __Locked (ignore)__ - when lock mode is set to `LockedIgnore`:  
   * Index definition changes will Not be applied.  
   * Modifying the index definition will return successfully and no error will be raised,  
     however, no change will be made to the index definition on the server.
  
-* `LockedError` - when lock mode is set to _'LockedError'_:  
+* __Locked (error)__ - when lock mode is set to `LockedError`:  
   * Index definitions changes will Not be applied.  
   * An exception will be thrown upon trying to modify the index.  
 
@@ -90,7 +90,7 @@ Consider the following scenario:
 | Parameters | Type | Description |
 |- | - | - |
 | __indexName__ | string | Index name for which to set lock mode |
-| __mode__ | `Unlock` / `LockedIgnore` / `LockedError` | Lock mode to set |
+| __mode__ | `"Unlock"` / `"LockedIgnore"` / `"LockedError"` | Lock mode to set |
 | __parameters__ | parameters object | List of indexes + lock mode to set |
 
 {CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Indexes\setLockMode.js /}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.js.markdown
@@ -1,0 +1,113 @@
+# Set Index Lock Mode Operation
+
+---
+
+{NOTE: }
+
+* The lock mode controls the behavior of index modifications.  
+  Use `SetIndexesLockOperation` to modify the __lock mode__ for a single index or multiple indexes.
+
+* __Indexes scope__:  
+  The lock mode can be set only for static-indexes, not for auto-indexes.
+
+* __Operation scope__:  
+  The lock mode will be updated on all nodes in the database group.
+
+* Setting the lock mode can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
+  Locking an index is not a security measure, the index can be unlocked at any time.  
+
+* In this page:
+    * [Lock modes](../../../../client-api/operations/maintenance/indexes/set-index-lock#lock-modes)
+    * [Sample usage flow](../../../../client-api/operations/maintenance/indexes/set-index-lock#sample-usage-flow)
+    * [Set lock mode - single index](../../../../client-api/operations/maintenance/indexes/set-index-lock#set-lock-mode---single-index)
+    * [Set lock mode - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-lock#set-lock-mode---multiple-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-lock#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Lock modes}
+
+* `Unlock` - when lock mode is set to _'Unlock'_:  
+  * Any change to the index definition will be applied.  
+  * If the new index definition differs from the one stored on the server,  
+    the index will be updated and the data will be re-indexed using the new index definition.  
+ 
+* `LockedIgnore` - when lock mode is set to _'LockedIgnore'_:  
+  * Index definition changes will Not be applied.  
+  * Modifying the index definition will return successfully and no error will be raised,  
+    however, no change will be made to the index definition on the server.
+ 
+* `LockedError` - when lock mode is set to _'LockedError'_:  
+  * Index definitions changes will Not be applied.  
+  * An exception will be thrown upon trying to modify the index.  
+
+{PANEL/}
+
+{PANEL: Sample usage flow}
+
+Consider the following scenario:
+
+* Your client application defines and [deploys a static-index](../../../../client-api/operations/maintenance/indexes/put-indexes) upon application startup.
+  
+* After the application has started, you make a change to your index definition and re-indexing occurs.   
+  However, if the index lock mode is _'Unlock'_, the next time your application will start,  
+  it will reset the index definition back to the original version.
+
+* Locking the index allows to make changes to the running index and prevents the application  
+  from setting it back to the previous definition upon startup. See the following steps:  
+<br>
+
+  1. Run your application  
+  2. Modify the index definition on the server (from Studio, or from another application),  
+     and then set this index lock mode to `LockedIgnore`.  
+  3. A side-by-side replacement index is created on the server.  
+     It will index your dataset according to the __new__ definition.  
+  4. At this point, if any instance of your original application is started,  
+     the code that defines and deploys the index upon startup will have no effect  
+     since the index is 'locked'.  
+  5. Once the replacement index is done indexing, it will replace the original index.  
+
+{PANEL/}
+
+{PANEL: Set lock mode - single index}
+
+{CODE:nodejs set_lock_single@ClientApi\Operations\Maintenance\Indexes\setLockMode.js /}
+
+{PANEL/}
+
+{PANEL: Set lock mode - multiple indexes}
+
+{CODE:nodejs set_lock_multiple@ClientApi\Operations\Maintenance\Indexes\setLockMode.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@ClientApi\Operations\Maintenance\Indexes\setLockMode.js /}
+
+| Parameters | Type | Description |
+|- | - | - |
+| __indexName__ | string | Index name for which to set lock mode |
+| __mode__ | `Unlock` / `LockedIgnore` / `LockedError` | Lock mode to set |
+| __parameters__ | parameters object | List of indexes + lock mode to set |
+
+{CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Indexes\setLockMode.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Change Index Priority](../../../../client-api/operations/maintenance/indexes/set-index-priority)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetLockMode.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetLockMode.cs
@@ -1,0 +1,118 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class SetLockMode
+    {
+        public SetLockMode()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region set_lock_single
+                // Define the set lock mode operation
+                // Pass index name & lock mode
+                var setLockModeOp = new SetIndexesLockOperation("Orders/Totals", IndexLockMode.LockedIgnore);
+
+                // Execute the operation by passing it to Maintenance.Send
+                store.Maintenance.Send(setLockModeOp);
+                
+                // Lock mode is now set to 'LockedIgnore'
+                // Any modifications done now to the index will Not be applied, and will Not throw
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region set_lock_multiple
+                // Define the index list and the new lock mode:
+                var indexes = new SetIndexesLockOperation.Parameters {
+                    IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"}, 
+                    Mode = IndexLockMode.LockedError
+                };
+                    
+                // Define the set lock mode operation, pass the indexes param
+                var setLockModeOp = new SetIndexesLockOperation(indexes);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                store.Maintenance.Send(setLockModeOp);
+                
+                // Lock mode is now set to 'LockedError' on both indexes
+                // Any modifications done now to either index will throw
+                #endregion
+            }
+        }
+        
+        public async Task SetLockModeAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region set_lock_single_async
+                    // Define the set lock mode operation
+                    // Pass index name & lock mode
+                    var setLockModeOp = new SetIndexesLockOperation("Orders/Totals", IndexLockMode.LockedIgnore);
+
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    await store.Maintenance.SendAsync(setLockModeOp);
+                    
+                    // Lock mode is now set to 'LockedIgnore'
+                    // Any modifications done now to the index will Not be applied, and will Not throw
+                    #endregion
+                }
+
+                {
+                    #region set_lock_multiple_async
+                    // Define the index list and the new lock mode:
+                    var indexes = new SetIndexesLockOperation.Parameters {
+                        IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"}, 
+                        Mode = IndexLockMode.LockedError
+                    };
+                    
+                    // Define the set lock mode operation, pass the indexes param
+                    var setLockModeOp = new SetIndexesLockOperation(indexes);
+                
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    await store.Maintenance.SendAsync(setLockModeOp);
+                    
+                    // Lock mode is now set to 'LockedError' on both indexes
+                    // Any modifications done now to either index will throw
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            // Available overloads:
+            public SetIndexesLockOperation(string indexName, IndexLockMode mode);
+            public SetIndexesLockOperation(Parameters parameters);
+            #endregion
+            */
+        }
+
+        private class Mode
+        {
+            #region syntax_2
+            public enum IndexLockMode
+            {
+                Unlock,
+                LockedIgnore,
+                LockedError
+            }
+            #endregion
+        }
+
+        #region syntax_3
+        public class Parameters
+        {
+            public string[] IndexNames { get; set; }
+            public IndexLockMode Mode { get; set; }
+        }
+        #endregion
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetLockMode.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetLockMode.cs
@@ -28,13 +28,13 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
             {
                 #region set_lock_multiple
                 // Define the index list and the new lock mode:
-                var indexes = new SetIndexesLockOperation.Parameters {
+                var parameters = new SetIndexesLockOperation.Parameters {
                     IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"}, 
                     Mode = IndexLockMode.LockedError
                 };
                     
-                // Define the set lock mode operation, pass the indexes param
-                var setLockModeOp = new SetIndexesLockOperation(indexes);
+                // Define the set lock mode operation, pass the parameters
+                var setLockModeOp = new SetIndexesLockOperation(parameters);
                 
                 // Execute the operation by passing it to Maintenance.Send
                 store.Maintenance.Send(setLockModeOp);
@@ -66,13 +66,13 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 {
                     #region set_lock_multiple_async
                     // Define the index list and the new lock mode:
-                    var indexes = new SetIndexesLockOperation.Parameters {
+                    var parameters = new SetIndexesLockOperation.Parameters {
                         IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"}, 
                         Mode = IndexLockMode.LockedError
                     };
                     
-                    // Define the set lock mode operation, pass the indexes param
-                    var setLockModeOp = new SetIndexesLockOperation(indexes);
+                    // Define the set lock mode operation, pass the parameters
+                    var setLockModeOp = new SetIndexesLockOperation(parameters);
                 
                     // Execute the operation by passing it to Maintenance.SendAsync
                     await store.Maintenance.SendAsync(setLockModeOp);

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetLockMode.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetLockMode.cs
@@ -17,6 +17,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 var setLockModeOp = new SetIndexesLockOperation("Orders/Totals", IndexLockMode.LockedIgnore);
 
                 // Execute the operation by passing it to Maintenance.Send
+                // An exception will be thrown if index does not exist
                 store.Maintenance.Send(setLockModeOp);
                 
                 // Lock mode is now set to 'LockedIgnore'
@@ -37,6 +38,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 var setLockModeOp = new SetIndexesLockOperation(parameters);
                 
                 // Execute the operation by passing it to Maintenance.Send
+                // An exception will be thrown if any of the specified indexes do not exist
                 store.Maintenance.Send(setLockModeOp);
                 
                 // Lock mode is now set to 'LockedError' on both indexes
@@ -56,6 +58,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                     var setLockModeOp = new SetIndexesLockOperation("Orders/Totals", IndexLockMode.LockedIgnore);
 
                     // Execute the operation by passing it to Maintenance.SendAsync
+                    // An exception will be thrown if index does not exist
                     await store.Maintenance.SendAsync(setLockModeOp);
                     
                     // Lock mode is now set to 'LockedIgnore'
@@ -75,6 +78,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                     var setLockModeOp = new SetIndexesLockOperation(parameters);
                 
                     // Execute the operation by passing it to Maintenance.SendAsync
+                    // An exception will be thrown if any of the specified indexes do not exist
                     await store.Maintenance.SendAsync(setLockModeOp);
                     
                     // Lock mode is now set to 'LockedError' on both indexes

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/SetLockMode.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/SetLockMode.java
@@ -1,0 +1,68 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexLockMode;
+import net.ravendb.client.documents.operations.indexes.SetIndexesLockOperation;
+
+public class SetLockMode {
+
+    private interface IFoo {
+        /*
+        //region set_lock_mode_1
+        public SetIndexesLockOperation(String indexName, IndexLockMode mode)
+        public SetIndexesLockOperation(SetIndexesLockOperation.Parameters parameters)
+        //endregion
+        */
+    }
+
+    private static class Foo {
+        //region set_lock_mode_2
+        public enum IndexLockMode {
+            UNLOCK,
+            LOCKED_IGNORE,
+            LOCKED_ERROR
+        }
+        //endregion
+
+        //region set_lock_mode_3
+        public static class Parameters {
+            private String[] indexNames;
+            private IndexLockMode mode;
+
+            public String[] getIndexNames() {
+                return indexNames;
+            }
+
+            public void setIndexNames(String[] indexNames) {
+                this.indexNames = indexNames;
+            }
+
+            public IndexLockMode getMode() {
+                return mode;
+            }
+
+            public void setMode(IndexLockMode mode) {
+                this.mode = mode;
+            }
+        }
+        //endregion
+    }
+
+    public SetLockMode() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region set_lock_mode_4
+            store.maintenance().send(new SetIndexesLockOperation("Orders/Totals", IndexLockMode.LOCKED_IGNORE));
+            //endregion
+
+            //region set_lock_mode_5
+
+            SetIndexesLockOperation.Parameters parameters = new SetIndexesLockOperation.Parameters();
+            parameters.setIndexNames(new String[]{ "Orders/Totals", "Orders/ByCompany" });
+            parameters.setMode(IndexLockMode.LOCKED_IGNORE);
+
+            store.maintenance().send(new SetIndexesLockOperation(parameters));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
@@ -1,0 +1,52 @@
+﻿import { DocumentStore } from "ravendb";
+גלי עשת
+const documentStore = new DocumentStore();
+
+async function setLockMode() {
+    {
+        //region set_lock_single
+        // Define the set lock mode operation
+        // Pass index name & lock mode
+        const setLockModeOp = new SetIndexesLockOperation("Orders/Totals", "LockedIgnore");
+
+        // Execute the operation by passing it to maintenance.send
+        await store.maintenance.send(setLockModeOp);
+
+        // Lock mode is now set to 'LockedIgnore'
+        // Any modifications done now to the index will Not be applied, and will Not throw
+        //endregion
+
+        //region set_lock_multiple
+        // Define the index list and the new lock mode:
+        const indexes = {
+            indexNames: ["Orders/Totals", "Orders/ByCompany"],
+            mode: "LockedError"
+        }
+
+        // Define the set lock mode operation, pass the indexes param
+        const setLockModeOp = new SetIndexesLockOperation(indexes);
+
+        // Execute the operation by passing it to maintenance.send
+        await store.maintenance.send(setLockModeOp);
+
+        // Lock mode is now set to 'LockedError' on both indexes
+        // Any modifications done now to either index will throw
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    // Available overloads:
+    const setLockModeOp = new SetIndexesLockOperation(indexName, mode);
+    const setLockModeOp = new SetIndexesLockOperation(parameters);
+    //endregion
+
+    //region syntax_2
+    // parameters object
+    {
+        indexNames, // string[], list of index names
+        mode        // Lock mode to set
+    }
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
@@ -1,5 +1,5 @@
 ﻿import { DocumentStore } from "ravendb";
-גלי עשת
+
 const documentStore = new DocumentStore();
 
 async function setLockMode() {
@@ -15,7 +15,8 @@ async function setLockMode() {
         // Lock mode is now set to 'LockedIgnore'
         // Any modifications done now to the index will Not be applied, and will Not throw
         //endregion
-
+    }
+    {
         //region set_lock_multiple
         // Define the index list and the new lock mode:
         const indexes = {

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
@@ -10,6 +10,7 @@ async function setLockMode() {
         const setLockModeOp = new SetIndexesLockOperation("Orders/Totals", "LockedIgnore");
 
         // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if index does not exist
         await store.maintenance.send(setLockModeOp);
 
         // Lock mode is now set to 'LockedIgnore'
@@ -28,6 +29,7 @@ async function setLockMode() {
         const setLockModeOp = new SetIndexesLockOperation(parameters);
 
         // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if any of the specified indexes do not exist
         await store.maintenance.send(setLockModeOp);
 
         // Lock mode is now set to 'LockedError' on both indexes

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
@@ -19,13 +19,13 @@ async function setLockMode() {
     {
         //region set_lock_multiple
         // Define the index list and the new lock mode:
-        const indexes = {
+        const parameters = {
             indexNames: ["Orders/Totals", "Orders/ByCompany"],
             mode: "LockedError"
         }
 
-        // Define the set lock mode operation, pass the indexes param
-        const setLockModeOp = new SetIndexesLockOperation(indexes);
+        // Define the set lock mode operation, pass the parameters
+        const setLockModeOp = new SetIndexesLockOperation(parameters);
 
         // Execute the operation by passing it to maintenance.send
         await store.maintenance.send(setLockModeOp);

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -7,7 +7,7 @@
     },
     {
         "Path": "set-index-lock.markdown",
-        "Name": "Set Index Lock",
+        "Name": "Set Index Lock Mode",
         "DiscussionId": "c1de9893-93fc-4326-8024-ce5512428123",
         "Mappings": [
             {

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -7,7 +7,7 @@
     },
     {
         "Path": "set-index-lock.markdown",
-        "Name": "Set Index Lock",
+        "Name": "Set Index Lock Mode",
         "DiscussionId": "c1de9893-93fc-4326-8024-ce5512428123",
         "Mappings": [
             {

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/.docs.json
@@ -7,7 +7,7 @@
     },
     {
         "Path": "set-index-lock.markdown",
-        "Name": "Set Index Lock",
+        "Name": "Set Index Lock Mode",
         "DiscussionId": "c1de9893-93fc-4326-8024-ce5512428123",
         "Mappings": [
             {


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2372/Node.js-Client-API-Operations-Maintenance-Indexes-Set-index-lock

@ml054
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-lock.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setlockMode.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling