### PR TITLE
RDoc-2343 Index Administration page

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/administration/.docs.json
@@ -1,25 +1,31 @@
 [
-  {
-    "Path": "/SNMP",
-    "Name": "SNMP",
-    "Mappings": []
-  },
-  {
-    "Path": "cli.markdown",
-    "Name": "CLI (Command Line Interface)",
-    "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
-    "Mappings": []
-  },
-  {
-    "Path": "statistics.markdown",
-    "Name": "Statistics",
-    "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
-    "Mappings": []
-  },
-  {
-    "Path": "index-administration.markdown",
-    "Name": "Index Administration",
-    "DiscussionId": "f59449f5-7a21-4210-8a45-0ca90870cc53",
-    "Mappings": []
-  }
+    {
+        "Path": "/SNMP",
+        "Name": "SNMP",
+        "Mappings": []
+    },
+    {
+        "Path": "cli.markdown",
+        "Name": "CLI (Command Line Interface)",
+        "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
+        "Mappings": []
+    },
+    {
+        "Path": "statistics.markdown",
+        "Name": "Statistics",
+        "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
+        "Mappings": []
+    },
+    {
+        "Path": "index-administration.markdown",
+        "Name": "Index Administration",
+        "DiscussionId": "f59449f5-7a21-4210-8a45-0ca90870cc53",
+        "LastSupportedVersion": "5.1",
+        "Mappings": [
+            {
+                "Version": 5.2,
+                "Key": "indexes/index-administration"
+            }
+        ]
+    }
 ]

--- a/Documentation/4.0/Raven.Documentation.Pages/server/configuration/server-configuration.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/configuration/server-configuration.markdown
@@ -40,7 +40,9 @@ EXPERT: The process affinity mask.
 
 {PANEL:Server.IndexingAffinityMask}
 
-EXPERT: The affinity mask to be used for indexing. Overrides the Server.NumberOfUnusedCoresByIndexes value. Should only be used if you also set `Server.ProcessAffinityMask`.
+EXPERT: The affinity mask to be used for indexing.  
+Overrides the `Server.NumberOfUnusedCoresByIndexes` value.  
+Should only be used if you also set `Server.ProcessAffinityMask`.
 
 - **Type**: `long`
 - **Default**: `null`
@@ -50,7 +52,8 @@ EXPERT: The affinity mask to be used for indexing. Overrides the Server.NumberOf
 
 {PANEL:Server.NumberOfUnusedCoresByIndexes}
 
-EXPERT: The numbers of cores that will be NOT running indexing. Defaults to 1 core that is kept for all other tasks and will not be used for indexing.
+EXPERT: The numbers of cores that will NOT be running indexing.  
+Defaults to 1 core that is kept for all other tasks and will not be used for indexing.
 
 - **Type**: `int`
 - **Default**: `1`
@@ -60,8 +63,8 @@ EXPERT: The numbers of cores that will be NOT running indexing. Defaults to 1 co
 
 {PANEL:Server.CpuCredits.ExhaustionBackupDelayInMin}
 
-**EXPERT:** When CPU credits are exhausted, backup tasks are canceled. This value 
-determines how many minutes the server will wait before retrying the backup task.  
+EXPERT: When CPU credits are exhausted, backup tasks are canceled.  
+This value determines how many minutes the server will wait before retrying the backup task.  
 
 - **Type**: `TimeSetting`  
 - **TimeUnit**: `TimeUnit.Minutes`  

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index-errors.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index-errors.dotnet.markdown
@@ -57,10 +57,7 @@
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
 - [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index-errors.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index-errors.js.markdown
@@ -51,10 +51,7 @@
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
 - [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.dotnet.markdown
@@ -41,10 +41,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.java.markdown
@@ -20,10 +20,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/delete-index.js.markdown
@@ -38,10 +38,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.dotnet.markdown
@@ -103,10 +103,7 @@ __How to enable the index__:
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.java.markdown
@@ -23,10 +23,7 @@ The **DisableIndexOperation** is used to turn the indexing off for a given index
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/disable-index.js.markdown
@@ -96,10 +96,7 @@ __How to enable the index__:
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.dotnet.markdown
@@ -65,10 +65,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.java.markdown
@@ -21,10 +21,7 @@ The **EnableIndexOperation** is used to turn on the indexing for a given index.
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/enable-index.js.markdown
@@ -59,10 +59,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.dotnet.markdown
@@ -62,10 +62,7 @@
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
 - [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.java.markdown
@@ -30,10 +30,7 @@
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
 - [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.js.markdown
@@ -57,10 +57,7 @@
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
 - [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
@@ -44,10 +44,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.java.markdown
@@ -26,10 +26,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
@@ -41,10 +41,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
@@ -50,10 +50,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.java.markdown
@@ -24,10 +24,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
@@ -47,10 +47,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
@@ -51,10 +51,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.java.markdown
@@ -25,10 +25,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
@@ -48,10 +48,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
@@ -46,7 +46,4 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.java.markdown
@@ -28,7 +28,4 @@ The **GetTermsOperation** will retrieve stored terms for a field of an index.
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
@@ -43,7 +43,4 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.dotnet.markdown
@@ -124,10 +124,7 @@ Using `PutIndexesOperation` with an IndexDefinition created from an __IndexDefin
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.java.markdown
@@ -28,10 +28,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/put-indexes.js.markdown
@@ -102,10 +102,7 @@ Using `PutIndexesOperation` with __IndexDefinition__ allows the following:
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-index.dotnet.markdown
@@ -46,10 +46,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-index.java.markdown
@@ -20,10 +20,7 @@ The **StartIndexOperation** is used to resume indexing for an index.
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-index.js.markdown
@@ -43,10 +43,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-indexing.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-indexing.dotnet.markdown
@@ -42,10 +42,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-indexing.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-indexing.java.markdown
@@ -16,10 +16,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-indexing.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/start-indexing.js.markdown
@@ -39,10 +39,7 @@
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-index.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-index.dotnet.markdown
@@ -51,7 +51,7 @@ __How to resume the index__:
 
 * To resume the index from the Studio - go to the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions).
 
-* Pausing the index is Not a persistent operation.  
+* Pausing the index is __Not a persistent operation__.  
   This means the paused index will resume upon either of the following:
     * The server is restarted.
     * The database is re-loaded (by disabling and then enabling the database state).  
@@ -93,10 +93,7 @@ __How to resume the index__:
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-index.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-index.java.markdown
@@ -22,10 +22,7 @@ The **StopIndexOperation** is used to pause indexing of a single index.
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-index.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-index.js.markdown
@@ -51,7 +51,7 @@ __How to resume the index__:
 
 * To resume the index from the Studio - go to the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions).
 
-* Pausing the index is Not a persistent operation.  
+* Pausing the index is __Not a persistent operation__.  
   This means the paused index will resume upon either of the following:
     * The server is restarted.
     * The database is re-loaded (by disabling and then enabling the database state).  
@@ -90,10 +90,7 @@ __How to resume the index__:
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-indexing.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-indexing.dotnet.markdown
@@ -89,10 +89,7 @@ __How to resume indexing__:
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-indexing.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-indexing.java.markdown
@@ -20,10 +20,7 @@ Use [StopIndexOperation](../../../../client-api/operations/maintenance/indexes/s
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-indexing.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/stop-indexing.js.markdown
@@ -88,10 +88,7 @@ __How to resume indexing__:
 
 - [What are Indexes](../../../../indexes/what-are-indexes)
 - [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
-
-### Server
-
-- [Index Administration](../../../../server/administration/index-administration)
+- [Index Administration](../../../../indexes/index-administration)
 
 ### Operations
 

--- a/Documentation/5.2/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/indexes/.docs.json
@@ -33,6 +33,17 @@
         "Mappings": []
     },
     {
+        "Path": "index-administration.markdown",
+        "Name": "Index Administration",
+        "DiscussionId": "fb0d8765-f1e9-4b4b-9b83-0e41f9e9326e",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "server/administration/index-administration"
+            }
+        ]
+    },
+    {
         "Path": "map-indexes.markdown",
         "Name": "Map Indexes",
         "DiscussionId": "87029c0c-4d79-4974-a1df-7ee00e2e084f",

--- a/Documentation/5.2/Raven.Documentation.Pages/indexes/creating-and-deploying.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/indexes/creating-and-deploying.java.markdown
@@ -148,7 +148,7 @@ will result in a creation of a index named `Auto/Employees/ByFirstNameAndLastNam
 
 ### Auto Indexes and Indexing State
 
-To reduce the server load, if auto-indexes are not queried for a certain amount of time defined in `Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin` setting (30 minutes by default), then they will be marked as `Idle`. You can read more about the implications of marking index as `Idle` [here](../server/administration/index-administration#index-prioritization).
+To reduce the server load, if auto-indexes are not queried for a certain amount of time defined in `Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin` setting (30 minutes by default), then they will be marked as `Idle`. You can read more about the implications of marking index as `Idle` [here](../studio/database/indexes/indexes-list-view#index-state).
 
 Setting this configuration option to a high value may result in performance degradation due to the possibility of having a high amount of unnecessary work that is all redundant and not needed by indexes to perform. This is _not_ a recommended configuration.
 

--- a/Documentation/5.2/Raven.Documentation.Pages/indexes/creating-and-deploying.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/indexes/creating-and-deploying.js.markdown
@@ -156,7 +156,7 @@ will result in a creation of a index named `Auto/Employees/ByFirstNameAndLastNam
 
 ### Auto Indexes and Indexing State
 
-To reduce the server load, if auto-indexes are not queried for a certain amount of time defined in `Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin` setting (30 minutes by default), then they will be marked as `Idle`. You can read more about the implications of marking index as `Idle` [here](../server/administration/index-administration#index-prioritization).
+To reduce the server load, if auto-indexes are not queried for a certain amount of time defined in `Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin` setting (30 minutes by default), then they will be marked as `Idle`. You can read more about the implications of marking index as `Idle` [here](../studio/database/indexes/indexes-list-view#index-state).
 
 Setting this configuration option to a high value may result in performance degradation due to the possibility of having a high amount of unnecessary work that is all redundant and not needed by indexes to perform. This is _not_ a recommended configuration.
 

--- a/Documentation/5.2/Raven.Documentation.Pages/indexes/index-administration.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/indexes/index-administration.markdown
@@ -1,0 +1,118 @@
+# Index Administration
+
+---
+
+{NOTE: }
+
+* Indexes can be easily managed from the [Studio](../studio/database/indexes/indexes-list-view#indexes-list-view) or via [maintenance operations](../client-api/operations/what-are-operations#what-are-operations) in the Client API.
+
+* The following actions can be applied:
+    * [Pause & resume index](../indexes/index-administration#pause-&-resume-index)
+    * [Pause & resume indexing](../indexes/index-administration#pause-&-resume-indexing)
+    * [Disable & enable index](../indexes/index-administration#disable-&-enable-index)
+    * [Disable & enable indexing](../indexes/index-administration#disable-&-enable-indexing)
+    * [Reset index](../indexes/index-administration#reset-index)
+    * [Delete index](../indexes/index-administration#delete-index)
+    * [Set index lock mode](../indexes/index-administration#set-index-lock-mode)
+    * [Set index priority](../indexes/index-administration#set-index-priority)
+    * [Customize indexing configuration](../indexes/index-administration#customize-indexing-configuration)
+
+{NOTE/}
+
+---
+
+{PANEL: Pause & resume index}
+
+* An index can be paused (and resumed).  
+* See [pause index](../client-api/operations/maintenance/indexes/stop-index) & [resume index](../client-api/operations/maintenance/indexes/start-index) for detailed information.  
+* Operation scope: Single node.
+
+{PANEL/}
+
+{PANEL: Pause & resume indexing}
+
+* You can pause (and resume) indexing of ALL indexes.  
+* See [pause indexing](../client-api/operations/maintenance/indexes/stop-indexing) & [resume indexing](../client-api/operations/maintenance/indexes/start-indexing) for detailed information.
+* Operation scope: Single node.
+
+{PANEL/}
+
+{PANEL: Disable & enable index}
+
+* An index can be disabled (and enabled), this is a persistent operation.  
+* See [disable index](../client-api/operations/maintenance/indexes/disable-index) & [enable index](../client-api/operations/maintenance/indexes/enable-index) for detailed information.
+* Operation scope: Single node, or all database-group nodes.
+
+{PANEL/}
+
+{PANEL: Disable & enable indexing}
+
+* Indexing can be disabled (and enabled) for ALL indexes, this is a persistent operation.  
+* This is done from the [database list view](../studio/database/databases-list-view#more-actions) in the Studio.  
+* Operation scope: All database-group nodes.  
+
+{PANEL/}
+
+{PANEL: Reset index}
+
+* Resetting an index will force re-indexing of all documents that match the index definition.  
+  An index usually needs to be reset once it reached its error quota and is in an _Error_ state.
+* See [reset index](../client-api/operations/maintenance/indexes/reet-index) for detailed information.
+* Operation scope: Single node.
+
+{PANEL/}
+
+{PANEL: Delete index}
+
+* An index can be deleted from the database.   
+* See [delete index](../client-api/operations/maintenance/indexes/delete-index) for detailed information.
+* Operation scope: All database-group nodes.
+
+{PANEL/}
+
+{PANEL: Set index lock mode}
+
+* The lock mode controls whether modifications to the index definition are applied (static indexes only). 
+* See [set index lock](../client-api/operations/maintenance/indexes/set-index-lock) for detailed information.
+* Operation scope: All database-group nodes.
+
+{PANEL/}  
+
+{PANEL: Set index priority}
+
+* Each index has a dedicated thread that handles all the work for the index.  
+  Setting the index priority will affect the thread priority at the operating system level.
+* See [set index priority](../client-api/operations/maintenance/indexes/set-index-priority) for detailed information.
+* Operation scope: All database-group nodes.
+
+{PANEL/}
+
+{PANEL: Customize indexing configuration}
+
+* There are many [indexing configuration](../server/configuration/indexing-configuration) options available.  
+
+* A configuration key with a __"per-index" scope__ can be customized for a specific index,  
+  overriding the server-wide and the database configuration values.
+
+* The "per-index" configuration key can be set from:
+  * The [configuration tab](../studio/database/indexes/create-map-index#configuration) in the Edit Index view in the Studio.  
+  * The [index class constructor](../indexes/creating-and-deploying#creating-an-index-with-custom-configuration) when defining an index.  
+  * The [index definition](../indexes/creating-and-deploying#using-maintenance-operations) when sending a [putIndexesOperation](../client-api/operations/maintenance/indexes/put-indexes).
+
+__Expert configuration options:__
+
+* [Server.IndexingAffinityMask](../server/configuration/server-configuration#server.indexingaffinitymask) - Control the affinity mask of indexing threads
+* [Server.NumberOfUnusedCoresByIndexes](../server/configuration/server-configuration#server.numberofunusedcoresbyindexes) - Set the number of cores that _won't_ be used by indexes
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [Indexes: Overview](../studio/database/indexes/indexes-overview#indexes-overview)
+- [What are Indexes](../indexes/what-are-indexes)
+
+### Troubleshooting
+
+- [Debugging Index Errors](../indexes/troubleshooting/debugging-index-errors)

--- a/Documentation/5.2/Raven.Documentation.Pages/indexes/index-administration.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/indexes/index-administration.markdown
@@ -97,7 +97,7 @@
 * The "per-index" configuration key can be set from:
   * The [configuration tab](../studio/database/indexes/create-map-index#configuration) in the Edit Index view in the Studio.  
   * The [index class constructor](../indexes/creating-and-deploying#creating-an-index-with-custom-configuration) when defining an index.  
-  * The [index definition](../indexes/creating-and-deploying#using-maintenance-operations) when sending a [putIndexesOperation](../client-api/operations/maintenance/indexes/put-indexes).
+  * The [index definition](../client-api/operations/maintenance/indexes/put-indexes#put-indexes-operation-with-indexdefinition) when sending a [putIndexesOperation](../client-api/operations/maintenance/indexes/put-indexes).
 
 __Expert configuration options:__
 

--- a/Documentation/5.2/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/server/administration/.docs.json
@@ -1,25 +1,25 @@
 [
-  {
-    "Path": "/SNMP",
-    "Name": "SNMP",
-    "Mappings": []
-  },
-  {
-    "Path": "cli.markdown",
-    "Name": "CLI (Command Line Interface)",
-    "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
-    "Mappings": []
-  },
-  {
-    "Path": "statistics.markdown",
-    "Name": "Statistics",
-    "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
-    "Mappings": []
-  },
-  {
-    "Path": "monitoring.markdown",
-    "Name": "Monitoring and Telegraf Plugin",
-    "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
-    "Mappings": []
-  }
+    {
+        "Path": "/SNMP",
+        "Name": "SNMP",
+        "Mappings": []
+    },
+    {
+        "Path": "cli.markdown",
+        "Name": "CLI (Command Line Interface)",
+        "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
+        "Mappings": []
+    },
+    {
+        "Path": "statistics.markdown",
+        "Name": "Statistics",
+        "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
+        "Mappings": []
+    },
+    {
+        "Path": "monitoring.markdown",
+        "Name": "Monitoring and Telegraf Plugin",
+        "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.2/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/server/administration/.docs.json
@@ -17,12 +17,6 @@
     "Mappings": []
   },
   {
-    "Path": "index-administration.markdown",
-    "Name": "Index Administration",
-    "DiscussionId": "f59449f5-7a21-4210-8a45-0ca90870cc53",
-    "Mappings": []
-  },
-  {
     "Path": "monitoring.markdown",
     "Name": "Monitoring and Telegraf Plugin",
     "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/create-map-index.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/create-map-index.markdown
@@ -152,18 +152,19 @@
 1. **Indexes Tab**  
    Click to see indexing options.
 2. **List of Indexes**  
-   Select to see the list of your current indexes.
-   You can only configure static indexes, not auto-indexes. 
-   Select the index for which you want to change the default settings.
+   Select to see the list of your current indexes.  
+   You can only configure static-indexes, not auto-indexes.  
+   Select the index for which you want to customize the default configuration.  
 3. **Configuration**  
-   Scroll down and select the Configuration tab.
+   Scroll down and select the Configuration tab.  
 4. **Add customized indexing configuration**  
-   Click to select configuration and change the value.  
+   Click to add a configuration key.  
 5. **Indexing Configuration Key**  
-   Paste or select the configuration key that you want to change.
+   Paste or select the configuration key that you want to set.  
+   You can set any [indexing configuration](../../../server/configuration/indexing-configuration) that has a __"per-index"__ scope.
 6. **Value**  
-   Enter the new value for this configuration.
-   * **Click Save** at the top of the interface when finished.
+   Enter the new value for this configuration key.  
+   Click **Save** at the top of the interface when done.  
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/indexes-list-view.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/indexes-list-view.markdown
@@ -120,10 +120,10 @@
   The index will stop indexing on the local node the browser is opened on.  
   See states explanation above (under Figure-1).  
 * **Priority**  
-  Set the indexing-process thread priority as RavenDB prioritizes requests-processing over [Indexing](../../../server/administration/index-administration#priority) by default.  
+  Set the indexing-process thread priority as RavenDB prioritizes requests-processing over indexing by default.  
 * **Mode**  
-  Set modifications behavior:  
-   * Unlocked - Changes to the index definitions will be applied. See [Side by Side Indexing](../../../studio/database/indexes/indexes-list-view#indexes-list-view---side-by-side-indexing)  
+  Set modifications behavior (static-indexes only):  
+   * Unlocked - Changes to the index definitions will be applied. See [Side by Side Indexing](../../../studio/database/indexes/indexes-list-view#indexes-list-view---side-by-side-indexing).  
    * Locked - Index definitions changes will not be applied! No Error will be raised.  
    * Locked(Error) - Index definitions changes will not be applied! An error is raised upon trying to modify.  
 
@@ -142,7 +142,7 @@
   * Click this button again ("Resume indexing")  
   * Restart the server  
   * Reload the database (by disabling and then enabling the database state)  
-  * Resume indexing from the client code. See [resume indexing](../../../client-api/operations/maintenance/indexes/start-indexing)
+  * Resume indexing from the client code. See [resume indexing](../../../client-api/operations/maintenance/indexes/start-indexing).
 
 {PANEL/}
 
@@ -232,7 +232,8 @@
 ### Indexes
 - [What are Indexes](../../../indexes/what-are-indexes)
 - [Indexing Basics](../../../indexes/indexing-basics)
-- 
+- [Index Administration](../../../indexes/index-administration)
+
 ### Studio
 - [Indexes Overview](../../../studio/database/indexes/indexes-overview#indexes-overview)
 - [Index History](../../../studio/database/indexes/index-history)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/Put.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/Put.cs
@@ -48,11 +48,18 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                                 Total = order.Lines.Sum(l => (l.Quantity * l.PricePerUnit) * (1 - l.Discount))
                             }"
                     },
-
-                    // Can provide other index definitions available on the IndexDefinition class, e.g.:
+                    
+                    // Reduce = ...,
+                    
+                    // Can provide other index definitions available on the IndexDefinition class
+                    // Override the default values, e.g.:
                     DeploymentMode = IndexDeploymentMode.Rolling,
                     Priority = IndexPriority.High,
-                    // Reduce = ..., see all options in syntax below
+                    Configuration = new IndexConfiguration
+                    {
+                        { "Indexing.IndexMissingFieldsAsNull", "true" }
+                    }
+                    // See all available properties in syntax below
                 };
 
                 // Define the put indexes operation, pass the index definition
@@ -87,11 +94,18 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                               };
                         });"
                     },
+                    
+                    // Reduce = ...,
                    
-                    // Can provide other index definitions available on the IndexDefinition class, e.g.:
+                    // Can provide other index definitions available on the IndexDefinition class
+                    // Override the default values, e.g.:
                     DeploymentMode = IndexDeploymentMode.Rolling,
                     Priority = IndexPriority.High,
-                    // Reduce = ..., see all options in syntax below
+                    Configuration = new IndexConfiguration
+                    {
+                        { "Indexing.IndexMissingFieldsAsNull", "true" }
+                    }
+                    // See all available properties in syntax below
                 };
 
                 // Define the put indexes operation, pass the index definition
@@ -175,10 +189,17 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
                             }"
                     },
 
-                    // Can provide other index definitions available on the IndexDefinition class, e.g.:
+                    // Reduce = ...,
+                   
+                    // Can provide other index definitions available on the IndexDefinition class
+                    // Override the default values, e.g.:
                     DeploymentMode = IndexDeploymentMode.Rolling,
                     Priority = IndexPriority.High,
-                    // Reduce = ..., see all options in syntax below
+                    Configuration = new IndexConfiguration
+                    {
+                        { "Indexing.IndexMissingFieldsAsNull", "true" }
+                    }
+                    // See all available properties in syntax below
                 };
 
                 // Define the put indexes operation, pass the index definition

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/put.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/put.js
@@ -26,11 +26,17 @@ async function getStats() {
                     Total = order.Lines.Sum(l => (l.Quantity * l.PricePerUnit) * (1 - l.Discount))
                 }`
         ]);
+        
+         // indexDefinition.reduce = ...
 
-        // Can provide other index definitions available on the IndexDefinition class, e.g.:
+        // Can provide other index definitions available on the IndexDefinition class
+        // Override the default values, e.g.:
         indexDefinition.deploymentMode = "Rolling";
         indexDefinition.priority = "High";
-        // indexDefinition.reduce = ..., see all options in syntax below
+        indexDefinition.configuration = {
+            "Indexing.IndexMissingFieldsAsNull": "true"
+        };
+        // See all available properties in syntax below
         
         // Define the put indexes operation, pass the index definition
         // Note: multiple index definitions can be passed, see syntax below
@@ -62,10 +68,16 @@ async function getStats() {
             });`
         ]);
 
-        // Can provide other index definitions available on the IndexDefinition class, e.g.:
+        // indexDefinition.reduce = ...
+
+        // Can provide other index definitions available on the IndexDefinition class
+        // Override the default values, e.g.:
         indexDefinition.deploymentMode = "Rolling";
         indexDefinition.priority = "High";
-        // indexDefinition.reduce = ..., see all options in syntax below
+        indexDefinition.configuration = {
+            "Indexing.IndexMissingFieldsAsNull": "true"
+        };
+        // See all available properties in syntax below
 
         // Define the put indexes operation, pass the index definition
         // Note: multiple index definitions can be passed, see syntax below

--- a/Documentation/5.3/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/indexes/.docs.json
@@ -33,6 +33,12 @@
         "Mappings": []
     },
     {
+        "Path": "index-administration.markdown",
+        "Name": "Index Administration",
+        "DiscussionId": "fb0d8765-f1e9-4b4b-9b83-0e41f9e9326e",
+        "Mappings": []
+    },
+    {
         "Path": "map-indexes.markdown",
         "Name": "Map Indexes",
         "DiscussionId": "87029c0c-4d79-4974-a1df-7ee00e2e084f",

--- a/Documentation/5.3/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/server/administration/.docs.json
@@ -1,25 +1,25 @@
 [
-  {
-    "Path": "/SNMP",
-    "Name": "SNMP",
-    "Mappings": []
-  },
-  {
-    "Path": "cli.markdown",
-    "Name": "CLI (Command Line Interface)",
-    "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
-    "Mappings": []
-  },
-  {
-    "Path": "statistics.markdown",
-    "Name": "Statistics",
-    "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
-    "Mappings": []
-  },
-  {
-    "Path": "monitoring.markdown",
-    "Name": "Monitoring and Telegraf Plugin",
-    "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
-    "Mappings": []
-  }
+    {
+        "Path": "/SNMP",
+        "Name": "SNMP",
+        "Mappings": []
+    },
+    {
+        "Path": "cli.markdown",
+        "Name": "CLI (Command Line Interface)",
+        "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
+        "Mappings": []
+    },
+    {
+        "Path": "statistics.markdown",
+        "Name": "Statistics",
+        "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
+        "Mappings": []
+    },
+    {
+        "Path": "monitoring.markdown",
+        "Name": "Monitoring and Telegraf Plugin",
+        "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.3/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/server/administration/.docs.json
@@ -17,12 +17,6 @@
     "Mappings": []
   },
   {
-    "Path": "index-administration.markdown",
-    "Name": "Index Administration",
-    "DiscussionId": "f59449f5-7a21-4210-8a45-0ca90870cc53",
-    "Mappings": []
-  },
-  {
     "Path": "monitoring.markdown",
     "Name": "Monitoring and Telegraf Plugin",
     "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/.docs.json
@@ -33,6 +33,12 @@
         "Mappings": []
     },
     {
+        "Path": "index-administration.markdown",
+        "Name": "Index Administration",
+        "DiscussionId": "fb0d8765-f1e9-4b4b-9b83-0e41f9e9326e",
+        "Mappings": []
+    },
+    {
         "Path": "map-indexes.markdown",
         "Name": "Map Indexes",
         "DiscussionId": "87029c0c-4d79-4974-a1df-7ee00e2e084f",

--- a/Documentation/5.4/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/administration/.docs.json
@@ -1,25 +1,25 @@
 [
-  {
-    "Path": "/SNMP",
-    "Name": "SNMP",
-    "Mappings": []
-  },
-  {
-    "Path": "cli.markdown",
-    "Name": "CLI (Command Line Interface)",
-    "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
-    "Mappings": []
-  },
-  {
-    "Path": "statistics.markdown",
-    "Name": "Statistics",
-    "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
-    "Mappings": []
-  },
-  {
-    "Path": "monitoring.markdown",
-    "Name": "Monitoring and Telegraf Plugin",
-    "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
-    "Mappings": []
-  }
+    {
+        "Path": "/SNMP",
+        "Name": "SNMP",
+        "Mappings": []
+    },
+    {
+        "Path": "cli.markdown",
+        "Name": "CLI (Command Line Interface)",
+        "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
+        "Mappings": []
+    },
+    {
+        "Path": "statistics.markdown",
+        "Name": "Statistics",
+        "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
+        "Mappings": []
+    },
+    {
+        "Path": "monitoring.markdown",
+        "Name": "Monitoring and Telegraf Plugin",
+        "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.4/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/administration/.docs.json
@@ -17,12 +17,6 @@
     "Mappings": []
   },
   {
-    "Path": "index-administration.markdown",
-    "Name": "Index Administration",
-    "DiscussionId": "f59449f5-7a21-4210-8a45-0ca90870cc53",
-    "Mappings": []
-  },
-  {
     "Path": "monitoring.markdown",
     "Name": "Monitoring and Telegraf Plugin",
     "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -33,6 +33,12 @@
         "Mappings": []
     },
     {
+        "Path": "index-administration.markdown",
+        "Name": "Index Administration",
+        "DiscussionId": "fb0d8765-f1e9-4b4b-9b83-0e41f9e9326e",
+        "Mappings": []
+    },
+    {
         "Path": "map-indexes.markdown",
         "Name": "Map Indexes",
         "DiscussionId": "87029c0c-4d79-4974-a1df-7ee00e2e084f",

--- a/Documentation/6.0/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/administration/.docs.json
@@ -1,25 +1,25 @@
 [
-  {
-    "Path": "/SNMP",
-    "Name": "SNMP",
-    "Mappings": []
-  },
-  {
-    "Path": "cli.markdown",
-    "Name": "CLI (Command Line Interface)",
-    "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
-    "Mappings": []
-  },
-  {
-    "Path": "statistics.markdown",
-    "Name": "Statistics",
-    "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
-    "Mappings": []
-  },
-  {
-    "Path": "monitoring.markdown",
-    "Name": "Monitoring and Telegraf Plugin",
-    "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
-    "Mappings": []
-  }
+    {
+        "Path": "/SNMP",
+        "Name": "SNMP",
+        "Mappings": []
+    },
+    {
+        "Path": "cli.markdown",
+        "Name": "CLI (Command Line Interface)",
+        "DiscussionId": "9a757074-8bee-4e4c-bab9-ec7217e881f3",
+        "Mappings": []
+    },
+    {
+        "Path": "statistics.markdown",
+        "Name": "Statistics",
+        "DiscussionId": "3677c851-1da8-45d3-a83f-8f577211c0b4",
+        "Mappings": []
+    },
+    {
+        "Path": "monitoring.markdown",
+        "Name": "Monitoring and Telegraf Plugin",
+        "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",
+        "Mappings": []
+    }
 ]

--- a/Documentation/6.0/Raven.Documentation.Pages/server/administration/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/administration/.docs.json
@@ -17,12 +17,6 @@
     "Mappings": []
   },
   {
-    "Path": "index-administration.markdown",
-    "Name": "Index Administration",
-    "DiscussionId": "f59449f5-7a21-4210-8a45-0ca90870cc53",
-    "Mappings": []
-  },
-  {
     "Path": "monitoring.markdown",
     "Name": "Monitoring and Telegraf Plugin",
     "DiscussionId": "f59c124a-b94a-4380-bff2-dcb1782ef1f6",


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2343/Index-Administration-page-Add-section-about-indexing-configuration

@shiranshalom 
File to be reviewed:
`Documentation/5.2/Raven.Documentation.Pages/indexes/index-administration.markdown`
(The other files are just small fixes, layout fixes, link fixes)