### PR TITLE
RDoc-2374 [Node.js] Client API > Operations > Maintenance > Indexes > Set index priority

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
@@ -9,7 +9,6 @@
   so indexing threads start with a lower priority than request-processing threads.  
 
 * Use `SetIndexesPriorityOperation` to increase or lower the index thread priority.  
-  Setting the priority will affect the indexing thread priority at the operating system level.
 
 * __Indexes scope__:  
   Index priority can be set for both static and auto indexes.  
@@ -20,6 +19,7 @@
 * Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
 
 * In this page:
+    * [Index priority](../../../../client-api/operations/maintenance/indexes/set-index-priority#index-priority)
     * [Set priority - single index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
     * [Set priority - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---multiple-indexes)
     * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
@@ -27,6 +27,18 @@
 {NOTE/}
 
 ---
+
+{PANEL: Index priority}
+
+Setting the priority will affect the indexing thread priority at the operating system level:  
+
+| Priority value | Indexing thread priority<br> at OS level | |
+| - | - | - |
+| __Low__ | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
+| __Normal__ (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
+| __High__ | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
+
+{PANEL/}
 
 {PANEL: Set priority - single index}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
@@ -1,0 +1,78 @@
+# Set Index Priority Operation
+
+---
+
+{NOTE: }
+
+* In RavenDB, each index has its own dedicated thread for all indexing work.  
+  By default, RavenDB prioritizes processing requests over indexing,  
+  so indexing threads start with a lower priority than request-processing threads.  
+
+* Use `SetIndexesPriorityOperation` to increase or lower the index thread priority.  
+  Setting the priority will affect the indexing thread priority at the operating system level.
+
+* __Indexes scope__:  
+  Index priority can be set for both static and auto indexes.  
+
+* __Operation scope__:  
+  The priority will be updated on all nodes in the database group.
+
+* Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
+
+* In this page:
+    * [Set priority - single index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
+    * [Set priority - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---multiple-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Set priority - single index}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync set_priority_single@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TAB:csharp:Async set_priority_single_async@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Set priority - multiple indexes}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync set_priority_multiple@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TAB:csharp:Async set_priority_multiple_async@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+
+| Parameters | | |
+| - | - | - |
+| **indexName** | string | Index name for which to change priority |
+| **priority** | `IndexingPriority` | Priority to set |
+| **parameters** | `SetIndexesPriorityOperation.Parameters` | List of indexes + Priority to set |
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+
+{CODE syntax_3@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Change Index Lock Mode](../../../../client-api/operations/maintenance/indexes/set-index-lock)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
@@ -14,7 +14,7 @@
 * __Indexes scope__:  
   Index priority can be set for both static and auto indexes.  
 
-* __Operation scope__:  
+* __Nodes scope__:  
   The priority will be updated on all nodes in the database group.
 
 * Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
@@ -54,7 +54,7 @@
 | - | - | - |
 | **indexName** | string | Index name for which to change priority |
 | **priority** | `IndexingPriority` | Priority to set |
-| **parameters** | `SetIndexesPriorityOperation.Parameters` | List of indexes + Priority to set |
+| **parameters** | `SetIndexesPriorityOperation.Parameters` | List of indexes + Priority to set.<br>An exception is thrown if any of the specified indexes do not exist. |
 
 {CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.java.markdown
@@ -1,0 +1,40 @@
+# Set Index Priority Operation
+
+**SetIndexesPriorityOperation**  allows you to change an index priority for a given index or indexes.
+
+## Syntax
+
+{CODE:java set_priority_1@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+{CODE:java set_priority_2@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+{CODE:java set_priority_3@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **name** | String | name of an index to change priority for |
+| **priority** | IndexingPriority | new index priority |
+| **parameters** | SetIndexesPriorityOperation.Parameters | list of indexes + new index priority |
+
+## Example I
+
+{CODE:java set_priority_4@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+## Example II
+
+{CODE:java set_priority_5@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Change Index Lock Mode](../../../../client-api/operations/maintenance/indexes/set-index-lock)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.java.markdown
@@ -1,6 +1,14 @@
 # Set Index Priority Operation
 
-**SetIndexesPriorityOperation**  allows you to change an index priority for a given index or indexes.
+**SetIndexesPriorityOperation**  allows you to change an index priority for a given index or indexes.  
+
+Setting the priority will affect the indexing thread priority at the operating system level:  
+
+| Priority value | Indexing thread priority<br> at OS level | |
+| - | - | - |
+| __Low__ | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
+| __Normal__ (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
+| __High__ | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
 
 ## Syntax
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
@@ -1,0 +1,70 @@
+# Set Index Priority Operation
+
+---
+
+{NOTE: }
+
+* In RavenDB, each index has its own dedicated thread for all indexing work.  
+  By default, RavenDB prioritizes processing requests over indexing,  
+  so indexing threads start with a lower priority than request-processing threads.  
+
+* Use `SetIndexesPriorityOperation` to increase or lower the index thread priority.  
+  Setting the priority will affect the indexing thread priority at the operating system level.
+
+* __Indexes scope__:  
+  Index priority can be set for both static and auto indexes.  
+
+* __Operation scope__:  
+  The priority will be updated on all nodes in the database group.
+
+* Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
+
+* In this page:
+    * [Set priority - single index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
+    * [Set priority - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---multiple-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Set priority - single index}
+
+{CODE:nodejs set_priority_single@ClientApi\Operations\Maintenance\Indexes\setPriority.js /}
+
+{PANEL/}
+
+{PANEL: Set priority - multiple indexes}
+
+{CODE:nodejs set_priority_multiple@ClientApi\Operations\Maintenance\Indexes\setPriority.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@ClientApi\Operations\Maintenance\Indexes\setPriority.js /}
+
+| Parameters | | |
+| - | - | - |
+| **indexName** | string | Index name for which to change priority |
+| **priority** | `"Low"` / `"Normal"` / `"High"` | Priority to set |
+| **parameters** | parameters object | List of indexes + Priority to set |
+
+{CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Indexes\setPriority.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Change Index Lock Mode](../../../../client-api/operations/maintenance/indexes/set-index-lock)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
@@ -14,7 +14,7 @@
 * __Indexes scope__:  
   Index priority can be set for both static and auto indexes.  
 
-* __Operation scope__:  
+* __Nodes scope__:  
   The priority will be updated on all nodes in the database group.
 
 * Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
@@ -47,8 +47,8 @@
 | Parameters | | |
 | - | - | - |
 | **indexName** | string | Index name for which to change priority |
-| **priority** | `"Low"` / `"Normal"` / `"High"` | Priority to set |
-| **parameters** | parameters object | List of indexes + Priority to set |
+| **priority** | `"Low"` /<br> `"Normal"` /<br> `"High"` | Priority to set |
+| **parameters** | parameters object | List of indexes + Priority to set.<br>An exception is thrown if any of the specified indexes do not exist. |
 
 {CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Indexes\setPriority.js /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
@@ -9,7 +9,6 @@
   so indexing threads start with a lower priority than request-processing threads.  
 
 * Use `SetIndexesPriorityOperation` to increase or lower the index thread priority.  
-  Setting the priority will affect the indexing thread priority at the operating system level.
 
 * __Indexes scope__:  
   Index priority can be set for both static and auto indexes.  
@@ -20,6 +19,7 @@
 * Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
 
 * In this page:
+    * [Index priority](../../../../client-api/operations/maintenance/indexes/set-index-priority#index-priority)
     * [Set priority - single index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
     * [Set priority - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---multiple-indexes)
     * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
@@ -27,6 +27,18 @@
 {NOTE/}
 
 ---
+
+{PANEL: Index priority}
+
+Setting the priority will affect the indexing thread priority at the operating system level:  
+
+| Priority value | Indexing thread priority<br> at OS level | |
+| - | - | - |
+| __Low__ | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
+| __Normal__ (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
+| __High__ | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
+
+{PANEL/}
 
 {PANEL: Set priority - single index}
 

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
@@ -24,14 +24,14 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 {
                     #region set_priority_multiple
                     // Define the index list and the new priority:
-                    var indexes = new SetIndexesPriorityOperation.Parameters
+                    var parameters = new SetIndexesPriorityOperation.Parameters
                     {
                         IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"},
                         Priority = IndexPriority.Low
                     };
 
-                    // Define the set priority operation, pass the indexes param
-                    var setPriorityOp = new SetIndexesPriorityOperation(indexes);
+                    // Define the set priority operation, pass the parameters
+                    var setPriorityOp = new SetIndexesPriorityOperation(parameters);
 
                     // Execute the operation by passing it to Maintenance.Send
                     store.Maintenance.Send(setPriorityOp);
@@ -57,14 +57,14 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                 {
                     #region set_priority_multiple_async
                     // Define the index list and the new priority:
-                    var indexes = new SetIndexesPriorityOperation.Parameters 
+                    var parameters = new SetIndexesPriorityOperation.Parameters 
                     {
                         IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"}, 
                         Priority = IndexPriority.Low
                     };
                 
-                    // Define the set priority operation, pass the indexes param
-                    var setPriorityOp = new SetIndexesPriorityOperation(indexes);
+                    // Define the set priority operation, pass the parameters
+                    var setPriorityOp = new SetIndexesPriorityOperation(parameters);
 
                     // Execute the operation by passing it to Maintenance.SendAsync
                     await store.Maintenance.SendAsync(setPriorityOp);

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
@@ -18,6 +18,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                     var setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.High);
 
                     // Execute the operation by passing it to Maintenance.Send
+                    // An exception will be thrown if index does not exist
                     store.Maintenance.Send(setPriorityOp);
                     #endregion
                 }
@@ -34,6 +35,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                     var setPriorityOp = new SetIndexesPriorityOperation(parameters);
 
                     // Execute the operation by passing it to Maintenance.Send
+                    // An exception will be thrown if any of the specified indexes do not exist
                     store.Maintenance.Send(setPriorityOp);
                     #endregion
                 }
@@ -51,6 +53,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                     var setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.High);
                 
                     // Execute the operation by passing it to Maintenance.SendAsync
+                    // An exception will be thrown if index does not exist
                     await store.Maintenance.SendAsync(setPriorityOp);
                     #endregion
                 }
@@ -67,6 +70,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                     var setPriorityOp = new SetIndexesPriorityOperation(parameters);
 
                     // Execute the operation by passing it to Maintenance.SendAsync
+                    // An exception will be thrown if any of the specified indexes do not exist
                     await store.Maintenance.SendAsync(setPriorityOp);
                     #endregion
                 }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
@@ -1,0 +1,107 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class SetPriority
+    {
+        public SetPriority()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region set_priority_single
+                    // Define the set priority operation
+                    // Pass index name & priority
+                    var setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.High);
+
+                    // Execute the operation by passing it to Maintenance.Send
+                    store.Maintenance.Send(setPriorityOp);
+                    #endregion
+                }
+                {
+                    #region set_priority_multiple
+                    // Define the index list and the new priority:
+                    var indexes = new SetIndexesPriorityOperation.Parameters
+                    {
+                        IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"},
+                        Priority = IndexPriority.Low
+                    };
+
+                    // Define the set priority operation, pass the indexes param
+                    var setPriorityOp = new SetIndexesPriorityOperation(indexes);
+
+                    // Execute the operation by passing it to Maintenance.Send
+                    store.Maintenance.Send(setPriorityOp);
+                    #endregion
+                }
+            }
+        }
+        
+        public async Task SetPriorityAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region set_priority_single_async
+                    // Define the set priority operation
+                    // Pass index name & priority
+                    var setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.High);
+                
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    await store.Maintenance.SendAsync(setPriorityOp);
+                    #endregion
+                }
+                {
+                    #region set_priority_multiple_async
+                    // Define the index list and the new priority:
+                    var indexes = new SetIndexesPriorityOperation.Parameters 
+                    {
+                        IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"}, 
+                        Priority = IndexPriority.Low
+                    };
+                
+                    // Define the set priority operation, pass the indexes param
+                    var setPriorityOp = new SetIndexesPriorityOperation(indexes);
+
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    await store.Maintenance.SendAsync(setPriorityOp);
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            // Available overloads:
+            public SetIndexesPriorityOperation(string indexName, IndexPriority priority);
+            public SetIndexesPriorityOperation(Parameters parameters);
+            #endregion
+            */
+        }
+
+        private class Priority
+        {
+            #region syntax_2
+            public enum IndexPriority
+            {
+                Low,
+                Normal,
+                High
+            }
+            #endregion
+        }
+        
+        #region syntax_3
+        public class Parameters
+        {
+            public string[] IndexNames { get; set; }
+            public IndexPriority Priority { get; set; }
+        }
+        #endregion
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/SetPriority.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/SetPriority.java
@@ -1,0 +1,68 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexPriority;
+import net.ravendb.client.documents.operations.indexes.SetIndexesPriorityOperation;
+
+public class ChangeIndexPriority {
+
+    private interface IFoo {
+        /*
+        //region set_priority_1
+        public SetIndexesPriorityOperation(String indexName, IndexPriority priority) {
+        public SetIndexesPriorityOperation(SetIndexesPriorityOperation.Parameters parameters)
+        //endregion
+        */
+    }
+
+    private static class Foo {
+        //region set_priority_2
+        public enum IndexPriority {
+            LOW,
+            NORMAL,
+            HIGH
+        }
+        //endregion
+
+        //region set_priority_3
+        public static class Parameters {
+            private String[] indexNames;
+            private IndexPriority priority;
+
+            public String[] getIndexNames() {
+                return indexNames;
+            }
+
+            public void setIndexNames(String[] indexNames) {
+                this.indexNames = indexNames;
+            }
+
+            public IndexPriority getPriority() {
+                return priority;
+            }
+
+            public void setPriority(IndexPriority priority) {
+                this.priority = priority;
+            }
+        }
+        //endregion
+    }
+
+    public ChangeIndexPriority() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region set_priority_4
+            store.maintenance().send(
+                new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.HIGH));
+            //endregion
+
+            //region set_priority_5
+            SetIndexesPriorityOperation.Parameters parameters = new SetIndexesPriorityOperation.Parameters();
+            parameters.setIndexNames(new String[]{ "Orders/Totals", "Orders/ByCompany" });
+            parameters.setPriority(IndexPriority.LOW);
+
+            store.maintenance().send(new SetIndexesPriorityOperation(parameters));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setPriority.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setPriority.js
@@ -10,6 +10,7 @@ async function setPriority() {
         const setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", "High");
 
         // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if index does not exist
         await store.maintenance.send(setPriorityOp);
         //endregion
 
@@ -26,6 +27,7 @@ async function setPriority() {
         const setPriorityOp = new SetIndexesPriorityOperation(parameters);
 
         // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if any of the specified indexes do not exist
         await store.maintenance.send(setPriorityOp);
         //endregion
     }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setPriority.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setPriority.js
@@ -1,0 +1,48 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function setPriority() {
+    {
+        //region set_priority_single
+        // Define the set priority operation
+        // Pass index name & priority
+        const setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", "High");
+
+        // Execute the operation by passing it to maintenance.send
+        await store.maintenance.send(setPriorityOp);
+        //endregion
+
+    }
+    {
+        //region set_priority_multiple
+        // Define the index list and the new priority:
+        const indexes = {
+            indexNames: ["Orders/Totals", "Orders/ByCompany"],
+            priority: "Low"
+        }
+
+        // Define the set priority operation, pass the indexes param
+        const setPriorityOp = new SetIndexesPriorityOperation(indexes);
+
+        // Execute the operation by passing it to maintenance.send
+        await store.maintenance.send(setPriorityOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    // Available overloads:
+    const setPriorityOp = new SetIndexesPriorityOperation(indexName, priority);
+    const setPriorityOp = new SetIndexesPriorityOperation(parameters);
+    //endregion
+
+    //region syntax_2
+    // parameters object
+    {
+        indexNames, // string[], list of index names
+        priority    // Priority to set
+    }
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setPriority.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setPriority.js
@@ -17,13 +17,13 @@ async function setPriority() {
     {
         //region set_priority_multiple
         // Define the index list and the new priority:
-        const indexes = {
+        const parameters = {
             indexNames: ["Orders/Totals", "Orders/ByCompany"],
             priority: "Low"
         }
 
-        // Define the set priority operation, pass the indexes param
-        const setPriorityOp = new SetIndexesPriorityOperation(indexes);
+        // Define the set priority operation, pass the parameters
+        const setPriorityOp = new SetIndexesPriorityOperation(parameters);
 
         // Execute the operation by passing it to maintenance.send
         await store.maintenance.send(setPriorityOp);


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2374/Node.js-Client-API-Operations-Maintenance-Indexes-Set-index-priority

@ml054
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/setPriority.js
```

@arekpalinski 
C# - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling