### PR TITLE
RDoc-2487 Client API > Session > Querying > Text Search > Fuzzy search

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.dotnet.markdown
@@ -25,8 +25,8 @@
 {CODE-TAB:csharp:DocumentQuery fuzzy_1@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
 {CODE-TAB:csharp:DocumentQuery_async fuzzy_2@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
-from Companies
-where fuzzy(Name = 'Ernts Hnadel', 0.5)
+from "Companies"
+where fuzzy(Name = "Ernts Hnadel", 0.5)
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.dotnet.markdown
@@ -12,14 +12,14 @@
 * Use the `Fuzzy` method when querying with `WhereEquals`.
 
 * In this page:
-    * [Fuzzy search](../../../../client-api/session/querying/text-search/proximity-search#fuzzy-search)
-    * [Syntax](../../../../client-api/session/querying/text-search/proximity-search#syntax)
+    * [Fuzzy search example](../../../../client-api/session/querying/text-search/fuzzy-search#fuzzy-search-example)
+    * [Syntax](../../../../client-api/session/querying/text-search/fuzzy-search#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: Fuzzy search}
+{PANEL: Fuzzy search example}
 
 {CODE-TABS}
 {CODE-TAB:csharp:DocumentQuery fuzzy_1@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.dotnet.markdown
@@ -1,27 +1,46 @@
 # Fuzzy Search
 
-Fuzzy search is supported via `Fuzzy` method.   
-This method is available only from [DocumentQuery](../../../../client-api/session/querying/document-query/what-is-document-query) level and can only be performed on single term values.  
-Because of that it can be used only right after `WhereEquals` method.
+---
 
-## Syntax
+{NOTE: }
 
-{CODE fuzzy_1@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
+* A __fuzzy search__ retrieves documents containing terms that closely match a given term instead of exact matches, 
+  assisting in finding relevant results when the search term is misspelled or has minor variations.
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **fuzzy** | `decimal` | Value between 0.0 and 1.0 where 1.0 means closer match. |
+* Fuzzy search is available only via [DocumentQuery](../../../../client-api/session/querying/document-query/what-is-document-query) or RQL.
 
-## Example
+* Use the `Fuzzy` method when querying with `WhereEquals`.
+
+* In this page:
+    * [Fuzzy search](../../../../client-api/session/querying/text-search/proximity-search#fuzzy-search)
+    * [Syntax](../../../../client-api/session/querying/text-search/proximity-search#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Fuzzy search}
 
 {CODE-TABS}
-{CODE-TAB:csharp:Sync fuzzy_2@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
-{CODE-TAB:csharp:Async fuzzy_3@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
+{CODE-TAB:csharp:DocumentQuery fuzzy_1@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
+{CODE-TAB:csharp:DocumentQuery_async fuzzy_2@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
 from Companies
 where fuzzy(Name = 'Ernts Hnadel', 0.5)
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\Querying\TextSearch\FuzzySearch.cs /}
+
+| Parameter   | Type      | Description                                                                                                       |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------------------|
+| **fuzzy**   | `decimal` | A value between `0.0` and `1.0`.<br>With a value closer to `1.0`, terms with a higher similarity will be matched. |
+
+{PANEL/}
 
 ## Related Articles
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.js.markdown
@@ -1,0 +1,47 @@
+# Fuzzy Search
+
+---
+
+{NOTE: }
+
+* A __fuzzy search__ retrieves documents containing terms that closely match a given term instead of exact matches, 
+  assisting in finding relevant results when the search term is misspelled or has minor variations.
+
+* Use the `fuzzy` method when querying with `whereEquals`.
+
+* In this page:
+    * [Fuzzy search](../../../../client-api/session/querying/text-search/proximity-search#fuzzy-search)
+    * [Syntax](../../../../client-api/session/querying/text-search/proximity-search#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Fuzzy search}
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query fuzzy@ClientApi\Session\Querying\TextSearch\fuzzySearch.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies"
+where fuzzy(Name = "Ernts Hnadel", 0.5)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Session\Querying\TextSearch\fuzzySearch.js /}
+
+| Parameter   | Type     | Description                                                                                                       |
+|-------------|----------|-------------------------------------------------------------------------------------------------------------------|
+| **fuzzy**   | `number` | A value between `0.0` and `1.0`.<br>With a value closer to `1.0`, terms with a higher similarity will be matched. |
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [Query overview](../../../../client-api/session/querying/how-to-query)
+- [Full-text search](../../../../client-api/session/querying/text-search/full-text-search)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.js.markdown
@@ -10,14 +10,14 @@
 * Use the `fuzzy` method when querying with `whereEquals`.
 
 * In this page:
-    * [Fuzzy search](../../../../client-api/session/querying/text-search/proximity-search#fuzzy-search)
-    * [Syntax](../../../../client-api/session/querying/text-search/proximity-search#syntax)
+    * [Fuzzy search example](../../../../client-api/session/querying/text-search/fuzzy-search#fuzzy-search-example)
+    * [Syntax](../../../../client-api/session/querying/text-search/fuzzy-search#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: Fuzzy search}
+{PANEL: Fuzzy search example}
 
 {CODE-TABS}
 {CODE-TAB:nodejs:Query fuzzy@ClientApi\Session\Querying\TextSearch\fuzzySearch.js /}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/FuzzySearch.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/FuzzySearch.cs
@@ -19,8 +19,8 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                         .DocumentQuery<Company>()
                          // Query with a term that is misspelled
                         .WhereEquals(x => x.Name, "Ernts Hnadel")
-                        // Call 'Fuzzy', 
-                        // Pass the required similarity, a decimal param
+                        // Call 'Fuzzy' 
+                        // Pass the required similarity, a decimal param between 0.0 and 1.0
                         .Fuzzy(0.5m)
                         .ToList();
                     
@@ -34,10 +34,10 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                     #region fuzzy_2
                     List<Company> companies = await asyncSession.Advanced
                         .AsyncDocumentQuery<Company>()
-                         // Query with a term that is for misspelled
+                         // Query with a term that is misspelled
                         .WhereEquals(x => x.Name, "Ernts Hnadel")
-                         // Call 'Fuzzy', 
-                         // Pass the required similarity, a decimal param
+                         // Call 'Fuzzy' 
+                         // Pass the required similarity, a decimal param between 0.0 and 1.0
                         .Fuzzy(0.5m)
                         .ToListAsync();
                     

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/FuzzySearch.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/FuzzySearch.cs
@@ -1,36 +1,57 @@
-﻿using Raven.Client.Documents.Session;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
 using Raven.Documentation.Samples.Orders;
 
 namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
 {
     public class FuzzySearch
     {
+        public async Task Examples()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region fuzzy_1
+                    List<Company> companies = session.Advanced
+                        .DocumentQuery<Company>()
+                         // Query with a term that is misspelled
+                        .WhereEquals(x => x.Name, "Ernts Hnadel")
+                        // Call 'Fuzzy', 
+                        // Pass the required similarity, a decimal param
+                        .Fuzzy(0.5m)
+                        .ToList();
+                    
+                    // Running the above query on the Northwind sample data returns document: companies/20-A
+                    // which contains "Ernst Handel" in its Name field.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region fuzzy_2
+                    List<Company> companies = await asyncSession.Advanced
+                        .AsyncDocumentQuery<Company>()
+                         // Query with a term that is for misspelled
+                        .WhereEquals(x => x.Name, "Ernts Hnadel")
+                         // Call 'Fuzzy', 
+                         // Pass the required similarity, a decimal param
+                        .Fuzzy(0.5m)
+                        .ToListAsync();
+                    
+                    // Running the above query on the Northwind sample data returns document: companies/20-A
+                    // which contains "Ernst Handel" in its Name field.
+                    #endregion
+                }
+            }
+        }
+        
         private interface IFoo<T>
         {
-            #region fuzzy_1
+            #region syntax
             IDocumentQuery<T> Fuzzy(decimal fuzzy);
-            #endregion
-        }
-
-        public void Sample1(IDocumentSession session)
-        {
-            #region fuzzy_2
-            session
-                .Advanced
-                .DocumentQuery<Company>()
-                .WhereEquals(x => x.Name, "Ernts Hnadel").Fuzzy(0.5m)
-                .ToList();
-            #endregion
-        }
-
-        public void Sample2(IAsyncDocumentSession session)
-        {
-            #region fuzzy_3
-            session
-                .Advanced
-                .AsyncDocumentQuery<Company>()
-                .WhereEquals(x => x.Name, "Ernts Hnadel").Fuzzy(0.5m)
-                .ToListAsync();
             #endregion
         }
     }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/TextSearch/fuzzySearch.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/TextSearch/fuzzySearch.js
@@ -1,0 +1,28 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function fuzzySearch() {
+    {
+        //region fuzzy
+        const employees = await session
+            .query({ collection: "Companies" })
+             // Query with a term that is misspelled
+            .whereEquals("Name", "Ernts Hnadel")
+             // Call 'fuzzy' 
+             // Pass the required similarity, a number between 0.0 and 1.0
+            .fuzzy(0.5)
+            .all();
+
+        // Running the above query on the Northwind sample data returns document: companies/20-A
+        // which contains "Ernst Handel" in its Name field.
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    fuzzy(fuzzy);
+    //endregion
+}


### PR DESCRIPTION
**Related issues:**
https://issues.hibernatingrhinos.com/issue/RDoc-2487/Node.js-Client-API-Session-Querying-Text-Search-Fuzzy-search

---

@ml054 - **Node.js files:**
```
Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/fuzzy-search.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Session/Querying/TextSearch/fuzzySearch.js
```