### PR TITLE
RDoc-2534 Database settings operations

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/.docs.json
@@ -1,5 +1,11 @@
 [
     {
+        "Path": "database-settings-operation.markdown",
+        "Name": "Database Settings Operations",
+        "DiscussionId": "43ab588b-0d2c-4604-854e-43e7e1bf44da",
+        "Mappings": []
+    },
+    {
         "Path": "put-client-configuration.markdown",
         "Name": "Put Client Configuration",
         "DiscussionId": "e05cdf82-e3a4-434e-86eb-494449e27bcc",

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/database-settings-operation.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/database-settings-operation.dotnet.markdown
@@ -1,0 +1,92 @@
+# Database Settings Operations
+
+---
+
+{NOTE: }
+  
+* The default database configuration settings can be customized:
+
+  * From the Client API - as described in this article.
+
+  * From the Studio - via the [Database Settings View](../../../../studio/database/settings/database-settings#database-settings).
+
+* In this page:  
+
+  * [Put database settings operation](../../../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)
+
+  * [Get database settings operation](../../../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)
+
+{WARNING: }
+Do not modify the database settings unless you are an expert and know what you're doing.  
+{WARNING/}
+
+{NOTE/}
+
+{PANEL: Put database settings operation}
+
+* Use `PutDatabaseSettingsOperation` to modify the default database configuration.
+
+* Only __database-level__ settings can be customized using this operation.  
+  See article [Configuration overview](../../../../server/configuration/configuration-options) to learn how to customize the __server-level__ settings.  
+
+* Note: for the changes to take effect, the database must be __reloaded__.  
+  Reloading is accomplished by disabling and enabling the database using [ToggleDatabasesStateOperation](../../../../client-api/operations/server-wide/toggle-databases-state).  
+  See the following example:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync put_database_settings@ClientApi\Operations\Maintenance\Configuration\DatabaseSettings.cs /}
+{CODE-TAB:csharp:Async put_database_settings_async@ClientApi\Operations\Maintenance\Configuration\DatabaseSettings.cs /}
+{CODE-TABS/}
+
+---
+
+__Syntax__:
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\DatabaseSettings.cs /}
+
+| Parameter             | Type                         | Description                                        |
+|-----------------------|------------------------------|----------------------------------------------------|
+| databaseName          | `string`                     | Name of database for which to change the settings. |
+| configurationSettings | `Dictionary<string, string>` | The configuration settings to set.                 |
+
+
+{PANEL/}
+
+{PANEL: Get database settings operation}
+
+* Use `GetDatabaseSettingsOperation` to get the configuration settings that were customized for the database.  
+
+* Only settings that have been changed will be retrieved.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_database_settings@ClientApi\Operations\Maintenance\Configuration\DatabaseSettings.cs /}
+{CODE-TAB:csharp:Async get_database_settings_async@ClientApi\Operations\Maintenance\Configuration\DatabaseSettings.cs /}
+{CODE-TABS/}
+
+---
+
+__Syntax__:
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\DatabaseSettings.cs /}
+
+| Parameter    | Type     | Description                                                 |
+|--------------|----------|-------------------------------------------------------------|
+| databaseName | `string` | The database name for which to get the customized settings. |
+
+
+{CODE syntax_3@ClientApi\Operations\Maintenance\Configuration\DatabaseSettings.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Database settings view](../../../../studio/database/settings/database-settings#database-settings)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [How to Get Client Configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [How to Get Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Toggle database state](../../../../client-api/operations/server-wide/toggle-databases-state)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/database-settings-operation.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/database-settings-operation.js.markdown
@@ -1,0 +1,86 @@
+# Database Settings Operations
+
+---
+
+{NOTE: }
+  
+* The default database configuration settings can be customized:
+
+  * From the Client API - as described in this article.
+
+  * From the Studio - via the [Database Settings View](../../../../studio/database/settings/database-settings#database-settings).
+
+* In this page:  
+
+  * [Put database settings operation](../../../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)
+
+  * [Get database settings operation](../../../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)
+
+{WARNING: }
+Do not modify the database settings unless you are an expert and know what you're doing.  
+{WARNING/}
+
+{NOTE/}
+
+{PANEL: Put database settings operation}
+
+* Use `PutDatabaseSettingsOperation` to modify the default database configuration.
+
+* Only __database-level__ settings can be customized using this operation.  
+  See article [Configuration overview](../../../../server/configuration/configuration-options) to learn how to customize the __server-level__ settings.  
+
+* Note: for the changes to take effect, the database must be __reloaded__.  
+  Reloading is accomplished by disabling and enabling the database using [ToggleDatabasesStateOperation](../../../../client-api/operations/server-wide/toggle-databases-state).  
+  See the following example:
+
+{CODE:nodejs put_database_settings@ClientApi\Operations\Maintenance\Configuration\databaseSettings.js /}
+
+---
+
+__Syntax__:
+
+{CODE:nodejs syntax_1@ClientApi\Operations\Maintenance\Configuration\databaseSettings.js /}
+
+| Parameter             | Type      | Description                                        |
+|-----------------------|-----------|----------------------------------------------------|
+| databaseName          | `string`  | Name of database for which to change the settings. |
+| configurationSettings | `object` | The configuration settings to set.                 |
+
+
+{PANEL/}
+
+{PANEL: Get database settings operation}
+
+* Use `GetDatabaseSettingsOperation` to get the configuration settings that were customized for the database.  
+
+* Only settings that have been changed will be retrieved.
+
+{CODE:nodejs get_database_settings@ClientApi\Operations\Maintenance\Configuration\databaseSettings.js /}
+
+---
+
+__Syntax__:
+
+{CODE:nodejs syntax_2@ClientApi\Operations\Maintenance\Configuration\databaseSettings.js /}
+
+| Parameter    | Type     | Description                                                 |
+|--------------|----------|-------------------------------------------------------------|
+| databaseName | `string` | The database name for which to get the customized settings. |
+
+
+{CODE:nodejs syntax_3@ClientApi\Operations\Maintenance\Configuration\databaseSettings.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Database settings view](../../../../studio/database/settings/database-settings#database-settings)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [How to Get Client Configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [How to Get Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Toggle database state](../../../../client-api/operations/server-wide/toggle-databases-state)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.dotnet.markdown
@@ -1,0 +1,58 @@
+# Toggle Databases State Operation <br> (Enable / Disable)
+---
+
+{NOTE: }
+
+* Use `ToggleDatabasesStateOperation` to enable/disable a single database or multiple databases.
+
+* The database will be enabled/disabled on all nodes in the [database-group](../../../studio/database/settings/manage-database-group).
+
+* In this page:
+
+  * [Enable database](../../../client-api/operations/server-wide/toggle-databases-state#enable-database)
+  * [Disable database](../../../client-api/operations/server-wide/toggle-databases-state#disable-database)
+  * [Syntax](../../../client-api/operations/server-wide/toggle-databases-state#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Enable database}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync enable@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TAB:csharp:Async enable_async@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Disable database}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TAB:csharp:Async disable_async@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+
+| Parameter         | Type     | Description                                                                               |
+|-------------------|----------|-------------------------------------------------------------------------------------------|
+| __databaseName__  | string   | Name of database for which to toggle state                                                |
+| __databaseNames__ | string[] | List of database names for which to toggle state                                          |
+| __disable__       | bool     | `true` - request to disable the database(s)<br>`false`- request to enable the database(s) |
+
+{CODE syntax_2@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+- [Database settings operations](../../../client-api/operations/maintenance/configuration/database-settings-operation)  
+
+### Studio
+- [Database-group](../../../studio/database/settings/manage-database-group)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.js.markdown
@@ -1,0 +1,52 @@
+# Toggle Databases State Operation <br> (Enable / Disable)
+---
+
+{NOTE: }
+
+* Use `ToggleDatabasesStateOperation` to enable/disable a single database or multiple databases.
+
+* The database will be enabled/disabled on all nodes in the [database-group](../../../studio/database/settings/manage-database-group).
+
+* In this page:
+
+  * [Enable database](../../../client-api/operations/server-wide/toggle-databases-state#enable-database)
+  * [Disable database](../../../client-api/operations/server-wide/toggle-databases-state#disable-database)
+  * [Syntax](../../../client-api/operations/server-wide/toggle-databases-state#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Enable database}
+
+{CODE:nodejs enable@ClientApi\Operations\Server\toggleDatabasesState.js /}
+
+{PANEL/}
+
+{PANEL: Disable database}
+
+{CODE:nodejs disable@ClientApi\Operations\Server\toggleDatabasesState.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@ClientApi\Operations\Server\toggleDatabasesState.js /}
+
+| Parameter         | Type     | Description                                                                               |
+|-------------------|----------|-------------------------------------------------------------------------------------------|
+| __databaseName__  | string   | Name of database for which to toggle state                                                |
+| __databaseNames__ | string[] | List of database names for which to toggle state                                          |
+| __disable__       | boolean  | `true` - request to disable the database(s)<br>`false`- request to enable the database(s) |
+
+{CODE:nodejs syntax_2@ClientApi\Operations\Server\toggleDatabasesState.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+- [Database settings operations](../../../client-api/operations/maintenance/configuration/database-settings-operation)  
+
+### Studio
+- [Database-group](../../../studio/database/settings/manage-database-group)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -249,8 +249,8 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplayTransactionsRecordingOperation  
 
 * __Database settings__:  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutDatabaseSettingsOperation  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetDatabaseSettingsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)  
 
 * __Identities__:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)  

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -236,8 +236,8 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplayTransactionsRecordingOperation  
 
 * __Database settings__:  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutDatabaseSettingsOperation  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetDatabaseSettingsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)  
 
 * __Identities__:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)  

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/DatabaseSettings.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/DatabaseSettings.cs
@@ -1,0 +1,150 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Xunit;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configuration
+{
+    public class DatabaseSettings
+    {
+        public void PutDatabaseSettings()
+        {
+            var documentStore = new DocumentStore();
+            using (documentStore)
+            {
+                #region put_database_settings
+                // 1. Modify the database settings:
+                // ======================+++=======
+                
+                // Define the settings dictionary with the key-value pairs to set, for example:
+                var settings = new Dictionary<string, string>
+                {
+                    ["Databases.QueryTimeoutInSec"] = "350", 
+                    ["Indexing.Static.DeploymentMode"] = "Rolling"
+                };
+
+                // Define the put database settings operation,
+                // specify the database name & pass the settings dictionary
+                var putDatabaseSettingsOp = new PutDatabaseSettingsOperation(documentStore.Database, settings);
+                    
+                // Execute the operation by passing it to Maintenance.Send
+                documentStore.Maintenance.Send(putDatabaseSettingsOp);
+                    
+                // 2. RELOAD the database for the change to take effect:
+                // =====================================================
+                
+                // Disable database
+                var disableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, true);
+                documentStore.Maintenance.Server.Send(disableDatabaseOperation);
+
+                // Enable database
+                var enableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, false);
+                documentStore.Maintenance.Server.Send(enableDatabaseOperation); 
+                #endregion
+            }
+        }
+        
+        public async Task PutDatabaseSettingsAsync()
+        {
+            var documentStore = new DocumentStore();
+            
+            using (documentStore)
+            {
+                #region put_database_settings_async
+                // 1. Modify the database settings:
+                // ======================+++=======
+                
+                // Define the settings dictionary with the key-value pairs to set, for example:
+                var settings = new Dictionary<string, string>
+                {
+                    ["Databases.QueryTimeoutInSec"] = "350", 
+                    ["Indexing.Static.DeploymentMode"] = "Rolling"
+                };
+
+                // Define the put database settings operation,
+                // specify the database name & pass the settings dictionary
+                var putDatabaseSettingsOp = new PutDatabaseSettingsOperation(documentStore.Database, settings);
+                    
+                // Execute the operation by passing it to Maintenance.SendAsync
+                await documentStore.Maintenance.SendAsync(putDatabaseSettingsOp);
+                    
+                // 2. RELOAD the database for the change to take effect:
+                // =====================================================
+                
+                // Disable database
+                var disableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, true);
+                await documentStore.Maintenance.Server.SendAsync(disableDatabaseOperation);
+
+                // Enable database
+                var enableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, false);
+                await documentStore.Maintenance.Server.SendAsync(enableDatabaseOperation); 
+                #endregion
+            }
+        }
+        
+        public void GetDatabaseSettings()
+        {
+            var documentStore = new DocumentStore();
+            using (documentStore)
+            {
+                #region get_database_settings
+                // Define the get database settings operation, specify the database name
+                var getDatabaseSettingsOp = new GetDatabaseSettingsOperation(documentStore.Database);
+                    
+                // Execute the operation by passing it to Maintenance.Send
+                var customizedSettings = documentStore.Maintenance.Send(getDatabaseSettingsOp);
+                
+                // Get the customized value
+                var customizedValue = customizedSettings.Settings["Databases.QueryTimeoutInSec"];
+                #endregion
+            }
+        }
+        
+        public async Task GetDatabaseSettingsAsync()
+        {
+            var documentStore = new DocumentStore();
+            
+            using (documentStore)
+            {
+                #region get_database_settings_async
+                // Define the get database settings operation, specify the database name
+                var getDatabaseSettingsOp = new GetDatabaseSettingsOperation(documentStore.Database);
+                    
+                // Execute the operation by passing it to Maintenance.SendAsync
+                var customizedSettings = await documentStore.Maintenance.SendAsync(getDatabaseSettingsOp);
+                
+                // Get the customized value
+                var customizedValue = customizedSettings.Settings["Databases.QueryTimeoutInSec"];
+                #endregion
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            PutDatabaseSettingsOperation(string databaseName, Dictionary<string, string> configurationSettings)
+            #endregion
+            */
+            
+            /*
+            #region syntax_2
+            GetDatabaseSettingsOperation(string databaseName)
+            #endregion
+            */
+            
+            /*
+            #region syntax_3
+            // Executing the operation returns the following object:
+            public class DatabaseSettings
+            {
+                // Configuration settings that have been customized
+                public Dictionary<string, string> Settings { get; set; }
+            }
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/DatabaseSettings.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/DatabaseSettings.cs
@@ -16,7 +16,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
             {
                 #region put_database_settings
                 // 1. Modify the database settings:
-                // ======================+++=======
+                // ================================
                 
                 // Define the settings dictionary with the key-value pairs to set, for example:
                 var settings = new Dictionary<string, string>
@@ -36,12 +36,12 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
                 // =====================================================
                 
                 // Disable database
-                var disableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, true);
-                documentStore.Maintenance.Server.Send(disableDatabaseOperation);
+                var disableDatabaseOp = new ToggleDatabasesStateOperation(documentStore.Database, true);
+                documentStore.Maintenance.Server.Send(disableDatabaseOp);
 
                 // Enable database
-                var enableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, false);
-                documentStore.Maintenance.Server.Send(enableDatabaseOperation); 
+                var enableDatabaseOp = new ToggleDatabasesStateOperation(documentStore.Database, false);
+                documentStore.Maintenance.Server.Send(enableDatabaseOp); 
                 #endregion
             }
         }
@@ -54,7 +54,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
             {
                 #region put_database_settings_async
                 // 1. Modify the database settings:
-                // ======================+++=======
+                // ================================
                 
                 // Define the settings dictionary with the key-value pairs to set, for example:
                 var settings = new Dictionary<string, string>
@@ -74,12 +74,12 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
                 // =====================================================
                 
                 // Disable database
-                var disableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, true);
-                await documentStore.Maintenance.Server.SendAsync(disableDatabaseOperation);
+                var disableDatabaseOp = new ToggleDatabasesStateOperation(documentStore.Database, true);
+                await documentStore.Maintenance.Server.SendAsync(disableDatabaseOp);
 
                 // Enable database
-                var enableDatabaseOperation = new ToggleDatabasesStateOperation(documentStore.Database, false);
-                await documentStore.Maintenance.Server.SendAsync(enableDatabaseOperation); 
+                var enableDatabaseOp = new ToggleDatabasesStateOperation(documentStore.Database, false);
+                await documentStore.Maintenance.Server.SendAsync(enableDatabaseOp); 
                 #endregion
             }
         }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
@@ -57,7 +57,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configura
                 // The configuration Etag
                 public long Etag { get; set; }
                 
-                // the current client-configuration deployed on the server for the database
+                // The current client-configuration deployed on the server for the database
                 public ClientConfiguration Configuration { get; set; }
             }
             #endregion

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ToggleDatabasesState.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ToggleDatabasesState.cs
@@ -8,7 +8,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
     {
         public ToggleDatabasesState()
         {
-            using (var store = new DocumentStore())
+            using (var documentStore = new DocumentStore())
             {
                 {
                     #region enable
@@ -20,8 +20,8 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
                     // var enableDatabaseOp =
                     //     new ToggleDatabasesStateOperation(new [] { "DB1", "DB2", ... }, disable: false);
                     
-                    // Execute the operation by passing it to Maintenance.Send
-                    var toggleResult = store.Maintenance.Server.Send(enableDatabaseOp);
+                    // Execute the operation by passing it to Maintenance.Server.Send
+                    var toggleResult = documentStore.Maintenance.Server.Send(enableDatabaseOp);
                     #endregion
                 }
                 { 
@@ -34,8 +34,8 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
                     // var disableDatabaseOp =
                     //     new ToggleDatabasesStateOperation(new [] { "DB1", "DB2", ... }, disable: true);
                     
-                    // Execute the operation by passing it to Maintenance.Send
-                    var toggleResult = store.Maintenance.Server.Send(disableDatabaseOp);
+                    // Execute the operation by passing it to Maintenance.Server.Send
+                    var toggleResult = documentStore.Maintenance.Server.Send(disableDatabaseOp);
                     #endregion
                 }
             }
@@ -43,9 +43,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
         
         public async Task ToggleDatabasesStateAsync()
         {
-            var store = new DocumentStore();
-            
-            using (store)
+            using (var documentStore = new DocumentStore())
             {
                 {
                     #region enable_async
@@ -53,8 +51,8 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
                     // specify the database name(s) & pass 'false' to enable
                     var enableDatabaseOp = new ToggleDatabasesStateOperation(new [] { "Foo", "Bar" }, disable: false);
                     
-                    // Execute the operation by passing it to Maintenance.SendAsync
-                    var toggleResult = await store.Maintenance.Server.SendAsync(enableDatabaseOp);
+                    // Execute the operation by passing it to Maintenance.Server.SendAsync
+                    var toggleResult = await documentStore.Maintenance.Server.SendAsync(enableDatabaseOp);
                     #endregion
                 }
                 { 
@@ -63,8 +61,8 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
                     // specify the database name(s) & pass 'true' to disable
                     var disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: true);
                     
-                    // Execute the operation by passing it to Maintenance.SendAsync
-                    var toggleResult = await store.Maintenance.Server.SendAsync(disableDatabaseOp);
+                    // Execute the operation by passing it to Maintenance.Server.SendAsync
+                    var toggleResult = await documentStore.Maintenance.Server.SendAsync(disableDatabaseOp);
                     #endregion
                 }
             }

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ToggleDatabasesState.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ToggleDatabasesState.cs
@@ -1,0 +1,100 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+    public class ToggleDatabasesState
+    {
+        public ToggleDatabasesState()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region enable
+                    // Define the toggle state operation
+                    // specify the database name & pass 'false' to enable
+                    var enableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: false);
+                    
+                    // To enable multiple databases use:
+                    // var enableDatabaseOp =
+                    //     new ToggleDatabasesStateOperation(new [] { "DB1", "DB2", ... }, disable: false);
+                    
+                    // Execute the operation by passing it to Maintenance.Send
+                    var toggleResult = store.Maintenance.Server.Send(enableDatabaseOp);
+                    #endregion
+                }
+                { 
+                    #region disable
+                    // Define the toggle state operation
+                    // specify the database name(s) & pass 'true' to disable
+                    var disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: true);
+                    
+                    // To disable multiple databases use:
+                    // var disableDatabaseOp =
+                    //     new ToggleDatabasesStateOperation(new [] { "DB1", "DB2", ... }, disable: true);
+                    
+                    // Execute the operation by passing it to Maintenance.Send
+                    var toggleResult = store.Maintenance.Server.Send(disableDatabaseOp);
+                    #endregion
+                }
+            }
+        }
+        
+        public async Task ToggleDatabasesStateAsync()
+        {
+            var store = new DocumentStore();
+            
+            using (store)
+            {
+                {
+                    #region enable_async
+                    // Define the toggle state operation
+                    // specify the database name(s) & pass 'false' to enable
+                    var enableDatabaseOp = new ToggleDatabasesStateOperation(new [] { "Foo", "Bar" }, disable: false);
+                    
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    var toggleResult = await store.Maintenance.Server.SendAsync(enableDatabaseOp);
+                    #endregion
+                }
+                { 
+                    #region disable_async
+                    // Define the toggle state operation
+                    // specify the database name(s) & pass 'true' to disable
+                    var disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: true);
+                    
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    var toggleResult = await store.Maintenance.Server.SendAsync(disableDatabaseOp);
+                    #endregion
+                }
+            }
+        }
+        
+        private class Foo
+        {
+            public class ToggleDatabasesStateOperation
+            {
+                /*
+                #region syntax_1
+                // Available overloads:
+                public ToggleDatabasesStateOperation(string databaseName, bool disable)
+                public ToggleDatabasesStateOperation(string[] databaseNames, bool disable)
+                #endregion
+                */
+                
+                /*
+                #region syntax_2
+                // Executing the operation returns the following object:
+                public class DisableDatabaseToggleResult
+                {
+                    public bool Disabled; // Is database disabled
+                    public string Name;   // Name of the database
+                    public bool Success;  // Has request succeeded
+                    public string Reason; // Reason for success or failure
+                }
+                #endregion
+                */
+            }
+        }
+    }
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/databaseSettings.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/databaseSettings.js
@@ -1,0 +1,65 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function databaseSettings() {
+    {
+        //region put_database_settings
+        // 1. Modify the database settings:
+        // ================================
+        
+        // Define a settings object with key-value pairs to set, for example:
+        const settings = {
+            "Databases.QueryTimeoutInSec": "350",
+            "Indexing.Static.DeploymentMode": "Rolling"
+        };
+
+        // Define the put database settings operation,
+        // specify the database name & pass the settings dictionary
+        const putDatabaseSettingsOp = new PutDatabaseSettingsOperation(documentStore.database, settings)
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(putDatabaseSettingsOp);
+
+        // 2. RELOAD the database for the change to take effect:
+        // =====================================================
+        
+        // Disable database
+        const disableDatabaseOp = new ToggleDatabasesStateOperation(documentStore.database, true);
+        await documentStore.maintenance.server.send(disableDatabaseOp);
+        
+        // Enable database
+        const enableDatabaseOp = new ToggleDatabasesStateOperation(documentStore.database, false);
+        await documentStore.maintenance.server.send(enableDatabaseOp);
+        //endregion
+    }
+    {
+        //region get_database_settings
+        // Define the get database settings operation, specify the database name
+        const getDatabaseSettingsOp = new GetDatabaseSettingsOperation(documentStore.database);
+
+        // Execute the operation by passing it to maintenance.send
+        const customizedSettings = await documentStore.maintenance.send(getDatabaseSettingsOp);
+
+        // Get the customized value
+        const customizedValue = customizedSettings.settings["Databases.QueryTimeoutInSec"];
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    const putDatabaseSettingsOp = new PutDatabaseSettingsOperation(databaseName, configurationSettings)
+    //endregion
+
+    //region syntax_2
+    const getDatabaseSettingsOp = new GetDatabaseSettingsOperation(databaseName);
+    //endregion
+
+    //region syntax_3
+    // Executing the operation returns the following object:
+    {
+        settings // An object with key-value configuration pairs
+    }
+    //endregion
+}

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/getClientConfig.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/getClientConfig.js
@@ -25,7 +25,7 @@ async function getClientConfig() {
     // Object returned from store.maintenance.send(getClientConfigOp):
     {
        etag,
-       configuration // the configution object
+       configuration // The configution object
     }
 
     // The configuration object:

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/toggleDatabasesState.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/toggleDatabasesState.js
@@ -7,11 +7,11 @@ async function toggleDatabasesState() {
         //region enable
         // Define the toggle state operation
         // specify the database name & pass 'false' to enable
-        const enableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: false);
+        const enableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", false);
 
         // To enable multiple databases use:
         // const enableDatabaseOp =
-        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], disable: false);
+        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], false);
 
         // Execute the operation by passing it to maintenance.server.send
         const toggleResult = await documentStore.maintenance.server.send(enableDatabaseOp);
@@ -21,11 +21,11 @@ async function toggleDatabasesState() {
         //region disable
         // Define the toggle state operation
         // specify the database name(s) & pass 'true' to disable
-        const disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: true);
+        const disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", true);
 
         // To disable multiple databases use:
         // const disableDatabaseOp =
-        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], disable: true);
+        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], true);
         
         // Execute the operation by passing it to maintenance.server.send
         const toggleResult = await documentStore.maintenance.server.send(disableDatabaseOp);

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/toggleDatabasesState.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/toggleDatabasesState.js
@@ -1,0 +1,52 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function toggleDatabasesState() {
+    {
+        //region enable
+        // Define the toggle state operation
+        // specify the database name & pass 'false' to enable
+        const enableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: false);
+
+        // To enable multiple databases use:
+        // const enableDatabaseOp =
+        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], disable: false);
+
+        // Execute the operation by passing it to maintenance.server.send
+        const toggleResult = await documentStore.maintenance.server.send(enableDatabaseOp);
+        //endregion
+    }
+    {
+        //region disable
+        // Define the toggle state operation
+        // specify the database name(s) & pass 'true' to disable
+        const disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: true);
+
+        // To disable multiple databases use:
+        // const disableDatabaseOp =
+        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], disable: true);
+        
+        // Execute the operation by passing it to maintenance.server.send
+        const toggleResult = await documentStore.maintenance.server.send(disableDatabaseOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    // Available overloads:
+    const enableDatabaseOp = new ToggleDatabasesStateOperation(databaseName, disable);
+    const enableDatabaseOp = new ToggleDatabasesStateOperation(databaseNames, disable);
+    //endregion
+
+    //region syntax_2
+    // Executing the operation returns an object with the following properties:
+    {
+        disabled, // Is database disabled
+        name,     // Name of the database
+        success,  // Has request succeeded
+        reason    // Reason for success or failure
+    }
+    //endregion
+}

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -249,8 +249,8 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplayTransactionsRecordingOperation  
 
 * __Database settings__:  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutDatabaseSettingsOperation  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetDatabaseSettingsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)  
 
 * __Identities__:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)  

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -236,8 +236,8 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplayTransactionsRecordingOperation  
 
 * __Database settings__:  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutDatabaseSettingsOperation  
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetDatabaseSettingsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)  
 
 * __Identities__:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)  


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2534/Node.js-Client-API-Operations-Maintenance-Configuration-Database-settings-operations

---

@ml054 - Node.js files:

**Database settings operations**:
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/database-settings-operation.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Maintenance/Configuration/databaseSettings.js

**Toggle databases state operation**:
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/toggleDatabasesState.js
