### PR TITLE
RDoc-2381 [Node.js] Client API > Operations > Maintenance > Indexes > Index has changed

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.dotnet.markdown
@@ -1,0 +1,62 @@
+# Index has Changed Operation
+
+ ---
+
+{NOTE: }
+
+* __When deploying an index__:  
+  * If the new index definition is __different__ than the current index definition on the server,  
+    the current index will be overwritten and data will be re-indexed according to the new index definition.
+  * If the new index definition is the __same__ as the one on the server,  
+    it will not be overwritten and re-indexing will not occur upon deploying the index.
+
+* __Prior to deploying an index:__,  
+  * Use `IndexHasChangedOperation` to check if the new index definition differs from the one  
+    on the server to avoid any unwanted changes to the existing indexed data.  
+
+* In this page:
+    * [Check if index has changed](../../../../client-api/operations/maintenance/indexes/index-has-changed#check-if-index-has-changed)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/index-has-changed#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Check if index has changed}
+
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync index_has_changed@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.cs /}
+{CODE-TAB:csharp:Async index_has_changed_async@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| __definition__ | [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) | The index definition to check |
+
+| Return Value | |
+| - | - |
+| `true` | When the index __does not exist__ on the server<br>or - <br>When the index definition __is different__ than the one deployed on the server  |
+| `false` | When the index definition is __the same__ as the one deployed on the server |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.java.markdown
@@ -1,0 +1,35 @@
+# Index has Changed Operation
+
+**IndexHasChangedOperation** will let you check if the given index definition differs from the one on a server. This might be useful when you want to check the prior index deployment, if the index will be overwritten, and if indexing data will be lost.
+
+## Syntax
+
+{CODE:java index_has_changed_1@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexDef** | `IndexDefinition` | index definition |
+
+| Return Value | |
+| ------------- | ----- |
+| true | if an index **does not exist** on a server |
+| true | if an index definition **does not match** the one from the **indexDef** parameter |
+| false | if there are no differences between an index definition on the server and the one from the **indexDef** parameter |
+
+## Example
+
+{CODE:java index_has_changed_2@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.js.markdown
@@ -1,0 +1,58 @@
+# Index has Changed Operation
+
+ ---
+
+{NOTE: }
+
+* __When deploying an index__:  
+  * If the new index definition is __different__ than the current index definition on the server,  
+    the current index will be overwritten and data will be re-indexed according to the new index definition.
+  * If the new index definition is the __same__ as the one on the server,  
+    it will not be overwritten and re-indexing will not occur upon deploying the index.
+
+* __Prior to deploying an index:__,  
+  * Use `IndexHasChangedOperation` to check if the new index definition differs from the one  
+    on the server to avoid any unwanted changes to the existing indexed data.  
+
+* In this page:
+    * [Check if index has changed](../../../../client-api/operations/maintenance/indexes/index-has-changed#check-if-index-has-changed)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/index-has-changed#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Check if index has changed}
+
+{CODE:nodejs index_has_changed@ClientApi\Operations\Maintenance\Indexes\indexHasChanged.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Operations\Maintenance\Indexes\indexHasChanged.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| __definition__ | [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) | The index definition to check |
+
+| Return Value | |
+| - | - |
+| `true` | When the index __does not exist__ on the server<br>or - <br>When the index definition __is different__ than the one deployed on the server  |
+| `false` | When the index definition is __the same__ as the one deployed on the server |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.cs
@@ -1,0 +1,71 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class IndexHasChanged
+    {
+        public IndexHasChanged()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region index_has_changed
+                // Some index definition
+                var indexDefinition = new IndexDefinition
+                {
+                    Name = "UsersByName",
+                    Maps = { "from user in docs.Users select new { user.Name }"}
+                };
+                
+                // Define the has-changed operation, pass the index definition
+                var indexHasChangedOp = new IndexHasChangedOperation(indexDefinition);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                bool indexHasChanged = store.Maintenance.Send(indexHasChangedOp);
+                
+                // Return values:
+                // false: The definition of the index passed is the SAME as the one deployed on the server  
+                // true:  The definition of the index passed is DIFFERENT than the one deployed on the server
+                //        Or - index does not exist
+                #endregion
+            }
+        }
+        
+        public async Task IndexHasChangedAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region index_has_changed_async
+                // Some index definition
+                var indexDefinition = new IndexDefinition
+                {
+                    Name = "UsersByName",
+                    Maps = { "from user in docs.Users select new { user.Name }"}
+                };
+                
+                // Define the has-changed operation, pass the index definition
+                var indexHasChangedOp = new IndexHasChangedOperation(indexDefinition);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                bool indexHasChanged = await store.Maintenance.SendAsync(indexHasChangedOp);
+                
+                // Return values:
+                // false: The definition of the index passed is the SAME as the one deployed on the server  
+                // true:  The definition of the index passed is DIFFERENT than the one deployed on the server
+                //        Or - index does not exist
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public IndexHasChangedOperation(IndexDefinition definition)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.java
@@ -1,0 +1,28 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexDefinition;
+import net.ravendb.client.documents.operations.indexes.IndexHasChangedOperation;
+
+public class IndexHasChanged {
+
+
+    private interface IFoo {
+        /*
+        //region index_has_changed_1
+        public IndexHasChangedOperation(IndexDefinition definition)
+        //endregion
+        */
+    }
+
+    public IndexHasChanged() {
+        try (IDocumentStore store = new DocumentStore()) {
+            IndexDefinition ordersIndexDefinition = null;
+            //region index_has_changed_2
+            Boolean ordersIndexHasChanged =
+                store.maintenance().send(new IndexHasChangedOperation(ordersIndexDefinition));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/indexHasChanged.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/indexHasChanged.js
@@ -1,0 +1,32 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getStats() {
+    {
+        //region index_has_changed
+        // Some index definition
+        const indexDefinition = new IndexDefinition();
+        indexDefinition.name = "UsersByName";
+        indexDefinition.maps = new Set([ `from user in docs.Users select new { user.Name }` ]);
+
+        // Define the has-changed operation, pass the index definition
+        const indexHasChangedOp = new IndexHasChangedOperation(indexDefinition);
+
+        // Execute the operation by passing it to maintenance.send
+        const indexHasChanged = await documentStore.maintenance.send(indexHasChangedOp);
+
+        // Return values:
+        // false: The definition of the index passed is the SAME as the one deployed on the server  
+        // true:  The definition of the index passed is DIFFERENT than the one deployed on the server
+        //        Or - index does not exist
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const indexHasChangedOp = new IndexHasChangedOperation(definition);
+    //endregion
+
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2381/Node.js-Client-API-Operations-Maintenance-Indexes-Index-has-changed

@ml054 
Node.js - files to be reviewed:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Indexes/indexHasChanged.js
```

**Notes:**
Java files in this PR are Not to be reviewed.
Only copied to 5.2 since we have no file bubbling