### PR TITLE
RDoc-2376 [Node.js] Client API > Operations > Maintenance > Indexes > Reset index

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/reset-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/reset-index.dotnet.markdown
@@ -1,0 +1,66 @@
+# Reset Index Operation
+
+---
+
+{NOTE: }
+
+* Use `ResetIndexOperation` to rebuild an index:  
+  * All existing indexed data will be removed.  
+  * All items matched by the index definition will be re-indexed.
+
+* __Indexes scope__:  
+  * Both static and auto indexes can be reset.
+
+* __Nodes scope__:  
+  * When resetting an index from the __client__:  
+    The index is reset only on the preferred node only, and Not on all the database-group nodes.  
+  * When resetting an index from the __Studio__ (from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions)):  
+    The index is reset on the local node the browser is opened on, even if it is Not the preferred node.  
+
+* If index is [disabled](../../../../client-api/operations/maintenance/indexes/disable-index) or [paused](../../../../client-api/operations/maintenance/indexes/stop-index) 
+  then resetting the index will put it back to the __normal__ running state  
+  on the local node where action was performed.
+
+* In this page:
+    * [Reset index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Reset index}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync reset@ClientApi\Operations\Maintenance\Indexes\ResetIndex.cs /}
+{CODE-TAB:csharp:Async reset_async@ClientApi\Operations\Maintenance\Indexes\ResetIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Operations\Maintenance\Indexes\ResetIndex.cs /}
+
+| Parameters | | |
+| - | - | - |
+| **indexName** | string | Name of an index to reset |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)  
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)  
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/reset-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/reset-index.java.markdown
@@ -1,0 +1,33 @@
+# Reset Index Operation
+
+**ResetIndexOperation** will remove all indexing data from a server for a given index so the indexation can start from scratch for that index.
+
+## Syntax
+
+{CODE:java reset_index_1@ClientApi\Operations\Maintenance\Indexes\ResetIndex.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | name of an index to reset |
+
+
+## Example
+
+{CODE:java reset_index_2@ClientApi\Operations\Maintenance\Indexes\ResetIndex.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)  
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)  
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/reset-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/reset-index.js.markdown
@@ -1,0 +1,63 @@
+# Reset Index Operation
+
+---
+
+{NOTE: }
+
+* Use `ResetIndexOperation` to rebuild an index:  
+  * All existing indexed data will be removed.  
+  * All items matched by the index definition will be re-indexed.  
+
+* __Indexes scope__:  
+  * Both static and auto indexes can be reset.
+
+* __Nodes scope__:  
+  * When resetting an index from the __client__:  
+    The index is reset only on the preferred node only, and Not on all the database-group nodes.  
+  * When resetting an index from the __Studio__ (from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions)):  
+    The index is reset on the local node the browser is opened on, even if it is Not the preferred node.  
+
+* If index is [disabled](../../../../client-api/operations/maintenance/indexes/disable-index) or [paused](../../../../client-api/operations/maintenance/indexes/stop-index) 
+  then resetting the index will put it back to the __normal__ running state  
+  on the local node where action was performed.
+
+* In this page:
+    * [Reset index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Reset index}
+
+{CODE:nodejs reset@ClientApi\Operations\Maintenance\Indexes\resetIndex.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Operations\Maintenance\Indexes\resetIndex.js /}
+
+| Parameters | | |
+| - | - | - |
+| **indexName** | string | Name of an index to reset |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../server/administration/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)  
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)  
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/ResetIndex.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/ResetIndex.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class ResetIndex
+    {
+        public ResetIndex()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region reset
+                // Define the reset index operation, pass index name
+                var resetIndexOp = new ResetIndexOperation("Orders/Totals");
+
+                // Execute the operation by passing it to Maintenance.Send
+                // An exception will be thrown if index does not exist
+                store.Maintenance.Send(resetIndexOp);
+                #endregion
+            }
+        }
+
+        public async Task ResetIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region reset_async
+                // Define the reset index operation, pass index name
+                var resetIndexOp = new ResetIndexOperation("Orders/Totals");
+
+                // Execute the operation by passing it to Maintenance.SendAsync
+                // An exception will be thrown if index does not exist
+                await store.Maintenance.SendAsync(resetIndexOp);
+                #endregion
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public ResetIndexOperation(string indexName);
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/ResetIndex.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/ResetIndex.java
@@ -1,0 +1,25 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.indexes.ResetIndexOperation;
+
+public class ResetIndex {
+
+    private interface IFoo {
+        /*
+        //region reset_index_1
+        public ResetIndexOperation(String indexName)
+        //endregion
+        */
+    }
+
+    public ResetIndex() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region reset_index_2
+            store.maintenance()
+                .send(new ResetIndexOperation("Orders/Totals"));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/resetIndex.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/resetIndex.js
@@ -1,0 +1,22 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getStats() {
+    {
+        //region reset
+        // Define the reset index operation, pass index name
+        const resetIndexOp = new ResetIndexOperation("Orders/Totals");
+
+        // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if index does not exist
+        await store.maintenance.send(resetIndexOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const resetIndexOp = new ResetIndexOperation(indexName);
+    //endregion
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2376/Node.js-Client-API-Operations-Maintenance-Indexes-Reset-index

@ml054
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/reset-index.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/resetIndex.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling