### PR TITLE
RDoc-2446 Client API > Session > Querying > Customize query 

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/document-query/what-is-document-query.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/document-query/what-is-document-query.dotnet.markdown
@@ -161,12 +161,12 @@ Refer to the corresponding documentation articles, marked with links starting wi
 Available custom methods and extensions:   
 
 - AddOrder
-- AfterQueryExecuted
-- AfterStreamExecuted
+- [Query] [AfterQueryExecuted](../../../../client-api/session/querying/how-to-customize-query#afterqueryexecuted)
+- [Query] [AfterStreamExecuted](../../../../client-api/session/querying/how-to-customize-query#afterstreamexecuted)
 - [Query] [AggregateBy](../../../../client-api/session/querying/how-to-perform-a-faceted-search)
 - [Query] [AggregateUsing](../../../../client-api/session/querying/how-to-perform-a-faceted-search)
 - AndAlso
-- BeforeQueryExecuted
+- [Query] [BeforeQueryExecuted](../../../../client-api/session/querying/how-to-customize-query#beforequeryexecuted)
 - Boost
 - CloseSubclause
 - CmpXchg
@@ -206,8 +206,9 @@ Available custom methods and extensions:
 - OrderByScore
 - OrderByScoreDescending
 - OrElse
+- [Query] [Projection](../../../../client-api/session/querying/how-to-customize-query#projection)
 - Proximity
-- RandomOrdering
+- [Query] [RandomOrdering](../../../../client-api/session/querying/how-to-customize-query#randomordering)
 - [Query] [RelatesToShape](../../../../client-api/session/querying/how-to-query-a-spatial-index)
 - Search
 - SelectFields
@@ -219,9 +220,9 @@ Available custom methods and extensions:
 - Statistics
 - SuggestUsing
 - Take
+- [Query] [Timings](../../../../client-api/session/querying/how-to-customize-query#timings)
 - UsingDefaultOperator
 - [Query] [WaitForNonStaleResults](../../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults)
-- [Query] [WaitForNonStaleResultsAsOf](../../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresultsasof)
 - Where
 - WhereBetween
 - WhereEndsWith

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
@@ -191,15 +191,18 @@ __Syntax__
 
 {PANEL: Projection}
 
-* By default, when [querying an an index](../../../indexes/querying/query-index), and projecting query results  
+* By default, when [querying an index](../../../indexes/querying/query-index), and projecting query results  
   (projecting means the query returns only specific document fields instead of the full document)  
-  then the server will try to retrieve the fields' values from the fields stored in the index.  
+  then the server will try to retrieve the fields' values from the fields [stored in the index](../../../indexes/storing-data-in-index).  
 
 * If the index does Not store those fields then the fields' values will be retrieved from the documents store.
 
 * Use the `Projection` method to customize and modify this behavior.
 
-* Learn more about projections in:
+* Note:  
+  Entities resulting from a projecting query are Not tracked by the session.  
+  Learn more about projections in:
+  
   * [Projections](../../../indexes/querying/projections)
   * [How to project query results](../../../client-api/session/querying/how-to-project-query-results)
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
@@ -1,194 +1,373 @@
-# Session: Querying: How to Customize a Query
+# How to Customize a Query
+
 ---
 
 {NOTE: }
 
-The following query customization options are available in the `IDocumentQueryCustomization` interface:
+* Use `Customize()` to set the following customization options on a specific [Query](../../../client-api/session/querying/how-to-query).   
+  Can be set for both dynamic-query and for index-query.
 
-- [BeforeQueryExecuted](../../../client-api/session/querying/how-to-customize-query#beforequeryexecuted)
-- [AfterQueryExecuted](../../../client-api/session/querying/how-to-customize-query#afterqueryexecuted)
-- [AfterStreamExecuted](../../../client-api/session/querying/how-to-customize-query#afterstreamexecuted)
-- [NoCaching](../../../client-api/session/querying/how-to-customize-query#nocaching)
-- [NoTracking](../../../client-api/session/querying/how-to-customize-query#notracking)
-- [ProjectionBehavior](../../../client-api/session/querying/how-to-customize-query#projectionbehavior)
-- [RandomOrdering](../../../client-api/session/querying/how-to-customize-query#randomordering)
-- [WaitForNonStaleResults](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults)
+* Each such customization can also be implemented via the [DocumentQuery](../../../client-api/session/querying/document-query/what-is-document-query) API.
+
+* Note:  
+  A query can also be customized on the Store or Session level by subscribing to `OnBeforeQuery`.  
+  Learn more in [Subscribing to Events](../../../client-api/session/how-to/subscribe-to-events). 
+
+* Customization methods available:
+
+  - [BeforeQueryExecuted](../../../client-api/session/querying/how-to-customize-query#beforequeryexecuted)
+  - [AfterQueryExecuted](../../../client-api/session/querying/how-to-customize-query#afterqueryexecuted)
+  - [AfterStreamExecuted](../../../client-api/session/querying/how-to-customize-query#afterstreamexecuted)
+  - [NoCaching](../../../client-api/session/querying/how-to-customize-query#nocaching)
+  - [NoTracking](../../../client-api/session/querying/how-to-customize-query#notracking)
+  - [Projection](../../../client-api/session/querying/how-to-customize-query#projection)
+  - [RandomOrdering](../../../client-api/session/querying/how-to-customize-query#randomordering)
+  - [Timings](../../../client-api/session/querying/how-to-customize-query#timings)
+  - [WaitForNonStaleResults](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults)
+
+* [Methods return value](../../../client-api/session/querying/how-to-customize-query#methods-return-value)
+
 
 {NOTE/}
 
 ---
 
-{PANEL:BeforeQueryExecuted}
+{PANEL: BeforeQueryExecuted}
 
-Allows you to modify the index query just before it's executed.
+* Use `BeforeQueryExecuted` to customize the query just before it is executed.
 
-{CODE customize_1_0@ClientApi\Session\Querying\HowToCustomize.cs /}
+{NOTE: }
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **action** | Action<[IndexQuery](../../../glossary/index-query)> | Action that will modify IndexQuery. |
-
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
-
-### Example
-
-{CODE customize_1_1@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-{PANEL/}
-
-{PANEL:AfterQueryExecuted}
-
-Allows you to retrieve a raw query result after it's executed.
-
-{CODE customize_1_0_0@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **action** | Action<[QueryResult](../../../glossary/query-result)> | Action that has the query result. |
-
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
-
-### Example
-
-{CODE customize_1_1_0@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-{PANEL/}
-
-{PANEL:AfterStreamExecuted}
-
-Allows you to retrieve a raw (blittable) result of the streaming query.
-
-{CODE customize_1_0_1@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **action** | Action<[BlittableJsonReaderObject](../../../glossary/blittable-json-reader-object)> | Action that has the single query result. |
-
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
-
-### Example
-
-{CODE customize_1_1_1@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-{PANEL/}
-
-{PANEL:NoCaching}
-
-By default, queries are cached. To disable query caching use the `NoCaching` customization.
-
-{CODE customize_2_0@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
-
-### Example
-
-{CODE customize_2_1@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-{PANEL/}
-
-{PANEL:NoTracking}
-
-To disable entity tracking by `Session` use `NoTracking`. Usage of this option will prevent holding the query results in memory.
-
-{CODE customize_3_0@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
-
-### Example
-
-{CODE customize_3_1@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-{PANEL/}
-
-{PANEL: ProjectionBehavior}
-
-By default, queries are satisfied with the values stored in the index. If the index 
-doesn't contain the requested values, they are retrieved from the documents 
-themselves.  
-
-This behavior can be configured using the `Projection` option, which takes a 
-`ProjectionBehavior`:  
-
-{CODE projectionbehavior@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-* `Default` - query will be satisfied with indexed data when possible, and directly 
-from the document when it is not.  
-* `FromIndex` - query will be satisfied with indexed data when possible, and when 
-it is not, the field is skipped.  
-* `FromIndexOrThrow` - query will be satisfied with indexed data. If the index does 
-not contain the requested data, an exception is thrown.  
-* `FromDocument` - query will be satisfied with document data when possible, and 
-when it is not, the field is skipped.  
-* `FromDocumentOrThrow` - query will be satisfied with document data. If the 
-document does not contain the requested data, an exception is thrown.  
-
-### Example
+__Example__
 
 {CODE-TABS}
-{CODE-TAB:csharp:Query projectionbehavior_query@ClientApi\Session\Querying\HowToCustomize.cs /}
-{CODE-TAB:csharp:RawQuery projectionbehavior_rawquery@ClientApi\Session\Querying\HowToCustomize.cs /}
-{CODE-TAB:csharp:DocumentQuery projectionbehavior_docquery@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query customize_1_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_1_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_1_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_1_4@ClientApi\Session\Querying\HowToCustomize.cs /}
 {CODE-TABS/}
 
-{PANEL/}
-
-{PANEL:RandomOrdering}
-
-To order results randomly, use the `RandomOrdering` method.
-
-{CODE customize_4_0@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **seed** | string | Seed used for ordering. Useful when repeatable random queries are needed. |
-
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
-
-### Example
-
-{CODE customize_4_1@ClientApi\Session\Querying\HowToCustomize.cs /}
-
-{PANEL/}
-
-{PANEL:WaitForNonStaleResults}
-
-Queries can be 'instructed' to wait for non-stale results for a specified amount of time using the `WaitForNonStaleResults` method. If the query won't be able to return 
-non-stale results within the specified (or default) timeout, then a `TimeoutException` is thrown.
-
-{NOTE: Cutoff Point}
-If a query sent to the server specifies that it needs to wait for non-stale results, then RavenDB sets the cutoff Etag for the staleness check.
-It is the Etag of the last document (or document tombstone), from the collection(s) processed by the index, as of the query arrived to the server.
-This way the server won't be waiting forever for the non-stale results even though documents are constantly updated meanwhile.
-
-If the last Etag processed by the index is greater than the cutoff then the results are considered as non-stale.
 {NOTE/}
 
+{NOTE: }
 
-{CODE customize_8_0@ClientApi\Session\Querying\HowToCustomize.cs /}
+__Syntax__
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **waitTimeout** | TimeSpan? | Time to wait for an index to return non-stale results. The default is 15 seconds. |
+{CODE customize_1_5@ClientApi\Session\Querying\HowToCustomize.cs /}
 
-| Return Value | |
-| ------------- | ----- |
+| Parameters | Type | Description                                                                                                                     |
+|------------| ---- |---------------------------------------------------------------------------------------------------------------------------------|
+| __action__ | `Action<IndexQuery>` | An _Action_ method that operates on the query.<br>The query is passed in the [IndexQuery](../../../glossary/index-query) param. |
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: AfterQueryExecuted}
+
+* Use `AfterQueryExecuted` to access the raw query result after it is executed.
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_2_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_2_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_2_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_2_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_2_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+| Parameters | Type | Description                                                                                                                 |
+|------------| ---- |-----------------------------------------------------------------------------------------------------------------------------|
+| __action__ | `Action<QueryResult>` | An _Action_ method that receives the raw query result.<br>The query result is passed in the [QueryResult](../../../glossary/query-result) param. |
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: AfterStreamExecuted}
+
+* Use `AfterStreamExecuted` to retrieve a raw (blittable) result of the streaming query.
+
+* Learn more in [how to stream query results](../../../client-api/session/querying/how-to-stream-query-results).
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_3_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_3_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_3_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_3_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_3_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+| Parameters | Type | Description                                                                                                                                                                                  |
+|------------| ---- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| __action__ | `Action<BlittableJsonReaderObject>` | An _Action_ method that recieves a single stream query result.<br>The stream result is passed in the [BlittableJsonReaderObject](../../../glossary/blittable-json-reader-object) param. |
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: NoCaching}
+
+* By default, query results are cached. 
+
+* You can use the `NoCaching` customization to disable query caching.
+
+* Learn more in [disable caching per session](../../../client-api/session/configuration/how-to-disable-caching).
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_4_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_4_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_4_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_4_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_4_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: NoTracking}
+
+* By default, the [Session](../../../client-api/session/what-is-a-session-and-how-does-it-work) tracks all changes made to all entities that it has either loaded, stored, or queried for.
+
+* You can use the `NoTracking` customization to disable entity tracking.  
+
+* See [disable entity tracking](../../../client-api/session/configuration/how-to-disable-tracking) for all other options.
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_5_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_5_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_5_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_5_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_5_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Projection}
+
+* By default, when [querying an an index](../../../indexes/querying/query-index), and projecting query results  
+  (projecting means the query returns only specific document fields instead of the full document)  
+  then the server will try to retrieve the fields' values from the fields stored in the index.  
+
+* If the index does Not store those fields then the fields' values will be retrieved from the documents store.
+
+* Use the `Projection` method to customize and modify this behavior.
+
+* Learn more about projections in:
+  * [Projections](../../../indexes/querying/projections)
+  * [How to project query results](../../../client-api/session/querying/how-to-project-query-results)
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_6_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_6_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_6_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_6_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Index the_index@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+In the above example:  
+
+  * Field _'FullName'_ is stored in the index (see index definition in the rightmost tab).  
+    However, the server will try to fetch the value from the document since the default behavior was modified to `FromDocumentOrThrow`.  
+  * An exception will be thrown since an _'Employee'_ document does not contain the property _'FullName'_.  
+    (based on the Northwind sample data).  
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_6_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+* `Default`  
+  Retrieve values from the stored index fields when available.  
+  If fields are not stored then get values from the document.  
+* `FromIndex`  
+  Retrieve values from the stored index fields when available.  
+  A field that is not stored in the index is skipped.  
+* `FromIndexOrThrow`  
+  Retrieve values from the stored index fields when available.  
+  An exception is thrown if the index does not store the requested field.  
+* `FromDocument`  
+  Retrieve values directly from the documents store.  
+  A field that is not found in the document is skipped.  
+* `FromDocumentOrThrow`  
+  Retrieve values directly from the documents store.  
+  An exception is thrown if the document does not contain the requested field.  
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: RandomOrdering}
+
+* Use `RandomOrdering` to order the query results randomly.  
+
+* More ordering options are available in this [Sorting](../../../indexes/querying/sorting) article.  
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_7_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_7_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_7_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_7_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_7_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+| Parameters | Type | Description                                                                                              |
+|------------| ------------- |-------------------------------------------------------------------------------------------------|
+| __seed__   | `string` | Order the search results randomly using this seed.<br>Useful when executing repeated random queries. |
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Timings}
+
+* Use `Timings` to get detailed stats of the time spent by the server on each part of the query.
+
+* The timing statistics will be included in the query results.
+
+* Learn more in [how to include query timings](../../../client-api/session/querying/debugging/query-timings).
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_9_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_9_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_9_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_9_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_9_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+| Parameters | Type | Description |
+|------------| ------------- | ----- |
+| __timings__ | `QueryTimings` | An out param that will be filled with the timings results |
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: WaitForNonStaleResults}
+
+* All queries in RavenDB provide results using an index, even when you don't specify one.  
+  See detailed explanation in [Queries always provide results using an index](../../../client-api/session/querying/how-to-query#queries-always-provide-results-using-an-index).
+
+* Use `WaitForNonStaleResults` to instruct the query to wait for non-stale results from the index.  
+
+* A `TimeoutException` will be thrown if the query is not able to return non-stale results within the specified  
+  (or default) timeout.
+
+* Learn more about stale results in [stale indexes](../../../indexes/stale-indexes).
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query customize_8_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:Query_async customize_8_2@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:DocumentQuery customize_8_3@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TAB:csharp:RawQuery customize_8_4@ClientApi\Session\Querying\HowToCustomize.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE customize_8_5@ClientApi\Session\Querying\HowToCustomize.cs /}
+
+| Parameters | Type | Description |
+|------------| ------------- |-----------|
+| __waitTimeout__ | `TimeSpan?` | Time to wait for non-stale results. <br>Default is 15 seconds. |
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Methods return value}
+
+All above customization methods return the following:
+
+| `Query` return value         | |
+|-----------------------------| ----- |
 | IDocumentQueryCustomization | Returns self for easier method chaining. |
 
-### Example
-
-{CODE customize_8_1@ClientApi\Session\Querying\HowToCustomize.cs /}
+| `DocumentQuery` return value      | |
+|---------------------------------| ----- |
+| IQueryBase | Returns self for easier method chaining. |
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.java.markdown
@@ -1,4 +1,4 @@
-# Session: Querying: How to Customize a Query
+# How to Customize a Query
 ---
 
 {NOTE: }

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.js.markdown
@@ -1,189 +1,290 @@
 # How to Customize a Query
+
 ---
 
 {NOTE: }
 
-The following query customization options are available:
+* The following query customization methods that are available for the __.NET client__ under `IDocumentQueryCustomization` 
+  are also available in the __Node.js client__.
 
-- ["beforeQueryExecuted" event](../../../client-api/session/querying/how-to-customize-query#beforequeryexecuted)
-- ["afterQueryExecuted" event](../../../client-api/session/querying/how-to-customize-query#afterqueryexecuted)
-- ["afterStreamExecuted" event](../../../client-api/session/querying/how-to-customize-query#afterstreamexecuted)
-- [noCaching()](../../../client-api/session/querying/how-to-customize-query#nocaching)
-- [noTracking()](../../../client-api/session/querying/how-to-customize-query#notracking)
-- [ProjectionBehavior](../../../client-api/session/querying/how-to-customize-query#projectionbehavior)
-- [randomOrdering()](../../../client-api/session/querying/how-to-customize-query#randomordering)
-- [waitForNonStaleResults()](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults)
+* These methods can be used for both a dynamic-query and an index-query.
 
-Query is an `EventEmitter`. It emits few events allowing you to customize its behavior.
+* Note:  
+  A [query](../../../client-api/session/querying/how-to-query) can also be customized on the Store or Session level by subscribing to the `beforeQuery` event.  
+  Learn more in [Subscribing to Events](../../../client-api/session/how-to/subscribe-to-events).
+
+* Customization methods available:
+
+  - [on ("beforeQueryExecuted")](../../../client-api/session/querying/how-to-customize-query#on-("beforequeryexecuted"))
+  - [on ("afterQueryExecuted")](../../../client-api/session/querying/how-to-customize-query#on-("afterqueryexecuted"))
+  - [noCaching](../../../client-api/session/querying/how-to-customize-query#nocaching)
+  - [noTracking](../../../client-api/session/querying/how-to-customize-query#notracking)
+  - [projectionBehavior](../../../client-api/session/querying/how-to-customize-query#projectionbehavior)
+  - [randomOrdering](../../../client-api/session/querying/how-to-customize-query#randomordering)
+  - [timings](../../../client-api/session/querying/how-to-customize-query#timings)
+  - [waitForNonStaleResults](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults)
+
 {NOTE/}
 
 ---
-{PANEL:BeforeQueryExecuted}
 
-Allows you to modify the index query just before it's executed.
+{PANEL: on ("beforeQueryExecuted")}
 
-{CODE:nodejs customize_1_0@ClientApi\Session\Querying\howToCustomize.js /}
+* Use `on("beforeQueryExecuted")` to customize the query just before it is executed.
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **action** | function | Action on the index query |
+{NOTE: }
 
-| Return Value | |
-| ------------- | ----- |
-| query | Returns self for easier method chaining. |
+__Example__
 
-### Example
+{CODE-TABS}
+{CODE-TAB:nodejs:Query customize_1_0@ClientApi\Session\Querying\howToCustomize.js /}
+{CODE-TAB:nodejs:Index index_1@ClientApi\Session\Querying\howToCustomize.js /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
 
 {CODE:nodejs customize_1_1@ClientApi\Session\Querying\howToCustomize.js /}
 
-{PANEL/}
+| Parameters       | Type            | Description                                                                                                                           |
+|------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| __eventHandler__ | (query) => void | A callback method that is invoked when the `beforeQueryExecuted` event is emitted.<br>The passed query param is of type `IndexQuery`. |
 
-{PANEL:AfterQueryExecuted}
-
-Allows you to retrieve a raw query result after it's executed.
-
-{CODE:nodejs customize_1_0_0@ClientApi\Session\Querying\howToCustomize.js /}
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **action** | function | Action on the query result |
-
-| Return Value | |
-| ------------- | ----- |
-| query | Returns self for easier method chaining |
-
-### Example
-
-{CODE:nodejs customize_1_1_0@ClientApi\Session\Querying\howToCustomize.js /}
+{NOTE/}
 
 {PANEL/}
 
-{PANEL:AfterStreamExecuted}
+{PANEL: on ("afterQueryExecuted")}
 
-Allows you to retrieve a raw result of the streaming query.
+* Use `on("afterQueryExecuted")` to access the raw query result after it is executed.
 
-{CODE:nodejs customize_1_0_1@ClientApi\Session\Querying\howToCustomize.js /}
+{NOTE: }
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **action** | function | Action on a single query result |
-
-| Return Value | |
-| ------------- | ----- |
-| query | Returns self for easier method chaining. |
-
-### Example
-
-{CODE:nodejs customize_1_1_1@ClientApi\Session\Querying\howToCustomize.js /}
-
-{PANEL/}
-
-{PANEL:NoCaching}
-
-By default, queries are cached. To disable query caching use the `noCaching()` customization.
+__Example__
 
 {CODE:nodejs customize_2_0@ClientApi\Session\Querying\howToCustomize.js /}
 
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
+{NOTE/}
 
-### Example
+{NOTE: }
+
+__Syntax__
 
 {CODE:nodejs customize_2_1@ClientApi\Session\Querying\howToCustomize.js /}
 
+| Parameters               | Type                  | Description                                                                                                                            |
+|--------------------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| __eventHandler__ | (queryResult) => void | A callback method that is invoked when the `afterQueryExecuted` event is emitted.<br> The passed query param is of type `QueryResult`. |
+
+{NOTE/}
+
 {PANEL/}
 
-{PANEL:NoTracking}
+{PANEL: noCaching}
+ 
+* By default, query results are cached.
 
-To disable entity tracking by `session` use `noTracking()`. Usage of this option will prevent holding the query results in memory.
+* You can use the `noCaching` customization to disable query caching.
+
+{NOTE: }
+
+__Example__
 
 {CODE:nodejs customize_3_0@ClientApi\Session\Querying\howToCustomize.js /}
 
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
+{NOTE/}
 
-### Example
+{NOTE: }
+
+__Syntax__
 
 {CODE:nodejs customize_3_1@ClientApi\Session\Querying\howToCustomize.js /}
-{PANEL/}
 
-{PANEL: ProjectionBehavior}
-
-By default, queries are satisfied with the values stored in the index. If the index 
-doesn't contain the requested values, they are retrieved from the documents 
-themselves.  
-
-{CODE:nodejs projectionbehavior@ClientApi\Session\Querying\HowToCustomize.js /}
-
-This behavior can be configured using the `projection` option, which takes a 
-`projectionBehavior`:  
-
-* `Default` - query will be satisfied with indexed data when possible, and directly 
-from the document when it is not.  
-* `FromIndex` - query will be satisfied with indexed data when possible, and when 
-it is not, the field is skipped.  
-* `FromIndexOrThrow` - query will be satisfied with indexed data. If the index does 
-not contain the requested data, an exception is thrown.  
-* `FromDocument` - query will be satisfied with document data when possible, and 
-when it is not, the field is skipped.  
-* `FromDocumentOrThrow` - query will be satisfied with document data. If the 
-document does not contain the requested data, an exception is thrown.  
-
-### Example 
-
-{CODE:nodejs projectionbehavior_query@ClientApi\Session\Querying\howToCustomize.js /} 
+{NOTE/}
 
 {PANEL/}
 
-{PANEL:RandomOrdering}
+{PANEL: noTracking}
 
-To order results randomly, use the `randomOrdering()` method.
+* By default, the [Session](../../../client-api/session/what-is-a-session-and-how-does-it-work) tracks all changes made to all entities that it has either loaded, stored, or queried for.
+
+* You can use the `noTracking` customization to disable entity tracking.
+
+* See [disable entity tracking](../../../client-api/session/configuration/how-to-disable-tracking) for all other options.
+
+{NOTE: }
+
+__Example__
 
 {CODE:nodejs customize_4_0@ClientApi\Session\Querying\howToCustomize.js /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **seed** | string | Seed used for ordering. Useful when repeatable random queries are needed. |
+{NOTE/}
 
-| Return Value | |
-| ------------- | ----- |
-| IDocumentQueryCustomization | Returns self for easier method chaining. |
+{NOTE: }
 
-### Example
+__Syntax__
 
 {CODE:nodejs customize_4_1@ClientApi\Session\Querying\howToCustomize.js /}
 
-{PANEL/}
-
-{PANEL:WaitForNonStaleResults}
-
-Queries can be 'instructed' to wait for non-stale results for a specified amount of time using the `waitForNonStaleResults()` method. If the query won't be able to return 
-non-stale results within the specified (or default) timeout, then a `TimeoutException` is thrown.
-
-{NOTE: Cutoff Point}
-If a query sent to the server specifies that it needs to wait for non-stale results, then RavenDB sets the cutoff Etag for the staleness check.
-It is the Etag of the last document (or document tombstone), from the collection(s) processed by the index, as of the query arrived to the server.
-This way the server won't be waiting forever for the non-stale results even though documents are constantly updated meanwhile.
-
-If the last Etag processed by the index is greater than the cutoff then the results are considered as non-stale.
 {NOTE/}
 
+{PANEL/}
+
+{PANEL: projectionBehavior}
+
+* By default, when [querying an index](../../../indexes/querying/query-index), and projecting query results  
+  (projecting means the query returns only specific document fields instead of the full document)  
+  then the server will try to retrieve the fields' values from the fields [stored in the index](../../../indexes/storing-data-in-index).
+
+* If the index does Not store those fields then the fields' values will be retrieved from the documents store.
+
+* Use the `selectFields` method to customize and modify this behavior for the specified fields.
+
+* Note:  
+  Entities resulting from a projecting query are Not tracked by the session.  
+  Learn more about projections in:  
+    * [Projections](../../../indexes/querying/projections)
+    * [How to project query results](../../../client-api/session/querying/how-to-project-query-results)
+
+{NOTE: }
+
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query customize_5_0@ClientApi\Session\Querying\howToCustomize.js /}
+{CODE-TAB:nodejs:Index index_2@ClientApi\Session\Querying\howToCustomize.js /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE:nodejs customize_5_1@ClientApi\Session\Querying\howToCustomize.js /}
+
+| Parameters             | Type     | Description                                                    |
+|------------------------|----------|----------------------------------------------------------------|
+| __properties__         | string[] | Fields' names for which to fetch values                        |
+| __projectionClass__    | object   | The projected results class                                    |
+| __projectionBehavior__ | string   | The requested projection behavior, see available options below |
+
+* `Default`  
+  Retrieve values from the stored index fields when available.  
+  If fields are not stored then get values from the document.
+* `FromIndex`  
+  Retrieve values from the stored index fields when available.  
+  A field that is not stored in the index is skipped.
+* `FromIndexOrThrow`  
+  Retrieve values from the stored index fields when available.  
+  An exception is thrown if the index does not store the requested field.
+* `FromDocument`  
+  Retrieve values directly from the documents store.  
+  A field that is not found in the document is skipped.
+* `FromDocumentOrThrow`  
+  Retrieve values directly from the documents store.  
+  An exception is thrown if the document does not contain the requested field.
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: randomOrdering}
+
+* Use `RandomOrdering` to order the query results randomly.
+
+{NOTE: }
+
+__Example__
+
+{CODE:nodejs customize_6_0@ClientApi\Session\Querying\howToCustomize.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE:nodejs customize_6_1@ClientApi\Session\Querying\howToCustomize.js /}
+
+| Parameters | Type   | Description                                                                                            |
+|------------|--------|--------------------------------------------------------------------------------------------------------|
+| __seed__   | string | Order the search results randomly using this seed. <br> Useful when executing repeated random queries. |
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: timings}
+
+* Use `Timings` to get detailed stats of the time spent by the server on each part of the query.
+
+* The timing statistics will be included in the query results.
+
+* Learn more in [how to include query timings](../../../client-api/session/querying/debugging/query-timings).
+
+{NOTE: }
+
+__Example__
+
+{CODE:nodejs customize_7_0@ClientApi\Session\Querying\howToCustomize.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Syntax__
+
+{CODE:nodejs customize_7_1@ClientApi\Session\Querying\howToCustomize.js /}
+
+| Parameters | Type | Description |
+| - |----------------| - |
+| __timings__ | `QueryTimings` | An _out_ param that will be filled with the timings results |
+
+| `QueryTimings` |  |  |
+| - |-----------------------------------|---------------------------------------------------|
+| __DurationInMs__ | long | Total duration |
+| __Timings__ | IDictionary<string, QueryTimings> | Dictionary with _QueryTimings_ info per time part |
+
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: waitForNonStaleResults}
+
+* All queries in RavenDB provide results using an index, even when you don't specify one.  
+  See detailed explanation in [Queries always provide results using an index](../../../client-api/session/querying/how-to-query#queries-always-provide-results-using-an-index).
+
+* Use `waitForNonStaleResults` to instruct the query to wait for non-stale results from the index.
+
+* A `TimeoutException` will be thrown if the query is not able to return non-stale results within the specified  
+  (or default) timeout.
+
+* Learn more about stale results in [stale indexes](../../../indexes/stale-indexes).
+
+{NOTE: }
+
+__Example__
 
 {CODE:nodejs customize_8_0@ClientApi\Session\Querying\howToCustomize.js /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **waitTimeout** | number | Time to wait for an index to return non-stale results. The default is 15 seconds. |
+{NOTE/}
 
-| Return Value | |
-| ------------- | ----- |
-| query | Returns self for easier method chaining. |
+{NOTE: }
 
-### Example
+__Syntax__
 
 {CODE:nodejs customize_8_1@ClientApi\Session\Querying\howToCustomize.js /}
+
+| Parameters      | Type   | Description                                                                           |
+|-----------------|--------|---------------------------------------------------------------------------------------|
+| **waitTimeout** | number | Time (ms) to wait for an index to return non-stale results.<br>Default is 15 seconds. |
+
+{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.js.markdown
@@ -1,4 +1,4 @@
-# Session: Querying: How to Customize a Query
+# How to Customize a Query
 ---
 
 {NOTE: }

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-query.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-query.dotnet.markdown
@@ -309,6 +309,7 @@ Available custom methods and extensions for the session's [Query](../../../clien
 - FirstOrDefaultAsync
 - [GroupByArrayValues](../../../client-api/session/querying/how-to-perform-group-by-query#by-array-values)
 - [GroupByArrayContent](../../../client-api/session/querying/how-to-perform-group-by-query#by-array-content)
+- Highlight
 - [Include](../../../client-api/how-to/handle-document-relationships)
 - [Intersect](../../../client-api/session/querying/how-to-use-intersect)
 - [Lazily](../../../client-api/session/querying/how-to-perform-queries-lazily)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-query.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-query.js.markdown
@@ -282,10 +282,12 @@ Available methods for the session's [query](../../../client-api/session/querying
 - longCount
 - [moreLikeThis](../../../client-api/session/querying/how-to-use-morelikethis)
 - negateNext
-- noCaching
-- noTracking
+- [noCaching](../../../client-api/session/querying/how-to-customize-query#nocaching)
+- [noTracking](../../../client-api/session/querying/how-to-customize-query#notracking)
 - not
 - [ofType](../../../client-api/session/querying/how-to-project-query-results#oftype)
+- [on("afterQueryExecuted")](../../../client-api/session/querying/how-to-customize-query#on-("afterqueryexecuted"))
+- [on("beforeQueryExecuted")](../../../client-api/session/querying/how-to-customize-query#on-("beforequeryexecuted"))
 - openSubclause
 - orderBy
 - orderByDescending
@@ -295,10 +297,10 @@ Available methods for the session's [query](../../../client-api/session/querying
 - orderByScoreDescending
 - orElse
 - proximity
-- randomOrdering
+- [randomOrdering](../../../client-api/session/querying/how-to-customize-query#randomordering)
 - relatesToShape
 - search
-- selectFields
+- [selectFields](../../../indexes/querying/projections#selectfields)
 - selectTimeSeries
 - single
 - singleOrNull
@@ -309,7 +311,7 @@ Available methods for the session's [query](../../../client-api/session/querying
 - take
 - timings
 - usingDefaultOperator
-- waitForNonStaleResults
+- [waitForNonStaleResults](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults)
 - whereBetween
 - whereEndsWith
 - whereEquals

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToCustomize.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToCustomize.cs
@@ -1,40 +1,549 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.Timings;
 using Raven.Client.Documents.Session;
 using Raven.Documentation.Samples.Orders;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 
 namespace Raven.Documentation.Samples.ClientApi.Session.Querying
 {
     public class HowToCustomize
     {
+        public async Task HowToCustomizeExamples()
+        {
+            using (var store = new DocumentStore())
+            {
+                var _logger = LoggingSource.Instance.GetLogger("", "");
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_1_1
+                    List<Employee> results = session
+                        .Query<Employee>()
+                         // Call 'Customize' with 'BeforeQueryExecuted'
+                        .Customize(x => x.BeforeQueryExecuted(query =>
+                        {
+                            // Can modify query parameters
+                            query.SkipDuplicateChecking = true;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"Query to be executed is: {query.Query}");
+                        }))
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_1_2
+                    List<Employee> results = await asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'BeforeQueryExecuted'
+                        .Customize(x => x.BeforeQueryExecuted(query =>
+                        {
+                            // Can modify query parameters
+                            query.SkipDuplicateChecking = true;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"Query to be executed is: {query.Query}");
+                        }))
+                        .Where(x => x.FirstName == "Robert")
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_1_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>()
+                        .WhereEquals(x => x.FirstName, "Robert")
+                         // Call 'BeforeQueryExecuted'
+                        .BeforeQueryExecuted(query =>
+                        {
+                            // Can modify query parameters
+                            query.SkipDuplicateChecking = true;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"Query to be executed is: {query.Query}");
+                        })
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_1_4
+                    List<Employee> results = session.Advanced
+                        .RawQuery<Employee>("from 'Employees' where FirstName == 'Robert'")
+                         // Call 'BeforeQueryExecuted'
+                        .BeforeQueryExecuted(query =>
+                        {
+                            // Can modify query parameters
+                            query.SkipDuplicateChecking = true;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"Query to be executed is: {query.Query}");
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_2_1
+                    List<Employee> results = session
+                        .Query<Employee>()
+                         // Call 'Customize' with 'AfterQueryExecuted'
+                        .Customize(x => x.AfterQueryExecuted(rawResult =>
+                        {
+                            // Can access the raw query result
+                            var queryDuration = rawResult.DurationInMs;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"{rawResult.LastQueryTime}");
+                        }))
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_2_2
+                    List<Employee> results = await asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'AfterQueryExecuted'
+                        .Customize(x => x.AfterQueryExecuted(rawResult =>
+                        {
+                            // Can access the raw query result
+                            var queryDuration = rawResult.DurationInMs;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"{rawResult.LastQueryTime}");
+                        }))
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_2_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>()
+                         // Call 'AfterQueryExecuted'
+                        .AfterQueryExecuted(rawResult =>
+                        {
+                            // Can access the raw query result
+                            var queryDuration = rawResult.DurationInMs;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"{rawResult.LastQueryTime}");
+                        })
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_2_4
+                    List<Employee> results = session.Advanced
+                        .RawQuery<Employee>("from 'Employees'")
+                         // Call 'AfterQueryExecuted'
+                        .AfterQueryExecuted(rawResult =>
+                        {
+                            // Can access the raw query result
+                            var queryDuration = rawResult.DurationInMs;
+                            // Can apply any needed action, e.g. write to log
+                            _logger.Info($"{rawResult.LastQueryTime}");
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_3_1
+                    long totalStreamedResultsSize = 0;
+                    
+                    // Define the query
+                    var query = session
+                        .Query<Employee>()
+                         // Call 'Customize' with 'AfterStreamExecuted'
+                        .Customize(x => x.AfterStreamExecuted(streamResult =>
+                            // Can access the stream result
+                            totalStreamedResultsSize += streamResult.Size));
+                        
+                    // Call 'Stream' to execute the query
+                    var streamResults = session.Advanced.Stream(query);
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_3_2
+                    long totalStreamedResultsSize = 0;
+                    
+                    // Define the query
+                    var query = asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'AfterStreamExecuted'
+                        .Customize(x => x.AfterStreamExecuted(streamResult =>
+                            // Can access the stream result
+                            totalStreamedResultsSize += streamResult.Size));
+                        
+                    // Call 'Stream' to execute the query
+                    var streamResults = await asyncSession.Advanced.StreamAsync(query);
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_3_3
+                    long totalStreamedResultsSize = 0;
+                    
+                    // Define the document query
+                    var query = session.Advanced
+                        .DocumentQuery<Employee>()
+                         // Call 'AfterStreamExecuted'
+                        .AfterStreamExecuted(streamResult =>
+                            // Can access the stream result
+                            totalStreamedResultsSize += streamResult.Size);
+                        
+                    // Call 'Stream' to execute the document query
+                    var streamResults = session.Advanced.Stream(query);
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_3_4
+                    long totalStreamedResultsSize = 0;
+                    
+                    // Define the raw query
+                    var query = session.Advanced
+                        .RawQuery<Employee>("from 'Employees'")
+                         // Call 'AfterStreamExecuted'
+                        .AfterStreamExecuted(streamResult =>
+                            // Can access the stream result
+                            totalStreamedResultsSize += streamResult.Size);
+
+                    // Call 'Stream' to execute the document query
+                    var streamResults = session.Advanced.Stream(query);
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_4_1
+                    List<Employee> results = session
+                        .Query<Employee>()
+                         // Call 'Customize' with 'NoCaching'
+                        .Customize(x => x.NoCaching())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_4_2
+                    List<Employee> results = await asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'NoCaching'
+                        .Customize(x => x.NoCaching())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_4_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>()
+                        .WhereEquals(x => x.FirstName, "Robert")
+                         // Call 'NoCaching'
+                        .NoCaching()
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_4_4
+                    List<Employee> results = session.Advanced
+                        .RawQuery<Employee>("from 'Employees' where FirstName == 'Robert'")
+                         // Call 'NoCaching'
+                        .NoCaching()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_5_1
+                    List<Employee> results = session
+                        .Query<Employee>()
+                         // Call 'Customize' with 'NoTracking'
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_5_2
+                    List<Employee> results = await asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'NoTracking'
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_5_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>()
+                        .WhereEquals(x => x.FirstName, "Robert")
+                         // Call 'NoTracking'
+                        .NoTracking()
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_5_4
+                    List<Employee> results = session.Advanced
+                        .RawQuery<Employee>("from 'Employees' where FirstName == 'Robert'")
+                         // Call 'NoTracking'
+                        .NoTracking()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_6_1
+                    List<string> results = session
+                        .Query<Employees_ByFullName.IndexEntry, Employees_ByFullName>()
+                         // Call 'Customize'
+                         // Pass the requested projection behavior to the 'Projection' method
+                        .Customize(x => x.Projection(ProjectionBehavior.FromDocumentOrThrow))
+                         // Select the fields that will be returned by the projection
+                        .Select(x => x.FullName)
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_6_2
+                    List<string> results = await asyncSession
+                        .Query<Employees_ByFullName.IndexEntry, Employees_ByFullName>()
+                         // Call 'Customize'
+                         // Pass the requested projection behavior to the 'Projection' method
+                        .Customize(x => x.Projection(ProjectionBehavior.FromDocumentOrThrow))
+                         // Select the fields that will be returned by the projection
+                        .Select(x => x.FullName)
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_6_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>("Employees/ByFullName")
+                         // Pass the requested projection behavior to the 'SelectFields' method
+                         // and specify the field that will be returned by the projection
+                        .SelectFields<Employee>(ProjectionBehavior.FromDocumentOrThrow, "FullName")
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_6_4
+                    List<Employee> results = session.Advanced
+                         // Define an RQL query that returns a projection
+                        .RawQuery<Employee>(@"from index 'Employees/ByFullName' select FullName")
+                         // Pass the requested projection behavior to the 'Projection' method
+                        .Projection(ProjectionBehavior.FromDocumentOrThrow)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_7_1
+                    List<Employee> results = session
+                        .Query<Employee>()
+                        // Call 'Customize' with 'RandomOrdering'
+                        .Customize(x => x.RandomOrdering())
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_7_2
+                    List<Employee> results = await asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'RandomOrdering'
+                        .Customize(x => x.RandomOrdering())
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_7_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>()
+                         // Call 'RandomOrdering'
+                        .RandomOrdering()
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_7_4
+                    List<Employee> results = session.Advanced
+                         // Define an RQL query that orders the results randomly
+                        .RawQuery<Employee>("from 'Employees' order by random()")
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region customize_8_1
+                    List<Employee> results = session
+                        .Query<Employee>()
+                         // Call 'Customize' with 'WaitForNonStaleResults'
+                        .Customize(x => x.WaitForNonStaleResults(TimeSpan.FromSeconds(10)))
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_8_2
+                    List<Employee> results = await asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'WaitForNonStaleResults'
+                        .Customize(x => x.WaitForNonStaleResults(TimeSpan.FromSeconds(10)))
+                        .Where(x => x.FirstName == "Robert")
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_8_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>()
+                        .WhereEquals(x => x.FirstName, "Robert")
+                         // Call 'WaitForNonStaleResults'
+                        .WaitForNonStaleResults(TimeSpan.FromSeconds(10))
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_8_4
+                    List<Employee> results = session.Advanced
+                        .RawQuery<Employee>("from 'Employees' where FirstName == 'Robert'")
+                         // Call 'WaitForNonStaleResults'
+                        .WaitForNonStaleResults(TimeSpan.FromSeconds(10))
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_9_1
+                    List<Employee> results = session
+                        .Query<Employee>()
+                         // Call 'Customize' with 'Timings'
+                         // Provide an out param for the timings results
+                        .Customize(x => x.Timings(out QueryTimings timings))
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region customize_9_2
+                    List<Employee> results = await asyncSession
+                        .Query<Employee>()
+                         // Call 'Customize' with 'Timings'
+                         // Provide an out param for the timings results
+                        .Customize(x => x.Timings(out QueryTimings timings))
+                        .Where(x => x.FirstName == "Robert")
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_9_3
+                    List<Employee> results = session.Advanced
+                        .DocumentQuery<Employee>()
+                        .WhereEquals(x => x.FirstName, "Robert")
+                         // Call 'Timings'.
+                         // Provide an out param for the timings results
+                        .Timings(out QueryTimings timings)
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region customize_9_4
+                    List<Employee> results = session.Advanced
+                        .RawQuery<Employee>("from 'Employees' where FirstName == 'Robert'")
+                         // Call 'Timings'.
+                         // Provide an out param for the timings results
+                        .Timings(out QueryTimings timings)
+                        .ToList();
+                    #endregion
+                }
+            }
+        }
+        
         private interface IFoo
         {
-            #region customize_1_0
+            #region customize_1_5
             IDocumentQueryCustomization BeforeQueryExecuted(Action<IndexQuery> action);
             #endregion
 
-            #region customize_1_0_0
+            #region customize_2_5
             IDocumentQueryCustomization AfterQueryExecuted(Action<QueryResult> action);
             #endregion
 
-            #region customize_1_0_1
+            #region customize_3_5
             IDocumentQueryCustomization AfterStreamExecuted(Action<BlittableJsonReaderObject> action);
             #endregion
 
-            #region customize_2_0
+            #region customize_4_5
             IDocumentQueryCustomization NoCaching();
             #endregion
 
-            #region customize_3_0
+            #region customize_5_5
             IDocumentQueryCustomization NoTracking();
             #endregion
 
-            #region projectionbehavior
+            #region customize_6_5
             IDocumentQueryCustomization Projection(ProjectionBehavior projectionBehavior);
 
             public enum ProjectionBehavior {
@@ -46,125 +555,42 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
             }
             #endregion
 
-            #region customize_4_0
+            #region customize_7_5
             IDocumentQueryCustomization RandomOrdering();
-
             IDocumentQueryCustomization RandomOrdering(string seed);
             #endregion
 
-            #region customize_8_0
+            #region customize_8_5
             IDocumentQueryCustomization WaitForNonStaleResults(TimeSpan? waitTimeout);
             #endregion
-        }
-
-        public HowToCustomize()
-        {
-            using (var store = new DocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    #region customize_1_1
-                    // set 'PageSize' to 10
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.BeforeQueryExecuted(query => query.PageSize = 10))
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region customize_1_1_0
-                    TimeSpan queryDuration;
-
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.AfterQueryExecuted(
-                            result => queryDuration = TimeSpan.FromMilliseconds(result.DurationInMs)))
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region customize_1_1_1
-
-                    long totalStreamedResultsSize = 0;
-
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.AfterStreamExecuted(
-                            result => totalStreamedResultsSize += result.Size))
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region customize_2_1
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.NoCaching())
-                        .Where(x => x.FirstName == "Robert")
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region customize_3_1
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.NoTracking())
-                        .Where(x => x.FirstName == "Robert")
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region projectionbehavior_query
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.Projection(ProjectionBehavior.FromDocument))
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region projectionbehavior_rawquery
-                    List<Employee> results = session.Advanced.RawQuery<Employee>(
-                        @"from Employees")
-                        .Projection(ProjectionBehavior.FromDocument)
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region projectionbehavior_docquery
-                    List<Employee> results = session.Advanced.DocumentQuery<Employee>()
-                        .SelectFields<Employee>(ProjectionBehavior.FromDocument)
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region customize_4_1
-                    // results will be ordered randomly each time
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.RandomOrdering())
-                        .Where(x => x.FirstName == "Robert")
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region customize_8_1
-                    List<Employee> results = session.Query<Employee>()
-                        .Customize(x => x.WaitForNonStaleResults())
-                        .Where(x => x.FirstName == "Robert")
-                        .ToList();
-                    #endregion
-                }
-            }
+            
+            #region customize_9_5
+            IDocumentQueryCustomization Timings(out QueryTimings timings);
+            #endregion
         }
     }
+
+    #region the_index
+    public class Employees_ByFullName : AbstractIndexCreationTask<Employee, Employees_ByFullName.IndexEntry>
+    {
+        // The IndexEntry class defines the index-fields.
+        public class IndexEntry
+        {
+            public string FullName { get; set; }
+        }
+            
+        public Employees_ByFullName()
+        {
+            // The 'Map' function defines the content of the index-fields
+            Map = employees => from employee in employees
+                select new IndexEntry
+                {
+                    FullName = $"{employee.FirstName} {employee.LastName}"
+                };
+            
+            // Store field 'FullName' in the index
+            Store(x => x.FullName, FieldStorage.Yes);
+        }
+    }
+    #endregion
 }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/howToCustomize.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/howToCustomize.js
@@ -3,139 +3,218 @@ import { DocumentStore } from "ravendb";
 const store = new DocumentStore();
 const session = store.openSession();
 
+const logger = getLogger({ module: "ravendb" });
+
 let action, queryCustomization, seed, waitTimeout, projectionBehavior;
+class Employee {}
+
+//region index_1
+class BlogPosts_ByTag extends AbstractJavaScriptIndexCreationTask<BlogPost> {
+    public constructor() {
+        super();
+
+        this.map(BlogPost, b => {
+            const result: TagResult[] = [];
+
+            b.tags.forEach(item => {
+                result.push({
+                    tag: item
+                });
+            });
+
+            return result;
+
+            // This fanout index outputs multiple index entries per each document,
+            // (an index-entry per tag in from the tags list).            
+            // The query can be customized to return the documents without the duplicates,
+            // (see the query example in the first tab).  
+        })
+    }
+}
+
+class BlogPost {
+    public id: string;
+    public title: string;
+    public body: string;
+    public tags: string[];
+}
+
+class TagResult {
+    public tag: string;
+}
+//endregion
+
+//region index_2
+class Employee_ByFullName extends AbstractJavaScriptIndexCreationTask<Employee> {
+    public constructor() {
+        super();
+
+        this.map(Employee, e => {
+            return {
+                fullName: e.firstName + " " + e.lastName
+            }
+        })
+
+        // Store field 'fullName' in the index
+        this.store("fullName", "Yes");
+    }
+}
+//endregion
+
+async function customizeExamples() {
+    {
+        //region customize_1_0
+        const results = await session
+             // Query an index
+            .query(BlogPost, BlogPosts_ByTag)
+             // Provide a callback for the 'beforeQueryExecuted' event 
+            .on("beforeQueryExecuted", query => {
+                // Can modify query parameters
+                (query as IndexQuery).skipDuplicateChecking = true;
+                // Can apply any needed action, e.g. write to log
+                logger.info(`Query to be executed is: ${query.query}`);
+            })
+            .all();
+        //endregion
+    }
+
+    {
+        //region customize_2_0
+        let queryDuration = 0;
+
+        const results = await session
+            .query<Employee>({ collection: "employees" })
+             // Provide a callback for the 'afterQueryExecuted' event 
+            .on("afterQueryExecuted", rawResult => {
+                // Can access the raw query result
+                queryDuration = rawResult.durationInMs
+                // Can apply any needed action, e.g. write to log
+                logger.info(`${rawResult.lastQueryTime}`);
+             })
+            .all();
+        //endregion
+    }
+
+    {
+        //region customize_3_0
+        const results = await session
+            .query<Employee>({ collection: "employees" })
+            .whereEquals("firstName", "Robert")
+             // Add a call to 'noCaching'
+            .noCaching()
+            .all();
+        //endregion
+    }
+
+    {
+        //region customize_4_0
+        const results = await session
+            .query<Employee>({ collection: "employees" })
+            .whereEquals("firstName", "Robert")
+            // Add a call to 'noTrcking'
+            .noTracking()
+            .all();
+        //endregion
+    }
+
+    {
+        //region customize_5_0
+        // The projection class: 
+        class EmployeeProjectedDetails {
+            private fullName: null;
+            constructor() {
+                this.fullName = null;
+            }
+        }
+        
+        // Define a query with a projection
+        const query = session
+             // Query an index that has stored fields
+            .query(Employee, Employee_ByFullName)
+             // Use 'selectFields' to project the query results
+             // Pass the requested projection behavior (3'rd param)
+            .selectFields(["fullName"], EmployeeProjectedDetails, "FromDocumentOrThrow")
+            .all();
+
+        // * Field 'fullName' is stored in the index.
+        //   However, the server will try to fetch the value from the document 
+        //   since the default behavior was modified to `FromDocumentOrThrow`.
+        
+        // * An exception will be thrown -
+        //   since an 'Employee' document does not contain the property 'fullName'.
+        //   (based on the Northwind sample data).        
+        //endregion
+    }
+    
+    {
+        //region customize_6_0
+        const results = await session
+            .query<Employee>({ collection: "employees" })
+            // Add a call to 'randomOrdering', can pass a seed
+            .randomOrdering("123")
+            .all();
+        //endregion
+    }
+
+    {
+        //region customize_7_0
+        let timingsResults;
+
+        const results = await session.query({ collection: "Products" })
+            .whereEquals("firstName", "Robert")
+             // Call 'timings', pass a callback function
+             // Output param 'timingsResults' will be filled with the timings details when query returns 
+            .timings(t => timingsResults = t)
+            .all();
+        //endregion
+    }
+
+    {
+        //region customize_8_0
+        const results = await session.query({ collection: "Products" })
+            .whereEquals("firstName", "Robert")
+             // Call 'waitForNonStaleResults', 
+             // Optionally, pass the time to wait. Default is 15 seconds.
+            .waitForNonStaleResults(10_000)
+            .all();
+        //endregion
+    }
+}
 
 {
     const query = session.query({ collection: "test" });
 
-    //region customize_1_0
-    query.on("beforeQueryExecuted", action);
+    //region customize_1_1
+    on("beforeQueryExecuted", eventHandler);
     //endregion
 
-    //region customize_1_0_0
-    query.on("afterQueryExecuted", action);
+    //region customize_2_1
+    on("afterQueryExecuted", eventHandler);
     //endregion
 
-
-    //region customize_1_0_1
-    query.on("afterStreamExecuted", action);
+    //region customize_3_1
+    noCaching();
     //endregion
 
-
-    //region customize_2_0
-    queryCustomization.noCaching();
+    //region customize_4_1
+    noTracking();
     //endregion
 
-    //region customize_3_0
-    queryCustomization.noTracking();
+    //region customize_5_1
+    selectFields(properties, projectionClass, projectionBehavior);
     //endregion
 
-    //region customize_4_0
-    queryCustomization.randomOrdering([seed]);
+    //region customize_6_1
+    randomOrdering();
+    randomOrdering(seed);
     //endregion
 
-    //region customize_8_0
-    queryCustomization.waitForNonStaleResults([waitTimeout]);
+    //region customize_7_1
+    timings(timingsCallback)
     //endregion
 
-    
-    //region projectionbehavior
-    queryCustomization.projection([projectionBehavior]);
+    //region customize_8_1
+    waitForNonStaleResults();
+    waitForNonStaleResults(waitTimeout);
     //endregion
-
-}
-
-class Employee {}
-
-
-
-async function customizeExamples() {
-    {
-        //region customize_1_1
-        await session
-            .query(Employee)
-            .on("beforeQueryExecuted", indexQuery => {
-                // set 'pageSize' to 10
-                indexQuery.pageSize = 10;  
-            })
-            .all();
-        //endregion
-    }
-
-    {
-        //region customize_1_1_0
-        let queryDuration;
-
-        await session.query(Employee)
-            .on("afterQueryExecuted", result => {
-                queryDuration = result.durationInMs;
-            })
-            .all();
-        //endregion
-    }
-
-    {
-        //region customize_1_1_1
-        let totalStreamedResultsSize;
-
-        await session.query(Employee)
-            .on("afterStreamExecuted", result => {
-                totalStreamedResultsSize += result.size;
-            });
-
-        //endregion
-    }
-
-    {
-        //region customize_2_1
-        session.advanced.on("beforeQuery",
-            event => event.queryCustomization.noCaching());
-
-        const results = await session.query({ collection: "Employees" })
-            .whereEquals("FirstName", "Robert")
-            .all();
-        //endregion
-    }
-
-    {
-        //region customize_3_1
-        session.advanced.on("beforeQuery",
-            event => event.queryCustomization.noTracking());
-
-        const results = await session.query({ collection: "Employees" })
-            .whereEquals("FirstName", "Robert")
-            .all();
-        //endregion
-    }
-
-    {
-        //region customize_4_1
-        session.advanced.on("beforeQuery",
-            event => event.queryCustomization.randomOrdering());
-
-        // result will be ordered randomly each time
-        const results = await session.query({ collection: "Employees" })
-            .whereEquals("FirstName", "Robert")
-            .all();
-        //endregion
-    }
-
-    {
-        //region customize_8_1
-        session.advanced.on("beforeQuery",
-            event => event.queryCustomization.waitForNonStaleResults());
-
-        const results = await session.query({ collection: "Employees" })
-            .whereEquals("FirstName", "Robert")
-            .all();
-        //endregion
-    }
-    {
-        //TODO - have to wait till 5.2 release to check that
-        //region projectionbehavior_query
-        await  session.advanced.on("beforeQuery",
-            event => event.queryCustomization.projection("FromDocument"));
-        //endregion
-    }
-
 }


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2446/Node.js-Client-API-Session-Querying-Customize-query

@aviv86 
C# files;
```
Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToCustomize.cs
```

@ml054 
Node.js files:
```
Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/howToCustomize.js
```