### PR TITLE
RDoc-2529 Get & Put client configuration operations

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/.docs.json
@@ -1,0 +1,14 @@
+[
+    {
+        "Path": "put-client-configuration.markdown",
+        "Name": "Put Client Configuration",
+        "DiscussionId": "e05cdf82-e3a4-434e-86eb-494449e27bcc",
+        "Mappings": []
+    },
+    {
+        "Path": "get-client-configuration.markdown",
+        "Name": "Get Client Configuration",
+        "DiscussionId": "43ab588b-0d2c-4604-854e-43e7e1bf44da",
+        "Mappings": []
+    }
+]

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.dotnet.markdown
@@ -1,0 +1,45 @@
+# Get Client Configuration Operation <br> (for database)
+
+{NOTE: }
+
+* It is recommended to first refer to the __client-configuration description__ in the [put client-configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration) article.
+  
+* Use `GetClientConfigurationOperation` to get the current client-configuration set on the server for the database.
+
+* In this page:
+    * [Get client-configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration#get-client-configuration)
+    * [Syntax](../../../../client-api/operations/maintenance/configuration/get-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: Get client-configuration}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_config@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+{CODE-TAB:csharp:Async get_config_async@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Put Client Configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [Get Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Put Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.java.markdown
@@ -1,0 +1,31 @@
+# Get Client Configuration Operation
+
+**GetClientConfigurationOperation** is used to return a client configuration, which is saved on the server and overrides client behavior. 
+
+## Syntax
+
+{CODE:java config_1_0@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+{CODE:java config_1_1@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+| Return Value | | |
+| ------------- | ----- | ---- |
+| **Etag** | String | Etag of configuration |
+| **Configuration** | `ClientConfiguration` | configuration which will be used by the client API |
+
+## Example
+
+{CODE:java config_1_2@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [How to Put Client Configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [How to Get Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [How to Put Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.js.markdown
@@ -5,7 +5,7 @@
 {NOTE: }
 
 * It is recommended to first refer to the __client-configuration description__ in the [put client-configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration) article.
-  
+
 * Use `GetClientConfigurationOperation` to get the current client-configuration set on the server for the database.
 
 * In this page:
@@ -18,18 +18,15 @@
 
 {PANEL: Get client-configuration}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync get_config@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
-{CODE-TAB:csharp:Async get_config_async@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
-{CODE-TABS/}
+{CODE:nodejs get_config@ClientApi\Operations\Maintenance\Configuration\getClientConfig.js /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+{CODE:nodejs syntax_1@ClientApi\Operations\Maintenance\Configuration\getClientConfig.js /}
 
-{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+{CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Configuration\getClientConfig.js /}
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.dotnet.markdown
@@ -34,7 +34,7 @@
 
 * In this page:
   * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
-  * [Put client-configuration example](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-example)
+  * [Put client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-(for-database))
   * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
 
 {NOTE /}
@@ -62,7 +62,7 @@ The following client-configuration options are available:
 
 {PANEL/}
 
-{PANEL: Put client-configuration example}
+{PANEL: Put client-configuration (for database)}
 
 {CODE put_config_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.dotnet.markdown
@@ -1,0 +1,98 @@
+# Put Client Configuration Operation <br> (for database)
+
+{NOTE: }
+
+* __What is__ the Client-Configuration:  
+  The Client-Configuration is a set of configuration options that apply to the client when communicating with the database.
+  See [what can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured) below.  
+
+* __Initializing__ the Client-Configuration:  
+  This configuration can be initialized from the client code when creating the Document Store via the [Conventions](../../../../client-api/configuration/conventions).
+  
+* __Overriding__ the initial Client-Configuration for the database:  
+
+    * From the client code:  
+      Use `PutClientConfigurationOperation` to set the client-configuration options on the server.  
+      See the example below.
+    
+    * From the Studio:  
+      Set the Client-Configuration from the [Client-Configuration view](../../../../studio/database/settings/client-configuration-per-database).
+
+* __Updating__ the running client:  
+  Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
+  the next time it makes a request to the database. 
+
+* The client-configuration set for the database overrides the [server-wide client-configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration).
+
+---
+
+* In this page:
+  * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
+  * [Put client-configuration example](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-example)
+  * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: What can be configured}
+
+The following client-configuration options are available:  
+
+* __Identity parts separator__:  
+  Set the separator used with automatically generated document identity IDs (default separator is `/`).  
+  Learn more about identity IDs creation [here](../../../../server/kb/document-identifier-generation#identity).
+
+* __Maximum number of requests per session__:  
+  Set this number to restrict the number of requests (Reads & Writes) per session in the client API.
+
+* __Read balance behavior__:  
+  Set the Read balance method the client will use when accessing a node with Read requests.  
+  Learn more in [Balancing client requests - overview](../../../../client-api/configuration/load-balance/overview) and [Read balance behavior](../../../../client-api/configuration/load-balance/read-balance-behavior).
+  
+* __Load balance behavior__:  
+  Set the Load balance method for Read & Write requests.  
+  Learn more in [Load balance behavior](../../../../client-api/configuration/load-balance/load-balance-behavior).
+
+{PANEL/}
+
+{PANEL: Put client-configuration example}
+
+{CODE put_config_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync put_config_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE-TAB:csharp:Async put_config_3@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+
+| Parameter         | Type                  | Description                                      |
+|-------------------|-----------------------|--------------------------------------------------|
+| __configuration__ | `ClientConfiguration` | Client configuration to be used for the database |
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration View](../../../../studio/database/settings/client-configuration-per-database)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Get Client Configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [Get Configuration (Server-Wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Put Client Configuration (Server-Wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+
+
+### Load balancing
+
+- [Load balancing client requests](../../../../client-api/configuration/load-balance/overview)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.java.markdown
@@ -1,0 +1,28 @@
+# Put Client Configuration Operation <br> (for database)
+
+**PutClientConfigurationOperation** is used to save a client configuration on the server. It allows you to override client's settings remotely. 
+
+## Syntax
+
+{CODE:java config_2_0@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+| Return Value | | |
+| ------------- | ----- | ---- |
+| **configuration** | `ClientConfiguration` | configuration which will be used by client API |
+
+## Example
+
+{CODE:java config_2_2@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [How to Get Client Configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [How to Get Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [How to Put Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
@@ -6,36 +6,36 @@
 
 * __What is the Client-Configuration__:  
   The Client-Configuration is a set of configuration options that apply to the client when communicating with the database.
-  See [what can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured) below.  
+  See [what can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured) below.
 
 * __Initializing the Client-Configuration__ (on the client):  
   This configuration can be initially customized from the client code when creating the Document Store via the [Conventions](../../../../client-api/configuration/conventions).
   
-* __Overriding the initial Client-Configuration for the database__ (on the server):  
+* __Overriding the initial Client-Configuration for the database__ (on the server):
 
     * From the client code:  
       Use `PutClientConfigurationOperation` to set the client-configuration options on the server.  
       See the example below.
-    
+
     * From the Studio:  
       Set the Client-Configuration from the [Client-Configuration view](../../../../studio/database/settings/client-configuration-per-database).
 
-* __Updating the running client__:  
+* __Updating the running client__:
 
-  * Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
-    the next time it makes a request to the database.  
+    * Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
+      the next time it makes a request to the database.
 
-  * Setting the Client-Configuration on the server enables administrators to dynamically control the client behavior after it has started running.  
-    e.g. manage load balancing of client requests on the fly in response to changing system demands.
+    * Setting the Client-Configuration on the server enables administrators to dynamically control the client behavior after it has started running.  
+      e.g. manage load balancing of client requests on the fly in response to changing system demands.
 
 * The client-configuration set for the database level __overrides__ the [server-wide client-configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration).
 
 ---
 
 * In this page:
-  * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
-  * [Put client-configuration example](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-example)
-  * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
+    * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
+    * [Put client-configuration example](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-example)
+    * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
 
 {NOTE /}
 
@@ -43,7 +43,7 @@
 
 {PANEL: What can be configured}
 
-The following client-configuration options are available:  
+The following client-configuration options are available:
 
 * __Identity parts separator__:  
   Set the separator used with automatically generated document identity IDs (default separator is `/`).  
@@ -55,7 +55,7 @@ The following client-configuration options are available:
 * __Read balance behavior__:  
   Set the Read balance method the client will use when accessing a node with Read requests.  
   Learn more in [Balancing client requests - overview](../../../../client-api/configuration/load-balance/overview) and [Read balance behavior](../../../../client-api/configuration/load-balance/read-balance-behavior).
-  
+
 * __Load balance behavior__:  
   Set the Load balance method for Read & Write requests.  
   Learn more in [Load balance behavior](../../../../client-api/configuration/load-balance/load-balance-behavior).
@@ -64,24 +64,21 @@ The following client-configuration options are available:
 
 {PANEL: Put client-configuration example}
 
-{CODE put_config_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE:nodejs put_config_1@ClientApi\Operations\Maintenance\Configuration\putClientConfig.js /}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync put_config_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
-{CODE-TAB:csharp:Async put_config_3@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
-{CODE-TABS/}
+{CODE:nodejs put_config_2@ClientApi\Operations\Maintenance\Configuration\putClientConfig.js /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE:nodejs syntax_1@ClientApi\Operations\Maintenance\Configuration\putClientConfig.js /}
 
-| Parameter         | Type                  | Description                                                            |
-|-------------------|-----------------------|------------------------------------------------------------------------|
-| __configuration__ | `ClientConfiguration` | Client configuration that will be set on the server (for the database) |
+| Parameter         | Type     | Description                                                            |
+|-------------------|----------|------------------------------------------------------------------------|
+| __configuration__ | `object` | Client configuration that will be set on the server (for the database) |
 
-{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Configuration\putClientConfig.js /}
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
@@ -34,7 +34,7 @@
 
 * In this page:
     * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
-    * [Put client-configuration example](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-example)
+    * [Put client-configuration (for-database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-(for-database))
     * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
 
 {NOTE /}
@@ -62,7 +62,7 @@ The following client-configuration options are available:
 
 {PANEL/}
 
-{PANEL: Put client-configuration example}
+{PANEL: Put client-configuration (for-database)}
 
 {CODE:nodejs put_config_1@ClientApi\Operations\Maintenance\Configuration\putClientConfig.js /}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/.docs.json
@@ -1,0 +1,14 @@
+[
+    {
+        "Path": "get-serverwide-client-configuration.markdown",
+        "Name": "Get Server Wide Client Configuration",
+        "DiscussionId": "9d3027b1-20a5-4a47-8a44-8206ed69aae7",
+        "Mappings": []
+    },
+    {
+        "Path": "put-serverwide-client-configuration.markdown",
+        "Name": "Put Server Wide Client Configuration",
+        "DiscussionId": "5bc87172-a4fc-48c6-8c05-77af41f4b053",
+        "Mappings": []
+    }
+]

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/get-serverwide-client-configuration.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/get-serverwide-client-configuration.dotnet.markdown
@@ -1,0 +1,41 @@
+# Get Client Configuration Operation (Server-Wide)
+---
+
+{NOTE: }
+
+* It is recommended to first refer to the [put server-wide client-configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration) article for general knowledge.
+
+* Use `GetServerWideClientConfigurationOperation` to get the current server-wide Client-Configuration set on the server.
+
+* In this page:
+    * [Get client-configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration#get-client-configuration)
+    * [Syntax](../../../../client-api/operations/maintenance/configuration/get-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: Get client-configuration}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_config@ClientApi\Operations\Server\GetClientConfig.cs /}
+{CODE-TAB:csharp:Async get_config_async@ClientApi\Operations\Server\GetClientConfig.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Operations\Server\GetClientConfig.cs /}
+
+| Return Value | |
+| ------------- | ---- |
+| `ClientConfiguration` | Configuration which will be used by the RavenDB Client |
+
+{PANEL/}
+
+## Related Articles
+
+- [Put client configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+- [Get client configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [Put client configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/get-serverwide-client-configuration.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/get-serverwide-client-configuration.js.markdown
@@ -18,20 +18,15 @@
 
 {PANEL: Get client-configuration}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync get_config@ClientApi\Operations\Server\GetClientConfig.cs /}
-{CODE-TAB:csharp:Async get_config_async@ClientApi\Operations\Server\GetClientConfig.cs /}
-{CODE-TABS/}
+{CODE:nodejs get_config@ClientApi\Operations\Server\getClientConfig.js /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax@ClientApi\Operations\Server\GetClientConfig.cs /}
+{CODE:nodejs syntax_1@ClientApi\Operations\Server\getClientConfig.js /}
 
-| Return Value          |                                                |
-|-----------------------|------------------------------------------------|
-| `ClientConfiguration` | Configuration which will be used by the Client |
+{CODE:nodejs syntax_2@ClientApi\Operations\Server\getClientConfig.js /}
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.dotnet.markdown
@@ -1,0 +1,57 @@
+# Put Client Configuration Operation (Server-Wide)
+
+
+{NOTE: }
+
+* The server-wide Client-Configuration is a set of configuration options that are set on the server and apply to any client when communicating with __any__ database in the cluster.  
+  See the available configuration options in the article about [put client-configuration for database](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured).
+
+* A Client-Configuration that is set at the database level will __override__ the server-wide Client-Configuration for that database.  
+  // todo check...order... etc.
+
+* To set the server-wide Client-Configuration on the server:  
+
+    * Use `PutServerWideClientConfigurationOperation` from the client code.  
+      See the example below.
+
+    * Set the server-wide Client-Configuration from the Studio [Client-Configuration view](../../../../studio/server/client-configuration).
+
+* Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
+  the next time it makes a request to the database.
+
+---
+
+* In this page:
+    * [Put client-configuration example](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-example)
+    * [Syntax](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: Put client-configuration example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync put_config_1@ClientApi\Operations\Server\PutClientConfig.cs /}
+{CODE-TAB:csharp:Async put_config_2@ClientApi\Operations\Server\PutClientConfig.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Server\PutClientConfig.cs /}
+
+| Parameter         | Type                  | Description                                 |
+|-------------------|-----------------------|---------------------------------------------|
+| __configuration__ | `ClientConfiguration` | Client configuration to be used server-wide |
+
+{CODE syntax_2@ClientApi\Operations\Server\PutClientConfig.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+- [Get client configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Get client configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [Put client configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.dotnet.markdown
@@ -14,9 +14,9 @@
 
     * Or, set the server-wide Client-Configuration from the Studio [Client-Configuration view](../../../../studio/server/client-configuration).
 
-* A Client-Configuration that is set on the server for the [database level](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
-  will __override__ the server-wide Client-Configuration for that database.  
-  A Client-Configuration that is set on the server __overrides__ the initial Client-Configuration that is set on the client when creating the Document Store.
+* A Client-Configuration that is set on the server __overrides__ the initial Client-Configuration that is set on the client when creating the Document Store.  
+  A Client-Configuration that is set on the server for the [database level](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+  will __override__ the server-wide Client-Configuration for that database.
 
 * Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
   the next time it makes a request to the database.
@@ -24,14 +24,14 @@
 ---
 
 * In this page:
-    * [Put client-configuration example](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-example)
+    * [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-example-(server-wide))
     * [Syntax](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#syntax)
 
 {NOTE /}
 
 ---
 
-{PANEL: Put client-configuration example}
+{PANEL: Put client-configuration (server-wide)}
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync put_config_1@ClientApi\Operations\Server\PutClientConfig.cs /}
@@ -53,6 +53,12 @@
 {PANEL/}
 
 ## Related Articles
+
+### Studio
+
+- [Client Configuration View](../../../../studio/server/client-configuration)
+
+### Operations
 
 - [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
 - [Get client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.dotnet.markdown
@@ -24,7 +24,7 @@
 ---
 
 * In this page:
-    * [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-example-(server-wide))
+    * [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-(server-wide))
     * [Syntax](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#syntax)
 
 {NOTE /}

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.js.markdown
@@ -7,7 +7,7 @@
 * The server-wide Client-Configuration is a set of configuration options that are set __on the server__ and apply to any client when communicating with __any__ database in the cluster.  
   See the available configuration options in the article about [put client-configuration for database](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured).
 
-* To set the server-wide Client-Configuration on the server:  
+* To set the server-wide Client-Configuration on the server:
 
     * Use `PutServerWideClientConfigurationOperation` from the client code.  
       See the example below.
@@ -33,22 +33,19 @@
 
 {PANEL: Put client-configuration example}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync put_config_1@ClientApi\Operations\Server\PutClientConfig.cs /}
-{CODE-TAB:csharp:Async put_config_2@ClientApi\Operations\Server\PutClientConfig.cs /}
-{CODE-TABS/}
+{CODE:nodejs put_config@ClientApi\Operations\Server\putClientConfig.js /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax_1@ClientApi\Operations\Server\PutClientConfig.cs /}
+{CODE:nodejs syntax_1@ClientApi\Operations\Server\putClientConfig.js /}
 
-| Parameter         | Type                  | Description                                                                             |
-|-------------------|-----------------------|-----------------------------------------------------------------------------------------|
-| __configuration__ | `ClientConfiguration` | Client configuration that will be set on the server<br>(server-wide, for all databases) |
+| Parameter         | Type     | Description                                                                             |
+|-------------------|----------|-----------------------------------------------------------------------------------------|
+| __configuration__ | `object` | Client configuration that will be set on the server<br>(server-wide, for all databases) |
 
-{CODE syntax_2@ClientApi\Operations\Server\PutClientConfig.cs /}
+{CODE:nodejs syntax_2@ClientApi\Operations\Server\putClientConfig.js /}
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.js.markdown
@@ -14,9 +14,9 @@
 
     * Or, set the server-wide Client-Configuration from the Studio [Client-Configuration view](../../../../studio/server/client-configuration).
 
-* A Client-Configuration that is set on the server for the [database level](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
-  will __override__ the server-wide Client-Configuration for that database.  
-  A Client-Configuration that is set on the server __overrides__ the initial Client-Configuration that is set on the client when creating the Document Store.
+* A Client-Configuration that is set on the server __overrides__ the initial Client-Configuration that is set on the client when creating the Document Store.  
+  A Client-Configuration that is set on the server for the [database level](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+  will __override__ the server-wide Client-Configuration for that database.
 
 * Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
   the next time it makes a request to the database.
@@ -24,14 +24,14 @@
 ---
 
 * In this page:
-    * [Put client-configuration example](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-example)
+    * [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-(server-wide))
     * [Syntax](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#syntax)
 
 {NOTE /}
 
 ---
 
-{PANEL: Put client-configuration example}
+{PANEL: Put client-configuration (server-wide)}
 
 {CODE:nodejs put_config@ClientApi\Operations\Server\putClientConfig.js /}
 
@@ -50,6 +50,12 @@
 {PANEL/}
 
 ## Related Articles
+
+### Studio
+
+- [Client Configuration View](../../../../studio/server/client-configuration)
+
+### Operations
 
 - [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
 - [Get client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/database/settings/client-configuration-per-database.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/database/settings/client-configuration-per-database.markdown
@@ -1,14 +1,22 @@
-﻿# Client Configuration (Per Database)
+﻿# Client Configuration (for database)
 ---
 
 {NOTE: }
 
-* The general server [Client Configuration](../../../studio/server/client-configuration) can be overwritten per database.  
+* You can override the [client-configuration](../../../studio/server/client-configuration) that is set server-wide __per database__:
+  
+ * From the Studio - as described in this article
+ * From the Client API - see [put client-configuration operation](../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration#put-client-configuration-(server-wide))
+
+* Setting the client-configuration from the studio sets the configuration on the RavenDB server.  
+  This enables administrators to dynamically control the client behavior even after it has started running.  
+  e.g. manage load balancing of client requests on the fly in response to changing system demands.
+
 {NOTE/}
 
 ---
 
-{PANEL: Client Requests Configuration - Per Database}
+{PANEL: Set the client-configuration (for database)}
 
 ![Figure 1. Client Configuration Per Database](images/client-configuration-database-1.png "Specific Client Configuration Per Database")
 
@@ -57,7 +65,18 @@ If a general server client-configuration is defined then this view will show the
 
 ## Related Articles
 
-- [Requests Configuration in Cluster](../../../studio/server/client-configuration)
+### Studio
+
+- [Set client-configuration (server-wide)](../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+- [Put client-configuration (for database)](../../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [Put client-configuration (server-wide)](../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+
+### Load Balancing
+
 - [Load Balancing Overview](../../../client-api/configuration/load-balance/overview)
 - [Read Balance Behavior](../../../client-api/configuration/load-balance/read-balance-behavior)
 - [Load Balance Behavior](../../../client-api/configuration/load-balance/load-balance-behavior)

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/server/client-configuration.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/server/client-configuration.markdown
@@ -1,16 +1,25 @@
-﻿# Client Configuration
+﻿# Client Configuration (server-wide)
 ---
 
 {NOTE: }
 
-* Configure the RavenDB client requests behavior for ***all*** databases in the cluster  
+* Set the client-configuration for __all__ databases in the cluster:  
 
-* These default values can be overwritten ***per database*** in [Client Requests Configuration - per database](../../studio/database/settings/client-configuration-per-database)  
+  * From the Studio - as described in this article
+  
+  * From the Client API - see [put client-configuration operation](../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+
+* These default values can be overwritten __per database__ in [client-configuration (for database)](../../studio/database/settings/client-configuration-per-database)
+
+* Setting the client-configuration from the studio sets the configuration on the RavenDB server.  
+  This enables administrators to dynamically control the client behavior even after it has started running.  
+  e.g. manage load balancing of client requests on the fly in response to changing system demands.
+
 {NOTE/}
 
 ---
 
-{PANEL: Client Requests Configuration}
+{PANEL: Set the client-configuration (server-wide)}
 
 ![Figure 1. Client Requests Configuration](images/client-configuration.png "Client Requests Configuration")
 
@@ -51,7 +60,18 @@
 
 ## Related Articles
 
-- [Requests Configuration Per Database](../../studio/database/settings/client-configuration-per-database)
+### Studio
+
+- [Set client-configuration (for database)](../../studio/database/settings/client-configuration-per-database)
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+- [Put client-configuration (for database)](../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [Put client-configuration (server-wide)](../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+
+### Load Balancing
+
 - [Load Balancing Overview](../../client-api/configuration/load-balance/overview)
 - [Read Balance Behavior](../../client-api/configuration/load-balance/read-balance-behavior)
 - [Load Balance Behavior](../../client-api/configuration/load-balance/load-balance-behavior)

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/server/client-configuration.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/server/client-configuration.markdown
@@ -66,7 +66,7 @@
 
 ### Operations
 
-- [What are Operations](../../../client-api/operations/what-are-operations)
+- [What are Operations](../../client-api/operations/what-are-operations)
 - [Put client-configuration (for database)](../../client-api/operations/maintenance/configuration/put-client-configuration)
 - [Put client-configuration (server-wide)](../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
 

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
@@ -1,0 +1,67 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Configuration;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configuration
+{
+    public class GetClientConfig
+    {
+        public GetClientConfig()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_config
+                // Define the get client-configuration operation 
+                var getClientConfigOp = new GetClientConfigurationOperation();
+                    
+                // Execute the operation by passing it to Maintenance.Send
+                GetClientConfigurationOperation.Result config = store.Maintenance.Send(getClientConfigOp);
+                
+                ClientConfiguration clientConfiguration = config.Configuration;
+                #endregion
+            }
+        }
+        
+        public async Task GetClientConfigAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region get_config_async
+                    // Define the get client-configuration operation 
+                    var getClientConfigOp = new GetClientConfigurationOperation();
+                
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    GetClientConfigurationOperation.Result config = 
+                        await store.Maintenance.SendAsync(getClientConfigOp);
+                
+                    ClientConfiguration clientConfiguration = config.Configuration;
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            public GetClientConfigurationOperation()
+            #endregion
+            */
+            
+            /*
+            #region syntax_2
+            // Executing the operation returns the following object: 
+            public class Result
+            {
+                // The configuration Etag
+                public long Etag { get; set; }
+                
+                // the current client-configuration deployed on the server for the database
+                public ClientConfiguration Configuration { get; set; }
+            }
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
@@ -15,9 +15,9 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
                 var getClientConfigOp = new GetClientConfigurationOperation();
                     
                 // Execute the operation by passing it to Maintenance.Send
-                GetClientConfigurationOperation.Result config = store.Maintenance.Send(getClientConfigOp);
+                GetClientConfigurationOperation.Result result = store.Maintenance.Send(getClientConfigOp);
                 
-                ClientConfiguration clientConfiguration = config.Configuration;
+                ClientConfiguration clientConfiguration = result.Configuration;
                 #endregion
             }
         }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.cs
@@ -1,0 +1,101 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Http;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configuration
+{
+    public class PutClientConfig
+    {
+        public PutClientConfig()
+        {
+            #region put_config_1
+            // You can initialize the client-configuration options when creating the Document Store:
+            // (This is optional)
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "ServerURL_1", "ServerURL_2", "..." },
+                Database = "DefaultDB",
+                Conventions = new DocumentConventions
+                {
+                    // Initialize some client-configuration options:
+                    MaxNumberOfRequestsPerSession = 100,
+                    IdentityPartsSeparator = '$'
+                    // ...
+                }
+            }.Initialize();
+            #endregion
+            
+            #region put_config_2
+            // Set (or override) the client-configuration using the put operation:
+            using (documentStore)
+            {
+                // Define the client-configuration object
+                ClientConfiguration clientConfiguration = new ClientConfiguration
+                {
+                    MaxNumberOfRequestsPerSession = 200,
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                    // ...
+                };
+                    
+                // Define the put client-configuration operation, pass the configuration 
+                var putClientConfigOp = new PutClientConfigurationOperation(clientConfiguration);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                documentStore.Maintenance.Send(putClientConfigOp);
+            }
+            #endregion
+        }
+        
+        public async Task PutClientConfigAsync()
+        {
+            var documentStore = new DocumentStore();
+            
+            #region put_config_3
+            // Set (or override) the client-configuration using the put operation:
+            using (documentStore)
+            {
+                // Define the client-configuration object
+                ClientConfiguration clientConfiguration = new ClientConfiguration
+                {
+                    MaxNumberOfRequestsPerSession = 200,
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                    // ...
+                };
+                    
+                // Define the put client-configuration operation, pass the configuration 
+                var putClientConfigOp = new PutClientConfigurationOperation(clientConfiguration);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                await documentStore.Maintenance.SendAsync(putClientConfigOp);
+            }
+            #endregion
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            public PutClientConfigurationOperation(ClientConfiguration configuration)
+            #endregion
+            */
+            
+            /*
+            #region syntax_2
+            public class ClientConfiguration
+            {
+                private char? _identityPartsSeparator;
+                public long Etag { get; set; }
+                public bool Disabled { get; set; }
+                public int? MaxNumberOfRequestsPerSession { get; set; }
+                public ReadBalanceBehavior? ReadBalanceBehavior { get; set; }
+                public LoadBalanceBehavior? LoadBalanceBehavior { get; set; }
+                public int? LoadBalancerContextSeed { get; set; }
+                public char? IdentityPartsSeparator;  // can be any character except '|'
+            }
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.cs
@@ -11,8 +11,10 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
         public PutClientConfig()
         {
             #region put_config_1
-            // You can initialize the client-configuration options when creating the Document Store:
-            // (This is optional)
+            // You can customize the client-configuration options in the client
+            // when creating the Document Store (this is optional):
+            // =================================================================
+            
             var documentStore = new DocumentStore
             {
                 Urls = new[] { "ServerURL_1", "ServerURL_2", "..." },
@@ -28,7 +30,9 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
             #endregion
             
             #region put_config_2
-            // Set (or override) the client-configuration using the put operation:
+            // Override the initial client-configuration in the server using the put operation:
+            // ================================================================================
+            
             using (documentStore)
             {
                 // Define the client-configuration object
@@ -53,7 +57,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
             var documentStore = new DocumentStore();
             
             #region put_config_3
-            // Set (or override) the client-configuration using the put operation:
+            // Override the initial client-configuration using the put operation:
             using (documentStore)
             {
                 // Define the client-configuration object
@@ -85,7 +89,6 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
             #region syntax_2
             public class ClientConfiguration
             {
-                private char? _identityPartsSeparator;
                 public long Etag { get; set; }
                 public bool Disabled { get; set; }
                 public int? MaxNumberOfRequestsPerSession { get; set; }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/GetClientConfig.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/GetClientConfig.cs
@@ -1,0 +1,52 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.ServerWide.Operations.Configuration;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+    public class GetClientConfig
+    {
+        public GetClientConfig()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region get_config
+                    // Define the get client-configuration operation 
+                    var getServerWideClientConfigOp = new GetServerWideClientConfigurationOperation();
+                    
+                    // Execute the operation by passing it to Maintenance.Server.Send
+                    ClientConfiguration config = store.Maintenance.Server.Send(getServerWideClientConfigOp);
+                    #endregion
+                }
+            }
+        }
+        
+        public async Task GetClientConfigAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region get_config_async
+                    // Define the get client-configuration operation 
+                    var getServerWideClientConfigOp = new GetServerWideClientConfigurationOperation();
+                    
+                    // Execute the operation by passing it to Maintenance.Server.SendAsync
+                    ClientConfiguration config = 
+                        await store.Maintenance.Server.SendAsync(getServerWideClientConfigOp);
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public GetServerWideClientConfigurationOperation()
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/PutClientConfig.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/PutClientConfig.cs
@@ -1,0 +1,79 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations.Configuration;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+    public class PutClientConfig
+    {
+        public PutClientConfig()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region put_config_1
+                // Define the client-configuration object
+                ClientConfiguration clientConfiguration = new ClientConfiguration
+                {
+                    MaxNumberOfRequestsPerSession = 100,
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                    // ...
+                };
+                    
+                // Define the put server-wide client-configuration operation, pass the configuration 
+                var putServerWideClientConfigOp = new PutServerWideClientConfigurationOperation(clientConfiguration);
+                
+                // Execute the operation by passing it to Maintenance.Server.Send
+                store.Maintenance.Server.Send(putServerWideClientConfigOp);
+                #endregion
+            }
+        }
+        
+        public async Task PutClientConfigAsync()
+        {
+            var store = new DocumentStore();
+            
+            #region put_config_2
+            // Define the client-configuration object
+            ClientConfiguration clientConfiguration = new ClientConfiguration
+            {
+                MaxNumberOfRequestsPerSession = 100,
+                ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                // ...
+            };
+                    
+            // Define the put server-wide client-configuration operation, pass the configuration 
+            var putServerWideClientConfigOp = new PutServerWideClientConfigurationOperation(clientConfiguration);
+                
+            // Execute the operation by passing it to Maintenance.Server.SendAsync
+           store.Maintenance.Server.SendAsync(putServerWideClientConfigOp);
+            #endregion
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            public PutServerWideClientConfigurationOperation(ClientConfiguration configuration)
+            #endregion
+            */
+            
+            /*
+            #region syntax_2
+            public class ClientConfiguration
+            {
+                private char? _identityPartsSeparator;
+                public long Etag { get; set; }
+                public bool Disabled { get; set; }
+                public int? MaxNumberOfRequestsPerSession { get; set; }
+                public ReadBalanceBehavior? ReadBalanceBehavior { get; set; }
+                public LoadBalanceBehavior? LoadBalanceBehavior { get; set; }
+                public int? LoadBalancerContextSeed { get; set; }
+                public char? IdentityPartsSeparator;  // can be any character except '|'
+            }
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Configuration/ClientConfig.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Configuration/ClientConfig.java
@@ -1,0 +1,72 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.configuration.ClientConfiguration;
+import net.ravendb.client.documents.operations.configuration.GetClientConfigurationOperation;
+import net.ravendb.client.documents.operations.configuration.PutClientConfigurationOperation;
+import net.ravendb.client.http.ReadBalanceBehavior;
+
+public class ClientConfig {
+
+    private interface IFoo {
+        /*
+        //region config_1_0
+        GetClientConfigurationOperation()
+        //endregion
+
+
+        //region config_2_0
+        PutClientConfigurationCommand(ClientConfiguration configuration)
+        //endregion
+        */
+    }
+
+    private static class Foo {
+        //region config_1_1
+        public static class Result {
+            private long etag;
+            private ClientConfiguration configuration;
+
+            public long getEtag() {
+                return etag;
+            }
+
+            public void setEtag(long etag) {
+                this.etag = etag;
+            }
+
+            public ClientConfiguration getConfiguration() {
+                return configuration;
+            }
+
+            public void setConfiguration(ClientConfiguration configuration) {
+                this.configuration = configuration;
+            }
+        }
+        //endregion
+    }
+
+    public ClientConfig() {
+        try (IDocumentStore store = new DocumentStore()) {
+            {
+                //region config_1_2
+                GetClientConfigurationOperation.Result config
+                    = store.maintenance().send(new GetClientConfigurationOperation());
+                ClientConfiguration clientConfiguration = config.getConfiguration();
+                //endregion
+            }
+
+            {
+                //region config_2_2
+                ClientConfiguration clientConfiguration = new ClientConfiguration();
+                clientConfiguration.setMaxNumberOfRequestsPerSession(100);
+                clientConfiguration.setReadBalanceBehavior(ReadBalanceBehavior.FASTEST_NODE);
+
+                store.maintenance().send(
+                    new PutClientConfigurationOperation(clientConfiguration));
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/getClientConfig.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/getClientConfig.js
@@ -1,0 +1,42 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getClientConfig() {
+    {
+        //region get_config
+        // Define the get client-configuration operation 
+        const getClientConfigOp = new GetClientConfigurationOperation();
+
+        // Execute the operation by passing it to maintenance.send
+        const result = await store.maintenance.send(getClientConfigOp);
+        
+        const configuration = result.configuration;
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    const getClientConfigOp = new GetClientConfigurationOperation();
+    //endregion
+
+    //region syntax_2
+    // Object returned from store.maintenance.send(getClientConfigOp):
+    {
+       etag,
+       configuration // the configution object
+    }
+
+    // The configuration object:
+    {
+        identityPartsSeparator,
+        etag,
+        disabled,
+        maxNumberOfRequestsPerSession,
+        readBalanceBehavior,
+        loadBalanceBehavior,
+        loadBalancerContextSeed
+    }
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/putClientConfig.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/putClientConfig.js
@@ -1,0 +1,59 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function putClientConfig() {
+    {
+        //region put_config_1
+        // You can customize the client-configuration options in the client
+        // when creating the Document Store (this is optional):
+        // =================================================================
+        
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+        
+        documentStore.conventions.maxNumberOfRequestsPerSession = 100;
+        documentStore.conventions.identityPartsSeparator = '$';
+        // ...
+        
+        documentStore.initialize();
+        //endregion
+    }
+    {
+        //region put_config_2
+        // Override the initial client-configuration in the server using the put operation:
+        // ================================================================================
+
+        // Define the client-configuration object
+        const clientConfiguration = {
+            maxNumberOfRequestsPerSession: 200,
+            readBalanceBehavior: "FastestNode",
+            // ...
+        };
+
+        // Define the put client-configuration operation, pass the configuration 
+        const putClientConfigOp = new PutClientConfigurationOperation(clientConfiguration);
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(putClientConfigOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    const putClientConfigOp = new PutClientConfigurationOperation(configuration);
+    //endregion
+
+    //region syntax_2
+    // The client-configuration object
+    {
+        identityPartsSeparator,
+        etag,
+        disabled,
+        maxNumberOfRequestsPerSession,
+        readBalanceBehavior,
+        loadBalanceBehavior,
+        loadBalancerContextSeed
+    }
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/getClientConfig.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/getClientConfig.js
@@ -1,0 +1,35 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getClientConfig() {
+    {
+        //region get_config
+
+        // Define the get client-configuration operation
+        const getServerWideClientConfigOp = new GetServerWideClientConfigurationOperation();
+
+        // Execute the operation by passing it to maintenance.server.send
+        const config = await documentStore.maintenance.server.send(getServerWideClientConfigOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    const getServerWideClientConfigOp = new GetServerWideClientConfigurationOperation();
+    //endregion
+
+    //region syntax_2
+    // Executing the operation returns the client-configuration object: 
+    {
+        identityPartsSeparator,
+        etag,
+        disabled,
+        maxNumberOfRequestsPerSession,
+        readBalanceBehavior,
+        loadBalanceBehavior,
+        loadBalancerContextSeed
+    }
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/putClientConfig.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/putClientConfig.js
@@ -1,0 +1,42 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function putClientConfig() {
+    {
+        //region put_config
+        // Define the client-configuration object
+        const clientConfiguration = {
+            maxNumberOfRequestsPerSession: 200,
+            readBalanceBehavior: "FastestNode",
+            // ...
+        };
+        
+        // Define the put server-wide client-configuration operation, pass the configuration 
+        const putServerWideClientConfigOp = 
+            new PutServerWideClientConfigurationOperation(clientConfiguration);
+        
+        // Execute the operation by passing it to maintenance.server.send
+        await documentStore.maintenance.server.send(putServerWideClientConfigOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    const putServerWideClientConfigOp = new PutServerWideClientConfigurationOperation(configuration);
+    //endregion
+
+    //region syntax_2
+    // The client-configuration object
+    {
+        identityPartsSeparator,
+        etag,
+        disabled,
+        maxNumberOfRequestsPerSession,
+        readBalanceBehavior,
+        loadBalanceBehavior,
+        loadBalancerContextSeed
+    }
+    //endregion
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/migration/client-api/client-breaking-changes.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/migration/client-api/client-breaking-changes.markdown
@@ -25,8 +25,8 @@ their behavior in previous versions.
   actions like load or query."`
 
 * **Type Changes**  
-  Many methods and types that used the `int` type in former RavenDB versions now use `long`,  
-  e.g. `QueryStatistics.TotalResults`  
+  Many methods related to paging information (Skip, Take, PageSize, TotalResults, etc.) that used the `int` type in former RavenDB versions now use `long`, 
+  e.g. `QueryStatistics.TotalResults`
 
 * **Indexing**  
   The default value of the 


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2529/Node.js-Get-Put-client-configuration-operations

---

@ml054 - Node.js files:

**Put client-configuration (for database)**
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/putClientConfig.js

**Get client-configuration (for database)**
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/getClientConfig.js

**Put client-configuration(server-wide)**
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/put-serverwide-client-configuration.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/putClientConfig.js

**Get client-configuration (server-wide)**
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/configuration/get-serverwide-client-configuration.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/getClientConfig.js