### PR TITLE
RDoc-2527  Fix links to the "Gather information" article

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/start/test-driver.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/start/test-driver.dotnet.markdown
@@ -1,0 +1,134 @@
+# Getting Started: Writing your Unit Test using TestDriver
+---
+
+{NOTE: }
+
+* In this section, we explain how to use [RavenDB.TestDriver](https://www.nuget.org/packages/RavenDB.TestDriver/) to write RavenDB unit tests.  
+
+* TestDriver uses an [Embedded Server](../server/embedded) package with the same set of [prerequisite](../server/embedded#prerequisite) as embedded servers to run the tests.  
+
+* In this page: 
+ - [RavenTestDriver](../start/test-driver#raventestdriver)
+ - [Pre-initializing the store](../start/test-driver#preinitialize)
+ - [ConfigureServer](../start/test-driver#configureserver)
+ - [Unit test](../start/test-driver#unittest)
+ - [Complete example](../start/test-driver#complete-example)
+ - [CI Servers](../start/test-driver#continuous-integration-servers)
+
+{NOTE/}
+
+{PANEL:RavenTestDriver}
+
+First, we define a class that derives from Raven's TestDriver.
+Let's start with reviewing the TestDriver's methods and properties and later we will get into implementation (a complete code sample of a RavenTestDriver can be found at the [bottom](../start/test-driver#complete-example) of the page).
+
+### Properties and Methods
+| Signature | Description |
+| ----------| ----- |
+| **protected virtual string DatabaseDumpFilePath => null;** | Allows you to override the path to the database dump file that will be loaded when calling ImportDatabase. |
+| **protected virtual Stream DatabaseDumpFileStream => null;** |  Allows you to override the stream containing the database dump that will be loaded when calling ImportDatabase.  |
+| **public IDocumentStore GetDocumentStore([CallerMemberName] string database = null, TimeSpan? waitForIndexingTimeout = null)** | Gets you an IDocumentStore instance for the requested database. |
+| **protected virtual void PreInitialize(IDocumentStore documentStore)** |Allows you to pre-initialize the IDocumentStore. |
+| **protected virtual void SetupDatabase(IDocumentStore documentStore)** | Allows you to initialize the database. |
+| **protected event EventHandler DriverDisposed;** |An event that is raised when the test driver has been disposed of. |
+| **public static void ConfigureServer(TestServerOptions options)** |Allows you to configure your server before running it|
+| **public void WaitForIndexing(IDocumentStore store, string database = null, TimeSpan? timeout = null)** | Allows you to wait for indexes to become non-stale. |
+| **public void WaitForUserToContinueTheTest(IDocumentStore store)** | Allows you to break the test and launch the Studio to examine the state of the database. |
+| **protected virtual void OpenBrowser(string url)** | Allows you to open the browser. |
+| **public virtual void Dispose()** | Allows you to dispose of the server. |
+
+{PANEL/}
+
+{PANEL:PreInitialize}
+
+Pre-Initializing the IDocumentStore allows you to mutate the conventions used by the document store.
+
+### Example
+
+{CODE test_driver_PreInitialize@Start\RavenDBTestDriver.cs /}
+
+{PANEL/}
+
+{PANEL:UnitTest}
+
+We use [xunit](https://www.nuget.org/packages/xunit/) for the test framework in the below example.  
+
+{NOTE: }
+Note that the test itself is meant to show different capabilities of the test driver and is not meant to be the most efficient.  
+{NOTE/}
+
+The example below depends on the `TestDocumentByName` index and `TestDocument` class that can be seen in the [full example](../start/test-driver#complete-example)
+
+### Example
+
+In the example, we get an `IDocumentStore` object to our test database, deploy an index, and insert two documents into the document store.  
+
+We then use `WaitForUserToContinueTheTest(store)` which launches the Studio so we can verify that the documents 
+and index are deployed (we can remove this line after the test succeeds).  
+
+Finally, we use `session.Query` to query for "TestDocument" where the name contains the word 'hello', 
+and we assert that we have only one such document.
+
+{CODE test_driver_MyFirstTest@Start\RavenDBTestDriver.cs /}
+
+{PANEL/}
+
+{PANEL: ConfigureServer}
+
+The `ConfigureServer` method allows you to be more in control of your server.  
+You can use it with `TestServerOptions` to change the path to the Raven server binaries, specify data storage path, adjust .NET framework versions, etc.
+
+* `ConfigureServer` can only be set once per test run.  
+  It needs to be set before `DocumentStore` is called.  
+  See an [example](../start/test-driver#complete-example) below.  
+
+* If it is called twice, or within the `DocumentStore` scope, you will get the following error message:
+  `System.InvalidOperationException : Cannot configure server after it was started. Please call 'ConfigureServer' method before any 'GetDocumentStore' is called.`  
+
+{INFO:TestServerOptions}
+
+Defining TestServerOptions allows you to be more in control of 
+how the embedded server is going to run with just a minor [definition change](../start/test-driver#example-2).
+
+* To see the complete list of `TestServerOptions`, which inherits from embedded servers, go to embedded [ServerOptions](../server/Embedded#getting-started).  
+* It's important to be sure that the correct [.NET FrameworkVersion](../server/Embedded#net-frameworkversion) is set.
+
+{INFO /}
+
+#### Example
+
+{CODE test_driver_ConfigureServer@Start\RavenDBTestDriver.cs /}
+
+{PANEL/}
+
+{PANEL:Complete Example}
+
+This is a full unit test using [Xunit](https://www.nuget.org/packages/xunit/).
+
+In the test, we get an `IDocumentStore` object to our test database, deploy an index, and insert two documents into the document store.  
+
+We then use `WaitForUserToContinueTheTest(store)` which launches the Studio so we can verify that the documents 
+and index are deployed (we can remove this line after the test succeeds).  
+
+Finally, we use `session.Query` to query for "TestDocument" where the name contains the word 'hello', 
+and we assert that we have only one such document.
+
+{CODE test_full_example@Start\RavenDBTestDriverFull.cs /}
+
+{PANEL/}
+
+
+{PANEL:Continuous Integration Servers}
+
+Best practice is to use a CI/CD server to help automate the testing and deployment of your new code. 
+Popular CI/CD products are [AppVeyor](https://www.appveyor.com/) or [Visual Studio Team Services (aka. VSTS)](https://visualstudio.microsoft.com/team-services/).
+
+{PANEL/}
+
+## Related Articles
+
+- [Running an Embedded Instance](../server/Embedded)
+
+### Troubleshooting
+
+- [Collect information for support](../server/troubleshooting/collect-info)

--- a/Documentation/5.4/Raven.Documentation.Pages/start/test-driver.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/start/test-driver.java.markdown
@@ -1,0 +1,115 @@
+# Getting Started: Writing your Unit Test using TestDriver
+
+In this section we will explain how to use [ravendb-test-driver](https://central.sonatype.com/search?q=g:net.ravendb%20%20a:ravendb-test-driver&core=gav&smo=true) in order to write unit tests for working with RavenDB.
+TestDriver uses an [ravendb-embedded](../server/embedded) package with the same set of [prerequisites](../server/embedded#prerequisites) to run the Server.
+
+- [RavenTestDriver](../start/test-driver#raventestdriver)
+- [Pre-initializing the store](../start/test-driver#preinitialize)
+- [ConfigureServer](../start/test-driver#configureserver)
+- [Unit test](../start/test-driver#unittest)
+- [Complete example](../start/test-driver#complete-example)
+
+{PANEL:RavenTestDriver}
+
+First, make sure you added Raven's TestDriver to your project dependencies:
+
+```
+<dependency>
+    <groupId>net.ravendb</groupId>
+    <artifactId>ravendb-test-driver</artifactId>
+    <version>4.1.3</version>
+    <scope>test</scope>
+</dependency>
+```
+
+After that, we define a class that derives from Raven's TestDriver.
+Lets start with reviewing the TestDriver's methods and later we will get into implementation (a complete code sample of a RavenTestDriver can be found at the [bottom](../start/test-driver##complete-example) of the page).
+
+### Methods
+| Signature | Description |
+| ----------| ----- |
+| **protected String getDatabaseDumpFilePath()** | Allows you to override the path to the database dump file that will be loaded when calling importDatabase. |
+| **protected InputStream getDatabaseDumpFileStream()** |  Allows you to override the stream containing the database dump that will be loaded when calling importDatabase.  |
+| **public IDocumentStore getDocumentStore()** | Gets you an IDocumentStore instance. |
+| **public IDocumentStore getDocumentStore(String database)** | Gets you an IDocumentStore instance for the requested database. |
+| **public IDocumentStore getDocumentStore(GetDocumentStoreOptions options)** | Gets you an IDocumentStore instance. |
+| **public IDocumentStore getDocumentStore(GetDocumentStoreOptions options, String database)** | Gets you an IDocumentStore instance for the requested database. |
+| **protected void preInitialize(IDocumentStore documentStore)** |Allows you to pre-initialize the IDocumentStore. |
+| **protected void setupDatabase(IDocumentStore documentStore)** | Allows you to initialize the database. |
+| **protected Consumer<RavenTestDriver> onDriverClosed** | An event that is raised when the test driver has been closed. |
+| **public static void configureServer(ServerOptions options)** |Allows you to configure your server before running it|
+| **public static void waitForIndexing(IDocumentStore store)** | Allows you to wait for indexes to become non-stale. |
+| **public static void waitForIndexing(IDocumentStore store, String database)** | Allows you to wait for indexes to become non-stale. |
+| **public static void waitForIndexing(IDocumentStore store, String database, Duration timeout)** | Allows you to wait for indexes to become non-stale. |
+| **protected void waitForUserToContinueTheTest(IDocumentStore store)** | Allows you to break the test and launch the Studio to examine the state of the database. |
+| **protected void openBrowser(String url)** | Allows you to open the browser. |
+| **public void close()** | Allows you to dispose of the server. |
+
+{PANEL/}
+
+{PANEL:PreInitialize}
+
+Pre-Initializing the IDocumentStore allows you to mutate the conventions used by the document store.
+
+### Example
+
+{CODE:java test_driver_PreInitialize@Start\RavenDBTestDriver.java /}
+
+{PANEL/}
+
+{PANEL:UnitTest}
+We'll be using [junit](https://junit.org/) for my test framework in the below example.
+Note that the test itself is meant to show different capabilities of the test driver and is not meant to be the most efficient.
+The example below depends on the `TestDocumentByName` index and `TestDocument` class that can be seen in the [full example](../start/test-driver#complete-example)
+
+### Example
+
+{CODE:java test_driver_MyFirstTest@Start\RavenDBTestDriver.java /}
+
+In the test we get an IDocumentStore to our test database. Deploy an index and insert two documents into it. 
+We then wait for the indexing to complete and launch the Studio so we can verify that the documents and index are deployed (we can remove this line once the test is working).
+At the end of the test we query for TestDocument where their name contains the world 'hello' and assert that we have only one such document.
+
+{PANEL/}
+
+{PANEL: ConfigureServer}
+
+Before RavenDB server can be started, TestDriver extracts binaries to `targetServerLocation` (Default: `.`). Optionally before doing this, target directory can be cleaned up (when `cleanTargetServerLocation` option is turned on (Default: false)). 
+
+The `configureServer` method allows you to be more in control on your server. 
+You can use it with `ServerOptions` to change the target path where Raven server binaries are extracted to or to specify where your RavenDB data is stored, security, etc.
+
+{INFO:ServerOptions}
+
+`ServerOptions` gives you control of how the embedded server is going to run
+with just a minor change. Here you can change your targetServerLocation.
+
+| Name | Type | Description |
+| ------------- | ------------- | ----- |
+| **targetServerLocation** | string | The temporary path used by TestDriver to extract server binary files (.dll) |
+| **logsPath** | string | Path to server logs files |
+| **dataDirectory**  | string | Path where server stores data files |
+| **cleanTargetServerLocation** | boolean | Should we remove all files from targetServerLocation before extracting server binaries? |
+
+{INFO /}
+
+### Example
+
+{CODE:java test_driver_ConfigureServer@Start\RavenDBTestDriver.java /}
+
+{PANEL/}
+
+{PANEL:Complete Example}
+
+{CODE:java test_full_example@Start\RavenDBTestDriverFull.java /}
+
+{PANEL/}
+
+
+## Related Articles
+
+- [Running an Embedded Instance](../server/Embedded)
+
+### Troubleshooting
+
+- [Collect information for support](../server/troubleshooting/collect-info)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Start/RavenDBTestDriver.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Start/RavenDBTestDriver.cs
@@ -1,0 +1,90 @@
+﻿using Raven.Client.Documents;
+using Raven.TestDriver;
+using Xunit;
+using System;
+using System.IO;
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+
+namespace RavenDBTestDriver
+{
+    public class RavenDBTestDriver : RavenTestDriver
+    {
+        #region test_driver_PreInitialize
+        //This allows us to modify the conventions of the store we get from 'GetDocumentStore'
+        protected override void PreInitialize(IDocumentStore documentStore)
+        {
+            documentStore.Conventions.MaxNumberOfRequestsPerSession = 50;
+        }
+        #endregion
+
+        #region test_driver_MyFirstTest
+        [Fact]
+        public void MyFirstTest()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new TestDocumentByName());
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new TestDocument { Name = "Hello world!" });
+                    session.Store(new TestDocument { Name = "Goodbye..." });
+                    session.SaveChanges();
+                }
+                // If we want to query documents, sometimes we need to wait for the indexes to catch up  
+                // to prevent using stale indexes.
+                WaitForIndexing(store);
+
+                // Sometimes we want to debug the test itself. This method redirects us to the studio
+                // so that we can see if the code worked as expected (in this case, created two documents).
+                WaitForUserToContinueTheTest(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<TestDocument, TestDocumentByName>().Where(x => x.Name == "hello").ToList();
+                    Assert.Single(query);
+                }
+            }
+        }
+        #endregion
+
+        [Fact]
+        public void TestDriveConfigureServer()
+        {
+            #region test_driver_ConfigureServer
+
+            var testServerOptions = new TestServerOptions
+            {
+                // Looks for the newest version on your machine including 3.1.15 and any newer patches
+                // but not major new releases (default is .NET version at time of server release).
+                FrameworkVersion = "3.1.15+",
+
+                // Specifies where ravendb server binaries are located (Optional)
+                ServerDirectory = "PATH_TO_RAVENDB_SERVER",
+
+                // Specifies where ravendb data will be placed/located (Optional)
+                DataDirectory = "PATH_TO_RAVENDB_DATADIR", 
+            };
+
+            ConfigureServer(testServerOptions);
+            #endregion
+        }
+
+
+    }
+
+    public class TestDocumentByName : AbstractIndexCreationTask<TestDocument>
+    {
+        public TestDocumentByName()
+        {
+            Map = docs => from doc in docs select new { doc.Name };
+            Indexes.Add(x => x.Name, FieldIndexing.Search);
+        }
+    }
+
+    public class TestDocument
+    {
+        public string Name { get; set; }
+    }
+
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Start/RavenDBTestDriverFull.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Start/RavenDBTestDriverFull.cs
@@ -1,0 +1,78 @@
+﻿#region test_full_example
+using Raven.Client.Documents;
+using Raven.TestDriver;
+using Xunit;
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+
+namespace RavenDBTestDriverFullExample
+{
+
+    public class RavenDBTestDriver : RavenTestDriver
+    {
+        public RavenDBTestDriver()
+        {
+            // ConfigureServer() must be set before calling GetDocumentStore()
+            // and can only be set once per test run.
+            ConfigureServer(new TestServerOptions
+            {
+                DataDirectory = "C:\\RavenDBTestDir"
+            });
+        }
+        // This allows us to modify the conventions of the store we get from 'GetDocumentStore'
+        protected override void PreInitialize(IDocumentStore documentStore)
+        {
+            documentStore.Conventions.MaxNumberOfRequestsPerSession = 50;
+        }
+
+        [Fact]
+        public void MyFirstTest()
+        {
+            // GetDocumentStore() evokes the Document Store, which establishes and manages communication
+            // between your client application and a RavenDB cluster via HTTP requests.
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new TestDocumentByName());
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new TestDocument { Name = "Hello world!" });
+                    session.Store(new TestDocument { Name = "Goodbye..." });
+                    session.SaveChanges();
+                }
+                // If we want to query documents, sometimes we need to wait for the indexes to catch up  
+                // to prevent using stale indexes.
+                WaitForIndexing(store);
+
+                // Sometimes we want to debug the test itself. This method redirects us to the studio
+                // so that we can see if the code worked as expected (in this case, created two documents).
+                WaitForUserToContinueTheTest(store);
+
+                // Queries are defined in the session scope.
+                // If there is no relevant index to quickly answer the query, RavenDB creates an auto-index
+                // based on the query parameters.
+                // This query will use the static index defined in lines 63-70 and filter the results by name.
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<TestDocument, TestDocumentByName>()
+                        .Where(x => x.Name == "hello").ToList();
+                    Assert.Single(query);
+                }
+            }
+        }
+    }
+    // AbstractIndexCreationTask allows you to create and manually define a static index. 
+    public class TestDocumentByName : AbstractIndexCreationTask<TestDocument>
+    {
+        public TestDocumentByName()
+        {
+            Map = docs => from doc in docs select new { doc.Name };
+            Indexes.Add(x => x.Name, FieldIndexing.Search);
+        }
+    }
+
+    public class TestDocument
+    {
+        public string Name { get; set; }
+    }
+}
+#endregion

--- a/Documentation/5.4/Samples/java/.gitignore
+++ b/Documentation/5.4/Samples/java/.gitignore
@@ -1,0 +1,5 @@
+/target
+.settings/
+.classpath
+.project
+docs-samples.*

--- a/Documentation/5.4/Samples/java/pom.xml
+++ b/Documentation/5.4/Samples/java/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.2.0</modelVersion>
+	<groupId>net.ravendb</groupId>
+	<artifactId>docs-samples</artifactId>
+	<version>4.2.0-SNAPSHOT</version>
+
+	<dependencies>
+    <dependency>
+      <groupId>net.ravendb</groupId>
+      <artifactId>ravendb</artifactId>
+      <version>4.2.1-SNAPSHOT</version>
+    </dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Start/RavenDBTestDriver.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Start/RavenDBTestDriver.java
@@ -1,0 +1,87 @@
+package net.ravendb.Start;
+
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.FieldIndexing;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.embedded.ServerOptions;
+import net.ravendb.test.driver.RavenTestDriver;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class RavenDBTestDriver extends RavenTestDriver {
+
+    //region test_driver_PreInitialize
+    //This allows us to modify the conventions of the store we get from 'getDocumentStore'
+    @Override
+    protected void preInitialize(IDocumentStore documentStore) {
+        documentStore.getConventions().setMaxNumberOfRequestsPerSession(50);
+    }
+    //endregion
+
+    //region test_driver_MyFirstTest
+    @Test
+    public void myFirstTest() {
+        try (IDocumentStore store = getDocumentStore()) {
+            store.executeIndex(new TestDocumentByName());
+
+            try (IDocumentSession session = store.openSession()) {
+                TestDocument testDocument1 = new TestDocument();
+                testDocument1.setName("Hello world!");
+                session.store(testDocument1);
+
+                TestDocument testDocument2 = new TestDocument();
+                testDocument2.setName("Goodbye...");
+                session.store(testDocument2);
+
+                session.saveChanges();
+            }
+
+            waitForIndexing(store); //If we want to query documents sometime we need to wait for the indexes to catch up
+            waitForUserToContinueTheTest(store); //Sometimes we want to debug the test itself, this redirect us to the studio
+
+            try (IDocumentSession session = store.openSession()) {
+                List<TestDocument> query = session.query(TestDocument.class, TestDocumentByName.class)
+                    .whereEquals("name", "hello")
+                    .toList();
+
+                Assert.assertEquals(1, query.size());
+            }
+        }
+    }
+    //endregion
+
+    @Test
+    public void testDriverConfigureServer() {
+        //region test_driver_ConfigureServer
+        ServerOptions testServerOptions = new ServerOptions();
+
+        // specify where ravendb server should be extracted (optional)
+        testServerOptions.setTargetServerLocation("PATH_TO_TEMPORARY_SERVER_LOCATION");
+
+        // Specify where ravendb data will be placed/located (optional)
+        testServerOptions.setDataDirectory("PATH_TO_RAVENDB_DATADIR");
+        //endregion
+    }
+
+    public static class TestDocumentByName extends AbstractIndexCreationTask {
+        public TestDocumentByName() {
+            map = "from doc in docs select new { doc.name }";
+            index("name", FieldIndexing.SEARCH);
+        }
+    }
+
+    public static class TestDocument {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Start/RavenDBTestDriverFull.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Start/RavenDBTestDriverFull.java
@@ -1,0 +1,77 @@
+package net.ravendb.Start;
+
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.FieldIndexing;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.embedded.ServerOptions;
+import net.ravendb.test.driver.RavenTestDriver;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+//region test_full_example
+public class RavenDBTestDriverFull extends RavenTestDriver {
+
+    //This allows us to modify the conventions of the store we get from 'getDocumentStore'
+    @Override
+    protected void preInitialize(IDocumentStore documentStore) {
+        documentStore.getConventions().setMaxNumberOfRequestsPerSession(50);
+    }
+
+    @Test
+    public void myFirstTest() {
+        ServerOptions serverOptions = new ServerOptions();
+        serverOptions.setDataDirectory("C:\\RavenDBTestDir");
+        configureServer(serverOptions);
+
+        try (IDocumentStore store = getDocumentStore()) {
+            store.executeIndex(new TestDocumentByName());
+
+            try (IDocumentSession session = store.openSession()) {
+                TestDocument testDocument1 = new TestDocument();
+                testDocument1.setName("Hello world!");
+                session.store(testDocument1);
+
+                TestDocument testDocument2 = new TestDocument();
+                testDocument2.setName("Goodbye...");
+                session.store(testDocument2);
+
+                session.saveChanges();
+            }
+
+            waitForIndexing(store); //If we want to query documents sometime we need to wait for the indexes to catch up
+            waitForUserToContinueTheTest(store); //Sometimes we want to debug the test itself, this redirect us to the studio
+
+            try (IDocumentSession session = store.openSession()) {
+                List<TestDocument> query = session.query(TestDocument.class, TestDocumentByName.class)
+                    .whereEquals("name", "hello")
+                    .toList();
+
+                Assert.assertEquals(1, query.size());
+            }
+        }
+    }
+
+    public static class TestDocumentByName extends AbstractIndexCreationTask {
+        public TestDocumentByName() {
+            map = "from doc in docs select new { doc.name }";
+            index("name", FieldIndexing.SEARCH);
+        }
+    }
+
+    public static class TestDocument {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+}
+//endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2527/Fix-links-to-the-Gather-information-article

Only copied the test-driver files to 5.4 and added the link to:
`- [Collect information for support](../server/troubleshooting/collect-info)`
