### PR TITLE
RDoc-2396 Document extensions > Revisions > Client API > Session > Get Revisions

### DIFF
--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/overview.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/overview.dotnet.markdown
@@ -28,9 +28,9 @@
 
 * __Get revisions__:  
 
-  * [GetFor](../../../document-extensions/revisions/client-api/session/loading#getfor) - retrieve all revisions kept for a document.
-  * [GetMetadataFor](../../../document-extensions/revisions/client-api/session/loading#getmetadatafor) - retrieve metadata for all revisions kept for a document.
-  * [Get](../../../document-extensions/revisions/client-api/session/loading#get) - retrieve revisions by change vector or creation time.
+  * [GetFor](../../../document-extensions/revisions/client-api/session/loading#get-all-revisions) - retrieve all revisions kept for a document.
+  * [GetMetadataFor](../../../document-extensions/revisions/client-api/session/loading#get-revisions-metadata) - retrieve metadata for all revisions kept for a document.
+  * [Get](../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-creation-time) - retrieve revisions by change vector or creation time.
   * Read [here](../../../client-api/session/how-to/perform-operations-lazily#getRevisions) about __lazy versions__ of `GetFor`, `GetMetadataFor`, and `Get`.
 
 ---

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/overview.js.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/overview.js.markdown
@@ -28,9 +28,9 @@
 
 * __Get revisions__:
 
-    * [getFor](../../../document-extensions/revisions/client-api/session/loading#getfor) - retrieve all revisions kept for a document.
-    * [getMetadataFor](../../../document-extensions/revisions/client-api/session/loading#getmetadatafor) - retrieve metadata for all revisions kept for a document.
-    * [get](../../../document-extensions/revisions/client-api/session/loading#get) - retrieve revisions by change vector or creation time.
+    * [getFor](../../../document-extensions/revisions/client-api/session/loading#get-all-revisions) - retrieve all revisions kept for a document.
+    * [getMetadataFor](../../../document-extensions/revisions/client-api/session/loading#get-revisions-metadata) - retrieve metadata for all revisions kept for a document.
+    * [get](../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-creation-time) - retrieve revisions by change vector or creation time.
     * Read [here](../../../client-api/session/how-to/perform-operations-lazily#getRevisions) about __lazy versions__ of `getFor`, `getMetadataFor`, and `get`.
 
 ---

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
@@ -1,7 +1,7 @@
 [
     {
         "Path": "loading.markdown",
-        "Name": "Loading",
+        "Name": "Get Revisions",
         "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
         "Mappings": [
             {

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.dotnet.markdown
@@ -5,7 +5,7 @@
 {NOTE: }
 
 * Using the Advanced Session methods you can __retrieve revisions and their metadata__  
-  from the database for the specified document:  
+  from the database for the specified document.  
 
 * These methods can also be executed lazily, see [get revisions lazily](../../../../client-api/session/how-to/perform-operations-lazily#getRevisons).   
   
@@ -15,7 +15,9 @@
 
   * [Get revisions metadata](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-metadata)  
 
-  * [Get revisions by change vector or by creation time](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-change-vector-or-by-creation-time)  
+  * [Get revisions by creation time](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-creation-time)  
+  
+  * [Get revisions by change vector](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-change-vector)  
 
 
 {NOTE/}
@@ -42,8 +44,8 @@ __Syntax__:
 | Parameters | Type | Description |
 | - | - |- |
 | **id** | `string` | Document ID for which to retrieve revisions |
-| **start** | `int` | First revision to retrieve |
-| **pageSize** | `int` | Number of revisions to retrieve per page |
+| **start** | `int` | First revision to retrieve, used for paging |
+| **pageSize** | `int` | Number of revisions to retrieve per results page |
 
 {PANEL/}
 
@@ -67,31 +69,22 @@ __Syntax__:
 | Parameters | Type | Description |
 | - | - |- |
 | **id** | `string` | Document ID for which to retrieve revisions' metadata |
-| **start** | `int` | First revision to retrieve metadata for |
-| **pageSize** | `int` | Number of revisions to retrieve per page |
+| **start** | `int` | First revision to retrieve metadata for, used for paging |
+| **pageSize** | `int` | Number of revisions to retrieve per results page |
 
 {PANEL/}
 
-{PANEL: Get revisions by change vector or by creation time}
+{PANEL: Get revisions by creation time}
 
-* Use `Get` to:  
-  * Retrieve a revision or multiple revisions by their **change vectors**  
-  * Retrieve a revision by its **creation time**  
+* Use `Get` to retrieve a revision by its **creation time**.
 
 ---
 
-__By change vector__:
+__Example__:
 
 {CODE-TABS}
-{CODE-TAB:csharp:Sync example_3.1_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-{CODE-TAB:csharp:Async example_3.1_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-{CODE-TABS/}
-
-__By creation time__:  
-
-{CODE-TABS}
-{CODE-TAB:csharp:Sync example_3.2_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-{CODE-TAB:csharp:Async example_3.2_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+{CODE-TAB:csharp:Sync example_3_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+{CODE-TAB:csharp:Async example_3_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TABS/}
 
 ---
@@ -102,10 +95,32 @@ __Syntax__:
 
 | Parameter | Type | Description |
 | - | - | - |
-| **changeVector** | `string` | A revision's change vector |
-| **changeVectors**| `IEnumerable<string>` | revisions' change vectors |
-| **date**| `DateTime ` | A revision's creation time |
 | **id** | `string` | Document ID for which to retrieve the revision by creation time |
+| **date** | `DateTime ` | The revision's creation time |
+
+{PANEL/}
+
+{PANEL: Get revisions by change vector}
+
+* Use `Get` to retrieve a revision or multiple revisions by their **change vectors**.  
+
+---
+
+__Example__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync example_4_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+{CODE-TAB:csharp:Async example_4_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+{CODE-TABS/}
+
+__Syntax__:
+
+{CODE syntax_4@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **changeVector** | `string` | The revision's change vector |
+| **changeVectors** | `IEnumerable<string>` | Change vectors of multiple revisions |
 
 {PANEL/}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.dotnet.markdown
@@ -1,116 +1,111 @@
-# Revisions: Loading Revisions
+# Get Revisions
 
 ---
 
 {NOTE: }
 
-You can retrieve revisions and their metadata from the database using these Session methods:  
+* Using the Advanced Session methods you can __retrieve revisions and their metadata__  
+  from the database for the specified document:  
 
-* `session.Advanced.Revisions.GetFor`  
-  Retrieves all the revisions currently kept for a specified document  
-* `session.Advanced.Revisions.GetMetadataFor`  
-  Retrieves the metadata for all the revisions currently kept for a specified document  
-* `session.Advanced.Revisions.Get`  
-  Retrieves a revision or multiple revisions by their change vectors  
-  Retrieves a revision by its creation time  
-
+* These methods can also be executed lazily, see [get revisions lazily](../../../../client-api/session/how-to/perform-operations-lazily#getRevisons).   
+  
 * In this page:  
-  * [`GetFor`](../../../../document-extensions/revisions/client-api/session/loading#getfor)  
-  * [`GetMetadataFor`](../../../../document-extensions/revisions/client-api/session/loading#getmetadatafor)  
-  * [`Get`](../../../../document-extensions/revisions/client-api/session/loading#get)  
+  
+  * [Get all revisions](../../../../document-extensions/revisions/client-api/session/loading#get-all-revisions)  
+
+  * [Get revisions metadata](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-metadata)  
+
+  * [Get revisions by change vector or by creation time](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-change-vector-or-by-creation-time)  
+
 
 {NOTE/}
 
 ---
 
-{PANEL: `GetFor`}
+{PANEL: Get all revisions}
 
-Use `GetFor` to retrieve all of the revisions currently kept for a specified document.  
+* Use `GetFor` to retrieve all of the revisions currently kept for the specified document.
 
-### Syntax
+---
 
-{CODE syntax_1@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **id** | string | ID of the document whose revisions are retrieved |
-| **start** | int | First revision to retrieve |
-| **pageSize** | int | How many revisions to retrieve per page |
-
-#### Example
+__Example__:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync example_1_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TAB:csharp:Async example_1_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TABS/}
 
+__Syntax__:
+
+{CODE syntax_1@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+
+| Parameters | Type | Description |
+| - | - |- |
+| **id** | `string` | Document ID for which to retrieve revisions |
+| **start** | `int` | First revision to retrieve |
+| **pageSize** | `int` | Number of revisions to retrieve per page |
+
 {PANEL/}
 
-{PANEL: `GetMetadataFor`}
+{PANEL: Get revisions metadata}
 
-Use `GetMetadataFor` to retrieve the metadata for all the revisions currently kept 
-for a specified document.  
+* Use `GetMetadataFor` to retrieve the metadata for all the revisions currently kept for the specified document.
 
-### Syntax
+---
 
-{CODE syntax_2@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **id** | string | ID of the document whose revisions' metadata is retrieved |
-| **start** | int | First revision to retrieve metadata for |
-| **pageSize** | int | how many revisions to retrieve per page |
-
-#### Example
+__Example__:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync example_2_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TAB:csharp:Async example_2_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TABS/}
 
+__Syntax__:
+
+{CODE syntax_2@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+
+| Parameters | Type | Description |
+| - | - |- |
+| **id** | `string` | Document ID for which to retrieve revisions' metadata |
+| **start** | `int` | First revision to retrieve metadata for |
+| **pageSize** | `int` | Number of revisions to retrieve per page |
+
 {PANEL/}
 
-{PANEL: `Get`}
+{PANEL: Get revisions by change vector or by creation time}
 
-Use `Get` to -  
+* Use `Get` to:  
+  * Retrieve a revision or multiple revisions by their **change vectors**  
+  * Retrieve a revision by its **creation time**  
 
-* Retrieve a revision or multiple revisions by their **change vectors**  
-* Retrieve a revision by its **creation time**  
+---
 
-### Syntax
-
-{CODE syntax_3@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-
-| Parameter | Type | Description |
-| ------------- | ------------- | ----- |
-| **changeVector** | `string` | a revision's change vectors |
-| **changeVectors**| `IEnumerable<string>` | revisions' change vectors |
-| **date**| `DateTime ` | a revision's creation time |
-
-#### Example I
-Get a revision by its change vector  
+__By change vector__:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync example_3.1_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TAB:csharp:Async example_3.1_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TABS/}
 
-#### Example II
-Get the metadata kept for a document's revisions, use it to find a revision's 
-change vector, and retrieve the revision using the change vector.  
+__By creation time__:  
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync example_3.2_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TAB:csharp:Async example_3.2_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
 {CODE-TABS/}
 
-#### Example III
-Get a revision by its creation time  
+---
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync example_3.3_sync@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-{CODE-TAB:csharp:Async example_3.3_async@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
-{CODE-TABS/}
+__Syntax__:
+
+{CODE syntax_3@DocumentExtensions\Revisions\ClientAPI\Session\Loading.cs /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **changeVector** | `string` | A revision's change vector |
+| **changeVectors**| `IEnumerable<string>` | revisions' change vectors |
+| **date**| `DateTime ` | A revision's creation time |
+| **id** | `string` | Document ID for which to retrieve the revision by creation time |
 
 {PANEL/}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.dotnet.markdown
@@ -7,7 +7,7 @@
 * Using the Advanced Session methods you can __retrieve revisions and their metadata__  
   from the database for the specified document.  
 
-* These methods can also be executed lazily, see [get revisions lazily](../../../../client-api/session/how-to/perform-operations-lazily#getRevisons).   
+* These methods can also be executed lazily, see [get revisions lazily](../../../../client-api/session/how-to/perform-operations-lazily#getRevisions).   
   
 * In this page:  
   

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.java.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.java.markdown
@@ -1,6 +1,6 @@
-# Revisions: Loading Revisions
+# Get Revisions
 
-There are a few methods that allow you to download revisions from a database:   
+There are a few methods that allow you to retrieve revisions from a database:   
 
 - **session.advanced().revisions().getFor** 
     - can be used to return all previous revisions for a specified document   

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.js.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.js.markdown
@@ -7,7 +7,7 @@
 * Using the Advanced Session methods you can __retrieve revisions and their metadata__  
   from the database for the specified document.  
 
-* These methods can also be executed lazily, see [get revisions lazily](../../../../client-api/session/how-to/perform-operations-lazily#getRevisons).
+* These methods can also be executed lazily, see [get revisions lazily](../../../../client-api/session/how-to/perform-operations-lazily#getRevisions).
 
 * In this page:
 

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.js.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.js.markdown
@@ -1,71 +1,129 @@
-# Revisions: Loading Revisions
+# Get Revisions
 
-There are a few methods that allow you to download revisions from a database:   
+---
 
-- **session.advanced.revisions.getFor()** 
-    - can be used to return all previous revisions for a specified document   
-- **session.advanced.revisions.getMetadataFor()**
-    - can be used to return metadata of all previous revisions for a specified document  
-- **session.advanced.revisions.get()**
-    - can be used to retrieve a revision(s) using a change vector(s)  
+{NOTE: }
 
-{PANEL:getFor}
+* Using the Advanced Session methods you can __retrieve revisions and their metadata__  
+  from the database for the specified document.  
 
-### Syntax
+* These methods can also be executed lazily, see [get revisions lazily](../../../../client-api/session/how-to/perform-operations-lazily#getRevisons).
+
+* In this page:
+
+    * [Get all revisions](../../../../document-extensions/revisions/client-api/session/loading#get-all-revisions)  
+
+    * [Get revisions metadata](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-metadata)  
+
+    * [Get revisions by creation time](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-creation-time)  
+   
+    * [Get revisions by change vector](../../../../document-extensions/revisions/client-api/session/loading#get-revisions-by-change-vector)  
+
+{NOTE/}
+
+---
+
+{PANEL: Get all revisions}
+
+* Use `getFor` to retrieve all of the revisions currently kept for the specified document.
+
+---
+
+__Example__:
+
+{CODE:nodejs example_1@document-extensions\revisions\client-api\session\loading.js /}
+
+__Syntax__:
 
 {CODE:nodejs syntax_1@document-extensions\revisions\client-api\session\loading.js /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **id** | string | document ID for which the revisions will be returned for |
-| **options** | object | |
-| &nbsp;&nbsp;*start* | number | used for paging - results start page  |
-| &nbsp;&nbsp;*pageSize* | number | used for paging - size of the results page |
-| &nbsp;&nbsp;*documentType* | class | type of results |
-| **callback** | error-first callback | results callback |
+| Parameters | Type | Description |
+| - | - |- |
+| **id** | string | Document ID for which to retrieve revisions |
+| **options** | options object | Used for paging |
 
-### Example
+{CODE:nodejs syntax_5@document-extensions\revisions\client-api\session\loading.js /}
 
-{CODE:nodejs example_1_sync@document-extensions\revisions\client-api\session\loading.js /}
+| Return value | |
+| - | - |
+| `Promise` | A `Promise` resolving to the document's revisions. <br>Revisions will be ordered by most recent revision first. |
 
 {PANEL/}
 
-{PANEL:getMetadataFor}
+{PANEL: Get revisions metadata}
 
-### Syntax
+* Use `getMetadataFor` to retrieve the metadata for all the revisions currently kept for the specified document.
 
-{CODE:nodejs syntax_2@document-extensions\revisions\client-api\session\loading.js /}
+---
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **id** | string | document ID for which the revisions will be returned for |
-| **options** | object | |
-| &nbsp;&nbsp;*start* | number | used for paging - results start page  |
-| &nbsp;&nbsp;*pageSize* | number | used for paging - size of the results page |
-| &nbsp;&nbsp;*documentType* | class | type of results |
-| **callback** | error-first callback | results callback |
+__Example__:
 
-### Example
+{CODE:nodejs example_2@document-extensions\revisions\client-api\session\loading.js /}
 
-{CODE:nodejs example_2_sync@document-extensions\revisions\client-api\session\loading.js /}
+__Syntax__:
+
+{CODE:nodejs syntax_1@document-extensions\revisions\client-api\session\loading.js /}
+
+| Parameters | Type | Description |
+| - | - |- |
+| **id** | string | Document ID for which to retrieve revisions' metadata |
+| **options** | options object | Used for paging |
+
+{CODE:nodejs syntax_5@document-extensions\revisions\client-api\session\loading.js /}
+
+| Return value | |
+| - | - |
+| `Promise` | A `Promise` resolving to a list of the revisions metadata. |
 
 {PANEL/}
 
-{PANEL:get}
+{PANEL: Get revisions by creation time}
 
-### Syntax
+* Use `get` to retrieve a revision by its **creation time**.
+
+---
+
+__Example__:
+
+{CODE:nodejs example_3@document-extensions\revisions\client-api\session\loading.js /}
+
+__Syntax__:
 
 {CODE:nodejs syntax_3@document-extensions\revisions\client-api\session\loading.js /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **changeVector** or **changeVectors**| string or string[] | one or many revision change vectors |
-| **documentType** | class | type of results |
-| **callback** | error-first callback | results callback |
+| Parameter | Type | Description |
+| - | - | - |
+| **id** | string | Document ID for which to retrieve the revision by creation time |
+| **date** | string | The revision's creation time |
 
-### Example
+| Return value | |
+| - | - |
+| `Promise` | A `Promise` resolving to the revision.<br>If no revision was created at the specified time, then the first revision that precedes it will be returned. |
 
-{CODE:nodejs example_3_sync@document-extensions\revisions\client-api\session\loading.js /}
+{PANEL/}
+
+{PANEL: Get revisions by change vector}
+
+* Use `get` to retrieve a revision or multiple revisions by their **change vectors**.
+
+---
+
+__Example__:
+
+{CODE:nodejs example_4@document-extensions\revisions\client-api\session\loading.js /}
+
+__Syntax__:
+
+{CODE:nodejs syntax_4@document-extensions\revisions\client-api\session\loading.js /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **changeVector** | string | The revision's change vector |
+| **changeVectors** | string[] | Change vectors of multiple revisions |
+
+| Return value | |
+| - | - |
+| `Promise` | A `Promise` resolving to the matching revision(s). |
 
 {PANEL/}
 
@@ -73,18 +131,18 @@ There are a few methods that allow you to download revisions from a database:
 
 ### Document Extensions
 
-* [Document Revisions Overview](../../../../document-extensions/revisions/overview)  
-* [Revert Revisions](../../../../document-extensions/revisions/revert-revisions)  
-* [Revisions and Other Features](../../../../document-extensions/revisions/revisions-and-other-features)  
+* [Document Revisions Overview](../../../../document-extensions/revisions/overview)
+* [Revert Revisions](../../../../document-extensions/revisions/revert-revisions)
+* [Revisions and Other Features](../../../../document-extensions/revisions/revisions-and-other-features)
 
 ### Client API
 
-* [Revisions: API Overview](../../../../document-extensions/revisions/client-api/overview)  
-* [Operations: Configuring Revisions](../../../../document-extensions/revisions/client-api/operations/configure-revisions)  
-* [Session: Including Revisions](../../../../document-extensions/revisions/client-api/session/including)  
-* [Session: Counting Revisions](../../../../document-extensions/revisions/client-api/session/counting)  
+* [Revisions: API Overview](../../../../document-extensions/revisions/client-api/overview)
+* [Operations: Configuring Revisions](../../../../document-extensions/revisions/client-api/operations/configure-revisions)
+* [Session: Including Revisions](../../../../document-extensions/revisions/client-api/session/including)
+* [Session: Counting Revisions](../../../../document-extensions/revisions/client-api/session/counting)
 
 ### Studio
 
-* [Settings: Document Revisions](../../../../studio/database/settings/document-revisions)  
+* [Settings: Document Revisions](../../../../studio/database/settings/document-revisions)
 * [Document Extensions: Revisions](../../../../studio/database/document-extensions/revisions)  

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/revisions-and-other-features.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/revisions-and-other-features.dotnet.markdown
@@ -50,7 +50,7 @@ to functionality along with their values.
 ---
 
 ### Code Sample
-Use [GetMetadataFor](../../document-extensions/revisions/client-api/session/loading#getmetadatafor) 
+Use [GetMetadataFor](../../document-extensions/revisions/client-api/session/loading#get-revisions-metadata) 
 to get a document's revisions metadata, and extract counters' data from the metadata.
 {CODE revisions-and-other-features_counters@DocumentExtensions\Revisions\ClientAPI\Session\RevisionsAndOtherFeatures.cs /}
 

--- a/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Revisions/ClientAPI/Session/Loading.cs
+++ b/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Revisions/ClientAPI/Session/Loading.cs
@@ -5,11 +5,147 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Json;
 using Raven.Documentation.Samples.Orders;
+using Xunit;
 
-namespace Raven.Documentation.Samples.ClientApi.Session.Revisions
+namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Session
 {
-    public class RevisionsLoading
+    public class GetRevisions
     {
+        public async Task Samples()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region example_1_sync
+                    // Get revisions for document 'orders/1-A'
+                    List<Order> orderRevisions = session
+                        .Advanced
+                        .Revisions
+                        .GetFor<Order>(id: "orders/1-A", start: 0, pageSize: 10);
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region example_1_async
+                    // Get revisions for document 'orders/1-A'
+                    List<Order> orderRevisions = await asyncSession
+                        .Advanced
+                        .Revisions
+                        .GetForAsync<Order>(id: "orders/1-A", start: 0, pageSize: 10);
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region example_2_sync
+                    // Get revisions' metadata for document 'orders/1-A'
+                    List<MetadataAsDictionary> orderRevisionsMetadata = session
+                        .Advanced
+                        .Revisions
+                        .GetMetadataFor(id: "orders/1-A", start: 0, pageSize: 10);
+                    
+                    // Each item returned is a revision's metadata, as can be verified in the @flags key
+                    var metadata = orderRevisionsMetadata[0];
+                    var flagsValue = metadata.GetString(Constants.Documents.Metadata.Flags);
+                    
+                    Assert.Contains("Revision", flagsValue);
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region example_2_async
+                    // Get revisions' metadata for document 'orders/1-A'
+                    List<MetadataAsDictionary> orderRevisionsMetadata = await asyncSession
+                        .Advanced
+                        .Revisions
+                        .GetMetadataForAsync(id: "orders/1-A", start: 0, pageSize: 10);
+                    
+                    // Each item returned is a revision's metadata, as can be verified in the @flags key
+                    var metadata = orderRevisionsMetadata[0];
+                    var flagsValue = metadata.GetString(Constants.Documents.Metadata.Flags);
+                    
+                    Assert.Contains("Revision", flagsValue);
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region example_3.1_sync
+                    // Get revisions metadata 
+                    List<MetadataAsDictionary> revisionsMetadata = session
+                        .Advanced
+                        .Revisions
+                        .GetMetadataFor("orders/1-A", start: 0, pageSize: 25);
+
+                    // Get the revision by its change vector
+                    var changeVector = revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector);
+                    
+                    Order revision = session
+                        .Advanced
+                        .Revisions
+                        .Get<Order>(changeVector);
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region example_3.1_async
+                    // Get revisions metadata 
+                    List<MetadataAsDictionary> revisionsMetadata = await asyncSession
+                        .Advanced
+                        .Revisions
+                        .GetMetadataForAsync("orders/1-A", start: 0, pageSize: 25);
+
+                    // Get the revision by its change vector
+                    var changeVector = revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector);
+                    
+                    Order revision = await asyncSession
+                        .Advanced
+                        .Revisions
+                        .GetAsync<Order>(changeVector);
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region example_3.2_sync
+                    // Get a revision by its creation time
+                    Order revisionFromLastYear = session
+                        .Advanced
+                        .Revisions
+                         // If no revision was created at the specified time,
+                         // then the first revision that precedes it will be returned
+                        .Get<Order>("orders/1-A", DateTime.Now.AddYears(-1));
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region example_3.2_async
+                    // Get a revision by its creation time
+                    Order revisionFromLastYear = await asyncSession
+                        .Advanced
+                        .Revisions
+                        // If no revision was created at the specified time,
+                        // then the first revision that precedes it will be returned
+                        .GetAsync<Order>("orders/1-A", DateTime.Now.AddYears(-1));
+                    #endregion
+                }
+            }
+        }
+        
         private interface IFoo
         {
             #region syntax_1
@@ -28,175 +164,10 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Revisions
             Dictionary<string, T> Get<T>(IEnumerable<string> changeVectors);
 
             // Get a revision by its creation time
-            // If no revision was created at that precise time, get the first revision to precede it
+            // If no revision was created at the specified time,
+            // then the first revision that precedes it will be returned
             T Get<T>(string id, DateTime date);
             #endregion
-        }
-
-        public async Task Samples()
-        {
-            using (var store = new DocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    #region example_1_sync
-                    List<Order> orderRevisions = session
-                        .Advanced
-                        .Revisions
-                        .GetFor<Order>(
-                            id: "orders/1-A",
-                            start: 0,
-                            pageSize: 10);
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region example_1_async
-                    List<Order> orderRevisions = await asyncSession
-                        .Advanced
-                        .Revisions
-                        .GetForAsync<Order>(
-                            id: "orders/1-A",
-                            start: 0,
-                            pageSize: 10);
-                    #endregion
-                }
-            }
-
-            using (var store = new DocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    #region example_2_sync
-                    List<MetadataAsDictionary> orderRevisionsMetadata =
-                        session
-                            .Advanced
-                            .Revisions
-                            .GetMetadataFor(
-                                id: "orders/1-A",
-                                start: 0,
-                                pageSize: 10);
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region example_2_async
-                    List<MetadataAsDictionary> orderRevisionsMetadata =
-                        await asyncSession
-                            .Advanced
-                            .Revisions
-                            .GetMetadataForAsync(
-                                id: "orders/1-A",
-                                start: 0,
-                                pageSize: 10);
-                    #endregion
-                }
-            }
-
-            using (var store = new DocumentStore())
-            {
-                string orderRevisionChangeVector = null;
-                using (var session = store.OpenSession())
-                {
-                    #region example_3.1_sync
-                    Order orderRevision =
-                        session
-                            .Advanced
-                            .Revisions
-                            // Get revisions by their change vectors
-                            .Get<Order>(orderRevisionChangeVector);
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region example_3.1_async
-                    Order orderRevision =
-                        await asyncSession
-                            .Advanced
-                            .Revisions
-                            // Get revisions by their change vectors
-                            .GetAsync<Order>(orderRevisionChangeVector);
-                    #endregion
-                }
-            }
-
-            using (var store = new DocumentStore())
-            {
-                string orderRevisionChangeVector = null;
-                using (var session = store.OpenSession())
-                {
-                    #region example_3.2_sync
-                    // Get revisions metadata 
-                    List<MetadataAsDictionary> revisionsMetadata = 
-                        session
-                            .Advanced
-                            .Revisions
-                            .GetMetadataFor("users/1", start: 0, pageSize: 25);
-
-                    // Get revision by its change vector
-                    User revison = 
-                        session
-                            .Advanced
-                            .Revisions
-                            .Get<User>(revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector));
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region example_3.2_async
-                    // Get revisions metadata 
-                    List<MetadataAsDictionary> revisionsMetadata =
-                        await asyncSession
-                            .Advanced
-                            .Revisions
-                            .GetMetadataForAsync("users/1", start: 0, pageSize: 25);
-
-                    // Get revision by its change vector
-                    User revison =
-                        await asyncSession
-                            .Advanced
-                            .Revisions
-                            .GetAsync<User>(revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector));
-                    #endregion
-                }
-            }
-
-            using (var store = new DocumentStore())
-            {
-                string orderRevisionChangeVector = null;
-                using (var session = store.OpenSession())
-                {
-                    #region example_3.3_sync
-                    User revisonAtYearAgo = 
-                        session
-                            .Advanced
-                            .Revisions
-                            // Get a revision by its creation time
-                            .Get<User>("users/1", DateTime.Now.AddYears(-1));
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region example_3.3_async
-                    User revisonAtYearAgo =
-                        await asyncSession
-                            .Advanced
-                            .Revisions
-                            // Get a revision by its creation time
-                            .GetAsync<User>("users/1", DateTime.Now.AddYears(-1));
-                    #endregion
-                }
-            }
-        }
-
-        private class User
-        {
-            public string Name { get; set; }
         }
     }
 }

--- a/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Revisions/ClientAPI/Session/Loading.cs
+++ b/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Revisions/ClientAPI/Session/Loading.cs
@@ -19,6 +19,7 @@ namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Ses
                 {
                     #region example_1_sync
                     // Get revisions for document 'orders/1-A'
+                    // Revisions will be ordered by most recent revision first
                     List<Order> orderRevisions = session
                         .Advanced
                         .Revisions
@@ -30,6 +31,7 @@ namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Ses
                 {
                     #region example_1_async
                     // Get revisions for document 'orders/1-A'
+                    // Revisions will be ordered by most recent revision first
                     List<Order> orderRevisions = await asyncSession
                         .Advanced
                         .Revisions
@@ -79,48 +81,7 @@ namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Ses
             {
                 using (var session = store.OpenSession())
                 {
-                    #region example_3.1_sync
-                    // Get revisions metadata 
-                    List<MetadataAsDictionary> revisionsMetadata = session
-                        .Advanced
-                        .Revisions
-                        .GetMetadataFor("orders/1-A", start: 0, pageSize: 25);
-
-                    // Get the revision by its change vector
-                    var changeVector = revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
-                    Order revision = session
-                        .Advanced
-                        .Revisions
-                        .Get<Order>(changeVector);
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region example_3.1_async
-                    // Get revisions metadata 
-                    List<MetadataAsDictionary> revisionsMetadata = await asyncSession
-                        .Advanced
-                        .Revisions
-                        .GetMetadataForAsync("orders/1-A", start: 0, pageSize: 25);
-
-                    // Get the revision by its change vector
-                    var changeVector = revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector);
-                    
-                    Order revision = await asyncSession
-                        .Advanced
-                        .Revisions
-                        .GetAsync<Order>(changeVector);
-                    #endregion
-                }
-            }
-
-            using (var store = new DocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    #region example_3.2_sync
+                    #region example_3_sync
                     // Get a revision by its creation time
                     Order revisionFromLastYear = session
                         .Advanced
@@ -133,7 +94,7 @@ namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Ses
 
                 using (var asyncSession = store.OpenAsyncSession())
                 {
-                    #region example_3.2_async
+                    #region example_3_async
                     // Get a revision by its creation time
                     Order revisionFromLastYear = await asyncSession
                         .Advanced
@@ -141,6 +102,49 @@ namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Ses
                         // If no revision was created at the specified time,
                         // then the first revision that precedes it will be returned
                         .GetAsync<Order>("orders/1-A", DateTime.Now.AddYears(-1));
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region example_4_sync
+                    // Get revisions metadata 
+                    List<MetadataAsDictionary> revisionsMetadata = session
+                        .Advanced
+                        .Revisions
+                        .GetMetadataFor("orders/1-A", start: 0, pageSize: 25);
+
+                    // Get the change-vector from the metadata
+                    var changeVector = revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector);
+                    
+                    // Get the revision by its change-vector
+                    Order revision = session
+                        .Advanced
+                        .Revisions
+                        .Get<Order>(changeVector);
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region example_4_async
+                    // Get revisions metadata 
+                    List<MetadataAsDictionary> revisionsMetadata = await asyncSession
+                        .Advanced
+                        .Revisions
+                        .GetMetadataForAsync("orders/1-A", start: 0, pageSize: 25);
+
+                    // Get the change-vector from the metadata
+                    var changeVector = revisionsMetadata[0].GetString(Constants.Documents.Metadata.ChangeVector);
+                    
+                    // Get the revision by its change-vector
+                    Order revision = await asyncSession
+                        .Advanced
+                        .Revisions
+                        .GetAsync<Order>(changeVector);
                     #endregion
                 }
             }
@@ -157,16 +161,15 @@ namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Ses
             #endregion
 
             #region syntax_3
+            T Get<T>(string id, DateTime date);
+            #endregion
+            
+            #region syntax_4
             // Get a revision by its change vector
             T Get<T>(string changeVector);
 
             // Get multiple revisions by their change vectors
             Dictionary<string, T> Get<T>(IEnumerable<string> changeVectors);
-
-            // Get a revision by its creation time
-            // If no revision was created at the specified time,
-            // then the first revision that precedes it will be returned
-            T Get<T>(string id, DateTime date);
             #endregion
         }
     }

--- a/Documentation/5.3/Samples/nodejs/document-extensions/revisions/client-api/session/loading.js
+++ b/Documentation/5.3/Samples/nodejs/document-extensions/revisions/client-api/session/loading.js
@@ -1,34 +1,14 @@
-
 import { DocumentStore } from "ravendb";
 
 const store = new DocumentStore();
 
-{
-    let id, options, callback, changeVector, documentType, changeVectors;
-
-    const session = store.openSession();
-    //region syntax_1
-    session.advanced.revisions.getFor(id, [options], [callback]);
-    //endregion
-
-    //region syntax_2
-    session.advanced.revisions.getMetadataFor(id, [options], [callback]);
-    //endregion
-
-    //region syntax_3
-    session.advanced.revisions.get(changeVector, [documentType], [callback]);
-    session.advanced.revisions.get(changeVectors, [documentType], [callback]);
-    //endregion
-}
-
-class Order { }
-
 async function samples() {
     {
         const session = store.openSession();
-
+        
         {
-            //region example_1_sync
+            //region example_1
+            // Get revisions for document 'orders/1-A'
             const orderRevisions = await session.advanced.revisions
                 .getFor("orders/1-A", {
                     start: 0,
@@ -36,23 +16,84 @@ async function samples() {
                 });
             //endregion
         }
-
         {
-            //region example_2_sync
+            //region example_2
+            // Get revisions' metadata for document 'orders/1-A'
             const orderRevisionsMetadata = await session.advanced.revisions
                 .getMetadataFor("orders/1-A", {
                     start: 0,
                     pageSize: 10
                 });
+
+            // Each item returned is a revision's metadata, as can be verified in the @flags key
+            const metadata = orderRevisionsMetadata[0];
+            const flagsValue = metadata[CONSTANTS.Documents.Metadata.FLAGS];
+
+            assertThat(flagsValue).contains("Revision");
             //endregion
         }
-
         {
-            let orderRevisionChangeVector;
-            //region example_3_sync
+            //region example_3
+            // Creation time to use, e.g. last year: 
+            const creationTime = new Date();
+            creationTime.setFullYear(creationTime.getFullYear() - 1);
+
+            // Get a revision by its creation time
+            // If no revision was created at the specified time,
+            // then the first revision that precedes it will be returned
             const orderRevision = await session.advanced.revisions
-                .get(orderRevisionChangeVector);
+                .get("orders/1-A", creationTime.toLocaleDateString());
+            //endregion
+        }
+        {
+            //region example_4
+            // Get revisions metadata 
+            const revisionsMetadata = await session.advanced.revisions
+                .getMetadataFor("orders/1-A", {
+                    start: 0,
+                    pageSize: 25
+                });
+            
+            // Get the change-vector from the metadata
+            var changeVector = revisionsMetadata[0][CONSTANTS.Documents.Metadata.CHANGE_VECTOR];
+            
+            // Get the revision by its change-vector
+            const orderRevision = await session.advanced.revisions
+                .get(changeVector);
             //endregion
         }
     }
+}
+
+{
+    const session = store.openSession();
+    //region syntax_1
+    // Available overloads:
+    await session.advanced.revisions.getFor(id);
+    await session.advanced.revisions.getFor(id, options);
+    //endregion
+
+    //region syntax_2
+    // Available overloads:
+    await session.advanced.revisions.getMetadataFor(id);
+    await session.advanced.revisions.getMetadataFor(id, options);
+    //endregion
+
+    //region syntax_3
+    await session.advanced.revisions.get(id, date);
+    //endregion
+
+    //region syntax_4
+    // Available overloads:
+    await session.advanced.revisions.get(changeVector);
+    await session.advanced.revisions.get(changeVectors);
+    //endregion
+
+    //region syntax_5
+    // options object
+    {
+        start,   // The first revision to retrieve, used for paging. Default is 0.
+        pageSize // Number of revisions to retrieve per results page. Default is 25.
+    }
+    //endregion
 }

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
@@ -1,7 +1,7 @@
 [
     {
         "Path": "loading.markdown",
-        "Name": "Loading",
+        "Name": "Get Revisions",
         "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
         "Mappings": [
             {

--- a/Documentation/6.0/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
@@ -1,7 +1,7 @@
 [
     {
         "Path": "loading.markdown",
-        "Name": "Loading",
+        "Name": "Get Revisions",
         "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
         "Mappings": [
             {


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2396/Node.js-Document-extensions-Revisions-Client-API-Session-Get-Revisions

@ml054
Node.js - file to be reviewed:
```
Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/loading.js.markdown
Documentation/5.3/Samples/nodejs/document-extensions/revisions/client-api/session/loading.js
```