### PR TITLE
RDoc-2447 Query timings page

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/include-explanations.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/include-explanations.dotnet.markdown
@@ -13,21 +13,21 @@
   you can use `IncludeExplanations` when querying with a [DocumentQuery](../../../../client-api/session/querying/document-query/what-is-document-query). 
 
 * In this page:
-    * [Include explanations in query](../../../../client-api/session/querying/debugging/include-explanations#include-explanations-in-query)  
+    * [Include explanations in a query](../../../../client-api/session/querying/debugging/include-explanations#include-explanations-in-a-query)  
     * [View explanations](../../../../client-api/session/querying/debugging/include-explanations#view-explanations)  
     * [Syntax](../../../../client-api/session/querying/debugging/include-explanations#syntax)  
 {NOTE/}
 
 ---
 
-{PANEL: Include explanations in query}
+{PANEL: Include explanations in a query}
 
 {CODE-TABS}
-{CODE-TAB:csharp:Sync explain@ClientApi\Session\Querying\Debugging\IncludeExplanations.cs /}
-{CODE-TAB:csharp:Async explain_async@ClientApi\Session\Querying\Debugging\IncludeExplanations.cs /}
+{CODE-TAB:csharp:DocumentQuery explain@ClientApi\Session\Querying\Debugging\IncludeExplanations.cs /}
+{CODE-TAB:csharp:DocumentQuery_async explain_async@ClientApi\Session\Querying\Debugging\IncludeExplanations.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products
-where search(Name, 'Syrup') or search(Name, 'Lager')
+from "Products"
+where search(Name, "Syrup") or search(Name, "Lager")
 include explanations()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
@@ -37,6 +37,7 @@ include explanations()
 {PANEL: View explanations}
 
 * The detailed explanations can be viewed from the __Query view__ in the Studio.  
+
 * Running a query with `include explanations()` will show an additional __Explanations Tab__.
 
 ![Figure 1. Explanations in the Studio](images/include-explanations-1.png "Include explanations")

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/include-explanations.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/include-explanations.java.markdown
@@ -10,10 +10,10 @@
 ## Example
 
 {CODE-TABS}
-{CODE-TAB:java:Java explain_2@ClientApi\Session\Querying\Debugging\IncludeExplanations.java /}
+{CODE-TAB:java:Query explain_2@ClientApi\Session\Querying\Debugging\IncludeExplanations.java /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products 
-where search(Name, 'Syrup')
+from "Products" 
+where search(Name, "Syrup")
 include explanations()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/include-explanations.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/include-explanations.js.markdown
@@ -12,20 +12,20 @@
 * Use `includeExplanations` in your query __to get the score details__ and see how it was calculated.  
 
 * In this page:
-    * [Include explanations in query](../../../../client-api/session/querying/debugging/include-explanations#include-explanations-in-query)  
+    * [Include explanations in a query](../../../../client-api/session/querying/debugging/include-explanations#include-explanations-in-a-query)  
     * [View explanations](../../../../client-api/session/querying/debugging/include-explanations#view-explanations)  
     * [Syntax](../../../../client-api/session/querying/debugging/include-explanations#syntax)  
 {NOTE/}
 
 ---
 
-{PANEL: Include explanations in query}
+{PANEL: Include explanations in a query}
 
 {CODE-TABS}
 {CODE-TAB:nodejs:Query explain@ClientApi\Session\Querying\Debugging\includeExplanations.js /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products
-where search(Name, 'Syrup') or search(Name, 'Lager')
+from "Products"
+where search(Name, "Syrup") or search(Name, "Lager")
 include explanations()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
@@ -4,22 +4,25 @@
 
 {NOTE: }
 
-* When making a query, you can request to get detailed stats of the time spent by RaveDB on each part of the query. 
-  i.e. duration of the search, loading documents, transforming results, etc.
- 
-* By default, getting the timings in queries is turned off.
+* When making a query, you can request to get detailed stats of the time spent by RavenDB on each part of the query. 
+  E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* __To get the query timings__ include a call to `Timings`.
+* By default, the timings stats are Not included in the query results.
+
+* __To include the query timings__ in the query results:  
+  add a call to `Timings()` in your query code, or add `include timings()` to an RQL query.  
+  See examples below.  
 
 * In this page:
-    * [Include timings in query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-query)
+    * [Include timings in a query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-a-query)
     * [View timings](../../../../client-api/session/querying/debugging/query-timings#view-timings)
     * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)  
+
 {NOTE/}
 
 ---
 
-{PANEL: Include timings in query}
+{PANEL: Include timings in a query}
 
 {CODE-TABS}
 {CODE-TAB:csharp:Query-sync timing_1@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
@@ -27,8 +30,8 @@
 {CODE-TAB:csharp:DocumentQuery-sync timing_2@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
 {CODE-TAB:csharp:DocumentQuery-async timing_4@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products
-where search(Name, 'Syrup') or search(Name, 'Lager')
+from "Products"
+where search(Name, "Syrup") or search(Name, "Lager")
 include timings()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
@@ -37,8 +40,9 @@ include timings()
 
 {PANEL: View timings}
 
-* The detailed timings can be viewed from the __Query view__ in the Studio.  
-* Running a query with `include Timings()` will show an additional __Timings Tab__  
+* The detailed timings can be viewed from the [Query view](../../../../studio/database/queries/query-view) in the Studio.  
+
+* Running an RQL query with `include timings()` will show an additional __Timings Tab__  
   with a graphical representation of the time spent in each query part.   
 
 ![Figure 1. Include timings graphical results](images/include-timings.png "Include timings results")

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
@@ -4,7 +4,8 @@
 
 {NOTE: }
 
-* When making a query, you can request to get detailed stats of the time spent by RavenDB on each part of the query. 
+* When making a query,  
+  you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
 * By default, the timings stats are Not included in the query results.

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
@@ -53,13 +53,13 @@ include timings()
 
 {CODE syntax@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
 
-| Parameters | Data type | Description |
-| - | - | - |
+| Parameter   | Type           | Description                                                 |
+|-------------|----------------|-------------------------------------------------------------|
 | __timings__ | `QueryTimings` | An _out_ param that will be filled with the timings results |
 
-| `QueryTimings` | | |
-| - | - | - |
-| __DurationInMs__ | `long` | Total duration |
-| __Timings__ | `IDictionary<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
+| `QueryTimings`   |                                     |                                                   |
+|------------------|-------------------------------------|---------------------------------------------------|
+| __DurationInMs__ | `long`                              | Total duration                                    |
+| __Timings__      | `IDictionary<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
 
 {PANEL/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
@@ -8,7 +8,7 @@
   you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* By default, the timings stats are Not included in the query results.
+* By default, the timings stats are Not included in the query results, to avoid the measuring overhead.
 
 * __To include the query timings__ in the query results:  
   add a call to `Timings()` in your query code, or add `include timings()` to an RQL query.  

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
@@ -4,7 +4,8 @@
 
 {NOTE: }
 
-* When making a query, you can request to get detailed stats of the time spent by RavenDB on each part of the query.
+* When making a query,  
+  you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
 * By default, the timings stats are Not included in the query results.

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
@@ -50,13 +50,13 @@ include timings()
 
 {CODE:nodejs syntax@ClientApi\Session\Querying\Debugging\includeQueryTimings.js /}
 
-| Parameters | Data type | Description |
-| - | - | - |
+| Parameter           | Type                        | Description                                                                                                                                                                    |
+|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | __timingsCallback__ | `(timingsCallback) => void` | <ul><li>A callback function with an output parameter.</li><li>The parameter passed to the callback will be filled with the `QueryTimings` object when query returns.</li></ul> |
 
-| `QueryTimings` | | |
-| - | - | - |
-| __durationInMs__ | `number` | Total duration |
-| __timings__ | `Record<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
+| `QueryTimings`   |                                |                                                   |
+|------------------|--------------------------------|---------------------------------------------------|
+| __durationInMs__ | `number`                       | Total duration                                    |
+| __timings__      | `Record<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
 
 {PANEL/}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
@@ -4,28 +4,31 @@
 
 {NOTE: }
 
-* When making a query, you can request to get detailed stats of the time spent by RaveDB on each part of the query. 
-  i.e. duration of the search, loading documents, transforming results, etc.
- 
-* By default, getting the timings in queries is turned off.
+* When making a query, you can request to get detailed stats of the time spent by RavenDB on each part of the query.
+  E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* __To get the query timings__ include a call to `timings`.
+* By default, the timings stats are Not included in the query results.
+
+* __To include the query timings__ in the query results:  
+  add a call to `timings()` in your query code, or add `include timings()` to an RQL query.  
+  See examples below.
 
 * In this page:
-    * [Include timings in query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-query)
+    * [Include timings in a query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-a-query)
     * [View timings](../../../../client-api/session/querying/debugging/query-timings#view-timings)
-    * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)  
+    * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)
+
 {NOTE/}
 
 ---
 
-{PANEL: Include timings in query}
+{PANEL: Include timings in a query}
 
 {CODE-TABS}
 {CODE-TAB:nodejs:Query timing@ClientApi\Session\Querying\Debugging\includeQueryTimings.js /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products
-where search(Name, 'Syrup') or search(Name, 'Lager')
+from "Products"
+where search(Name, "Syrup") or search(Name, "Lager")
 include timings()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
@@ -34,9 +37,10 @@ include timings()
 
 {PANEL: View timings}
 
-* The detailed timings can be viewed from the __Query view__ in the Studio.  
-* Running a query with `include Timings()` will show an additional __Timings Tab__  
-  with a graphical representation of the time spent in each query part.   
+* The detailed timings can be viewed from the [Query view](../../../../studio/database/queries/query-view) in the Studio.  
+
+* Running an RQL query with `include timings()` will show an additional __Timings Tab__  
+  with a graphical representation of the time spent in each query part.
 
 ![Figure 1. Include timings graphical results](images/include-timings.png "Include timings results")
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
@@ -8,7 +8,7 @@
   you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* By default, the timings stats are Not included in the query results.
+* By default, the timings stats are Not included in the query results, to avoid the measuring overhead.
 
 * __To include the query timings__ in the query results:  
   add a call to `timings()` in your query code, or add `include timings()` to an RQL query.  

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.cs
@@ -43,13 +43,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToList();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
                     // Get specific parts duration: 
+                    // ============================
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
-                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
-                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
                 
@@ -66,13 +67,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToList();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
                     // Get specific parts duration: 
+                    // ============================
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
-                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
-                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
 
@@ -92,13 +94,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToListAsync();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
                     // Get specific parts duration: 
+                    // ============================
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
-                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
-                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
                 
@@ -115,13 +118,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToListAsync();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
-                    // Get specific parts duration: 
+                    // Get specific parts duration:
+                    // ============================ 
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
-                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
-                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
             }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.cs
@@ -16,10 +16,10 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
 {
     public class IncludeQueryTimings
     {
-        public interface IFoo<T>
+        public interface IFoo
         {
             #region syntax
-            IDocumentQuery<T> Timings(out QueryTimings timings);
+            IDocumentQueryCustomization Timings(out QueryTimings timings);
             #endregion
         }
 
@@ -47,7 +47,9 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                     
                     // Get specific parts duration: 
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
+                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
                 
@@ -68,7 +70,9 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                     
                     // Get specific parts duration: 
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
+                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
 
@@ -92,7 +96,9 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                     
                     // Get specific parts duration: 
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
+                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
                 
@@ -113,7 +119,9 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                     
                     // Get specific parts duration: 
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
+                    
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timings.Timings["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
             }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/Debugging/includeQueryTimings.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/Debugging/includeQueryTimings.js
@@ -32,10 +32,14 @@ async function timings() {
         .all();
 
     // Get total query duration:
+    // =========================    
     const totalQueryDuration = timingsResults.durationInMs;
 
-    // Get specific parts duration, e.g. get the optimizer part:
-    const optimizerDuration = timings.timings.optimizer.durationInMs;
-    // or: timings.timings["optimizer"].durationInMs;
+    // Get specific parts duration:
+    // ============================
+    const optimizerDuration = timingsResults.timings.optimizer.durationInMs;
+    // or: timingsResults.timings["optimizer"].durationInMs;    
+    const luceneDuration = timingsResults.timings.query.timings.lucene.durationInMs;
+    // or: timingsResults.timings["query"].timings.["lucene"].durationInMs;
     //endregion
 }

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
@@ -4,7 +4,8 @@
 
 {NOTE: }
 
-* When making a query, you can request to get detailed stats of the time spent by RavenDB on each part of the query.
+* When making a query,   
+  you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
 * By default, the timings stats are Not included in the query results.
@@ -17,6 +18,7 @@
     * [Include timings in a query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-a-query)
     * [View timings](../../../../client-api/session/querying/debugging/query-timings#view-timings)
     * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)
+    * [Timings in a sharded database](../../../../client-api/session/querying/debugging/query-timings#timings-in-a-sharded-database)
 
 {NOTE/}
 
@@ -61,5 +63,13 @@ include timings()
 |------------------|-------------------------------------|---------------------------------------------------|
 | __DurationInMs__ | `long`                              | Total duration                                    |
 | __Timings__      | `IDictionary<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
+
+{PANEL/}
+
+{PANEL: Timings in a sharded database}
+
+* In a sharded database, timings for each part are provided __per shard__.
+
+* Learn more in [timings in a sharded database](../../../../sharding/querying#timing-queries).
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
@@ -4,39 +4,25 @@
 
 {NOTE: }
 
-* When running a query, you can request for statistics regarding 
-  the time it takes to perform the whole query as well as parts 
-  of it like the duration of document search and loading.  
-* By default, this feature is **disabled**.  
-  To **enable** it, add `include timings()` to an RQL query or call 
-  `.Timings()` from your code.  
+* When making a query, you can request to get detailed stats of the time spent by RavenDB on each part of the query.
+  E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* In this page:  
-    * [Including Timings In a Query](../../../../client-api/session/querying/debugging/query-timings#including-timings-in-a-query)  
-        * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)  
-        * [Example](../../../../client-api/session/querying/debugging/query-timings#example)
-    * [Viewing Timings](../../../../client-api/session/querying/debugging/query-timings#viewing-timings)  
+* By default, the timings stats are Not included in the query results.
+
+* __To include the query timings__ in the query results:  
+  add a call to `Timings()` in your query code, or add `include timings()` to an RQL query.  
+  See examples below.
+
+* In this page:
+    * [Include timings in a query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-a-query)
+    * [View timings](../../../../client-api/session/querying/debugging/query-timings#view-timings)
+    * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: Including Timings In a Query}
-
-## Syntax
-
-{CODE syntax@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
-
-| Parameters | Data type | Description |
-| - | - | - |
-| __timings__ | `QueryTimings` | An _out_ param that will be filled with the timings |
-
-| `QueryTimings` | | |
-| - | - | - |
-| __DurationInMs__ | `long` | Total duration |
-| __Timings__ | `IDictionary<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
-
-## Example
+{PANEL: Include timings in a query}
 
 {CODE-TABS}
 {CODE-TAB:csharp:Query-sync timing_1@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
@@ -44,25 +30,36 @@
 {CODE-TAB:csharp:DocumentQuery-sync timing_2@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
 {CODE-TAB:csharp:DocumentQuery-async timing_4@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products
-where search(Name, 'Syrup') or search(Name, 'Lager')
+from "Products"
+where search(Name, "Syrup") or search(Name, "Lager")
 include timings()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 
 {PANEL/}
 
-{PANEL: Viewing Timings}
+{PANEL: View timings}
 
-* Timings can be viewed using Studio's [Query view](../../../../studio/database/queries/query-view).  
-* If `include Timings()` is added to an RQL query Studio will display an additional **Timings** tab 
-  with a graphical representation of the time it took to perform each query part.   
+* The detailed timings can be viewed from the [Query view](../../../../studio/database/queries/query-view) in the Studio.
+
+* Running an RQL query with `include timings()` will show an additional __Timings Tab__  
+  with a graphical representation of the time spent in each query part.
 
 ![Figure 1. Include timings graphical results](images/include-timings.png "Include timings results")
 
-{NOTE: }
-In a sharded database, timings are provided per shard.  
-Read more about it [here](../../../../sharding/querying#timing-queries).  
-{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.cs /}
+
+| Parameter   | Type           | Description                                                 |
+|-------------|----------------|-------------------------------------------------------------|
+| __timings__ | `QueryTimings` | An _out_ param that will be filled with the timings results |
+
+| `QueryTimings`   |                                     |                                                   |
+|------------------|-------------------------------------|---------------------------------------------------|
+| __DurationInMs__ | `long`                              | Total duration                                    |
+| __Timings__      | `IDictionary<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.dotnet.markdown
@@ -8,7 +8,7 @@
   you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* By default, the timings stats are Not included in the query results.
+* By default, the timings stats are Not included in the query results, to avoid the measuring overhead.
 
 * __To include the query timings__ in the query results:  
   add a call to `Timings()` in your query code, or add `include timings()` to an RQL query.  

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.java.markdown
@@ -4,60 +4,67 @@
 
 {NOTE: }
 
-* When running a query, you can request for statistics regarding 
-  the time it takes to perform the whole query as well as parts 
-  of it like the duration of document search and loading.  
-* By default, this feature is **disabled**.  
-  To **enable** it, add `include timings()` to an RQL query or call 
-  `.timings()` from your code.  
+* When making a query,  
+  you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
+  E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* In this page:  
-    * [Including Timings In a Query](../../../../client-api/session/querying/debugging/query-timings#including-timings-in-a-query)  
-        * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)  
-        * [Example](../../../../client-api/session/querying/debugging/query-timings#example)
-    * [Viewing Timings](../../../../client-api/session/querying/debugging/query-timings#viewing-timings)  
+* By default, the timings stats are Not included in the query results.
+
+* __To include the query timings__ in the query results:  
+  add a call to `timings()` in your query code, or add `include timings()` to an RQL query.  
+  See examples below.
+
+* In this page:
+    * [Include timings in a query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-a-query)
+    * [View timings](../../../../client-api/session/querying/debugging/query-timings#view-timings)
+    * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)
+    * [Timings in a sharded database](../../../../client-api/session/querying/debugging/query-timings#timings-in-a-sharded-database)
 
 {NOTE/}
 
 ---
 
-{PANEL: Including Timings In a Query}
-
-## Syntax
-
-{CODE:java timing_1@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.java /}
-
-The `QueryTimings` object will be filled with the timings when the query returns.  
-
-| `QueryTimings` | | |
-| - | - | - |
-| __durationInMs__ | `number` | Total duration |
-| __timings__ | `Record<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
-
-## Example
+{PANEL: Include timings in a query}
 
 {CODE-TABS}
-{CODE-TAB:java:Java timing_2@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.java /}
+{CODE-TAB:java:Query timing_2@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.java /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products 
-where search(Name, 'Syrup')
+from "Products"
+where search(Name, "Syrup") or search(Name, "Lager")
 include timings()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 
 {PANEL/}
 
-{PANEL: Viewing Timings}
+{PANEL: View timings}
 
-* Timings can be viewed using Studio's [Query view](../../../../studio/database/queries/query-view).  
-* If `include Timings()` is added to an RQL query Studio will display an additional **Timings** tab 
-  with a graphical representation of the time it took to perform each query part.   
+* The detailed timings can be viewed from the [Query view](../../../../studio/database/queries/query-view) in the Studio.
+
+* Running an RQL query with `include timings()` will show an additional __Timings Tab__  
+  with a graphical representation of the time spent in each query part.
 
 ![Figure 1. Include timings graphical results](images/include-timings.png "Include timings results")
 
-{NOTE: }
-In a sharded database, timings are provided per shard.  
-Read more about it [here](../../../../sharding/querying#timing-queries).  
-{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:java timing_1@ClientApi\Session\Querying\Debugging\IncludeQueryTimings.java /}
+
+The `QueryTimings` object will be filled with the timings when the query returns.  
+
+| `QueryTimings`   |                             |                                                   |
+|------------------|-----------------------------|---------------------------------------------------|
+| __durationInMs__ | `long`                   | Total duration                                    |
+| __timings__      | `Map<String, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
+
+{PANEL/}
+
+{PANEL: Timings in a sharded database}
+
+* In a sharded database, timings for each part are provided __per shard__.
+
+* Learn more in [timings in a sharded database](../../../../sharding/querying#timing-queries).
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.java.markdown
@@ -8,7 +8,7 @@
   you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* By default, the timings stats are Not included in the query results.
+* By default, the timings stats are Not included in the query results, to avoid the measuring overhead.
 
 * __To include the query timings__ in the query results:  
   add a call to `timings()` in your query code, or add `include timings()` to an RQL query.  

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
@@ -4,63 +4,69 @@
 
 {NOTE: }
 
-* When running a query, you can request for statistics regarding 
-  the time it takes to perform the whole query as well as parts 
-  of it like the duration of document search and loading.  
-* By default, this feature is **disabled**.  
-  To **enable** it, add `include timings()` to an RQL query or call 
-  `.timings()` from your code.  
+* When making a query,  
+  you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
+  E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* In this page:  
-    * [Including Timings In a Query](../../../../client-api/session/querying/debugging/query-timings#including-timings-in-a-query)  
-        * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)  
-        * [Example](../../../../client-api/session/querying/debugging/query-timings#example)
-    * [Viewing Timings](../../../../client-api/session/querying/debugging/query-timings#viewing-timings)  
+* By default, the timings stats are Not included in the query results.
+
+* __To include the query timings__ in the query results:  
+  add a call to `timings()` in your query code, or add `include timings()` to an RQL query.  
+  See examples below.
+
+* In this page:
+    * [Include timings in a query](../../../../client-api/session/querying/debugging/query-timings#include-timings-in-a-query)
+    * [View timings](../../../../client-api/session/querying/debugging/query-timings#view-timings)
+    * [Syntax](../../../../client-api/session/querying/debugging/query-timings#syntax)
+    * [Timings in a sharded database](../../../../client-api/session/querying/debugging/query-timings#timings-in-a-sharded-database)
 
 {NOTE/}
 
 ---
 
-{PANEL: Including Timings In a Query}
-
-## Syntax
-
-{CODE:nodejs syntax@client-api\Session\Querying\Debugging\includeQueryTimings.js /}
-
-| Parameters | Data type | Description |
-| - | - | - |
-| __timingsCallback__ | `(timingsCallback) => void` | <ul><li>A callback function with an output parameter.</li><li>The parameter passed to the callback will be filled with the `QueryTimings` object when the query returns.</li></ul> |
-
-| `QueryTimings` | | |
-| - | - | - |
-| __durationInMs__ | `number` | Total duration |
-| __timings__ | `Record<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
-
-
-## Example
+{PANEL: Include timings in a query}
 
 {CODE-TABS}
-{CODE-TAB:nodejs:Query timing@client-api\Session\Querying\Debugging\includeQueryTimings.js /}
+{CODE-TAB:nodejs:Query timing@client-api\session\querying\debugging\includeQueryTimings.js /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Products
-where search(Name, 'Syrup') or search(Name, 'Lager')
+from "Products"
+where search(Name, "Syrup") or search(Name, "Lager")
 include timings()
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 
 {PANEL/}
 
-{PANEL: Viewing Timings}
+{PANEL: View timings}
 
-* Timings can be viewed using Studio's [Query view](../../../../studio/database/queries/query-view).  
-* If `include Timings()` is added to an RQL query Studio will display an additional **Timings** tab 
-  with a graphical representation of the time it took to perform each query part.   
+* The detailed timings can be viewed from the [Query view](../../../../studio/database/queries/query-view) in the Studio.
+
+* Running an RQL query with `include timings()` will show an additional __Timings Tab__  
+  with a graphical representation of the time spent in each query part.
 
 ![Figure 1. Include timings graphical results](images/include-timings.png "Include timings results")
 
-{NOTE: }
-In a sharded database, timings are provided per shard.  
-Read more about it [here](../../../../sharding/querying#timing-queries).  
-{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\session\querying\debugging\includeQueryTimings.js /}
+
+| Parameter           | Type                        | Description                                                                                                                                                                    |
+|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| __timingsCallback__ | `(timingsCallback) => void` | <ul><li>A callback function with an output parameter.</li><li>The parameter passed to the callback will be filled with the `QueryTimings` object when query returns.</li></ul> |
+
+| `QueryTimings`   |                                |                                                   |
+|------------------|--------------------------------|---------------------------------------------------|
+| __durationInMs__ | `number`                       | Total duration                                    |
+| __timings__      | `Record<string, QueryTimings>` | Dictionary with `QueryTimings` info per time part |
+
+{PANEL/}
+
+{PANEL: Timings in a sharded database}
+
+* In a sharded database, timings for each part are provided __per shard__.
+
+* Learn more in [timings in a sharded database](../../../../sharding/querying#timing-queries).
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
@@ -8,7 +8,7 @@
   you can request to get detailed stats of the time spent by RavenDB on each part of the query.  
   E.g. duration of search, loading documents, transforming results, total duration, etc.
 
-* By default, the timings stats are Not included in the query results.
+* By default, the timings stats are Not included in the query results, to avoid the measuring overhead.
 
 * __To include the query timings__ in the query results:  
   add a call to `timings()` in your query code, or add `include timings()` to an RQL query.  

--- a/Documentation/6.0/Raven.Documentation.Pages/sharding/querying.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/sharding/querying.markdown
@@ -307,18 +307,16 @@ recently and the document modified first would be the last result.
 
 {PANEL: Timing Queries}
 
-The duration of queries and query parts (e.g. optimization 
-or execution time) can be measured using API or Studio.  
+* The duration of queries and query parts (e.g. optimization or execution time) can be measured using API or Studio.
 
-Timing is **disabled** by default, to avoid the measuring overhead. 
-It can be enabled per query by adding `include timings()` to an RQL 
-query or calling [`.Timings()`](../client-api/session/querying/debugging/query-timings#syntax) 
-in a [Linq](../client-api/session/querying/how-to-query#session.query) 
-query, as explained [here](../client-api/session/querying/debugging/query-timings).  
+* In a sharded database, the timings for each part will be provided __per shard__.
 
-To time queries in a sharded database using Studio open the 
-[Query View](../studio/database/queries/query-view), enable timings 
-as explained above, run the query, and open the **Timing** tab.  
+* Timing is disabled by default, to avoid the measuring overhead.  
+  It can be enabled per query by adding `include timings()` to an RQL query or calling [`Timings()`](../client-api/session/querying/debugging/query-timings#syntax) 
+  in your query code, as explained in [include query timings](../client-api/session/querying/debugging/query-timings).
+
+* To view the query timings in the Studio, open the [Query View](../studio/database/queries/query-view),  
+  run an RQL query with `include timings()`, and open the __Timings tab__.
 
 !["Timing Shards Querying"](images/querying_timing.png "Timing Shards Querying")
 

--- a/Documentation/6.0/Raven.Documentation.Pages/sharding/querying.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/sharding/querying.markdown
@@ -306,6 +306,7 @@ recently and the document modified first would be the last result.
 {PANEL/}
 
 {PANEL: Timing Queries}
+
 The duration of queries and query parts (e.g. optimization 
 or execution time) can be measured using API or Studio.  
 

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.cs
@@ -16,10 +16,10 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
 {
     public class IncludeQueryTimings
     {
-        public interface IFoo<T>
+        public interface IFoo
         {
             #region syntax
-            IDocumentQuery<T> Timings(out QueryTimings timings);
+            IDocumentQueryCustomization Timings(out QueryTimings timings);
             #endregion
         }
 
@@ -43,11 +43,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToList();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
                     // Get specific parts duration: 
+                    // ============================
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
                 
@@ -64,11 +67,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToList();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
-                    // Get specific parts duration: 
+                    // Get specific parts duration:
+                    // ============================
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
 
@@ -88,11 +94,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToListAsync();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
                     // Get specific parts duration: 
+                    // ============================
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
                 
@@ -109,11 +118,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.Debugging
                         .ToListAsync();
 
                     // Get total query duration:
+                    // =========================
                     var totalQueryDuration = timings.DurationInMs;
                     
                     // Get specific parts duration: 
+                    // ============================
                     IDictionary<string, QueryTimings> timingsDictionary = timings.Timings;
                     var optimizerDuration = timingsDictionary["Optimizer"].DurationInMs;
+                    var luceneDuration = timingsDictionary["Query"].Timings["Lucene"].DurationInMs;
                     #endregion
                 }
             }

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Querying/Debugging/IncludeQueryTimings.java
@@ -15,7 +15,7 @@ public class IncludeQueryTimings {
 
     public interface IFoo<T> {
         //region timing_1
-        IDocumentQuery<T> timings(Reference<QueryTimings> timings);
+        IDocumentQueryCustomization timings(Reference<QueryTimings> timings);
         //endregion
     }
 

--- a/Documentation/6.0/Samples/nodejs/client-api/session/querying/debugging/includeQueryTimings.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/session/querying/debugging/includeQueryTimings.js
@@ -32,10 +32,14 @@ async function timings() {
         .all();
 
     // Get total query duration:
+    // =========================    
     const totalQueryDuration = timingsResults.durationInMs;
 
-    // Get specific parts duration, e.g. get the optimizer part:
-    const optimizerDuration = timings.timings.optimizer.durationInMs;
-    // or: timings.timings["optimizer"].durationInMs;
+    // Get specific parts duration:
+    // ============================
+    const optimizerDuration = timingsResults.timings.optimizer.durationInMs;
+    // or: timingsResults.timings["optimizer"].durationInMs;    
+    const luceneDuration = timingsResults.timings.query.timings.lucene.durationInMs;
+    // or: timingsResults.timings["query"].timings.["lucene"].durationInMs;
     //endregion
 }


### PR DESCRIPTION
**Related issues:**
https://issues.hibernatingrhinos.com/issue/RDoc-2447/Fix-query-timings-page

@ml054 - **Node.js files:**

```
Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/Debugging/includeQueryTimings.js

Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/debugging/query-timings.js.markdown
Documentation/6.0/Samples/nodejs/client-api/session/querying/debugging/includeQueryTimings.js
```