### PR TITLE
RDoc-2405 Document extensions > Revisions > Client API > Session > Count Revisions

### DIFF
--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
@@ -43,7 +43,7 @@
     },
     {
         "Path": "counting.markdown",
-        "Name": "Counting",
+        "Name": "Count Revisions",
         "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
         "Mappings": [
             {

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/counting.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/counting.dotnet.markdown
@@ -1,39 +1,39 @@
-# Revisions: Counting Revisions
+# Count Revisions
 
 ---
 
 {NOTE: }
 
-* A document's revisions can be counted using the `session.Advanced.Revisions.GetCountFor` method.  
+* You can get the number of revisions a document has by using the advance session method `GetCountFor`.
 
 * In this page:  
-   * [`GetCountFor`](../../../../document-extensions/revisions/client-api/session/counting#getcountfor)  
-   * [Usage Sample](../../../../document-extensions/revisions/client-api/session/counting#usage-sample)  
+   * [Get revisions count](../../../../document-extensions/revisions/client-api/session/get-revisions-count)
+   * [syntax](../../../../document-extensions/revisions/client-api/session/counting#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: `GetCountFor`}
+{PANEL: Get revisions count}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync getCount@DocumentExtensions\Revisions\ClientAPI\Session\Counting.cs /}
+{CODE-TAB:csharp:Async getCount_async@DocumentExtensions\Revisions\ClientAPI\Session\Counting.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
 
 {CODE syntax@DocumentExtensions\Revisions\ClientAPI\Session\Counting.cs /}
 
 | Parameter | Type | Description |
-| ------------- | ------------- | ------------- |
-| **id** | string | ID of the document whose revisions are counted |
+| - | - | - |
+| **id** | string | Document ID for which revisions are counted |
 
-* **Return Value**: `long`  
-  The number of revisions for this document  
-
-{PANEL/}
-
-{PANEL: Usage Sample}
-
-Get the number of revisions created for a document:
-{CODE-TABS}
-{CODE-TAB:csharp:Sync example_sync@DocumentExtensions\Revisions\ClientAPI\Session\Counting.cs /}
-{CODE-TAB:csharp:Async example_async@DocumentExtensions\Revisions\ClientAPI\Session\Counting.cs /}
-{CODE-TABS/}
+| Return value | |
+| - | - |
+| `long` | The number of revisions for the specified document |
 
 {PANEL/}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/counting.js.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/counting.js.markdown
@@ -1,0 +1,55 @@
+# Count Revisions
+
+---
+
+{NOTE: }
+
+* You can get the number of revisions a document has by using the advance session method `getCountFor`.
+
+* In this page:  
+   * [Get revisions count](../../../../document-extensions/revisions/client-api/session/get-revisions-count)
+   * [syntax](../../../../document-extensions/revisions/client-api/session/counting#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get revisions count}
+
+{CODE:nodejs getCount@document-extensions\revisions\client-api\session\getCount.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@document-extensions\revisions\client-api\session\getCount.js /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **id** | string | Document ID for which revisions are counted |
+
+| Return value | |
+| - | - |
+| `Promise` | A `Promise` resolving to the number of revisions for the specified document |
+
+{PANEL/}
+
+## Related Articles
+
+### Document Extensions
+
+* [Document Revisions Overview](../../../../document-extensions/revisions/overview)  
+* [Revert Revisions](../../../../document-extensions/revisions/revert-revisions)  
+* [Revisions and Other Features](../../../../document-extensions/revisions/revisions-and-other-features)  
+
+### Client API
+
+* [Revisions: API Overview](../../../../document-extensions/revisions/client-api/overview)  
+* [Operations: Configuring Revisions](../../../../document-extensions/revisions/client-api/operations/configure-revisions)  
+* [Session: Loading Revisions](../../../../document-extensions/revisions/client-api/session/loading)  
+* [Session: Including Revisions](../../../../document-extensions/revisions/client-api/session/including)  
+
+### Studio
+
+* [Settings: Document Revisions](../../../../studio/database/settings/document-revisions)  
+* [Document Extensions: Revisions](../../../../studio/database/document-extensions/revisions)  

--- a/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Revisions/ClientAPI/Session/Counting.cs
+++ b/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Revisions/ClientAPI/Session/Counting.cs
@@ -1,40 +1,37 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Raven.Client;
+﻿using System.Threading.Tasks;
 using Raven.Client.Documents;
-using Raven.Client.Json;
-using Raven.Documentation.Samples.Orders;
 
-namespace Raven.Documentation.Samples.ClientApi.Session.Revisions
+namespace Raven.Documentation.Samples.DocumentExtensions.Revisions.ClientAPI.Session
 {
-    public class Loading
+    public class getCount
     {
-        private interface IFoo
-        {
-            #region syntax
-            long GetCountFor(string id);
-            #endregion
-        }
-
         public async Task Samples()
         {
             using (var store = new DocumentStore())
             {
-                var CompanyProfile = new Company { Name = "Persian Rugs" };
                 using (var session = store.OpenSession())
                 {
-                    #region example_sync
-                    var revisionsCount = session.Advanced.Revisions.GetCountFor(CompanyProfile.Id);
+                    #region getCount
+                    // Get the number of revisions for document 'companies/1-A"
+                    var revisionsCount = session.Advanced.Revisions.GetCountFor("companies/1-A");
                     #endregion
                 }
 
                 using (var asyncSession = store.OpenAsyncSession())
                 {
-                    #region example_async
-                    var revisionsCount = await asyncSession.Advanced.Revisions.GetCountForAsync(CompanyProfile.Id);
+                    #region getCount_async
+                    // Get the number of revisions for document 'companies/1-A"
+                    var revisionsCount = await asyncSession.Advanced.Revisions.GetCountForAsync("companies/1-A");
                     #endregion
                 }
             }
+        }
+        
+        private interface IFoo
+        {
+            #region syntax
+            long GetCountFor(string id);
+            #endregion
         }
     }
 }

--- a/Documentation/5.3/Samples/nodejs/document-extensions/revisions/client-api/session/getCount.js
+++ b/Documentation/5.3/Samples/nodejs/document-extensions/revisions/client-api/session/getCount.js
@@ -1,0 +1,21 @@
+import { DocumentStore } from "ravendb";
+
+const store = new DocumentStore();
+
+async function getCount() {
+
+    const session = store.openSession();
+
+    //region getCount
+    // Get the number of revisions for document 'companies/1-A"
+    const revisionsCount = await session.advanced.revisions.getCountFor("companies/1-A");
+    //endregion
+}
+
+{
+    const session = store.openSession();
+    
+    //region syntax
+    await session.advanced.revisions.getCountFor(id);
+    //endregion
+}

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
@@ -43,7 +43,7 @@
     },
     {
         "Path": "counting.markdown",
-        "Name": "Counting",
+        "Name": "Count Revisions",
         "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
         "Mappings": [
             {

--- a/Documentation/6.0/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/.docs.json
@@ -43,7 +43,7 @@
     },
     {
         "Path": "counting.markdown",
-        "Name": "Counting",
+        "Name": "Count Revisions",
         "DiscussionId": "ba3f27dd-dc68-4851-a6bd-3c0166703820",
         "Mappings": [
             {


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2405/Node.js-Document-extensions-Revisions-Client-API-Session-Count-Revisions

@ml054
Node.js - files to be reviewed:
```
Documentation/5.3/Raven.Documentation.Pages/document-extensions/revisions/client-api/session/counting.js.markdown
Documentation/5.3/Samples/nodejs/document-extensions/revisions/client-api/session/getCount.js
```