### PR TITLE
RDoc-2535  Cannot project twice when making a query

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-perform-group-by-query.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-perform-group-by-query.dotnet.markdown
@@ -58,7 +58,7 @@ select key() as EmployeeCompanyPair, count()
 ### By Array Values
 
 In order to group by values of array, you need to use `GroupByArrayValues`. The following query will group by `Product` property from `Lines` collection 
-and calculate the count per ordered products. Underneath a [fanout](../../../indexes/fanout-indexes), an auto map-reduce index will be created to handle such query. 
+and calculate the count per ordered products. Underneath a fanout, an auto map-reduce index will be created to handle such query. 
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync group_by_4@ClientApi\Session\Querying\HowToPerformGroupByQuery.cs /}

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-perform-group-by-query.java.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-perform-group-by-query.java.markdown
@@ -55,7 +55,7 @@ select key() as EmployeeCompanyPair, count()
 ### By Array Values
 
 In order to group by values of array, you need to use `groupBy(array(...))`. The following query will group by `product` field from `Lines` collection 
-and calculate the count per ordered products. Underneath a [fanout](../../../indexes/fanout-indexes), an auto map-reduce index will be created to handle such query. 
+and calculate the count per ordered products. Underneath a fanout, an auto map-reduce index will be created to handle such query. 
 
 {CODE-TABS}
 {CODE-TAB:java:Java group_by_4@ClientApi\Session\Querying\HowToPerformGroupByQuery.java /}

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-perform-group-by-query.js.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/querying/how-to-perform-group-by-query.js.markdown
@@ -55,7 +55,7 @@ select key() as EmployeeCompanyPair, count() as Count
 ### By Array Values
 
 In order to group by values of array, you need to use `groupBy(array(...))`. The following query will group by `product` field from `lines` collection 
-and calculate the count per ordered products. Underneath a [fanout](../../../indexes/fanout-indexes), an auto map-reduce index will be created to handle such query. 
+and calculate the count per ordered products. Underneath a fanout, an auto map-reduce index will be created to handle such query. 
 
 {CODE-TABS}
 {CODE-TAB:nodejs:Node.js group_by_4@client-api\session\querying\howToPerformGroupByQuery.js /}

--- a/Documentation/4.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/4.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -69,8 +69,14 @@
   {
     "Path": "fanout-indexes.markdown",
     "Name": "Fanout Indexes",
-    "DiscussionId": "9b0f12df-a433-4d4b-928f-dadddac66214",
-    "Mappings": []
+    "LastSupportedVersion": "5.1",
+    "DiscussionId": "8dd0873a-83c2-4148-8710-b15951047700",
+    "Mappings": [
+        {
+            "Version": 5.2,
+            "Key": "indexes/indexing-nested-data"
+        }
+    ]
   },
   {
     "Path": "sorting-and-collation.markdown",

--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/.docs.json
@@ -75,8 +75,14 @@
   {
     "Path": "fanout-indexes.markdown",
     "Name": "Fanout Indexes",
+    "LastSupportedVersion": "5.1",
     "DiscussionId": "8dd0873a-83c2-4148-8710-b15951047700",
-    "Mappings": []
+      "Mappings": [
+          {
+              "Version": 5.2,
+              "Key": "indexes/indexing-nested-data"
+          }
+      ]
   },
   {
     "Path": "sorting-and-collation.markdown",

--- a/Documentation/4.2/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/4.2/Raven.Documentation.Pages/indexes/.docs.json
@@ -75,8 +75,14 @@
   {
     "Path": "fanout-indexes.markdown",
     "Name": "Fanout Indexes",
+    "LastSupportedVersion": "5.1",
     "DiscussionId": "8dd0873a-83c2-4148-8710-b15951047700",
-    "Mappings": []
+    "Mappings": [
+        {
+            "Version": 5.2,
+            "Key": "indexes/indexing-nested-data"
+        }
+    ]
   },
   {
     "Path": "sorting-and-collation.markdown",

--- a/Documentation/5.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -75,8 +75,14 @@
     {
         "Path": "fanout-indexes.markdown",
         "Name": "Fanout Indexes",
+        "LastSupportedVersion": "5.1",
         "DiscussionId": "8dd0873a-83c2-4148-8710-b15951047700",
-        "Mappings": []
+        "Mappings": [
+            {
+                "Version": 5.2,
+                "Key": "indexes/indexing-nested-data"
+            }
+        ]
     },
     {
         "Path": "sorting-and-collation.markdown",

--- a/Documentation/5.1/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.1/Raven.Documentation.Pages/indexes/.docs.json
@@ -75,8 +75,14 @@
     {
         "Path": "fanout-indexes.markdown",
         "Name": "Fanout Indexes",
+        "LastSupportedVersion": "5.1",
         "DiscussionId": "8dd0873a-83c2-4148-8710-b15951047700",
-        "Mappings": []
+        "Mappings": [
+            {
+                "Version": 5.2,
+                "Key": "indexes/indexing-nested-data"
+            }
+        ]
     },
     {
         "Path": "sorting-and-collation.markdown",

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
@@ -203,8 +203,8 @@ __Syntax__
   Entities resulting from a projecting query are Not tracked by the session.  
   Learn more about projections in:
   
-  * [Projections](../../../indexes/querying/projections)
-  * [How to project query results](../../../client-api/session/querying/how-to-project-query-results)
+  * [Project index query results](../../../indexes/querying/projections)
+  * [Project dynamic query results](../../../client-api/session/querying/how-to-project-query-results)
 
 {NOTE: }
 

--- a/Documentation/5.2/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/indexes/.docs.json
@@ -113,7 +113,12 @@
         "Path": "indexing-nested-data.markdown",
         "Name": "Indexing Nested Data",
         "DiscussionId": "8dd0873a-83c2-4148-8710-b15951047700",
-        "Mappings": []
+        "Mappings": [
+            {
+                "Version": 4.1,
+                "Key": "indexes/fanout-indexes"
+            }
+        ]
     },
     {
         "Path": "indexing-hierarchical-data.markdown",

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/indexing-performance.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/database/Indexes/indexing-performance.markdown
@@ -81,7 +81,7 @@ In this page:
        - [Multi-map indexes](../../../indexes/multi-map-indexes): Shows how to map a second collection in the same index.  
        - [Map-reduce indexes](../../../indexes/map-reduce-indexes): Shows how to create complex aggregations of data that is 
          stored and updated inside the index, improving querying performance.  
-       - [Fanout indexes](../../../indexes/fanout-indexes): Shows how to define indexes that output multiple entries per document.  
+       - [Fanout indexes](../../../indexes/indexing-nested-data): Shows how to define indexes that output multiple entries per document.  
 
  3. **ReplacementOf**  
     * Temporary prefix of index that is rebuilding after definition changes are saved.  

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
@@ -11,7 +11,7 @@
 
 * In this page:
 
-  * [Projections overview](../../../client-api/session/querying/how-to-project-query-results#overview)
+  * [Projections overview](../../../client-api/session/querying/how-to-project-query-results#projections-overview)
 
   * [Projection Methods](../../../client-api/session/querying/how-to-project-query-results#select):  
       * [Select](../../../client-api/session/querying/how-to-project-query-results#select)  
@@ -93,7 +93,7 @@ __The cost of projections__:
 * But while calculations within a projection are allowed, having a very complex logic can impact query performance.  
   So RavenDB limits the total time it will spend processing a query and its projections.  
   Exceeding this time limit will fail the query. This is configurable, see the following configuration keys:  
-      * [Databases.QueryTimeoutInSec](../../..server/configuration/database-configuration#databases.querytimeoutinsec)
+      * [Databases.QueryTimeoutInSec](../../../server/configuration/database-configuration#databases.querytimeoutinsec)
       * [Databases.QueryOperationTimeoutInSec](../../../server/configuration/database-configuration#databases.queryoperationtimeoutinsec)
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
@@ -131,7 +131,7 @@ __Example II - Projecting arrays and objects__:
 from "Orders"
 select ShipTo, Lines[].ProductName as Products
 
-// Using object literal syntax:
+// Using JavaScript object literal syntax:
 from "Orders" as x
 select {
     ShipTo: x.ShipTo, 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
@@ -31,7 +31,7 @@
 __What are projections__:
 
 * A projection refers to the __transformation of query results__ into a customized structure,  
-  modifying the shape of the data returned from the server.
+  modifying the shape of the data returned by the server.
   
 * Instead of retrieving the full document and then picking relevant data from it,  
   you can return a subset of the data, specifying the document fields you want to get from the server.  
@@ -79,6 +79,9 @@ __Projections are the final stage in the query pipeline__:
 
 * Within the projection you can only filter what data will be returned from the matching documents,  
   but you cannot filter which documents will be returned. That has already been determined earlier in the query pipeline.
+
+* Only a single projection request can be made per Query (and DocumentQuery).  
+  Learn more in [single projection per query](../../../client-api/session/querying/how-to-project-query-results#single-projection-per-query).
 
 ---
 
@@ -132,7 +135,7 @@ select ShipTo, Lines[].ProductName as Products
 from "Orders" as x
 select {
     ShipTo: x.ShipTo, 
-    Products: x.Lines.map(y=>y.ProductName)
+    Products: x.Lines.map(y => y.ProductName)
 }
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
@@ -158,7 +161,7 @@ select {
 
 {NOTE: }
 
-<a id="projectionWithCalculations" /> __Example V - Projection with calculations__:
+<a id="projectionWithCalculations" /> __Example IV - Projection with calculations__:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Query projections_4@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
@@ -179,7 +182,7 @@ select {
 
 {NOTE: }
 
-__Example IV - Projecting using functions__:
+__Example V - Projecting using functions__:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Query projections_5@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
@@ -358,11 +361,6 @@ select Name, Phone
 
 {PANEL/}
 
-// move to indexes article... todo..
-{NOTE If the projected fields are stored inside the index itself (`FieldStorage.Yes` in the index definition),
-then the query results will be created directly from there instead of retrieving documents in order to project.
-/}
-
 ## Related Articles
 
 ### Session
@@ -373,7 +371,7 @@ then the query results will be created directly from there instead of retrieving
 ### Indexes
 
 - [Querying an index](../../../indexes/querying/query-index)
-- [Projections when querying an index](../../../indexes/querying/projections)
+- [Project index query results](../../../indexes/querying/projections)
 
 ### Server
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
@@ -1,0 +1,333 @@
+# Project Query Results
+---
+
+{NOTE: }
+
+* Applying a projection in a query allows you to shape the query results to meet specific requirements,  
+  delivering just the data needed instead of the original full document content. 
+
+* In this page:
+
+  * [Projections overview](../../../client-api/session/querying/how-to-project-query-results#overview)
+
+  * [Projection Methods](../../../client-api/session/querying/how-to-project-query-results#select):  
+      * [Select](../../../client-api/session/querying/how-to-project-query-results#select)  
+      * [SelectFields](../../../client-api/session/querying/how-to-project-query-results#selectfields)  
+      * [ProjectInto](../../../client-api/session/querying/how-to-project-query-results#projectinto)   
+
+  * [Single projection usage](../../../)
+
+{NOTE/}
+
+---
+
+{PANEL: Projections overview}
+
+---
+
+__What are projections__:
+
+* A projection refers to the __transformation of query results__ into a customized structure,  
+  modifying the shape of the data returned from the server:
+  
+      * You can return a subset of the data, specifying the document fields you want to get from the server,  
+        instead of retrieving the full document and then picking relevant data from it.  
+
+      * The query can load [related documents](../../../indexes/indexing-related-documents#what-are-related-documents) and have their data merged into the projection results.
+
+      * Objects and arrays can be projected, fields can be renamed, and any calculation can be made within the projection.
+
+---
+
+__When to use projections__:
+
+* Projections allow you to tailor the query results specifically to your needs.  
+  Getting specific details to display can be useful when presenting data to users or populating user interfaces.  
+  Projection queries are also useful with [subscriptions](../../../client-api/data-subscriptions/what-are-data-subscriptions) 
+  since all transformation work is done on the server side without having to send a lot of data over the wire.
+
+* Returning partial document data from the server reduces network traffic,  
+  as clients receive only relevant data required for a particular task, enhancing overall performance.  
+
+* Savings can be significant if you need to show just a bit of information from a large document. For example:  
+  the size of the result when querying for all "Orders" documents where "Company" is "companies/65-A" is 19KB.  
+  Performing the same query and projecting only the "Employee" and "OrderedAt" fields results in only 5KB.
+
+* However, when you need to actively work with the complete set of data on the client side,  
+  then do use a query without a projection to retrieve the full document from the server.
+
+---
+
+__Projections are not tracked by the session__:
+
+* On the client side, the resulting projected entities returned by the query are not tracked by the Session.
+
+* Any modification made to a projection entity will not modify the corresponding document on the server when SaveChanges is called.
+
+---
+
+__Projections are the final stage in the query pipeline__:
+
+* Projections are applied as the last stage in the query pipeline,  
+  after the query has been processed, filtered, sorted, and paged.
+
+* This means that the projection does Not apply to all the documents in the collection,  
+  but only to the documents matching the query predicate.
+
+* Within the projection you can only filter what data will be returned from the matching documents,  
+  but you cannot filter which documents will be returned. That has already been determined earlier in the query pipeline.
+
+---
+
+__The cost of projections__:
+
+* While computations within a projection are allowed, having a very complex logic can impact query performance.
+
+* RavenDB limits the total time it will spend processing a query and its projections.  
+  Exceeding this time limit will fail the query. This is configurable, see the following configuration keys:  
+      * [Databases.QueryTimeoutInSec](../../..server/configuration/database-configuration#databases.querytimeoutinsec)
+      * [Databases.QueryOperationTimeoutInSec](../../../server/configuration/database-configuration#databases.queryoperationtimeoutinsec)
+
+{PANEL/}
+
+{PANEL: Select}
+
+The most common way to perform a query with a projection is to use the `Select` method.  
+You can specify what fields from a document you want to retrieve and even provide a complex expression.
+
+### Example I - Projecting Individual Fields of the Document
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_1@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_1_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Companies
+select Name, Address.City as City, Address.Country as Country
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example II - Projecting Arrays and Objects
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_2@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_2_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders
+select ShipTo, Lines[].ProductName as Products
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example III - Projection with Expression
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_3@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_3_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e
+select {
+    FullName : e.FirstName + " " + e.LastName
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IV - Projection with `let`
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_12@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_12_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare function output(e) {
+	var format = function(p){ return p.FirstName + " " + p.LastName; };
+	return { FullName : format(e) };
+}
+from Employees as e select output(e)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example V - Projection with Calculation
+
+Queries in RavenDB do not allow any computation to occur during the query phase. 
+This is done to ensure that queries in RavenDB can always use an index to answer the query promptly and efficiently. 
+RQL does allow you to perform computation inside the select,
+either to project specific fields out or to massage the data from the query in every way imaginable
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_4@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_4_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders as o
+select {
+    Total : o.Lines.reduce(
+        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VI - Projection Using a Loaded Document
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_5@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_5_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders as o
+load o.Company as c
+select {
+	CompanyName: c.Name,
+	ShippedAt: o.ShippedAt
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VII - Projection with Dates
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_6@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_6_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select { 
+    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), 
+    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1,
+    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VIII - Projection with Raw JavaScript Code
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_7@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_7_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select {
+    Date : new Date(Date.parse(e.Birthday)), 
+    Name : e.FirstName.substr(0,3)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IX - Projection with Metadata
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_13@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_13_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select {
+     Name : e.FirstName, 
+     Metadata : getMetadata(e)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:SelectFields}
+
+The `SelectFields` method can only be used with the [Document Query](../../../client-api/session/querying/document-query/what-is-document-query). 
+It has two overloads:
+
+{CODE-BLOCK: csharp}
+// 1) By array of fields
+IDocumentQuery<TProjection> SelectFields<TProjection>(params string[] fields);
+// 2) By projection type
+IDocumentQuery<TProjection> SelectFields<TProjection>();
+{CODE-BLOCK/}
+
+1) The fields of the projection are specified as a `string` array of field names. It also takes the type of the projection as 
+a generic parameter.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync selectFields@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async selectFields_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Index projections_9@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Class projections_9_class@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact'
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+2) The projection is defined by simply passing the projection type as the generic parameter.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync selectFields_2@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async selectFields_2_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Index projections_9@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Class projections_9_class@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact'
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+#### Projection Behavior
+
+The `SelectFields` methods can also take a `ProjectionBehavior` parameter, which 
+determines whether the query should retrieve indexed data or directly retrieve 
+document data, and what to do when the data can't be retrieved. Learn more 
+[here](../../../client-api/session/querying/how-to-customize-query#projection).  
+
+{CODE-BLOCK: csharp}
+IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior,
+                                                      params string[] fields);
+
+IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior);
+{CODE-BLOCK/}
+
+{PANEL/}
+
+{PANEL:ProjectInto}
+
+This extension method retrieves all public fields and properties of the type given in generic and uses them to perform projection to the requested type.
+You can use this method instead of using `Select` together with all fields of the projection class.
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_8@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_8_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact' 
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TAB:csharp:Index projections_9@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Class projections_9_class@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:OfType (As) - simple projection}
+
+`OfType` or `As` is a client-side projection. The easiest explanation of how it works is to take the results that the server returns and map them to given type. This may become useful when querying an index that contains fields that are not available in mapped type.
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync projections_10@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Async projections_10_async@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Index projections_11@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+// move to indexes article...
+{NOTE If the projected fields are stored inside the index itself (`FieldStorage.Yes` in the index definition), then the query results will be created directly from there instead of retrieving documents in order to project. /}
+
+## Related Articles
+
+### Session
+
+- [Query Overview](../../../client-api/session/querying/how-to-query)
+- [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results)
+
+### Querying
+
+- [Querying an Index](../../../indexes/querying/query-index)
+- [Projections](../../../indexes/querying/projections)
+
+### Server
+
+- [JavaScript Engine](../../../server/kb/javascript-engine)  

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.java.markdown
@@ -1,0 +1,170 @@
+# Project Query Results
+
+Instead of pulling full documents in query results you can just grab some pieces of data from documents. You can also transform the projected
+results. The projections are defined with the usage of:
+
+- [SelectFields](../../../client-api/session/querying/how-to-project-query-results#selectfields)
+- [OfType](../../../client-api/session/querying/how-to-project-query-results#oftype---simple-projection)
+
+{PANEL:SelectFields}
+
+The most common way to perform a query with projection is to use the `selectFields` method. You can specify what fields from a document you want to retrieve.
+
+### Example I - Projecting Individual Fields of the Document
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_1@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Companies
+select Name, Address.City as City, Address.Country as Country
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example II - Projecting Arrays and Objects
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_2@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders
+select ShipTo, Lines[].ProductName as Products
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example III - Projection with Expression
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_3@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e
+select {
+    FullName : e.FirstName + " " + e.LastName
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IV - Projection with `declared function`
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_12@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare function output(e) {
+	var format = function(p){ return p.FirstName + " " + p.LastName; };
+	return { FullName : format(e) };
+}
+from Employees as e select output(e)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example V - Projection with Calculation
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_4@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders as o
+select {
+    Total : o.Lines.reduce(
+        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VI - Projection Using a Loaded Document
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_5@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders as o
+load o.Company as c
+select {
+	CompanyName: c.Name,
+	ShippedAt: o.ShippedAt
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VII - Projection with Dates
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_6@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select { 
+    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), 
+    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1,
+    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VIII - Projection with Raw JavaScript Code
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_7@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select {
+    Date : new Date(Date.parse(e.Birthday)), 
+    Name : e.FirstName.substr(0,3)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IX - Projection with Metadata
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_13@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select {
+     Name : e.FirstName, 
+     Metadata : getMetadata(e)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+This method overload retrieves all public fields of the class given in generic and uses them to perform projection to the requested type.
+You can use this method instead of using `selectFields` together with all fields of the projection class.
+
+### Example X
+
+{CODE-TABS}
+{CODE-TAB:java:Java projections_8@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact' 
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TAB:java:Index projections_9_0@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+{CODE-TAB:java:Class projections_9_1@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:OfType - simple projection}
+
+`ofType` is a client-side projection. The easiest explanation of how it works is to take the results that the server returns and map them to given type. This may become useful when querying an index that contains fields that are not available in mapped type.
+
+### Example
+
+{CODE:java projections_10@ClientApi\Session\Querying\HowToProjectQueryResults.java /}
+
+{PANEL/}
+
+{NOTE Projected entities (even named types) are not tracked by the session. /}
+
+{NOTE If the projected fields are stored inside the index itself (`FieldStorage.YES` in the index definition), then the query results will be created directly from there instead of retrieving documents in order to project. /}
+
+## Related Articles
+
+### Session
+
+- [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results)
+
+### Querying
+
+- [Basics](../../../indexes/querying/query-index)
+- [Projections](../../../indexes/querying/projections)
+
+### Server
+
+- [JavaScript Engine](../../../server/kb/javascript-engine)  

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.js.markdown
@@ -1,0 +1,186 @@
+# Project Query Results
+
+Instead of pulling full documents in query results you can just grab some pieces of data from documents. You can also transform the projected
+results. The projections are defined with the usage of:
+
+- [selectFields()](../../../client-api/session/querying/how-to-project-query-results#selectfields())
+- [projectInto](../../../client-api/session/querying/how-to-project-query-results#projectinto)  
+- [ofType()](../../../client-api/session/querying/how-to-project-query-results#oftype)
+
+{PANEL:SelectFields()}
+
+The most common way to perform a query with projection is to use the `selectFields()` method, which let's you specify what fields from a document you want to retrieve.
+
+### Example I - Projecting Individual Fields of the Document
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_1@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Companies
+select Name, Address.City as City, Address.Country as Country
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example II - Projecting Arrays and Objects
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_2@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders
+select ShipTo, Lines[].ProductName as Products
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example III - Projection with Expression
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_3@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e
+select {
+    fullName : e.FirstName + " " + e.LastName
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IV - Projection with `declared function`
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_12@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare function output(e) {
+	var format = function(p){ return p.FirstName + " " + p.LastName; };
+	return { FullName : format(e) };
+}
+from Employees as e select output(e)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example V - Projection with Calculation
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_4@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders as o
+select {
+    Total : o.Lines.reduce(
+        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VI - Projection Using a Loaded Document
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_5@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders as o
+load o.Company as c
+select {
+	CompanyName: c.Name,
+	ShippedAt: o.ShippedAt
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VII - Projection with Dates
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_6@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select { 
+    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), 
+    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1,
+    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VIII - Projection with Raw JavaScript Code
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_7@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select {
+    Date : new Date(Date.parse(e.Birthday)), 
+    Name : e.FirstName.substr(0,3)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IX - Projection with Metadata
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_13@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees as e 
+select {
+     Name : e.FirstName, 
+     Metadata : getMetadata(e)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example X
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Node.js projections_8@client-api\session\querying\howToProjectQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact' 
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TAB:nodejs:Index projections_9_0@client-api\session\querying\howToProjectQueryResults.js /}
+
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:projectInto}
+
+This extension method retrieves all public fields and properties of the type given in generic and uses them to perform projection to the requested type.
+
+You can use this method instead of using selectFields` together with all fields of the projection class.
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Index index_10@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact' 
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:OfType}
+
+`ofType()` is a client-side projection - in JS it only sets the type of the result entries. The easiest explanation of how it works is to take the results that the server returns and assign them to instance of the type indicated by the parameter.
+
+### Example
+
+{CODE:nodejs projections_10@client-api\session\querying\howToProjectQueryResults.js /}
+
+{PANEL/}
+
+{NOTE Projected entities (even named types) are not tracked by the session. /}
+
+{NOTE If the projected fields are stored inside the index itself (`"Yes"` in the index definition), then the query results will be created directly from there instead of retrieving documents in order to project. /}
+
+## Related Articles
+
+### Session
+
+- [Query Overview](../../../client-api/session/querying/how-to-query)
+- [How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results)
+
+### Querying
+
+- [Querying an Index](../../../indexes/querying/query-index)
+- [Projections](../../../indexes/querying/projections)
+
+### Server
+
+- [JavaScript Engine](../../../server/kb/javascript-engine)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.dotnet.markdown
@@ -1,0 +1,297 @@
+# Project Index Query Results
+
+There are couple of ways to perform projections in RavenDB:
+
+- projections using [Select](../../indexes/querying/projections#select)
+- using [SelectFields](../../indexes/querying/projections#selectfields)
+- using [ProjectInto](../../indexes/querying/projections#projectinto)
+- using [OfType (As)](../../indexes/querying/projections#oftype-(as))
+
+## What are Projections and When to Use Them
+
+When performing a query, we usually pull the full document back from the server.
+
+However, we often need to display the data to the user. Instead of pulling the whole document back and picking just what we'll show, we can ask the server to send us just the details we want to show the user and thus reduce the amount of traffic on the network.   
+
+The savings can be very significant if we need to show just a bit of information on a large document.  
+
+A good example in the sample data set would be the order document. If we ask for all the Orders where Company is "companies/65-A", the size of the result that we get back from the server is 19KB.
+
+However, if we perform the same query and ask to get back only the Employee and OrderedAt fields, the size of the result is only 5KB.  
+
+Aside from allowing you to pick only a portion of the data, projection functions give you the ability to rename some fields, load external documents, and perform transformations on the results. 
+
+## Projections are Applied as the Last Stage in the Query
+
+It is important to understand that projections are applied after the query has been processed, filtered, sorted, and paged. The projection doesn't apply to all the documents in the database, only to the results that are actually returned.  
+This reduces the load on the server significantly, since we can avoid doing work only to throw it immediately after. It also means that we cannot do any filtering work as part of the projection. You can filter what will be returned, but not which documents will be returned. That has already been determined earlier in the query pipeline.  
+
+## The Cost of Running a Projection
+
+Another consideration to take into account is the cost of running the projection. It is possible to make the projection query expensive to run. RavenDB has limits on the amount of time it will spend in evaluating the projection, and exceeding these (quite generous) limits will fail the query.
+
+## Projections and Stored Fields
+
+If a projection function only requires fields that are stored, then the document will not be loaded from storage and all data will come from the index directly. This can increase query performance (by the cost of disk space used) in many situations when whole document is not needed. You can read more about field storing [here](../../indexes/storing-data-in-index).
+
+{PANEL:Select}
+
+The most basic projection can be done using LINQ `Select` method:
+
+### Example I - Projecting Individual Fields of the Document
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_1@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_1@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName'
+select FirstName, LastName
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+This will issue a query to a database, requesting only `FirstName` and `LastName` from all documents that index entries match query predicate from `Employees/ByFirstAndLastName` index. What does it mean? If an index entry matches our query predicate, then we will try to extract all requested fields from that particular entry. If all requested fields are available in there, then we do not download it from storage. The index `Employees/ByFirstAndLastName` used in the above query is not storing any fields, so the documents will be fetched from storage.
+
+### Example II - Projecting Stored Fields
+
+If we create an index that stores `FirstName` and `LastName` and it requests only those fields in query, then **the data will come from the index directly**.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_1_stored@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_1_stored@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastNameWithStoredFields'
+select FirstName, LastName
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example III - Projecting Arrays and Objects
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_2@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_3@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShipToAndLines' as o
+select 
+{ 
+    ShipTo: o.ShipTo, 
+    Products : o.Lines.map(function(y){return y.ProductName;}) 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IV - Projection with Expression
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_3@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_1@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName' as e
+select 
+{ 
+    FullName : e.FirstName + " " + e.LastName 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example V - Projection with `let`
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_4@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_1@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare function output(e) {
+	var format = function(p){ return p.FirstName + " " + p.LastName; };
+	return { FullName : format(e) };
+}
+from index 'Employees/ByFirstAndLastName' as e select output(e)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VI - Projection with Calculation
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_9@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_3@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShipToAndLines' as o
+select {
+    Total : o.Lines.reduce(
+        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VII - Projection With a Count() Predicate
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_count_in_projection@ClientApi\Session\Querying\HowToProjectQueryResults.cs /}
+{CODE-TAB:csharp:Index indexes_4@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Orders as o 
+load o.Company as c 
+select 
+{ 
+    CompanyName : c.Name, 
+    ShippedAt : o.ShippedAt, 
+    TotalProducts : o.Lines.length, 
+    TotalDiscountedProducts : o.Lines.filter(x => x.Discount > 0 ).length 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VIII - Projection Using a Loaded Document
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_5@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_4@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShippedAtAndCompany' as o
+load o.Company as c
+select {
+	CompanyName: c.Name,
+	ShippedAt: o.ShippedAt
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IX - Projection with Dates
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_6@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_2@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstNameAndBirthday' as e 
+select { 
+    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), 
+    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1,
+    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example X - Projection with Raw JavaScript Code
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_7@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_2@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstNameAndBirthday' as e 
+select {
+    Date : new Date(Date.parse(e.Birthday)), 
+    Name : e.FirstName.substr(0,3)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example XI - Projection with Metadata
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_8@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index indexes_1@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName' as e 
+select {
+     Name : e.FirstName, 
+     Metadata : getMetadata(e)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:SelectFields}
+
+The `SelectFields` method can only be used with the [Document Query](../../client-api/session/querying/document-query/what-is-document-query). 
+It has two overloads:
+
+{CODE-BLOCK: csharp}
+// 1) By array of fields
+IDocumentQuery<TProjection> SelectFields<TProjection>(params string[] fields);
+// 2) By projection type
+IDocumentQuery<TProjection> SelectFields<TProjection>();
+{CODE-BLOCK/}
+
+1) The fields of the projection are specified as a `string` array of field names. It also takes the type of the projection as 
+a generic parameter.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query selectFields_1@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index index_10@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Class projections_10_class@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact'
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+2) The projection is defined by simply passing the projection type as the generic parameter.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query selectFields_2@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Index index_10@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Class projections_10_class@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact'
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+#### Projection Behavior
+
+The `SelectFields` methods can also take a `ProjectionBehavior` parameter, which 
+determines whether the query should retrieve indexed data or directly retrieve 
+document data, and what to do when the data can't be retrieved. Learn more 
+[here](../../client-api/session/querying/how-to-customize-query#projection).  
+
+{CODE-BLOCK: csharp}
+IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior,
+                                                      params string[] fields);
+
+IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior);
+{CODE-BLOCK/}
+
+{PANEL/}
+
+{PANEL:ProjectInto}
+
+This extension method retrieves all public fields and properties of the type given in generic and uses them to perform projection to the requested type.
+
+You can use this method instead of using `Select` together with all fields of the projection class.
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query projections_10@Indexes\Querying\Projections.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact' 
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TAB:csharp:Index index_10@Indexes\Querying\Projections.cs /}
+{CODE-TAB:csharp:Class projections_10_class@Indexes\Querying\Projections.cs /}
+
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:OfType (As)}
+
+`OfType` or `As` is a client-side projection. You can read more about it [here](../../client-api/session/querying/how-to-project-query-results#oftype-(as)---simple-projection).
+
+{PANEL/}
+
+## Projections and the Session
+Because you are working with projections and not directly with documents, they are _not_ tracked by the session. Modifications to a projection will not modify the document when SaveChanges is called.
+
+## Related Articles
+
+### Querying 
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Client API
+
+- [How to Project Query Results](../../client-api/session/querying/how-to-project-query-results)
+
+### Knowledge Base
+
+- [JavaScript Engine](../../server/kb/javascript-engine)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.dotnet.markdown
@@ -257,7 +257,7 @@ select ContactName, ContactTitle
 
 {PANEL: SelectFields}
 
-The `SelectFields` method can only be used by a [Document Query](../../../client-api/session/querying/document-query/what-is-document-query).  
+The `SelectFields` method can only be used by a [Document Query](../../client-api/session/querying/document-query/what-is-document-query).  
 It has two overloads:
 
 {CODE-BLOCK: csharp}

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.dotnet.markdown
@@ -81,7 +81,7 @@ from index "Orders/ByCompanyAndShipToAndLines"
 where Company == "companies/65-A"
 select ShipTo.City as ShipToCity, Lines[].ProductName as Products
 
-// Using object literal syntax:
+// Using JavaScript object literal syntax:
 from index "Orders/ByCompanyAndShipToAndLines" as x
 where Company == "companies/65-A"
 select {

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.java.markdown
@@ -1,0 +1,202 @@
+# Querying: Projections
+
+There are couple of ways to perform projections in RavenDB:
+
+- projections using [SelectFields](../../indexes/querying/projections#selectfields)
+- using [OfType](../../indexes/querying/projections#oftype)
+
+## What are Projections and When to Use Them
+
+When performing a query, we usually pull the full document back from the server.
+
+However, we often need to display the data to the user. Instead of pulling the whole document back and picking just what we'll show, we can ask the server to send us just the details we want to show the user and thus reduce the amount of traffic on the network.   
+
+The savings can be very significant if we need to show just a bit of information on a large document.  
+
+A good example in the sample data set would be the order document. If we ask for all the Orders where Company is "companies/65-A", the size of the result that we get back from the server is 19KB.
+
+However, if we perform the same query and ask to get back only the Employee and OrderedAt fields, the size of the result is only 5KB.  
+
+Aside from allowing you to pick only a portion of the data, projection functions give you the ability to rename some fields, load external documents, and perform transformations on the results. 
+
+## Projections are Applied as the Last Stage in the Query
+
+It is important to understand that projections are applied after the query has been processed, filtered, sorted, and paged. The projection doesn't apply to all the documents in the database, only to the results that are actually returned.  
+This reduces the load on the server significantly, since we can avoid doing work only to throw it immediately after. It also means that we cannot do any filtering work as part of the projection. You can filter what will be returned, but not which documents will be returned. That has already been determined earlier in the query pipeline.  
+
+## The Cost of Running a Projection
+
+Another consideration to take into account is the cost of running the projection. It is possible to make the projection query expensive to run. RavenDB has limits on the amount of time it will spend in evaluating the projection, and exceeding these (quite generous) limits will fail the query.
+
+## Projections and Stored Fields
+
+If a projection function only requires fields that are stored, then the document will not be loaded from storage and all data will come from the index directly. This can increase query performance (by the cost of disk space used) in many situations when whole document is not needed. You can read more about field storing [here](../../indexes/storing-data-in-index).
+
+{PANEL:SelectFields}
+The most basic projection can be done using `selectFields` method:
+
+### Example I - Projecting Individual Fields of the Document
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_1@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_1@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName'
+select FirstName, LastName
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+This will issue a query to a database, requesting only `FirstName` and `LastName` from all documents that index entries match query predicate from `Employees/ByFirstAndLastName` index. What does it mean? If an index entry matches our query predicate, then we will try to extract all requested fields from that particular entry. If all requested fields are available in there, then we do not download it from storage. The index `Employees/ByFirstAndLastName` used in the above query is not storing any fields, so the documents will be fetched from storage.
+
+### Example II - Projecting Stored Fields
+
+If we create an index that stores `FirstName` and `LastName` and it requests only those fields in query, then **the data will come from the index directly**.
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_1_stored@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_1_stored@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastNameWithStoredFields'
+select FirstName, LastName
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example III - Projecting Arrays and Objects
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_2@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_3@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShipToAndLines' as o
+select 
+{ 
+    ShipTo: o.ShipTo, 
+    Products : o.Lines.map(function(y){return y.ProductName;}) 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IV - Projection with Expression
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_3@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_1@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName' as e
+select 
+{ 
+    FullName : e.FirstName + " " + e.LastName 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example V - Projection with `declared function`
+{CODE-TABS}
+{CODE-TAB:java:Query projections_4@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_1@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare function output(e) {
+	var format = function(p){ return p.FirstName + " " + p.LastName; };
+	return { FullName : format(e) };
+}
+from index 'Employees/ByFirstAndLastName' as e select output(e)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VI - Projection with Calculation
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_9@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_3@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShipToAndLines' as o
+select {
+    Total : o.Lines.reduce(
+        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VII - Projection Using a Loaded Document
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_5@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_4@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShippedAtAndCompany' as o
+load o.Company as c
+select {
+	CompanyName: c.Name,
+	ShippedAt: o.ShippedAt
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VIII - Projection with Dates
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_6@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_2@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstNameAndBirthday' as e 
+select { 
+    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), 
+    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1,
+    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IX - Projection with Raw JavaScript Code
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_7@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_2@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstNameAndBirthday' as e 
+select {
+    Date : new Date(Date.parse(e.Birthday)), 
+    Name : e.FirstName.substr(0,3)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example X - Projection with Metadata
+
+{CODE-TABS}
+{CODE-TAB:java:Query projections_8@Indexes\Querying\Projections.java /}
+{CODE-TAB:java:Index indexes_1@Indexes\Querying\Projections.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName' as e 
+select {
+     Name : e.FirstName, 
+     Metadata : getMetadata(e)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+
+{PANEL:OfType}
+
+`OfType` is a client-side projection. You can read more about it [here](../../client-api/session/querying/how-to-project-query-results#oftype-(as)---simple-projection).
+
+{PANEL/}
+
+## Projections and the Session
+Because you are working with projections and not directly with documents, they are _not_ tracked by the session. Modifications to a projection will not modify the document when `saveChanges` is called.
+
+## Related Articles
+
+### Querying 
+
+- [Basics](../../indexes/querying/query-index)
+
+### Client API
+
+- [How to Project Query Results](../../client-api/session/querying/how-to-project-query-results)
+
+### Knowledge Base
+
+- [JavaScript Engine](../../server/kb/javascript-engine)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.js.markdown
@@ -1,0 +1,221 @@
+# Querying: Projections
+
+There are couple of ways to perform projections in RavenDB:
+
+- projections using [selectFields](../../indexes/querying/projections#selectfields)
+- using [projectInto](../../indexes/querying/projections#projectinto)
+- using [ofType](../../indexes/querying/projections#oftype)
+
+## What are Projections and When to Use Them
+
+When performing a query, we usually pull the full document back from the server.
+
+However, we often need to display the data to the user. Instead of pulling the whole document back and picking just what we'll show, we can ask the server to send us just the details we want to show the user and thus reduce the amount of traffic on the network.   
+
+The savings can be very significant if we need to show just a bit of information on a large document.  
+
+A good example in the sample data set would be the order document. If we ask for all the Orders where Company is "companies/65-A", the size of the result that we get back from the server is 19KB.
+
+However, if we perform the same query and ask to get back only the `Employee` and `OrderedAt` fields, the size of the result is only 5KB.  
+
+Aside from allowing you to pick only a portion of the data, projection functions give you the ability to rename some fields, load external documents, and perform transformations on the results. 
+
+## Projections are Applied as the Last Stage in the Query
+
+It is important to understand that projections are applied after the query has been processed, filtered, sorted, and paged. The projection doesn't apply to all the documents in the database, only to the results that are actually returned.  
+This reduces the load on the server significantly, since we can avoid doing work only to throw it immediately after. It also means that we cannot do any filtering work as part of the projection. You can filter what will be returned, but not which documents will be returned. That has already been determined earlier in the query pipeline.  
+
+## The Cost of Running a Projection
+
+Another consideration to take into account is the cost of running the projection. It is possible to make the projection query expensive to run. RavenDB has limits on the amount of time it will spend in evaluating the projection, and exceeding these (quite generous) limits will fail the query.
+
+## Projections and Stored Fields
+
+If a projection function only requires fields that are stored, then the document will not be loaded from storage and all data will come from the index directly. This can increase query performance (by the cost of disk space used) in many situations when whole document is not needed. You can read more about field storing [here](../../indexes/storing-data-in-index).
+
+{PANEL:selectFields}
+The most basic projection can be done using `selectFields()` method:
+
+### Example I - Projecting Individual Fields of the Document
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_1@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_1@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName'
+select FirstName, LastName
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+This will issue a query to a database, requesting only `FirstName` and `LastName` from all documents that index entries match query predicate from `Employees/ByFirstAndLastName` index. What does it mean? If an index entry matches our query predicate, then we will try to extract all requested fields from that particular entry. If all requested fields are available in there, then we do not download it from storage. The index `Employees/ByFirstAndLastName` used in the above query is not storing any fields, so the documents will be fetched from storage.
+
+### Example II - Projecting Stored Fields
+
+If we create an index that stores `FirstName` and `LastName` and it requests only those fields in query, then **the data will come from the index directly**.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_1_stored@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_1_stored@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastNameWithStoredFields'
+select FirstName, LastName
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example III - Projecting Arrays and Objects
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_2@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_3@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShipToAndLines' as o
+select 
+{ 
+    ShipTo: o.ShipTo, 
+    Products : o.Lines.map(function(y){return y.ProductName;}) 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IV - Projection with Expression
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_3@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_1@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName' as e
+select 
+{ 
+    FullName : e.FirstName + " " + e.LastName 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example V - Projection with `declared function`
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_4@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_1@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare function output(e) {
+	var format = function(p){ return p.FirstName + " " + p.LastName; };
+	return { FullName : format(e) };
+}
+from index 'Employees/ByFirstAndLastName' as e select output(e)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VI - Projection with Calculation
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_9@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_3@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShipToAndLines' as o
+select {
+    Total : o.Lines.reduce(
+        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VII - Projection Using a Loaded Document
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_5@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_4@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Orders/ByShippedAtAndCompany' as o
+load o.Company as c
+select {
+	CompanyName: c.Name,
+	ShippedAt: o.ShippedAt
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example VIII - Projection with Dates
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_6@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_2@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstNameAndBirthday' as e 
+select { 
+    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), 
+    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1,
+    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example IX - Projection with Raw JavaScript Code
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_7@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_2@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstNameAndBirthday' as e 
+select {
+    Date : new Date(Date.parse(e.Birthday)), 
+    Name : e.FirstName.substr(0,3)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example X - Projection with Metadata
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query projections_8@indexes\querying\projections.js /}
+{CODE-TAB:nodejs:Index indexes_1@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Employees/ByFirstAndLastName' as e 
+select {
+     Name : e.FirstName, 
+     Metadata : getMetadata(e)
+}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:projectInto}
+
+This extension method retrieves all public fields and properties of the type given in generic and uses them to perform projection to the requested type.
+
+You can use this method instead of using selectFields` together with all fields of the projection class.
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Index index_10@indexes\querying\projections.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Companies/ByContact' 
+select Name, Phone
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:ofType}
+
+`ofType()` is a client-side projection. You can read more about it [here](../../client-api/session/querying/how-to-project-query-results#oftype-(as)---simple-projection).
+
+{PANEL/}
+
+## Projections and the Session
+Because you are working with projections and not directly with documents, they are _not_ tracked by the session. Modifications to a projection will not modify the document when `saveChanges()` is called.
+
+## Related Articles
+
+### Querying 
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Client API
+
+- [How to Project Query Results](../../client-api/session/querying/how-to-project-query-results)
+
+### Knowledge Base
+
+- [JavaScript Engine](../../server/kb/javascript-engine)

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToProjectQueryResults.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToProjectQueryResults.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries;
 using Raven.Documentation.Samples.Orders;
@@ -19,40 +17,30 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                 using (var session = store.OpenSession())
                 {
                     #region projections_1
-                    // Define a dynamic query on the Companies collection
                     var projectedResults = session
+                        // Make a dynamic query on the Companies collection
                         .Query<Company>()
-                         // Call Select to define the new structure that will be returned per Company document
-                        .Select(x => new
-                        {
-                            Name = x.Name,
-                            City = x.Address.City,
-                            Country = x.Address.Country
-                        })
+                        // Call Select to define the new structure that will be returned per Company document
+                        .Select(x => new {Name = x.Name, City = x.Address.City, Country = x.Address.Country})
                         .ToList();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
-                    // it is a new object containing only the specified fields.
+                    // it is a new object containing ONLY the fields specified in the Select.
                     #endregion
                 }
 
                 using (var asyncSession = store.OpenAsyncSession())
                 {
                     #region projections_1_async
-                    // Define a dynamic query on the Companies collection
                     var results = await asyncSession
+                        // Make a dynamic query on the Companies collection
                         .Query<Company>()
-                         // Call Select to define the new structure that will be returned per Company document
-                        .Select(x => new
-                        {
-                            Name = x.Name,
-                            City = x.Address.City,
-                            Country = x.Address.Country
-                        })
+                        // Call Select to define the new structure that will be returned per Company document
+                        .Select(x => new {Name = x.Name, City = x.Address.City, Country = x.Address.Country})
                         .ToListAsync();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
-                    // it is a new object containing only the specified fields.
+                    // it is a new object containing ONLY the fields specified in the Select.
                     #endregion
                 }
 
@@ -145,27 +133,11 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                         .ToListAsync();
                     #endregion
                 }
-                
-                // todo !!!
-                using (var session = store.OpenSession())
-                {
-                    #region projections_count_in_projection
-                    var results = (from o in session.Query<Order>()
-                        let c = RavenQuery.Load<Company>(o.Company)
-                        select new
-                        {
-                            CompanyName = c.Name,
-                            ShippedAt = o.ShippedAt,
-                            TotalProducts = o.Lines.Count(), //both empty syntax and with a predicate is supported
-                            TotalDiscountedProducts = o.Lines.Count(x => x.Discount > 0)
-                        }).ToList();
-                    #endregion
-                }
 
                 using (var session = store.OpenSession())
                 {
                     #region projections_5
-                    // Use the LINQ query syntax notation
+                    // Use LINQ query syntax notation
                     var projectedResults = (from e in session.Query<Employee>()
                         // Define a function
                         let format = (Func<Employee, string>)(p => p.FirstName + " " + p.LastName)
@@ -173,14 +145,15 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                         {
                             // Call the function from the projection
                             FullName = format(e)
-                        }).ToList();
+                        })
+                        .ToList();
                     #endregion
                 }
 
                 using (var asyncSession = store.OpenAsyncSession())
                 {
                     #region projections_5_async
-                    // Use the LINQ query syntax notation
+                    // Use LINQ query syntax notation
                     var projectedResults = await (from e in asyncSession.Query<Employee>()
                         // Define a function
                         let format = (Func<Employee, string>)(p => p.FirstName + " " + p.LastName)
@@ -188,35 +161,40 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                         {
                             // Call the function from the projection
                             FullName = format(e)
-                        }).ToListAsync();
+                        })
+                        .ToListAsync();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region projections_6
+                    // Use LINQ query syntax notation
                     var projectedResults = (from o in session.Query<Order>()
                         // Use RavenQuery.Load to load the related Company document
                         let c = RavenQuery.Load<Company>(o.Company)
                         select new
                         {
-                            CompanyName = c.Name,   // info from the related Company document
+                            CompanyName = c.Name, // info from the related Company document
                             ShippedAt = o.ShippedAt // info from the Order document
-                        }).ToList();
+                        })
+                        .ToList();
                     #endregion
                 }
 
                 using (var asyncSession = store.OpenAsyncSession())
                 {
                     #region projections_6_async
+                    // Use LINQ query syntax notation
                     var projectedResults = (from o in asyncSession.Query<Order>()
                         // Use RavenQuery.Load to load the related Company document
                         let c = RavenQuery.Load<Company>(o.Company)
                         select new
                         {
-                            CompanyName = c.Name,   // info from the related Company document
+                            CompanyName = c.Name, // info from the related Company document
                             ShippedAt = o.ShippedAt // info from the Order document
-                        }).ToListAsync();
+                        })
+                        .ToListAsync();
                     #endregion
                 }
 
@@ -253,9 +231,8 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                 using (var session = store.OpenSession())
                 {
                     #region projections_8
-                    // Use the LINQ query syntax notation
-                    var projectedResults = (from e in session.Query<Employee>()
-                        select new
+                    var projectedResults = session.Query<Employee>()
+                        .Select(e => new
                         {
                             // Provide a JavaScript expression to the RavenQuery.Raw method
                             Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(e.Birthday))"),
@@ -268,9 +245,8 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                 using (var asyncSession = store.OpenAsyncSession())
                 {
                     #region projections_8_async
-                    // Use the LINQ query syntax notation
-                    var projectedResults = await (from e in asyncSession.Query<Employee>()
-                        select new
+                    var projectedResults = await asyncSession.Query<Employee>()
+                        .Select(e => new
                         {
                             // Provide a JavaScript expression to the RavenQuery.Raw method
                             Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(e.Birthday))"),
@@ -279,16 +255,14 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                         .ToListAsync();
                     #endregion
                 }
-                
+
                 using (var session = store.OpenSession())
                 {
                     #region projections_9
-                    // Use the LINQ query syntax notation
-                    var projectedResults = (from e in session.Query<Employee>()
-                        select new
+                    var projectedResults = session.Query<Employee>()
+                        .Select(e => new
                         {
-                            Name = e.FirstName,
-                            Metadata = RavenQuery.Metadata(e) // Get the metadata
+                            Name = e.FirstName, Metadata = RavenQuery.Metadata(e) // Get the metadata
                         })
                         .ToList();
                     #endregion
@@ -297,27 +271,25 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                 using (var asyncSession = store.OpenAsyncSession())
                 {
                     #region projections_9_async
-                    // Use the LINQ query syntax notation
-                    var projectedResults = await (from e in asyncSession.Query<Employee>()
-                        select new
+                    var projectedResults = await asyncSession.Query<Employee>()
+                        .Select(e => new
                         {
-                            Name = e.FirstName,
-                            Metadata = RavenQuery.Metadata(e) // Get the metadata
+                            Name = e.FirstName, Metadata = RavenQuery.Metadata(e) // Get the metadata
                         })
                         .ToListAsync();
                     #endregion
                 }
-                
+
                 using (var session = store.OpenSession())
                 {
                     #region projections_10
                     var projectedResults = session
                         .Query<Company>()
-                         // Call 'ProjectInto' instead of using 'Select'
-                         // Pass the projection class
+                        // Call 'ProjectInto' instead of using 'Select'
+                        // Pass the projection class
                         .ProjectInto<ContactDetails>()
                         .ToList();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
                     // it is an object of type 'ContactDetails'.
                     #endregion
@@ -328,27 +300,27 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                     #region projections_10_async
                     var projectedResults = await asyncSession
                         .Query<Company>()
-                         // Call 'ProjectInto' instead of using 'Select'
-                         // Pass the projection class
+                        // Call 'ProjectInto' instead of using 'Select'
+                        // Pass the projection class
                         .ProjectInto<ContactDetails>()
                         .ToListAsync();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
                     // it is an object of type 'ContactDetails'.
                     #endregion
                 }
-                
+
                 using (var session = store.OpenSession())
                 {
                     #region projections_11
                     // Make a dynamic DocumentQuery
                     var projectedResults = session.Advanced
                         .DocumentQuery<Company>()
-                         // Call 'SelectFields'
-                         // Pass the projection class type
+                        // Call 'SelectFields'
+                        // Pass the projection class type
                         .SelectFields<ContactDetails>()
                         .ToList();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
                     // it is an object of type 'ContactDetails'.
                     #endregion
@@ -360,36 +332,36 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                     // Make a dynamic DocumentQuery
                     var projectedResults = await asyncSession.Advanced
                         .AsyncDocumentQuery<Company>()
-                         // Call 'SelectFields'
-                         // Pass the projection class type
+                        // Call 'SelectFields'
+                        // Pass the projection class type
                         .SelectFields<ContactDetails>()
                         .ToListAsync();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
                     // it is an object of type 'ContactDetails'.
                     #endregion
                 }
-                
+
                 using (var session = store.OpenSession())
                 {
                     #region projections_12
                     // Define an array with the field names that will be projected
-                    var projectionFields = new string[] {
-                         // Fields from 'ContactDetails' class:
-                        "Name",
-                        "Phone"
+                    var projectionFields = new string[]
+                    {
+                        // Fields from 'ContactDetails' class:
+                        "Name", "Phone"
                     };
 
                     // Make a dynamic DocumentQuery
                     var projectedResults = session.Advanced
                         .DocumentQuery<Company>()
-                         // Call 'SelectFields'
-                         // Pass the projection class type & the fields to be projected from it
+                        // Call 'SelectFields'
+                        // Pass the projection class type & the fields to be projected from it
                         .SelectFields<ContactDetails>(projectionFields)
                         .ToList();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
-                    // it is an object of type 'ContactDetails' containing data only for the specified fields.
+                    // it is an object of type 'ContactDetails' containing data ONLY for the specified fields.
                     #endregion
                 }
 
@@ -397,25 +369,25 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                 {
                     #region projections_12_async
                     // Define an array with the field names that will be projected
-                    var projectionFields = new string[] {
-                         // Fields from 'ContactDetails' class:
-                        "Name",
-                        "Phone"
+                    var projectionFields = new string[]
+                    {
+                        // Fields from 'ContactDetails' class:
+                        "Name", "Phone"
                     };
 
                     // Make a dynamic DocumentQuery
                     var projectedResults = await asyncSession.Advanced
                         .AsyncDocumentQuery<Company>()
-                         // Call 'SelectFields'
-                         // Pass the projection class type & the fields to be projected from it
+                        // Call 'SelectFields'
+                        // Pass the projection class type & the fields to be projected from it
                         .SelectFields<ContactDetails>(projectionFields)
                         .ToListAsync();
-                    
+
                     // Each resulting object in the list is Not a 'Company' entity,
-                    // it is an object of type 'ContactDetails' containing data only for the specified fields.
+                    // it is an object of type 'ContactDetails' containing data ONLY for the specified fields.
                     #endregion
                 }
-                
+
                 using (var session = store.OpenSession())
                 {
                     #region projections_13
@@ -424,13 +396,10 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                     {
                         var projectedResults = session
                             .Query<Company>()
-                             // Make first projection
+                            // Make first projection
                             .ProjectInto<ContactDetails>()
-                             // A second projection is not supported and will throw
-                            .Select(x => new
-                            {
-                                Name = x.Name
-                            })
+                            // A second projection is not supported and will throw
+                            .Select(x => new {Name = x.Name})
                             .ToList();
                     }
                     catch (Exception e)
@@ -440,112 +409,8 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                     }
                     #endregion
                 }
-                
-                ///////////////////////////////////////////////////////////////////////////
-
-                using (var session = store.OpenSession())
-                {
-                    #region projections_8_index
-                    var projectedResults = session.Query<Company, Companies_ByContact>()
-                        .ProjectInto<ContactDetails>()
-                        .ToList();
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region projections_8_async_index
-                    var projectedResults = await asyncSession.Query<Company, Companies_ByContact>()
-                        .ProjectInto<ContactDetails>()
-                        .ToListAsync();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region projections_10
-                    // query index 'Products_BySupplierName' 
-                    // return documents from collection 'Products' that have a supplier 'Norske Meierier'
-                    // project them to 'Products'
-                    List<Product> projectedResults = session
-                        .Query<Products_BySupplierName.Result, Products_BySupplierName>()
-                        .Where(x => x.Name == "Norske Meierier")
-                        .OfType<Product>()
-                        .ToList();
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region projections_10_async
-                    // query index 'Products_BySupplierName' 
-                    // return documents from collection 'Products' that have a supplier 'Norske Meierier'
-                    // project them to 'Products'
-                    List<Product> projectedResults = await asyncSession
-                        .Query<Products_BySupplierName.Result, Products_BySupplierName>()
-                        .Where(x => x.Name == "Norske Meierier")
-                        .OfType<Product>()
-                        .ToListAsync();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region selectFields
-                    var fields = new string[] {
-                        "Name", 
-                        "Phone"
-                    };
-
-                    var projectedResults = session
-                        .Advanced
-                        .DocumentQuery<Company, Companies_ByContact>()
-                        .SelectFields<ContactDetails>(fields)
-                        .ToList();
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region selectFields_async
-                    var fields = new string[]{
-                        "Name",
-                        "Phone"
-                    };
-
-                    var projectedResults = await asyncSession
-                        .Advanced
-                        .AsyncDocumentQuery<Company, Companies_ByContact>()
-                        .SelectFields<ContactDetails>(fields)
-                        .ToListAsync();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region selectFields_2
-                    var projectedResults = session
-                        .Advanced
-                        .DocumentQuery<Company, Companies_ByContact>()
-                        .SelectFields<ContactDetails>()
-                        .ToList();
-                    #endregion
-                }
-
-                using (var asyncSession = store.OpenAsyncSession())
-                {
-                    #region selectFields_2_async
-                    var projectedResults = await asyncSession
-                        .Advanced
-                        .AsyncDocumentQuery<Company, Companies_ByContact>()
-                        .SelectFields<ContactDetails>()
-                        .ToListAsync();
-                    #endregion
-                }
             }
         }
-        
-        ///////////////////////////////////////////////////////////////
 
         #region projections_class
         public class ContactDetails
@@ -554,55 +419,6 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
             public string Name { get; set; }
             public string Phone { get; set; }
             public string Fax { get; set; }
-        }
-        #endregion
-
-        ///////////////////////////////////////////////////////////////
-
-        #region projections_9
-        public class Companies_ByContact : AbstractIndexCreationTask<Company>
-        {
-            public Companies_ByContact()
-            {
-                Map = companies => companies
-                    .Select(x => new
-                    {
-                        Name = x.Contact.Name,
-                        x.Phone
-                    });
-
-                StoreAllFields(FieldStorage.Yes); // Name and Phone fields can be retrieved directly from index
-            }
-        }
-        #endregion
-        
-        #region projections_9_class
-        public class ContactDetails1
-        {
-            public string Name { get; set; }
-            public string Phone { get; set; }
-        }
-        #endregion
-
-        #region projections_11
-        public class Products_BySupplierName : AbstractIndexCreationTask<Product>
-        {
-            public class Result
-            {
-                public string Name { get; set; }
-            }
-
-            public Products_BySupplierName()
-            {
-                Map =
-                    products =>
-                        from product in products
-                        let supplier = LoadDocument<Supplier>(product.Supplier)
-                        select new
-                        {
-                            Name = supplier.Name
-                        };
-            }
         }
         #endregion
     }

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToProjectQueryResults.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToProjectQueryResults.cs
@@ -1,0 +1,422 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Documentation.Samples.Orders;
+using Xunit;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Querying
+{
+    public class HowToProjectQueryResults
+    {
+        public async Task Examples()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region projections_1
+                    // request Name, City and Country for all entities from 'Companies' collection
+                    var results = session
+                        .Query<Company>()
+                        .Select(x => new
+                        {
+                            Name = x.Name,
+                            City = x.Address.City,
+                            Country = x.Address.Country
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_1_async
+                    // request Name, City and Country for all entities from 'Companies' collection
+                    var results = await asyncSession
+                        .Query<Company>()
+                        .Select(x => new
+                        {
+                            Name = x.Name,
+                            City = x.Address.City,
+                            Country = x.Address.Country
+                        })
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_2
+                    var results = session
+                        .Query<Order>()
+                        .Select(x => new
+                        {
+                            ShipTo = x.ShipTo,
+                            Products = x.Lines.Select(y => y.ProductName),
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_2_async
+                    var results = await asyncSession
+                        .Query<Order>()
+                        .Select(x => new
+                        {
+                            ShipTo = x.ShipTo,
+                            Products = x.Lines.Select(y => y.ProductName),
+                        })
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_3
+                    var results = (from e in session.Query<Employee>()
+                                   select new
+                                   {
+                                       FullName = e.FirstName + " " + e.LastName,
+                                   }).ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_3_async
+                    var results = await (from e in asyncSession.Query<Employee>()
+                                         select new
+                                         {
+                                             FullName = e.FirstName + " " + e.LastName,
+                                         }).ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_4
+                    var results = session
+                        .Query<Order>()
+                        .Select(x => new
+                        {
+                            Total = x.Lines.Sum(l => l.PricePerUnit * l.Quantity),
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_4_async
+                    var results = await asyncSession
+                        .Query<Order>()
+                        .Select(x => new
+                        {
+                            Total = x.Lines.Sum(l => l.PricePerUnit * l.Quantity),
+                        })
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_count_in_projection
+                    var results = (from o in session.Query<Order>()
+                                    let c = RavenQuery.Load<Company>(o.Company)
+                        select new
+                        {
+                            CompanyName = c.Name,
+                            ShippedAt = o.ShippedAt,
+                            TotalProducts = o.Lines.Count(), //both empty syntax and with a predicate is supported
+                            TotalDiscountedProducts = o.Lines.Count(x => x.Discount > 0)
+                        }).ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_5
+                    var results = (from o in session.Query<Order>()
+                                   let c = RavenQuery.Load<Company>(o.Company)
+                                   select new
+                                   {
+                                       CompanyName = c.Name,
+                                       ShippedAt = o.ShippedAt
+                                   }).ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_5_async
+                    var results = (from o in asyncSession.Query<Order>()
+                                   let c = RavenQuery.Load<Company>(o.Company)
+                                   select new
+                                   {
+                                       CompanyName = c.Name,
+                                       ShippedAt = o.ShippedAt
+                                   }).ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_6
+                    var results = session
+                        .Query<Employee>()
+                        .Select(e => new
+                        {
+                            DayOfBirth = e.Birthday.Day,
+                            MonthOfBirth = e.Birthday.Month,
+                            Age = DateTime.Today.Year - e.Birthday.Year
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_6_async
+                    var results = await asyncSession
+                        .Query<Employee>()
+                        .Select(e => new
+                        {
+                            DayOfBirth = e.Birthday.Day,
+                            MonthOfBirth = e.Birthday.Month,
+                            Age = DateTime.Today.Year - e.Birthday.Year
+                        })
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_7
+                    var results = from e in session.Query<Employee>()
+                                  select new
+                                  {
+                                      Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(e.Birthday))"),
+                                      Name = RavenQuery.Raw(e.FirstName, "substr(0,3)"),
+                                  };
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_7_async
+                    var results = await (from e in asyncSession.Query<Employee>()
+                                         select new
+                                         {
+                                             Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(e.Birthday))"),
+                                             Name = RavenQuery.Raw(e.FirstName, "substr(0,3)"),
+                                         }).ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_8
+                    var results = session.Query<Company, Companies_ByContact>()
+                        .ProjectInto<ContactDetails>()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_8_async
+                    var results = await asyncSession.Query<Company, Companies_ByContact>()
+                        .ProjectInto<ContactDetails>()
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_10
+                    // query index 'Products_BySupplierName' 
+                    // return documents from collection 'Products' that have a supplier 'Norske Meierier'
+                    // project them to 'Products'
+                    List<Product> results = session
+                        .Query<Products_BySupplierName.Result, Products_BySupplierName>()
+                        .Where(x => x.Name == "Norske Meierier")
+                        .OfType<Product>()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_10_async
+                    // query index 'Products_BySupplierName' 
+                    // return documents from collection 'Products' that have a supplier 'Norske Meierier'
+                    // project them to 'Products'
+                    List<Product> results = await asyncSession
+                        .Query<Products_BySupplierName.Result, Products_BySupplierName>()
+                        .Where(x => x.Name == "Norske Meierier")
+                        .OfType<Product>()
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_12
+                    var results = (from e in session.Query<Employee>()
+                                   let format = (Func<Employee, string>)(p => p.FirstName + " " + p.LastName)
+                                   select new
+                                   {
+                                       FullName = format(e)
+                                   }).ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_12_async
+                    var results = await (from e in asyncSession.Query<Employee>()
+                                         let format = (Func<Employee, string>)(p => p.FirstName + " " + p.LastName)
+                                         select new
+                                         {
+                                             FullName = format(e)
+                                         }).ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_13
+                    var results = (from e in session.Query<Employee>()
+                                   select new
+                                   {
+                                       Name = e.FirstName,
+                                       Metadata = RavenQuery.Metadata(e),
+                                   }).ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_13_async
+                    var results = await (from e in asyncSession.Query<Employee>()
+                                         select new
+                                         {
+                                             Name = e.FirstName,
+                                             Metadata = RavenQuery.Metadata(e),
+                                         }).ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region selectFields
+                    var fields = new string[]{
+                        "Name",
+                        "Phone"
+                    };
+
+                    var results = session
+                        .Advanced
+                        .DocumentQuery<Company, Companies_ByContact>()
+                        .SelectFields<ContactDetails>(fields)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region selectFields_async
+                    var fields = new string[]{
+                        "Name",
+                        "Phone"
+                    };
+
+                    var results = await asyncSession
+                        .Advanced
+                        .AsyncDocumentQuery<Company, Companies_ByContact>()
+                        .SelectFields<ContactDetails>(fields)
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region selectFields_2
+                    var results = session
+                        .Advanced
+                        .DocumentQuery<Company, Companies_ByContact>()
+                        .SelectFields<ContactDetails>()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region selectFields_2_async
+                    var results = await asyncSession
+                        .Advanced
+                        .AsyncDocumentQuery<Company, Companies_ByContact>()
+                        .SelectFields<ContactDetails>()
+                        .ToListAsync();
+                    #endregion
+                }
+            }
+        }
+
+        #region projections_9
+        public class Companies_ByContact : AbstractIndexCreationTask<Company>
+        {
+            public Companies_ByContact()
+            {
+                Map = companies => companies
+                    .Select(x => new
+                    {
+                        Name = x.Contact.Name,
+                        x.Phone
+                    });
+
+                StoreAllFields(FieldStorage.Yes); // Name and Phone fields can be retrieved directly from index
+            }
+        }
+        #endregion
+
+        #region projections_9_class
+        public class ContactDetails
+        {
+            public string Name { get; set; }
+
+            public string Phone { get; set; }
+        }
+        #endregion
+
+        #region projections_11
+        public class Products_BySupplierName : AbstractIndexCreationTask<Product>
+        {
+            public class Result
+            {
+                public string Name { get; set; }
+            }
+
+            public Products_BySupplierName()
+            {
+                Map =
+                    products =>
+                        from product in products
+                        let supplier = LoadDocument<Supplier>(product.Supplier)
+                        select new
+                        {
+                            Name = supplier.Name
+                        };
+            }
+        }
+        #endregion
+
+    }
+}

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Projections.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Projections.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Documentation.Samples.Orders;
+using Raven.Client.Documents.Linq;
+using System.Collections.Generic;
+
+namespace Raven.Documentation.Samples.Indexes.Querying
+{
+    #region indexes_1
+    public class Employees_ByFirstAndLastName : AbstractIndexCreationTask<Employee>
+    {
+        public Employees_ByFirstAndLastName()
+        {
+            Map = employees => from employee in employees
+                               select new
+                               {
+                                   FirstName = employee.FirstName,
+                                   LastName = employee.LastName
+                               };
+        }
+    }
+    #endregion
+
+    #region indexes_1_stored
+    public class Employees_ByFirstAndLastNameWithStoredFields : AbstractIndexCreationTask<Employee>
+    {
+        public Employees_ByFirstAndLastNameWithStoredFields()
+        {
+            Map = employees => from employee in employees
+                               select new
+                               {
+                                   FirstName = employee.FirstName,
+                                   LastName = employee.LastName
+                               };
+            StoreAllFields(FieldStorage.Yes); // FirstName and LastName fields can be retrieved directly from index
+        }
+    }
+    #endregion
+
+    #region indexes_2
+    public class Employees_ByFirstNameAndBirthday : AbstractIndexCreationTask<Employee>
+    {
+        public Employees_ByFirstNameAndBirthday()
+        {
+            Map = employees => from employee in employees
+                               select new
+                               {
+                                   FirstName = employee.FirstName,
+                                   Birthday = employee.Birthday
+                               };
+        }
+    }
+    #endregion
+
+    #region indexes_3
+    public class Orders_ByShipToAndLines : AbstractIndexCreationTask<Order>
+    {
+        public Orders_ByShipToAndLines()
+        {
+            Map = orders => from order in orders
+                            select new
+                            {
+                                ShipTo = order.ShipTo,
+                                Lines = order.Lines
+                            };
+        }
+    }
+    #endregion
+
+    #region indexes_4
+    public class Orders_ByShippedAtAndCompany : AbstractIndexCreationTask<Order>
+    {
+        public Orders_ByShippedAtAndCompany()
+        {
+            Map = orders => from order in orders
+                            select new
+                            {
+                                ShippedAt = order.ShippedAt,
+                                Company = order.Company
+                            };
+        }
+    }
+    #endregion
+
+    public class Projections
+    {
+        public void Sample()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region projections_1
+                    var results = session
+                        .Query<Employee, Employees_ByFirstAndLastName>()
+                        .Select(x => new
+                        {
+                            FirstName = x.FirstName,
+                            LastName = x.LastName
+                        })
+                        .ToList();
+                    #endregion
+                }
+                using (var session = store.OpenSession())
+                {
+                    #region projections_1_stored
+                    var results = session
+                        .Query<Employee, Employees_ByFirstAndLastNameWithStoredFields>()
+                        .Select(x => new
+                        {
+                            FirstName = x.FirstName,
+                            LastName = x.LastName
+                        })
+                        .ToList();
+                    #endregion
+                }
+                using (var session = store.OpenSession())
+                {
+                    #region projections_2
+                    var results = session
+                        .Query<Order, Orders_ByShipToAndLines>()
+                        .Select(x => new
+                        {
+                            ShipTo = x.ShipTo,
+                            Products = x.Lines.Select(y => y.ProductName),
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_3
+                    var results = session
+                        .Query<Employee, Employees_ByFirstAndLastName>()
+                        .Select(x => new
+                        {
+                            FullName = x.FirstName + " " + x.LastName
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_4
+                    var results = (from e in session.Query<Employee, Employees_ByFirstAndLastName>()
+                                   let format = (Func<Employee, string>)(p => p.FirstName + " " + p.LastName)
+                                   select new
+                                   {
+                                       FullName = format(e)
+                                   }).ToList();
+                    #endregion
+                }
+                using (var session = store.OpenSession())
+                {
+                    #region projections_5
+                    var results = (from o in session.Query<Order, Orders_ByShippedAtAndCompany>()
+                                   let c = RavenQuery.Load<Company>(o.Company)
+                                   select new
+                                   {
+                                       CompanyName = c.Name,
+                                       ShippedAt = o.ShippedAt
+                                   }).ToList();
+                    #endregion
+                }
+                using (var session = store.OpenSession())
+                {
+                    #region projections_6
+                    var results = session
+                        .Query<Employee, Employees_ByFirstNameAndBirthday>()
+                        .Select(e => new
+                        {
+                            DayOfBirth = e.Birthday.Day,
+                            MonthOfBirth = e.Birthday.Month,
+                            Age = DateTime.Today.Year - e.Birthday.Year
+                        }).ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_7
+                    var results = session
+                        .Query<Employee, Employees_ByFirstNameAndBirthday>()
+                        .Select(e => new
+                        {
+                            Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(e.Birthday))"),
+                            Name = RavenQuery.Raw(e.FirstName, "substr(0,3)")
+                        }).ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_8
+                    var results = session
+                        .Query<Employee, Employees_ByFirstAndLastName>()
+                        .Select(e => new
+                        {
+                            Name = e.FirstName,
+                            Metadata = RavenQuery.Metadata(e),
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_9
+                    var results = session
+                        .Query<Order, Orders_ByShipToAndLines>()
+                        .Select(x => new
+                        {
+                            Total = x.Lines.Sum(l => l.PricePerUnit * l.Quantity)
+
+                        })
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region selectfields_1
+                    var fields = new string[]{
+                        "Name",
+                        "Phone"
+                    };
+
+                    var results = session
+                        .Advanced
+                        .DocumentQuery<Company, Companies_ByContact>()
+                        .SelectFields<ContactDetails>(fields)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region selectfields_2
+                        var results = session
+                        .Advanced
+                        .DocumentQuery<Company, Companies_ByContact>()
+                        .SelectFields<ContactDetails>()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_10
+                    var results = session.Query<Company, Companies_ByContact>()
+                        .ProjectInto<ContactDetails>()
+                        .ToList();
+                    #endregion
+                }
+            }
+        }
+    }
+
+    #region index_10
+    public class Companies_ByContact : AbstractIndexCreationTask<Company>
+    {
+        public Companies_ByContact()
+        {
+            Map = companies => companies
+                .Select(x => new
+                {
+                    Name = x.Contact.Name,
+                    x.Phone
+                });
+
+            StoreAllFields(FieldStorage.Yes); // Name and Phone fields can be retrieved directly from index
+        }
+    }
+    #endregion
+
+    #region projections_10_class
+    public class ContactDetails
+    {
+        public string Name { get; set; }
+
+        public string Phone { get; set; }
+    }
+    #endregion
+}
+

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Projections.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Projections.cs
@@ -1,289 +1,780 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
-using Raven.Documentation.Samples.Orders;
 using Raven.Client.Documents.Linq;
-using System.Collections.Generic;
+using Raven.Documentation.Samples.Orders;
+using Raven.Client.Documents.Session;
 
 namespace Raven.Documentation.Samples.Indexes.Querying
 {
-    #region indexes_1
-    public class Employees_ByFirstAndLastName : AbstractIndexCreationTask<Employee>
-    {
-        public Employees_ByFirstAndLastName()
-        {
-            Map = employees => from employee in employees
-                               select new
-                               {
-                                   FirstName = employee.FirstName,
-                                   LastName = employee.LastName
-                               };
-        }
-    }
-    #endregion
-
-    #region indexes_1_stored
-    public class Employees_ByFirstAndLastNameWithStoredFields : AbstractIndexCreationTask<Employee>
-    {
-        public Employees_ByFirstAndLastNameWithStoredFields()
-        {
-            Map = employees => from employee in employees
-                               select new
-                               {
-                                   FirstName = employee.FirstName,
-                                   LastName = employee.LastName
-                               };
-            StoreAllFields(FieldStorage.Yes); // FirstName and LastName fields can be retrieved directly from index
-        }
-    }
-    #endregion
-
-    #region indexes_2
-    public class Employees_ByFirstNameAndBirthday : AbstractIndexCreationTask<Employee>
-    {
-        public Employees_ByFirstNameAndBirthday()
-        {
-            Map = employees => from employee in employees
-                               select new
-                               {
-                                   FirstName = employee.FirstName,
-                                   Birthday = employee.Birthday
-                               };
-        }
-    }
-    #endregion
-
-    #region indexes_3
-    public class Orders_ByShipToAndLines : AbstractIndexCreationTask<Order>
-    {
-        public Orders_ByShipToAndLines()
-        {
-            Map = orders => from order in orders
-                            select new
-                            {
-                                ShipTo = order.ShipTo,
-                                Lines = order.Lines
-                            };
-        }
-    }
-    #endregion
-
-    #region indexes_4
-    public class Orders_ByShippedAtAndCompany : AbstractIndexCreationTask<Order>
-    {
-        public Orders_ByShippedAtAndCompany()
-        {
-            Map = orders => from order in orders
-                            select new
-                            {
-                                ShippedAt = order.ShippedAt,
-                                Company = order.Company
-                            };
-        }
-    }
-    #endregion
-
     public class Projections
     {
-        public void Sample()
+        public async Task Examples()
         {
             using (var store = new DocumentStore())
             {
                 using (var session = store.OpenSession())
                 {
                     #region projections_1
-                    var results = session
-                        .Query<Employee, Employees_ByFirstAndLastName>()
+                    var projectedResults = session
+                         // Query the index
+                        .Query<Employees_ByNameAndTitle.IndexEntry, Employees_ByNameAndTitle>()
+                         // Can filter by index-field, e.g. query only for sales representatives
+                        .Where(x => x.Title == "sales representative")
+                         // Call 'Select' to return only the first and last name per matching document
                         .Select(x => new
                         {
-                            FirstName = x.FirstName,
-                            LastName = x.LastName
+                            EmployeeFirstName = x.FirstName,
+                            EmployeeLastName = x.LastName
                         })
                         .ToList();
+                    
+                    // Each resulting object in the list is Not an 'Employee' entity,
+                    // it is a new object containing ONLY the fields specified in the Select
+                    // ('EmployeeFirstName' & 'EmployeeLastName').
                     #endregion
                 }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_1_async
+                    var projectedResults = await asyncSession
+                         // Query the index
+                        .Query<Employees_ByNameAndTitle.IndexEntry, Employees_ByNameAndTitle>()
+                         // Can filter by index-field, e.g. query only for sales representatives
+                        .Where(x => x.Title == "sales representative")
+                         // Call 'Select' to return only the first and last name per matching document
+                        .Select(x => new 
+                        {
+                            EmployeeFirstName = x.FirstName,
+                            EmployeeLastName = x.LastName
+                        })
+                        .ToListAsync();
+                    
+                    // Each resulting object in the list is Not an 'Employee' entity,
+                    // it is a new object containing ONLY the fields specified in the Select
+                    // ('EmployeeFirstName' & 'EmployeeLastName').
+                    #endregion
+                }
+                
                 using (var session = store.OpenSession())
                 {
                     #region projections_1_stored
-                    var results = session
-                        .Query<Employee, Employees_ByFirstAndLastNameWithStoredFields>()
+                    var projectedResults = session
+                        .Query<Employees_ByNameAndTitleWithStoredFields.IndexEntry,
+                            Employees_ByNameAndTitleWithStoredFields>()
                         .Select(x => new
                         {
-                            FirstName = x.FirstName,
-                            LastName = x.LastName
+                            // Project fields 'FirstName' and 'LastName' which are stored in the index
+                            EmployeeFirstName = x.FirstName,
+                            EmployeeLastName = x.LastName
                         })
                         .ToList();
                     #endregion
                 }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_1_stored_async
+                    var projectedResults = await asyncSession
+                        .Query<Employees_ByNameAndTitleWithStoredFields.IndexEntry,
+                            Employees_ByNameAndTitleWithStoredFields>()
+                        .Select(x => new
+                        {
+                            // Project fields 'FirstName' and 'LastName' which are stored in the index
+                            EmployeeFirstName = x.FirstName,
+                            EmployeeLastName = x.LastName
+                        })
+                        .ToListAsync();
+                    #endregion
+                }
+                
                 using (var session = store.OpenSession())
                 {
                     #region projections_2
-                    var results = session
-                        .Query<Order, Orders_ByShipToAndLines>()
+                    var projectedResults = session
+                        .Query<Orders_ByCompanyAndShipToAndLines.IndexEntry, Orders_ByCompanyAndShipToAndLines>()
+                        .Where(x => x.Company == "companies/65-A")
                         .Select(x => new
                         {
-                            ShipTo = x.ShipTo,
-                            Products = x.Lines.Select(y => y.ProductName),
+                            // Retrieve a property from an object
+                            ShipToCity = x.ShipTo.City,
+                            // Retrieve all product names from the Lines array
+                            Products = x.Lines.Select(y => y.ProductName)
                         })
                         .ToList();
                     #endregion
                 }
 
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_2_async
+                    var projectedResults = await asyncSession
+                        .Query<Orders_ByCompanyAndShipToAndLines.IndexEntry, Orders_ByCompanyAndShipToAndLines>()
+                        .Where(x => x.Company == "companies/65-A")
+                        .Select(x => new
+                        {
+                            // Retrieve a property from an object
+                            ShipToCity = x.ShipTo.City,
+                            // Retrieve all product names from the Lines array
+                            Products = x.Lines.Select(y => y.ProductName)
+                        })
+                        .ToListAsync();
+                    #endregion
+                }
+                
                 using (var session = store.OpenSession())
                 {
                     #region projections_3
-                    var results = session
-                        .Query<Employee, Employees_ByFirstAndLastName>()
+                    var projectedResults = session
+                        .Query<Employees_ByNameAndTitle.IndexEntry, Employees_ByNameAndTitle>()
                         .Select(x => new
                         {
+                            // Any expression can be provided for the projected content
                             FullName = x.FirstName + " " + x.LastName
                         })
                         .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_3_async
+                    var projectedResults = await asyncSession
+                        .Query<Employees_ByNameAndTitle.IndexEntry, Employees_ByNameAndTitle>()
+                        .Select(x => new
+                        {
+                            // Any expression can be provided for the projected content
+                            FullName = x.FirstName + " " + x.LastName
+                        })
+                        .ToListAsync();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region projections_4
-                    var results = (from e in session.Query<Employee, Employees_ByFirstAndLastName>()
-                                   let format = (Func<Employee, string>)(p => p.FirstName + " " + p.LastName)
-                                   select new
-                                   {
-                                       FullName = format(e)
-                                   }).ToList();
-                    #endregion
-                }
-                using (var session = store.OpenSession())
-                {
-                    #region projections_5
-                    var results = (from o in session.Query<Order, Orders_ByShippedAtAndCompany>()
-                                   let c = RavenQuery.Load<Company>(o.Company)
-                                   select new
-                                   {
-                                       CompanyName = c.Name,
-                                       ShippedAt = o.ShippedAt
-                                   }).ToList();
-                    #endregion
-                }
-                using (var session = store.OpenSession())
-                {
-                    #region projections_6
-                    var results = session
-                        .Query<Employee, Employees_ByFirstNameAndBirthday>()
-                        .Select(e => new
+                    var projectedResults = session
+                        .Query<Orders_ByCompanyAndShipToAndLines.IndexEntry, Orders_ByCompanyAndShipToAndLines>()
+                        .Select(x => new
                         {
-                            DayOfBirth = e.Birthday.Day,
-                            MonthOfBirth = e.Birthday.Month,
-                            Age = DateTime.Today.Year - e.Birthday.Year
-                        }).ToList();
+                            // Any calculations can be done within a projection
+                            TotalProducts = x.Lines.Count,
+                            TotalDiscountedProducts = x.Lines.Count(x => x.Discount > 0),
+                            TotalPrice = x.Lines.Sum(l => l.PricePerUnit * l.Quantity)
+                        })
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenSession())
+                {
+                    #region projections_4_async
+                    var projectedResults = await asyncSession
+                        .Query<Orders_ByCompanyAndShipToAndLines.IndexEntry, Orders_ByCompanyAndShipToAndLines>()
+                        .Select(x => new
+                        {
+                            // Any calculations can be done within a projection
+                            TotalProducts = x.Lines.Count,
+                            TotalDiscountedProducts = x.Lines.Count(x => x.Discount > 0),
+                            TotalPrice = x.Lines.Sum(l => l.PricePerUnit * l.Quantity)
+                        })
+                        .ToListAsync();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
+                    #region projections_5
+                    var projectedResults =
+                        // Use LINQ query syntax notation
+                        (from x in session
+                                .Query<Employees_ByNameAndTitle.IndexEntry, Employees_ByNameAndTitle>()
+                            // Define a function
+                            let format =
+                                (Func<Employees_ByNameAndTitle.IndexEntry, string>)(p =>
+                                    p.FirstName + " " + p.LastName)
+                            select new
+                            {
+                                // Call the function from the projection
+                                FullName = format(x)
+                            })
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_5_async
+                    var projectedResults =
+                        // Use LINQ query syntax notation
+                        await (from x in asyncSession
+                                    .Query<Employees_ByNameAndTitle.IndexEntry, Employees_ByNameAndTitle>()
+                                // Define a function
+                                let format =
+                                    (Func<Employees_ByNameAndTitle.IndexEntry, string>)(p =>
+                                        p.FirstName + " " + p.LastName)
+                                select new
+                                {
+                                    // Call the function from the projection
+                                    FullName = format(x)
+                                })
+                            .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region projections_6
+                    var projectedResults = 
+                        // Use LINQ query syntax notation
+                        (from o in session
+                                .Query<Orders_ByCompanyAndShippedAt.IndexEntry, Orders_ByCompanyAndShippedAt>()
+                            // Use RavenQuery.Load to load the related Company document
+                            let c = RavenQuery.Load<Company>(o.Company)
+                            select new
+                            {
+                                CompanyName = c.Name,   // info from the related Company document
+                                ShippedAt = o.ShippedAt // info from the Order document
+                            })
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_6_async
+                    // Use LINQ query syntax notation
+                    var projectedResults = 
+                        await (from o in asyncSession
+                                    .Query<Orders_ByCompanyAndShippedAt.IndexEntry, Orders_ByCompanyAndShippedAt>()
+                            // Use RavenQuery.Load to load the related Company document
+                            let c = RavenQuery.Load<Company>(o.Company)
+                            select new
+                            {
+                                CompanyName = c.Name,   // info from the related Company document
+                                ShippedAt = o.ShippedAt // info from the Order document
+                            })
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
                     #region projections_7
-                    var results = session
-                        .Query<Employee, Employees_ByFirstNameAndBirthday>()
-                        .Select(e => new
+                    var projectedResults = session
+                        .Query<Employees_ByFirstNameAndBirthday.IndexEntry, Employees_ByFirstNameAndBirthday>()
+                        .Select(x => new
                         {
-                            Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(e.Birthday))"),
-                            Name = RavenQuery.Raw(e.FirstName, "substr(0,3)")
-                        }).ToList();
+                            DayOfBirth = x.Birthday.Day,
+                            MonthOfBirth = x.Birthday.Month,
+                            Age = DateTime.Today.Year - x.Birthday.Year
+                        })
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_7_async
+                    var projectedResults = await asyncSession
+                        .Query<Employees_ByFirstNameAndBirthday.IndexEntry, Employees_ByFirstNameAndBirthday>()
+                        .Select(x => new
+                        {
+                            DayOfBirth = x.Birthday.Day,
+                            MonthOfBirth = x.Birthday.Month,
+                            Age = DateTime.Today.Year - x.Birthday.Year
+                        })
+                        .ToListAsync();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region projections_8
-                    var results = session
-                        .Query<Employee, Employees_ByFirstAndLastName>()
-                        .Select(e => new
+                    var projectedResults = session
+                        .Query<Employees_ByFirstNameAndBirthday.IndexEntry, Employees_ByFirstNameAndBirthday>()
+                        .Select(x => new
                         {
-                            Name = e.FirstName,
-                            Metadata = RavenQuery.Metadata(e),
+                            // Provide a JavaScript expression to the RavenQuery.Raw method
+                            Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(x.Birthday))"),
+                            Name = RavenQuery.Raw(x.FirstName, "substr(0,3)")
                         })
                         .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_8_async
+                    var projectedResults = await asyncSession
+                        .Query<Employees_ByFirstNameAndBirthday.IndexEntry, Employees_ByFirstNameAndBirthday>()
+                        .Select(x => new
+                        {
+                            // Provide a JavaScript expression to the RavenQuery.Raw method
+                            Date = RavenQuery.Raw<DateTime>("new Date(Date.parse(x.Birthday))"),
+                            Name = RavenQuery.Raw(x.FirstName, "substr(0,3)")
+                        })
+                        .ToListAsync();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region projections_9
-                    var results = session
-                        .Query<Order, Orders_ByShipToAndLines>()
+                    var projectedResults = session
+                        .Query<Employees_ByFirstNameAndBirthday.IndexEntry, Employees_ByFirstNameAndBirthday>()
                         .Select(x => new
                         {
-                            Total = x.Lines.Sum(l => l.PricePerUnit * l.Quantity)
-
+                            Name = x.FirstName,
+                            Metadata = RavenQuery.Metadata(x) // Get the metadata
                         })
                         .ToList();
                     #endregion
                 }
-
-                using (var session = store.OpenSession())
+                
+                using (var asyncSession = store.OpenAsyncSession())
                 {
-                    #region selectfields_1
-                    var fields = new string[]{
-                        "Name",
-                        "Phone"
-                    };
-
-                    var results = session
-                        .Advanced
-                        .DocumentQuery<Company, Companies_ByContact>()
-                        .SelectFields<ContactDetails>(fields)
-                        .ToList();
-                    #endregion
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    #region selectfields_2
-                        var results = session
-                        .Advanced
-                        .DocumentQuery<Company, Companies_ByContact>()
-                        .SelectFields<ContactDetails>()
-                        .ToList();
+                    #region projections_9_async
+                    var projectedResults = await asyncSession
+                        .Query<Employees_ByFirstNameAndBirthday.IndexEntry, Employees_ByFirstNameAndBirthday>()
+                        .Select(x => new
+                        {
+                            Name = x.FirstName,
+                            Metadata = RavenQuery.Metadata(x) // Get the metadata
+                        })
+                        .ToListAsync();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region projections_10
-                    var results = session.Query<Company, Companies_ByContact>()
+                    var projectedResults = session
+                        .Query<Companies_ByContactDetailsAndPhone.IndexEntry, Companies_ByContactDetailsAndPhone>()
+                        .Where(x => x.ContactTitle == "owner")
+                         // Call 'ProjectInto' instead of using 'Select'
+                         // Pass the projection class
                         .ProjectInto<ContactDetails>()
                         .ToList();
+                    
+                    // Each resulting object in the list is Not a 'Company' entity,
+                    // it is an object of type 'ContactDetails'.
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_10_async
+                    var projectedResults = await asyncSession
+                        .Query<Companies_ByContactDetailsAndPhone.IndexEntry, Companies_ByContactDetailsAndPhone>()
+                        .Where(x => x.ContactTitle == "owner")
+                         // Call 'ProjectInto' instead of using 'Select'
+                         // Pass the projection class
+                        .ProjectInto<ContactDetails>()
+                        .ToListAsync();
+                    
+                    // Each resulting object in the list is Not a 'Company' entity,
+                    // it is an object of type 'ContactDetails'.
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_11
+                    // Query an index with DocumentQuery
+                    var projectedResults = session.Advanced
+                        .DocumentQuery<Products_ByNamePriceQuantityAndUnits.IndexEntry,
+                            Products_ByNamePriceQuantityAndUnits>()
+                         // Call 'SelectFields'
+                         // Pass the projection class type
+                        .SelectFields<ProductDetails>()
+                        .ToList();
+                    
+                    // Each resulting object in the list is Not a 'Product' entity,
+                    // it is an object of type 'ProductDetails'.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_11_async
+                    // Query an index with DocumentQuery
+                    var projectedResults = await asyncSession.Advanced
+                        .AsyncDocumentQuery<Products_ByNamePriceQuantityAndUnits.IndexEntry, 
+                            Products_ByNamePriceQuantityAndUnits>()
+                         // Call 'SelectFields'
+                         // Pass the projection class type
+                        .SelectFields<ProductDetails>()
+                        .ToListAsync();
+                    
+                    // Each resulting object in the list is Not a 'Product' entity,
+                    // it is an object of type 'ProductDetails'.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region projections_12
+                    // Define an array with the field names that will be projected
+                    var fields = new string[] {
+                        "ProductName",
+                        "PricePerUnit"
+                    };
+                    
+                    // Query an index with DocumentQuery
+                    var projectedResults = session.Advanced
+                        .DocumentQuery<Companies_ByContactDetailsAndPhone.IndexEntry,
+                            Companies_ByContactDetailsAndPhone>()
+                         // Call 'SelectFields'
+                         // Pass the projection class type & the fields to be projected from it
+                        .SelectFields<ProductDetails>(fields)
+                        .ToList();
+                    
+                    // Each resulting object in the list is Not a 'Product' entity,
+                    // it is an object of type 'ProductDetails' containing data ONLY for the specified fields.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_12_async
+                    // Define an array with the field names that will be projected
+                    var fields = new string[] {
+                        "ProductName",
+                        "PricePerUnit"
+                    };
+                    
+                    // Query an index with DocumentQuery
+                    var projectedResults = await asyncSession.Advanced
+                        .AsyncDocumentQuery<Companies_ByContactDetailsAndPhone.IndexEntry,
+                            Companies_ByContactDetailsAndPhone>()
+                         // Call 'SelectFields'
+                         // Pass the projection class type & the fields to be projected from it
+                        .SelectFields<ProductDetails>(fields)
+                        .ToListAsync();
+                    
+                    // Each resulting object in the list is Not a 'Product' entity,
+                    // it is an object of type 'ProductDetails' containing data ONLY for the specified fields.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region projections_13_1
+                    var projectedResults = session
+                        .Query<Employees_ByNameAndTitleWithStoredFields.IndexEntry,
+                            Employees_ByNameAndTitleWithStoredFields>()
+                         // Call 'Customize'
+                         // Pass the requested projection behavior to the 'Projection' method
+                        .Customize(x => x.Projection(ProjectionBehavior.FromIndexOrThrow))
+                         // Select the fields that will be returned by the projection
+                        .Select(x => new EmployeeDetails
+                        {
+                            FirstName = x.FirstName,
+                            Title = x.Title
+                        })
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region projections_13_2
+                    var projectedResults = session.Advanced
+                        .DocumentQuery<Employees_ByNameAndTitleWithStoredFields.IndexEntry,
+                            Employees_ByNameAndTitleWithStoredFields>()
+                         // Pass the requested projection behavior to the 'SelectFields' method
+                         // and specify the field that will be returned by the projection
+                        .SelectFields<EmployeeDetails>(ProjectionBehavior.FromIndexOrThrow)
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region projections_13_3
+                    var projectedResults = session.Advanced
+                        // Define an RQL query that returns a projection
+                        .RawQuery<EmployeeDetails>(
+                            @"from index 'Employees/ByNameAndTitleWithStoredFields' select FirstName, Title")
+                        // Pass the requested projection behavior to the 'Projection' method
+                        .Projection(ProjectionBehavior.FromIndexOrThrow)
+                        .ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region projections_14
+                    List<Company> results = session
+                        .Query<Companies_ByContactDetailsAndPhone.IndexEntry, Companies_ByContactDetailsAndPhone>()
+                         // Here we filter by an IndexEntry field,
+                         // The compiler recognizes 'x' as an IndexEntry type
+                        .Where(x => x.ContactTitle == "owner")
+                         // Here we let the compiler know that results are of type 'Company' documents
+                        .OfType<Company>()
+                        .ToList();
+                    #endregion
+                }
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region projections_14_async
+                    List<Company> results = await asyncSession
+                        .Query<Companies_ByContactDetailsAndPhone.IndexEntry, Companies_ByContactDetailsAndPhone>()
+                         // Here we filter by an IndexEntry field,
+                         // The compiler recognizes 'x' as an IndexEntry type
+                        .Where(x => x.ContactTitle == "owner")
+                         // Here we let the compiler know that results are of type 'Company' documents
+                        .OfType<Company>()
+                        .ToListAsync();
                     #endregion
                 }
             }
         }
+        
+        private interface IFoo
+        {
+            #region projection_behavior syntax
+            // For Query:
+            IDocumentQueryCustomization Projection(ProjectionBehavior projectionBehavior);
+
+            // For DocumentQuery:
+            IDocumentQuery<TProjection> SelectFields<TProjection>(
+                ProjectionBehavior projectionBehavior, params string[] fields);
+
+            IDocumentQuery<TProjection> SelectFields<TProjection>(
+                ProjectionBehavior projectionBehavior);
+
+            // Projection behavior options:
+            public enum ProjectionBehavior {
+                Default,
+                FromIndex,
+                FromIndexOrThrow,
+                FromDocument,
+                FromDocumentOrThrow
+            }
+            #endregion
+        }
     }
 
-    #region index_10
-    public class Companies_ByContact : AbstractIndexCreationTask<Company>
+    #region index_1
+    public class Employees_ByNameAndTitle : AbstractIndexCreationTask<Employee>
     {
-        public Companies_ByContact()
+        public class IndexEntry
         {
-            Map = companies => companies
-                .Select(x => new
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            public string Title { get; set; }
+        }
+        
+        public Employees_ByNameAndTitle()
+        {
+            Map = employees => from employee in employees
+                
+                select new IndexEntry
                 {
-                    Name = x.Contact.Name,
-                    x.Phone
-                });
-
-            StoreAllFields(FieldStorage.Yes); // Name and Phone fields can be retrieved directly from index
+                    FirstName = employee.FirstName,
+                    LastName = employee.LastName,
+                    Title = employee.Title
+                };
         }
     }
     #endregion
 
-    #region projections_10_class
+    #region index_1_stored
+    public class Employees_ByNameAndTitleWithStoredFields : AbstractIndexCreationTask<Employee>
+    {    
+        public class IndexEntry
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            public string Title { get; set; }
+        }
+        
+        public Employees_ByNameAndTitleWithStoredFields()
+        {
+            Map = employees => from employee in employees
+                select new IndexEntry
+                {
+                    FirstName = employee.FirstName,
+                    LastName = employee.LastName,
+                    Title = employee.Title
+                };
+            
+            // Store some fields in the index:
+            Stores.Add(x => x.FirstName, FieldStorage.Yes);
+            Stores.Add(x => x.LastName, FieldStorage.Yes);
+        }
+    }
+    #endregion
+    
+    #region projections_class_1
+    public class EmployeeDetails
+    {
+        public string FirstName { get; set; } 
+        public string Title { get; set; }
+    }
+    #endregion
+    
+    #region index_2
+    public class Orders_ByCompanyAndShipToAndLines : AbstractIndexCreationTask<Order>
+    {
+        public class IndexEntry
+        {
+            public string Company { get; set; }
+            public Address ShipTo { get; set; }
+            public List<OrderLine> Lines { get; set; }
+        }
+        
+        public Orders_ByCompanyAndShipToAndLines()
+        {
+            Map = orders => from order in orders
+                select new IndexEntry
+                {
+                    Company = order.Company,
+                    ShipTo = order.ShipTo,
+                    Lines = order.Lines
+                };
+        }
+    }
+    
+    // public class Address
+    // {
+    //     public string Line1 { get; set; }
+    //     public string Line2 { get; set; }
+    //     public string City { get; set; }
+    //     public string Region { get; set; }
+    //     public string PostalCode { get; set; }
+    //     public string Country { get; set; }
+    //     public Location Location { get; set; }
+    // }
+
+    // public class OrderLine
+    // {
+    //     public string Product { get; set; }
+    //     public string ProductName { get; set; }
+    //     public decimal PricePerUnit { get; set; }
+    //     public int Quantity { get; set; }
+    //     public decimal Discount { get; set; }
+    // }
+    #endregion
+    
+    #region index_3
+    public class Orders_ByCompanyAndShippedAt : AbstractIndexCreationTask<Order>
+    {
+        public class IndexEntry
+        {
+            public string Company { get; set; }
+            public DateTime? ShippedAt { get; set; }
+        }
+        
+        public Orders_ByCompanyAndShippedAt()
+        {
+            Map = orders => from order in orders
+                
+                select new IndexEntry
+                {
+                    Company = order.Company,
+                    ShippedAt = order.ShippedAt
+                };
+        }
+    }
+    #endregion
+    
+    #region index_4
+    public class Employees_ByFirstNameAndBirthday : AbstractIndexCreationTask<Employee>
+    {
+        public class IndexEntry
+        {
+            public string FirstName { get; set; }
+            public DateTime Birthday { get; set; }
+        }
+        
+        public Employees_ByFirstNameAndBirthday()
+        {
+            Map = employees => from employee in employees
+                
+                select new IndexEntry
+                {
+                    FirstName = employee.FirstName,
+                    Birthday = employee.Birthday
+                };
+        }
+    }
+    #endregion
+    
+    #region index_5
+    public class Companies_ByContactDetailsAndPhone : AbstractIndexCreationTask<Company>
+    {
+        public class IndexEntry
+        {
+            public string ContactName { get; set; }
+            public string ContactTitle { get; set; }
+            public string Phone { get; set; }
+        }
+        
+        public Companies_ByContactDetailsAndPhone()
+        {
+            Map = companies => companies
+                .Select(x => new IndexEntry
+                {
+                    ContactName = x.Contact.Name,
+                    ContactTitle = x.Contact.Title,
+                    Phone = x.Phone
+                });
+        }
+    }
+    #endregion
+
+    #region projections_class_5
     public class ContactDetails
     {
-        public string Name { get; set; }
-
-        public string Phone { get; set; }
+        // The projection class contains field names from the index-fields
+        public string ContactName { get; set; }
+        public string ContactTitle { get; set; }
+    }
+    #endregion
+    
+    #region index_6
+    public class Products_ByNamePriceQuantityAndUnits : AbstractIndexCreationTask<Product>
+    {
+        public class IndexEntry
+        {
+            public string ProductName { get; set; }
+            public string QuantityPerUnit { get; set; }
+            public decimal PricePerUnit { get; set; }
+            public int UnitsInStock { get; set; }
+            public int UnitsOnOrder { get; set; }
+        }
+        
+        public Products_ByNamePriceQuantityAndUnits()
+        {
+            Map = products => from product in products
+                
+                select new IndexEntry
+                {
+                    ProductName = product.Name,
+                    QuantityPerUnit = product.QuantityPerUnit,
+                    PricePerUnit = product.PricePerUnit,
+                    UnitsInStock = product.UnitsInStock,
+                    UnitsOnOrder = product.UnitsOnOrder
+                };
+        }
+    }
+    #endregion
+    
+    #region projections_class_6
+    public class ProductDetails
+    {
+        // The projection class contains field names from the index-fields
+        public string ProductName { get; set; }
+        public decimal PricePerUnit { get; set; }
+        public int UnitsInStock { get; set; }
     }
     #endregion
 }

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Querying/HowToProjectQueryResults.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Querying/HowToProjectQueryResults.java
@@ -1,0 +1,221 @@
+package net.ravendb.ClientApi.Session.Querying;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.FieldStorage;
+import net.ravendb.client.documents.queries.Query;
+import net.ravendb.client.documents.queries.QueryData;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.List;
+
+public class HowToProjectQueryResults {
+
+    private static class Company {
+
+    }
+
+    private static class Order {
+
+    }
+
+    private static class Employee {
+
+    }
+    private static class Total {
+
+    }
+
+    private static class NameCityAndCountry {
+    }
+
+    private static class ShipToAndProducts {
+
+    }
+
+    private static class Product {
+
+    }
+
+    private static class OrderProjection {
+
+    }
+
+    private static class EmployeeProjection {
+
+    }
+
+    private static class FullName {
+        private String fullName;
+
+        public String getFullName() {
+            return fullName;
+        }
+
+        public void setFullName(String fullName) {
+            this.fullName = fullName;
+        }
+    }
+
+    public void examples() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_1
+                // request name, city and country for all entities from 'Companies' collection
+                QueryData queryData = new QueryData(
+                    new String[] { "Name", "Address.city", "Address.country"},
+                    new String[] { "Name", "City", "Country"});
+                List<NameCityAndCountry> results = session
+                    .query(Company.class)
+                    .selectFields(NameCityAndCountry.class, queryData)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_2
+                QueryData queryData = new QueryData(new String[]{ "ShipTo", "Lines[].ProductName" },
+                    new String[]{"ShipTo", "Products"});
+
+                List<ShipToAndProducts> results = session.query(Order.class)
+                    .selectFields(ShipToAndProducts.class, queryData)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_3
+                List<FullName> results = session.advanced().rawQuery(FullName.class, "from Employees as e " +
+                    "select {" +
+                    "    FullName : e.FirstName + \" \" + e.LastName " +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_4
+                List<Total> results = session.advanced().rawQuery(Total.class, "from Orders as o " +
+                    "select { " +
+                    "    Total : o.Lines.reduce( " +
+                    "        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0) " +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_5
+                List<OrderProjection> results = session.advanced().rawQuery(OrderProjection.class, "from Orders as o " +
+                    "load o.Company as c " +
+                    "select { " +
+                    "    CompanyName: c.Name," +
+                    "    ShippedAt: o.ShippedAt" +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_6
+                List<EmployeeProjection> results = session.advanced().rawQuery(EmployeeProjection.class, "from Employees as e " +
+                    "select { " +
+                    "    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), " +
+                    "    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1, " +
+                    "    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() " +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_7
+                List<EmployeeProjection> results = session.advanced().rawQuery(EmployeeProjection.class, "from Employees as e " +
+                    "select { " +
+                    "    Date : new Date(Date.parse(e.Birthday)), " +
+                    "    Name : e.FirstName.substr(0,3) " +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_8
+                List<ContactDetails> results = session.query(Company.class, Companies_ByContact.class)
+                    .selectFields(ContactDetails.class)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_10
+                // query index 'Products_BySupplierName'
+                // return documents from collection 'Products' that have a supplier 'Norske Meierier'
+                // project them to 'Products'
+                List<Product> results = session.query(Products_BySupplierName.Result.class, Products_BySupplierName.class)
+                    .whereEquals("Name", "Norske Meierier")
+                    .ofType(Product.class)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_12
+                List<Employee> results = session.advanced().rawQuery(Employee.class, "declare function output(e) { " +
+                    "    var format = function(p){ return p.FirstName + \" \" + p.LastName; }; " +
+                    "    return { FullName : format(e) }; " +
+                    "} " +
+                    "from Employees as e select output(e)").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_13
+                List<Employee> results = session.advanced().rawQuery(Employee.class, "from Employees as e " +
+                    "select {" +
+                    "     Name : e.FirstName, " +
+                    "     Metadata : getMetadata(e)" +
+                    "}").toList();
+                //endregion
+            }
+        }
+    }
+
+    //region projections_9_0
+    private class Companies_ByContact extends AbstractIndexCreationTask {
+        public Companies_ByContact() {
+
+            map = "from c in docs.Companies select new  { Name = c.Contact.Name, Phone = c.Phone } ";
+
+            storeAllFields(FieldStorage.YES); // name and phone fields can be retrieved directly from index
+        }
+    }
+    //endregion
+
+    //region projections_9_1
+    public static class ContactDetails {
+        private String name;
+        private String phone;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getPhone() {
+            return phone;
+        }
+
+        public void setPhone(String phone) {
+            this.phone = phone;
+        }
+    }
+    //endregion
+
+    //region projections_11
+    public static class Products_BySupplierName extends AbstractIndexCreationTask {
+        public static class Result {
+        }
+
+    }
+    //endregion
+}

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Projections.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Projections.java
@@ -1,0 +1,216 @@
+package net.ravendb.Indexes.Querying;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.FieldStorage;
+import net.ravendb.client.documents.queries.QueryData;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.List;
+
+public class Projections {
+
+    private static class Employee {
+
+    }
+
+    private static class EmployeeProjection {
+
+    }
+
+    private static class FirstAndLastName {
+
+    }
+
+    private static class ShipToAndProducts {
+
+    }
+
+    private static class OrderProjection {
+
+    }
+
+    private static class Order {
+
+    }
+
+    private static class Total {
+
+    }
+
+    private static class FullName {
+        private String fullName;
+
+        public String getFullName() {
+            return fullName;
+        }
+
+        public void setFullName(String fullName) {
+            this.fullName = fullName;
+        }
+    }
+
+    //region indexes_1
+    public static class Employees_ByFirstAndLastName extends AbstractIndexCreationTask {
+        public Employees_ByFirstAndLastName() {
+            map = "docs.Employees.Select(employee => new {" +
+                "    FirstName = employee.FirstName," +
+                "    LastName = employee.LastName" +
+                "})";
+        }
+    }
+    //endregion
+
+    //region indexes_1_stored
+    public static class Employees_ByFirstAndLastNameWithStoredFields extends AbstractIndexCreationTask {
+        public Employees_ByFirstAndLastNameWithStoredFields() {
+            map = "docs.Employees.Select(employee => new {" +
+                "    FirstName = employee.FirstName," +
+                "    LastName = employee.LastName" +
+                "})";
+
+            storeAllFields(FieldStorage.YES); // firstName and lastName fields can be retrieved directly from index
+        }
+    }
+    //endregion
+
+    //region indexes_2
+    public static class Employees_ByFirstNameAndBirthday extends AbstractIndexCreationTask {
+        public Employees_ByFirstNameAndBirthday() {
+            map = "docs.Employees.Select(employee => new {" +
+                "    FirstName = employee.FirstName," +
+                "    Birthday = employee.Birthday" +
+                "})";
+        }
+    }
+    //endregion
+
+    //region indexes_3
+    public static class Orders_ByShipToAndLines extends AbstractIndexCreationTask {
+        public Orders_ByShipToAndLines() {
+            map = "docs.Orders.Select(order => new {" +
+                "    ShipTo = order.ShipTo," +
+                "    Lines = order.Lines" +
+                "})";
+        }
+    }
+    //endregion
+
+    //region indexes_4
+    public static class Orders_ByShippedAtAndCompany extends AbstractIndexCreationTask {
+        public Orders_ByShippedAtAndCompany() {
+            map = "docs.Orders.Select(order => new {" +
+                "    ShippedAt = order.ShippedAt," +
+                "    Company = order.Company" +
+                "})";
+        }
+    }
+    //endregion
+
+
+    public Projections() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_1
+                List<FirstAndLastName> results = session
+                    .query(Employee.class, Employees_ByFirstAndLastName.class)
+                    .selectFields(FirstAndLastName.class, "FirstName", "LastName")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_1_stored
+                List<FirstAndLastName> results = session
+                    .query(Employee.class, Employees_ByFirstAndLastNameWithStoredFields.class)
+                    .selectFields(FirstAndLastName.class, "FirstName", "LastName")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_2
+                QueryData queryData = new QueryData(new String[]{"ShipTo", "Lines[].ProductName"},
+                    new String[]{"ShipTo", "Products"});
+
+                List<ShipToAndProducts> results = session.query(Order.class)
+                    .selectFields(ShipToAndProducts.class, queryData)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_3
+                List<FullName> results = session.advanced().rawQuery(FullName.class, "from Employees as e " +
+                    "select {" +
+                    "    FullName : e.FirstName + \" \" + e.LastName " +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_4
+                List<Employee> results = session.advanced().rawQuery(Employee.class, "declare function output(e) { " +
+                    "    var format = function(p){ return p.FirstName + \" \" + p.LastName; }; " +
+                    "    return { FullName : format(e) }; " +
+                    "} " +
+                    "from Employees as e select output(e)").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_5
+                List<OrderProjection> results = session.advanced().rawQuery(OrderProjection.class, "from Orders as o " +
+                    "load o.company as c " +
+                    "select { " +
+                    "    CompanyName: c.Name," +
+                    "    ShippedAt: o.ShippedAt" +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_6
+                List<EmployeeProjection> results = session.advanced().rawQuery(EmployeeProjection.class, "from Employees as e " +
+                    "select { " +
+                    "    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(), " +
+                    "    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1, " +
+                    "    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() " +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_7
+                List<EmployeeProjection> results = session.advanced().rawQuery(EmployeeProjection.class, "from Employees as e " +
+                    "select { " +
+                    "    Date : new Date(Date.parse(e.Birthday)), " +
+                    "    Name : e.FirstName.substr(0,3) " +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_8
+                List<Employee> results = session.advanced().rawQuery(Employee.class, "from Employees as e " +
+                    "select {" +
+                    "     Name : e.FirstName, " +
+                    "     Metadata : getMetadata(e)" +
+                    "}").toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region projections_9
+                List<Total> results = session.advanced().rawQuery(Total.class, "from Orders as o " +
+                    "select { " +
+                    "    Total : o.Lines.reduce( " +
+                    "        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0) " +
+                    "}").toList();
+                //endregion
+            }
+
+        }
+    }
+}

--- a/Documentation/6.0/Samples/nodejs/client-api/session/querying/howToProjectQueryResults.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/session/querying/howToProjectQueryResults.js
@@ -1,0 +1,190 @@
+import * as assert from "assert";
+import {DocumentStore, QueryData, AbstractCsharpIndexCreationTask} from "ravendb";
+
+class Product { }
+class Companies { }
+class Orders { }
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+async function examples() {
+    {
+        //region projections_1
+        // request name, city and country for all entities from 'Companies' collection
+        const queryData = new QueryData(
+            [ "Name", "Address.City", "Address.Country"],
+            [ "Name", "City", "Country"]);
+        const results = await session
+            .query(Companies)
+            .selectFields(queryData, Companies)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_2
+        const queryData = new QueryData(
+            [ "ShipTo", "Lines[].ProductName" ],
+            [ "ShipTo", "Products" ]);
+
+        const results = await session.query(Orders)
+            .selectFields(queryData, Orders)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_3
+        const results = await session.advanced
+            .rawQuery(
+            `from Employees as e select {
+                FullName: e.FirstName + " " + e.LastName 
+            }`)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_4
+        const results = await session.advanced
+            .rawQuery(`from Orders as o select { 
+                Total : o.Lines.reduce( 
+                    (acc , l) => 
+                        acc += l.PricePerUnit * l.Quantity, 0) 
+            }`)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_5
+        const results = await session.advanced
+            .rawQuery(`from Orders as o 
+            load o.Company as c 
+            select { 
+                CompanyName: c.Name,
+                ShippedAt: o.ShippedAt
+            }`)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_6
+        const results = await session.advanced
+            .rawQuery(
+                `from Employees as e 
+                select { 
+                    DayOfBirth: new Date(Date.parse(e.Birthday)).getDate(), 
+                    MonthOfBirth: new Date(Date.parse(e.Birthday)).getMonth() + 1, 
+                    Age: new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+                }`)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_7
+        const results = session.advanced
+            .rawQuery(
+                `from Employees as e 
+                select { 
+                    Date : new Date(Date.parse(e.Birthday)), 
+                    Name : e.FirstName.substr(0,3) 
+                }`)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_8
+        const results = await session.query({ indexName: "Companies/ByContact" })
+            .selectFields([ "Name", "Phone" ])
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_10
+        // query index 'Products_BySupplierName'
+        // return documents from collection 'Products' that have a supplier 'Norske Meierier'
+        // project them to instance of Product
+        const results = await session.query({ indexName: "Products/BySupplierName" })
+            .whereEquals("Name", "Norske Meierier")
+            .ofType(Product)
+            .all();
+        assert.ok(results[0] instanceof Product);
+        //endregion
+    }
+
+    {
+        //region projections_12
+        const results = await session.advanced
+            .rawQuery(
+                `declare function output(e) { 
+                    var format = function(p){ return p.FirstName + " " + p.LastName; }; 
+                    return { FullName : format(e) }; 
+                } 
+                from Employees as e select output(e)`)
+            .all();
+        //endregion
+    }
+
+    {
+        //region projections_13
+        const results = await session.advanced
+            .rawQuery(
+                `from Employees as e 
+                select {
+                     Name : e.FirstName, 
+                     Metadata : getMetadata(e)
+                }`)
+            .all();
+        //endregion
+    }
+
+    //region projections_9_0
+    class Companies_ByContact extends AbstractCsharpIndexCreationTask {
+        constructor() {
+            super();
+            this.map = `docs.Company.Select(company => new {    
+                                Name = company.Contact.Name,    
+                                Phone = company.Phone
+                            })`;
+            this.storeAllFields("Yes"); // name and phone fields can be retrieved directly from index
+        }
+    }
+    //endregion
+
+    //region projections_9_1
+    class ContactDetails {
+        constructor(name, phone) {
+            this.name = name;
+            this.phone = phone;
+        }
+    }
+    //endregion
+
+    //region projections_11
+    class Products_BySupplierName_Result { }
+
+    class Products_BySupplierName extends AbstractCsharpIndexCreationTask { }
+    //endregion
+
+    {
+        //region index_10
+        class Companies_ByContact  extends AbstractCsharpIndexCreationTask {
+            constructor() {
+                super();
+
+                this.map = `docs.Company.Select(company => new {    
+                                Name = company.Contact.Name,    
+                                Phone = company.Phone
+                            })`;
+            }
+        }
+        //endregion
+    }
+
+}

--- a/Documentation/6.0/Samples/nodejs/indexes/querying/projections.js
+++ b/Documentation/6.0/Samples/nodejs/indexes/querying/projections.js
@@ -1,0 +1,231 @@
+import {
+    DocumentStore,
+    AbstractIndexCreationTask,
+    MoreLikeThisStopWords,
+    QueryData, AbstractCsharpIndexCreationTask
+} from "ravendb";
+
+const store = new DocumentStore('http://127.0.0.1:8080', 'Northwind2');
+const session = store.openSession();
+
+class Employee { }
+
+class EmployeeProjection { }
+
+class FirstAndLastName { }
+
+class ShipToAndProducts { }
+
+class OrderProjection { }
+
+class Company{}
+class ContactDetails{}
+
+class Order { }
+
+class Total { }
+
+class FullName {
+    constructor(fullName) {
+        this.fullName = fullName;
+    }
+}
+
+//region indexes_1
+class Employees_ByFirstAndLastName extends AbstractCsharpIndexCreationTask {
+    constructor() {
+        super();
+
+        this.map = `docs.Employees.Select(employee => new {    
+            FirstName = employee.FirstName,    
+            LastName = employee.LastName
+        })`;
+    }
+}
+//endregion
+
+//region indexes_1_stored
+class Employees_ByFirstAndLastNameWithStoredFields extends AbstractCsharpIndexCreationTask {
+    constructor() {
+        super();
+
+        this.map = `docs.Employees.Select(employee => new {    
+            FirstName = employee.FirstName,    
+            LastName = employee.LastName
+        })`;
+
+        this.storeAllFields("Yes"); // FirstName and LastName fields can be retrieved directly from index
+    }
+}
+//endregion
+
+//region indexes_2
+class Employees_ByFirstNameAndBirthday extends AbstractCsharpIndexCreationTask {
+    constructor() {
+        super();
+
+        this.map = `docs.Employees.Select(employee => new {    
+            FirstName = employee.FirstName,    
+            Birthday = employee.Birthday
+        })`;
+    }
+}
+//endregion
+
+//region indexes_3
+class Orders_ByShipToAndLines extends AbstractCsharpIndexCreationTask {
+    constructor() {
+        super();
+
+        this.map = "docs.Orders.Select(order => new {" +
+            "    ShipTo = order.ShipTo," +
+            "    Lines = order.Lines" +
+            "})";
+    }
+}
+//endregion
+
+//region indexes_4
+class Orders_ByShippedAtAndCompany extends AbstractCsharpIndexCreationTask {
+    constructor() {
+        super();
+
+        this.map = `docs.Orders.Select(order => new {    
+            ShippedAt = order.ShippedAt,    
+            Company = order.Company
+        })`;
+    }
+}
+//endregion
+
+
+async function projections() {
+    
+        {
+            //region projections_1
+            const results = await session
+                .query({ indexName: "Employees/ByFirstAndLastName" })
+                .selectFields([ "FirstName", "LastName" ])
+                .all();
+            //endregion
+        }
+
+        {
+            //region projections_1_stored
+            const results = await session
+                .query({ indexName: "Employees/ByFirstAndLastNameWithStoredFields" })
+                .selectFields("FirstName", "LastName")
+                .all();
+            //endregion
+        }
+
+        {
+            //region projections_2
+            const queryData = new QueryData(
+                [ "ShipTo", "Lines[].ProductName" ],
+                [ "ShipTo", "Products" ]);
+
+            const results = await session.query(Order)
+                .selectFields(queryData, Order)
+                .all();
+            //endregion
+        }
+
+        {
+            //region projections_3
+            const results = await session.advanced.rawQuery(`from Employees as e select {    
+                FullName : e.FirstName + " " + e.LastName 
+            }`).all();
+            //endregion
+        }
+
+        {
+            //region projections_4
+            const results = await session.advanced
+                .rawQuery(`declare function output(e) {     
+                        var format = function(p) { 
+                            return p.FirstName + " " + p.LastName; 
+                        };     
+    
+                        return { FullName : format(e) }; 
+                    } from Employees as e select output(e)`)
+                    .all();
+                    
+            //endregion
+        }
+
+        {
+            //region projections_5
+            const results = await session.advanced
+                .rawQuery(
+                    `from Orders as o load o.Company as c select {     
+                        CompanyName: c.Name,    
+                        ShippedAt: o.ShippedAt
+                    }`).all();
+            //endregion
+        }
+
+        {
+            //region projections_6
+            const results = await session.advanced
+                .rawQuery(
+                `from Employees as e select {     
+                    DayOfBirth : new Date(Date.parse(e.Birthday)).getDate(),     
+                    MonthOfBirth : new Date(Date.parse(e.Birthday)).getMonth() + 1,     
+                    Age : new Date().getFullYear() - new Date(Date.parse(e.Birthday)).getFullYear() 
+                    }`).all();
+            //endregion
+        }
+
+        {
+            //region projections_7
+            const results = await session.advanced
+                .rawQuery(
+                    `from Employees as e select {     
+                        Date : new Date(Date.parse(e.Birthday)),     
+                        Name : e.FirstName.substr(0,3) 
+                    }`).all();
+            //endregion
+        }
+
+        {
+            //region projections_8
+            const results = await session.advanced
+                .rawQuery(`from Employees as e select {     
+                    Name : e.FirstName,      
+                    Metadata : getMetadata(e)
+                }`).all();
+            //endregion
+        }
+
+        {
+            //region projections_9
+            const results = await session.advanced.rawQuery(
+                `from Orders as o select {     
+                    Total: o.Lines.reduce(
+                        (acc , l) => acc += l.PricePerUnit * l.Quantity, 0) 
+                    }`).all();
+            //endregion
+        }
+}
+
+{
+
+    {
+        //region index_10
+        class Companies_ByContact  extends AbstractCsharpIndexCreationTask {
+            constructor() {
+                super();
+
+                this.map = `docs.Company.select(company => new {    
+                    Name = company.Contact.Name,    
+                    Phone = company.Phone
+                })`;
+            }
+        }
+        //endregion
+    }
+
+    //region
+}
+


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2535/Cannot-project-twice-when-making-a-query

@maciejaszyk - Files to review:

**Dynamic query projections:**
Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-project-query-results.dotnet.markdown
Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToProjectQueryResults.cs

**Index query projections:**
Documentation/6.0/Raven.Documentation.Pages/indexes/querying/projections.dotnet.markdown
Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Projections.cs

Note:
1. *.js and *.java files were only "copied over" to the 6.0 directory so they are visible as well - so no need to review them for now
2. Node.js fixes will be applied in issue: 
    https://issues.hibernatingrhinos.com/issue/RDoc-2245/Node.js-projectInto-in-Node.js-fix-article
