### PR TITLE
RDoc-2523 Add relevant Corax information in the Sorting article

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/server/configuration/configuration-options.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/server/configuration/configuration-options.markdown
@@ -1,0 +1,145 @@
+# Configuration Overview
+
+---
+
+{NOTE: }
+
+* RavenDB comes with default settings that are configured for best results.  
+  If needed, you can customize the default configuration to suit your specific needs.
+
+* Any __configuration key__ can be modified by either of the following options:
+    * [Environment variables](../../server/configuration/configuration-options#environment-variables)
+    * [settings.json](../../server/configuration/configuration-options#settings.json)
+    * [Command line arguments](../../server/configuration/configuration-options#command-line-arguments)
+    * [Database settings view](../../server/configuration/configuration-options#database-settings-view) (database scope only)
+
+{NOTE/}
+
+{PANEL: Environment variables}
+
+{NOTE: }
+
+* To set a configuration key as an environment variable:
+
+    * Add the prefix `RAVEN_` to the configuration key name
+    * Replace all period characters (`.`) with the underscore character (`_`)
+
+* The server will retrieve these environment variables and apply their values.
+
+{NOTE/}
+
+{NOTE: }
+
+__Example__:
+
+* To set configuration key [Security.Certificate.Path](../../server/configuration/security-configuration#security.certificate.path) from an environment variable,  
+  add the environment variable `RAVEN_Security_Certificate_Path`.
+
+{CODE-BLOCK:plain}
+// In Windows PowerShell:
+$Env:RAVEN_Security_Certificate_Path=/config/raven-server.certificate.pfx
+
+// This will set the path to your .pfx certificate file
+{CODE-BLOCK/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: settings.json}
+
+{INFO: }
+_settings.json_ configuration values **override** their matching [environment variables](../../server/configuration/configuration-options#environment-variables) values.
+{INFO/}
+
+{NOTE: }
+
+* The `settings.json` file is created by RavenDB when running the server for the first time,  
+  duplicating the `settings.default.json` file located in the same directory as the server executable.
+
+* If you want to apply configuration keys to _settings.json_ prior to running the server for the first time,  
+  you can manually copy _settings.default.json_ to _settings.json_ and make your changes there.
+
+* The file is read and applied only on server startup.
+
+* To set a configuration key from _settings.json_ simply add the key and its value to the file.
+
+{NOTE/}
+
+{NOTE: }
+
+__Example__:
+
+{CODE-BLOCK:json}
+{
+"ServerUrl": "http://127.0.0.1:8080",
+"Setup.Mode": "None",
+"License.Path": "D:\\RavenDB\\Server\\license.json"
+}
+{CODE-BLOCK/}
+
+__JSON Arrays__
+
+Configuration options that include multiple values (like strings separated by `;`)  
+can be configured using regular JSON arrays.  
+For example, to set [Security.WellKnownCertificates.Admin](../../server/configuration/security-configuration#security.wellknowncertificates.admin) use:
+
+{CODE-BLOCK:json}
+{
+"Security.WellKnownCertificates.Admin" : [ "297430d6d2ce259772e4eccf97863a4dfe6b048c", "e6a3b45b062d509b3382282d196efe97d5956ccb" ]
+}
+{CODE-BLOCK/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Command line arguments}
+
+{INFO: }
+Command line arguments configuration values **override** their matching  
+[environment variables](../../server/configuration/configuration-options#environment-variables) and [settings.json](../../server/configuration/configuration-options#settings.json) values.  
+{INFO/}
+
+{NOTE: }
+
+* The server can be configured using command line arguments that are passed to the console application  
+  (or while running as a daemon).
+
+* Find additional details about Command Line Arguments [here](../../server/configuration/command-line-arguments).
+
+{NOTE/}
+
+{NOTE: }
+
+__Example__:
+
+{CODE-BLOCK:bash}
+./Raven.Server --Setup.Mode=None
+{CODE-BLOCK/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Database settings view}
+
+{NOTE: }
+
+* When the server is up and running, you can modify configuration keys that are in the __database scope__ from the [Database settings view](../../studio/database/settings/database-settings) in the Studio.
+
+* After modifying a database configuration key from this view, the database must be [reloaded](../../studio/database/settings/database-settings#how-to-reload-the-database) for the change to take effect.
+
+{NOTE/}
+
+{PANEL/}
+
+## Related articles
+
+### Configuration
+
+- [Command Line Arguments](../../server/configuration/command-line-arguments)
+
+### Administration
+
+- [Command Line Interface (CLI)](../../server/administration/cli)

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/database/settings/database-settings.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/database/settings/database-settings.markdown
@@ -4,12 +4,10 @@
 
 {NOTE: }
 
-* The **Database Settings View** lists all the database and server configuration keys & values.  
+* The __Database Settings View__ lists all the database and server configuration keys & values.  
 
-* Only the **database scope** configuration keys can be edited from this view.  
-  Configuration keys that relate only to the **server scope** are edited in the 
-  [`settings.json` file](../../../server/configuration/configuration-options#settings.json) 
-  and can only be viewed here.  
+* In this view, you can only edit the __database-scope__ configuration keys. __Server-scope__ keys are read-only.  
+  To edit a server-scope key follow any of the available options listed in the [Configuration overview](../../../server/configuration/configuration-options) article.  
 
 * After editing & saving a configuration key, the change does not take effect 
   until the database is [reloaded](../../../studio/database/settings/database-settings#how-to-reload-the-database).  

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
@@ -1,0 +1,309 @@
+# Sort Query Results
+
+---
+
+{NOTE: }
+
+* When making a query, the server will return the results __sorted__ only if explicitly requested by the query.  
+  If no sorting method is specified when issuing the query then results will not be sorted.
+
+* Sorting is applied by the server after the query filtering stage.  
+  Applying filtering is recommended as it reduces the number of results RavenDB needs to sort  
+  when querying a large dataset.
+
+* Multiple sorting actions can be chained.
+
+* This article provides examples of sorting query results when making a __dynamic-query__.  
+  For sorting results when querying a __static-index__ see [sort index query results](../../../indexes/querying/sorting).
+
+* In this page:
+    * [Order by field value](../../../client-api/session/querying/sort-query-results#order-by-field-value)
+ 
+    * [Order by score](../../../client-api/session/querying/sort-query-results#order-by-score)
+  
+    * [Order by random](../../../client-api/session/querying/sort-query-results#order-by-random)
+   
+    * [Order by spatial](../../../client-api/session/querying/sort-query-results#order-by-spatial)
+     
+    * [Order by count (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-count-(aggregation-query))
+  
+    * [Order by sum (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-sum-(aggregation-query))
+
+    * [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type)
+
+    * [Chain ordering](../../../client-api/session/querying/sort-query-results#chain-ordering)
+
+    * [Custom sorters](../../../client-api/session/querying/sort-query-results#custom-sorters) 
+
+    * [Syntax](../../../client-api/session/querying/sort-query-results#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Order by field value}
+
+* Use `OrderBy` or `OrderByDescending` to order the results by the specified document-field.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_1@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_2@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_3@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+__Ordering Type__:
+
+* By default, the `OrderBy` methods will determine the `OrderingType` from the property path expression  
+  and specify that ordering type in the generated RQL that is sent to the server.  
+
+* E.g. in the above example, ordering by `x => x.UnitsInStock` will result in `OrderingType.Long`  
+  because that property data type is an integer.
+
+* Different ordering can be forced - see [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type) below.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by score}
+
+* When querying with some filtering conditions, a basic score is calculated for each item in the results  
+  by the underlying indexing engine. (Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html)).
+
+* The higher the score value the better the match.  
+
+* Use `OrderByScore` or `OrderByScoreDescending` to order by this score.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_4@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_5@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_6@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock < 5 or Discontinued == true
+order by score()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+__Get resulting score__:
+
+---
+
+* __@Index-score metadata property__:  
+  The score is available in the `@index-score` metadata property within each result.  
+  Learn how to retrieve the resulting score from the metadata in [Get resulting score](../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score).  
+  <br>
+  Note the following difference between the underlying indexing engines:
+
+    * When using __Lucene__:  
+      This metadata property is always available in the results.
+      Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
+
+    * When using __Corax__:  
+      In order to enhance performance, this property is not included in the results by default.  
+      To get this metadata property you must set the `Indexing.Corax.IncludeDocumentScore` configuration value to _true_.
+      Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+
+* __Include explanations__:  
+  Another option to get the score details and see how it was calculated is to request to include explanations in the query.
+  Currently, this is only available when using Lucene.  
+  See [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by random}
+
+* Use `RandomOrdering` to randomize the order of the query results.
+
+* An optional seed parameter can be passed.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_7@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_8@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_9@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by random()
+// order by random(someSeed)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by spatial}
+
+* If your data contains geographical locations,  
+  spatial query results can be sorted based on their distance from a specific point.
+
+* See detailed explanation in [Spatial Sorting](../../../client-api/session/querying/how-to-make-a-spatial-query#spatial-sorting).
+
+{PANEL/}
+
+{PANEL: Order by count (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `Count` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_10@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_11@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_12@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by count() as long
+select key() as "Category", count()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by sum (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `Sum` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_13@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_14@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_15@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by Sum as long
+select key() as 'Category', sum(UnitsInStock) as Sum
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Force ordering type}
+
+* By default, the `OrderBy` methods will determine the `OrderingType` from the property path expression  
+  and specify that ordering type in the generated RQL that is sent to the server.
+
+* A different ordering can be forced by passing the ordering type explicitly to `OrderBy` or `OrderByDescending`.
+
+* The following ordering types are available:
+
+    * `OrderingType.Long`
+    * `OrderingType.Double`
+    * `OrderingType.AlphaNumeric`
+    * `OrderingType.String` (lexicographic ordering)
+
+* When using RQL directly, if no ordering type is specified, then the server defaults to lexicographic ordering.
+
+{NOTE: }
+
+__Using alphanumeric ordering example__:
+
+* When ordering mixed-character strings by the default lexicographical ordering  
+  then comparison is done character by character based on the Unicode values.  
+  For example, "Abc9" will come after "Abc10" since 9 is greater than 1.
+
+* If you want the digit characters to be ordered as numbers then use alphanumeric ordering  
+  where "Abc10" will result after "Abc9".
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_16@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_17@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_18@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+order by QuantityPerUnit as alphanumeric
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{CODE sort_16_results@ClientApi\Session\Querying\SortQueryResults.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Chain ordering}
+
+* It is possible to chain multiple orderings in the query.  
+  Any combination of secondary sorting is possible as the fields are indexed independently of one another.
+
+* There is no limit on the number of sorting actions that can be chained.
+  
+* This is achieved by using the `ThenBy` (`ThenByDescending`) and `ThenByScore` (`ThenByScoreDescending`) methods.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_19@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_20@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_21@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long desc, score(), Name
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Custom sorters }
+
+* The Lucene indexing engine allows you to create your own custom sorters.  
+  Custom sorters are not supported by [Corax](../../../indexes/search-engine/corax).  
+ 
+* Custom sorters can be deployed to the server by either:  
+
+     * Sending the [Put Sorters Operation](../../../client-api/operations/maintenance/sorters/put-sorter) from your code.
+  
+     * Uploading a custom sorter from Studio, see [Custom Sorters View](../../../studio/database/settings/custom-sorters).
+
+* Once the custom sorter is deployed, you can sort the query results with it.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_22@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_23@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_24@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by custom(UnitsInStock, "MySorter")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\Querying\SortQueryResults.cs /}
+
+| Parameter      | Type                          | Description                                                                                                                                                                |
+|----------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| __path__       | `string`                      | The name of the field to sort by                                                                                                                                           |
+| __path__       | `Expression<Func<T, object>>` | A lambda expression to the field by which to sort                                                                                                                          |
+| __ordering__   | `QueryStatistics`             | The ordering type that will be used to sort the results:<br>`OrderingType.Long`<br>`OrderingType.Double`<br>`OrderingType.AlphaNumeric`<br>`OrderingType.String` (default) |
+| __sorterName__ | `string`                      | The name of your custom sorter class                                                                                                                                       |
+
+{PANEL/}
+
+## Related Articles
+
+#### Client API
+
+- [Query Overview](../../../client-api/session/querying/how-to-query)
+
+### Querying
+
+- [Customize query](../../../client-api/session/querying/how-to-customize-query)
+- [Group by query](../../../client-api/session/querying/how-to-perform-group-by-query)
+- [Spatial query](../../../client-api/session/querying/how-to-make-a-spatial-query)
+- [Full-text search](../../../client-api/session/querying/text-search/full-text-search)
+
+### Indexes
+
+- [Sort index query results](../../../indexes/querying/sorting)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
@@ -1,0 +1,285 @@
+# Sort Query Results
+
+---
+
+{NOTE: }
+
+* When making a query, the server will return the results __sorted__ only if explicitly requested by the query.  
+  If no sorting method is specified when issuing the query then results will not be sorted.
+
+* Sorting is applied by the server after the query filtering stage.  
+  Applying filtering is recommended as it reduces the number of results RavenDB needs to sort  
+  when querying a large dataset.
+
+* Multiple sorting actions can be chained.
+
+* This article provides examples of sorting query results when making a __dynamic-query__.  
+  For sorting results when querying a __static-index__ see [sort index query results](../../../indexes/querying/sorting).
+
+* In this page:
+    * [Order by field value](../../../client-api/session/querying/sort-query-results#order-by-field-value)
+ 
+    * [Order by score](../../../client-api/session/querying/sort-query-results#order-by-score)
+  
+    * [Order by random](../../../client-api/session/querying/sort-query-results#order-by-random)
+   
+    * [Order by spatial](../../../client-api/session/querying/sort-query-results#order-by-spatial)
+     
+    * [Order by count (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-count-(aggregation-query))
+  
+    * [Order by sum (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-sum-(aggregation-query))
+
+    * [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type)
+
+    * [Chain ordering](../../../client-api/session/querying/sort-query-results#chain-ordering)
+
+    * [Custom sorters](../../../client-api/session/querying/sort-query-results#custom-sorters) 
+
+    * [Syntax](../../../client-api/session/querying/sort-query-results#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Order by field value}
+
+* Use `orderBy` or `orderByDescending` to order the results by the specified document-field.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_1@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+__Ordering Type__:
+
+* If no ordering type is specified in the query then the server will apply the default lexicographical ordering.
+
+* In the above example, the ordering type was set to `Long`.
+
+* Different ordering can be forced - see [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type) below.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by score}
+
+* When querying with some filtering conditions, a basic score is calculated for each item in the results  
+  by the underlying indexing engine.
+
+* The higher the score value the better the match.  
+
+* Use `orderByScore` or `orderByScoreDescending` to order by this score.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_2@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock < 5 or Discontinued == true
+order by score()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+__Get resulting score__:
+
+---
+
+* __@Index-score metadata property__:  
+  The score is available in the `@index-score` metadata property within each result.  
+  Learn how to retrieve the resulting score from the metadata in [Get resulting score](../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score).  
+  <br>
+  Note the following difference between the underlying indexing engines:
+
+  * When using __Lucene__:  
+    This metadata property is always available in the results. 
+    Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
+  
+  * When using __Corax__:  
+    In order to enhance performance, this property is not included in the results by default.  
+    To get this metadata property you must set the `Indexing.Corax.IncludeDocumentScore` configuration value to _true_. 
+    Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).    
+
+* __Include explanations__:  
+  Another option to get the score details and see how it was calculated is to request to include explanations in the query. 
+  Currently, this is only available when using Lucene.  
+  See [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by random}
+
+* Use `randomOrdering` to randomize the order of the query results.
+
+* An optional seed parameter can be passed.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_3@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by random()
+// order by random(someSeed)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by spatial}
+
+* If your data contains geographical locations,  
+  spatial query results can be sorted based on their distance from a specific point.
+
+* See detailed explanation in [Spatial Sorting](../../../client-api/session/querying/how-to-make-a-spatial-query#spatial-sorting).
+
+{PANEL/}
+
+{PANEL: Order by count (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `count` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_4@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by count() as long
+select key() as "Category", count()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by sum (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `sum` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_5@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by sum as long
+select key() as 'Category', sum(UnitsInStock) as sum
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Force ordering type}
+
+* If no ordering type is specified in the query then the server will apply the default lexicographical ordering.
+
+* A different ordering can be forced by passing the ordering type explicitly to `orderBy` or `orderByDescending`.
+
+* The following ordering types are available:
+
+    * `Long`
+    * `Double`
+    * `AlphaNumeric`
+    * `String` (lexicographic ordering)
+
+{NOTE: }
+
+__Using alphanumeric ordering example__:
+
+* When ordering mixed-character strings by the default lexicographical ordering  
+  then comparison is done character by character based on the Unicode values.  
+  For example, "Abc9" will come after "Abc10" since 9 is greater than 1.
+
+* If you want the digit characters to be ordered as numbers then use alphanumeric ordering  
+  where "Abc10" will result after "Abc9".
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_6@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+order by QuantityPerUnit as alphanumeric
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{CODE:nodejs sort_6_results@client-api\session\querying\sortQueryResults.js /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Chain ordering}
+
+* It is possible to chain multiple orderings in the query.  
+  Any combination of secondary sorting is possible as the fields are indexed independently of one another.
+
+* There is no limit on the number of sorting actions that can be chained.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_7@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long desc, score(), Name
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Custom sorters }
+
+* The Lucene indexing engine allows you to create your own custom sorters.  
+  Custom sorters are not supported by [Corax](../../../indexes/search-engine/corax).  
+
+* Custom sorters can be deployed to the server by either:  
+
+     * Sending the [Put Sorters Operation](../../../client-api/operations/maintenance/sorters/put-sorter) from your code.
+  
+     * Uploading a custom sorter from Studio, see [Custom Sorters View](../../../studio/database/settings/custom-sorters).
+
+* Once the custom sorter is deployed, you can sort the query results with it.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_8@client-api\session\querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by custom(UnitsInStock, "MySorter")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\session\querying\sortQueryResults.js /}
+
+| Parameter    | Type     | Description                                                                                                            |
+|--------------|----------|------------------------------------------------------------------------------------------------------------------------|
+| __field__    | `string` | The name of the field to sort by                                                                                       |
+| __ordering__ | `string` | The ordering type that will be used to sort the results:<br>`Long`<br>`Double`<br>`AlphaNumeric`<br>`String` (default) |
+| __options__  | `object` | An object that specifies the custom `sorterName`                                                                       |
+
+{PANEL/}
+
+## Related Articles
+
+#### Client API
+
+- [Query Overview](../../../client-api/session/querying/how-to-query)
+
+### Querying
+
+- [Customize query](../../../client-api/session/querying/how-to-customize-query)
+- [Group by query](../../../client-api/session/querying/how-to-perform-group-by-query)
+- [Spatial query](../../../client-api/session/querying/how-to-make-a-spatial-query)
+- [Full-text search](../../../client-api/session/querying/text-search/full-text-search)
+
+### Indexes
+
+- [Sort index query results](../../../indexes/querying/sorting)

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/SortQueryResults.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/SortQueryResults.cs
@@ -1,0 +1,511 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Documentation.Samples.Orders;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Session;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Querying
+{
+    public class SortQueryResults
+    {
+        public async Task CanOrderResults()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    // Order by document field
+                    // =======================
+                    
+                    #region sort_1
+                    List<Product> products = session
+                         // Make a dynamic query on the Products collection    
+                        .Query<Product>()
+                         // Apply filtering (optional)
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'OrderBy', pass the document-field by which to order the results
+                        .OrderBy(x => x.UnitsInStock)
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value in ascending order,
+                    // with smaller values listed first.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_2
+                    List<Product> products = await asyncSession
+                         // Make a dynamic query on the Products collection    
+                        .Query<Product>()
+                         // Apply filtering (optional)
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'OrderBy', pass the document-field by which to order the results
+                        .OrderBy(x => x.UnitsInStock)
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value in ascending order,
+                    // with smaller values listed first.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_3
+                    List<Product> products = session.Advanced
+                         // Make a DocumentQuery on the Products collection    
+                        .DocumentQuery<Product>()
+                         // Apply filtering (optional)
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Call 'OrderBy', pass the document-field by which to order the results
+                        .OrderBy(x => x.UnitsInStock)
+                        .ToList();
+
+                    // Results will be sorted by the 'UnitsInStock' value in ascending order,
+                    // with smaller values listed first.
+                    #endregion
+                }
+                
+                // Order by score
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_4
+                    List<Product> products = session
+                        .Query<Product>()
+                         // Apply filtering
+                        .Where(x => x.UnitsInStock < 5 || x.Discontinued)
+                         // Call 'OrderByScore'
+                        .OrderByScore()
+                        .ToList();
+                    
+                    // Results will be sorted by the score value
+                    // with best matching documents (higher score values) listed first.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_5
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                         // Apply filtering
+                        .Where(x => x.UnitsInStock < 5 || x.Discontinued)
+                         // Call 'OrderByScore'
+                        .OrderByScore()
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the score value
+                    // with best matching documents (higher score values) listed first.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_6
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Apply filtering
+                        .WhereLessThan(x => x.UnitsInStock, 5)
+                        .OrElse()
+                        .WhereEquals(x => x.Discontinued, true)
+                         // Call 'OrderByScore'
+                        .OrderByScore()
+                        .ToList();
+                    
+                    // Results will be sorted by the score value
+                    // with best matching documents (higher score values) listed first.
+                    #endregion
+                }
+                
+                // Order by random
+                // ===============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_7
+                    List<Product> products = session
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'Customize' with 'RandomOrdering'
+                        .Customize(x => x.RandomOrdering())
+                         // An optional seed can be passed, e.g.:
+                         // .Customize(x => x.RandomOrdering('someSeed'))
+                        .ToList();
+                    
+                    // Results will be randomly ordered.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_8
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'Customize' with 'RandomOrdering'
+                        .Customize(x => x.RandomOrdering())
+                         // An optional seed can be passed, e.g.:
+                         // .Customize(x => x.RandomOrdering('someSeed'))
+                        .ToListAsync();
+                    
+                    // Results will be randomly ordered.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_9
+                    List<Product> products = session.Advanced  
+                        .DocumentQuery<Product>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Call 'RandomOrdering'
+                        .RandomOrdering()
+                         // An optional seed can be passed, e.g.:
+                         // .RandomOrdering('someSeed')
+                        .ToList();
+                    
+                    // Results will be randomly ordered.
+                    #endregion
+                }
+                
+                // Order by Count
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_10
+                    var numberOfProductsPerCategory = session
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Count the number of product documents per category
+                            Count = x.Count()
+                        })
+                         // Order by the Count value
+                        .OrderBy(x => x.Count)
+                        .ToList();
+                    
+                    // Results will contain the number of Product documents per category
+                    // ordered by that count in ascending order.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_11
+                    var numberOfProductsPerCategory = await asyncSession
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Count the number of product documents per category
+                            Count = x.Count()
+                        })
+                         // Order by the Count value
+                        .OrderBy(x => x.Count)
+                        .ToListAsync();
+                    
+                    // Results will contain the number of Product documents per category
+                    // ordered by that count in ascending order.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_12
+                    var numberOfProductsPerCategory = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Group by Category
+                        .GroupBy("Category")
+                        .SelectKey("Category")
+                         // Count the number of product documents per category
+                        .SelectCount()
+                         // Order by the Count value
+                         // Here you need to specify the ordering type explicitly 
+                        .OrderBy("Count", OrderingType.Long)
+                        .ToList();
+                    
+                    // Results will contain the number of Product documents per category
+                    // ordered by that count in ascending order.
+                    #endregion
+                }
+                
+                // Order by Sum
+                // ============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_13
+                    var numberOfUnitsInStockPerCategory = session
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Sum the number of units in stock per category
+                            Sum = x.Sum(x => x.UnitsInStock)
+                        })
+                         // Order by the Sum value
+                        .OrderBy(x => x.Sum)
+                        .ToList();
+                    
+                    // Results will contain the total number of units in stock per category
+                    // ordered by that number in ascending order.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_14
+                    var numberOfUnitsInStockPerCategory = await asyncSession
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Sum the number of units in stock per category
+                            Sum = x.Sum(x => x.UnitsInStock)
+                        })
+                         // Order by the Sum value
+                        .OrderBy(x => x.Sum)
+                        .ToListAsync();
+                    
+                    // Results will contain the total number of units in stock per category
+                    // ordered by that number in ascending order.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_15
+                    var numberOfUnitsInStockPerCategory = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Group by Category
+                        .GroupBy("Category")
+                        .SelectKey("Category")
+                         // Sum the number of units in stock per category
+                        .SelectSum(new GroupByField
+                        {
+                            FieldName = "UnitsInStock",
+                            ProjectedName = "Sum"
+                        })
+                         // Order by the Sum value
+                         // Here you need to specify the ordering type explicitly 
+                        .OrderBy("Sum", OrderingType.Long)
+                        .ToList();
+                    
+                    // Results will contain the total number of units in stock per category
+                    // ordered by that number in ascending order.
+                    #endregion
+                }
+                
+                // Force ordering type
+                // ===================
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_16
+                    List<Product> products = session
+                        .Query<Product>()
+                         // Call 'OrderBy', order by field 'QuantityPerUnit'
+                         // Pass a second param, requesting to order the text alphanumerically
+                        .OrderBy(x => x.QuantityPerUnit, OrderingType.AlphaNumeric)
+                        .ToList();
+                    #endregion
+                    
+                    #region sort_16_results
+                    // Running the above query on the NorthWind sample data,
+                    // would produce the following order for the QuantityPerUnit field:
+                    // ================================================================
+                    
+                    // "1 kg pkg."
+                    // "1k pkg."
+                    // "2 kg box."
+                    // "4 - 450 g glasses"
+                    // "5 kg pkg."
+                    // ...
+                    
+                    // While running with the default Lexicographical ordering would have produced:
+                    // ============================================================================
+                    
+                    // "1 kg pkg."
+                    // "10 - 200 g glasses"
+                    // "10 - 4 oz boxes"
+                    // "10 - 500 g pkgs."
+                    // "10 - 500 g pkgs."
+                    // ...
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_17
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                         // Call 'OrderBy', order by field 'QuantityPerUnit'
+                         // Pass a second param, requesting to order the text alphanumerically
+                        .OrderBy(x => x.QuantityPerUnit, OrderingType.AlphaNumeric)
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_18
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Call 'OrderBy', order by field 'QuantityPerUnit'
+                         // Pass a second param, requesting to order the text alphanumerically
+                        .OrderBy(x => x.QuantityPerUnit, OrderingType.AlphaNumeric)
+                        .ToList();
+                    #endregion
+                }
+                
+                // Chain ordering
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_19
+                    List<Product> products = session
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Apply the primary sort by 'UnitsInStock'
+                        .OrderByDescending(x => x.UnitsInStock)
+                         // Apply a secondary sort by the score (for products with the same # of units in stock)
+                        .ThenByScore()
+                         // Apply another sort by 'Name' (for products with same # of units in stock and same score)
+                        .ThenBy(x => x.Name)
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value (descending),
+                    // then by score,
+                    // and then by 'Name' (ascending).
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_20
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Apply the primary sort by 'UnitsInStock'
+                        .OrderByDescending(x => x.UnitsInStock)
+                         // Apply a secondary sort by the score (for products with the same # of units in stock)
+                        .ThenByScore()
+                         // Apply another sort by 'Name' (for products with same # of units in stock and same score)
+                        .ThenBy(x => x.Name)
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value (descending),
+                    // then by score,
+                    // and then by 'Name' (ascending).
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_21
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Apply the primary sort by 'UnitsInStock'
+                        .OrderByDescending(x => x.UnitsInStock)
+                         // Apply a secondary sort by the score
+                        .OrderByScore()
+                         // Apply another sort by 'Name'
+                        .OrderBy(x => x.Name)
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value (descending),
+                    // then by score,
+                    // and then by 'Name' (ascending).
+                    #endregion
+                }
+                
+                // Custom sorters
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_22
+                    List<Product> products = session
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Order by field 'UnitsInStock', pass the name of your custom sorter class
+                        .OrderBy(x => x.UnitsInStock, "MySorter")
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value
+                    // according to the logic from 'MySorter' class
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_23
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Order by field 'UnitsInStock', pass the name of your custom sorter class
+                        .OrderBy(x => x.UnitsInStock, "MySorter")
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value
+                    // according to the logic from 'MySorter' class
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_24
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Order by field 'UnitsInStock', pass the name of your custom sorter class
+                        .OrderBy(x => x.UnitsInStock, "MySorter")
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value
+                    // according to the logic from 'MySorter' class
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo<TResult>
+        {
+            #region syntax
+            // OrderBy overloads:
+            IOrderedQueryable<T> OrderBy<T>(string path, OrderingType ordering);
+            IOrderedQueryable<T> OrderBy<T>(Expression<Func<T, object>> path, OrderingType ordering);
+            IOrderedQueryable<T> OrderBy<T>(string path, string sorterName);
+            IOrderedQueryable<T> OrderBy<T>(Expression<Func<T, object>> path, string sorterName);
+
+            // OrderByDescending overloads:
+            IOrderedQueryable<T> OrderByDescending<T>(string path, OrderingType ordering);
+            IOrderedQueryable<T> OrderByDescending<T>(Expression<Func<T, object>> path, OrderingType ordering);
+            IOrderedQueryable<T> OrderByDescending<T>(string path, string sorterName);
+            IOrderedQueryable<T> OrderByDescending<T>(Expression<Func<T, object>> path, string sorterName);
+            #endregion
+        }
+    }
+}

--- a/Documentation/6.0/Samples/nodejs/client-api/session/querying/sortQueryResults.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/session/querying/sortQueryResults.js
@@ -1,0 +1,172 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function sortQueryResults() {
+    {
+        //region sort_1
+        const products = await session
+             // Make a dynamic query on the 'products' collection    
+            .query({ collection: "products" })
+             // Apply filtering (optional)
+            .whereGreaterThan("UnitsInStock", 10)
+             // Call 'orderBy'
+             // Pass the document-field by which to order the results and the ordering type
+            .orderBy("UnitsInStock", "Long")
+            .all(); 
+
+        // Results will be sorted by the 'UnitsInStock' value in ascending order,
+        // with smaller values listed first.
+        //endregion
+    }
+
+    {
+        //region sort_2
+        const products = await session
+            .query({ collection: "products" })
+             // Apply filtering
+            .whereLessThan("UnitsInStock", 5)
+            .orElse()
+            .whereEquals("Discontinued", true)
+             // Call 'orderByScore'
+            .orderByScore()
+            .all();
+
+        // Results will be sorted by the score value
+        // with best matching documents (higher score values) listed first.
+        //endregion
+    }
+
+    {
+        //region sort_3
+        const products = await session
+            .query({ collection: "products" })
+            .whereGreaterThan("UnitsInStock", 10)
+             // Call 'randomOrdering'
+            .randomOrdering()
+             // An optional seed can be passed, e.g.:
+             // .randomOrdering("someSeed")
+            .all();
+
+        // Results will be randomly ordered.
+        //endregion
+    }
+
+    {
+        //region sort_4
+        const numberOfProductsPerCategory = await session
+            .query({ collection: "products" })
+             // Group by category
+            .groupBy("Category")
+            .selectKey("Category")
+             // Count the number of product documents per category
+            .selectCount()
+             // Order by the count value
+            .orderBy("count", "Long")
+            .all();
+
+        // Results will contain the number of Product documents per category
+        // ordered by that count in ascending order.
+        //endregion
+    }
+
+    {
+        //region sort_5
+        const numberOfUnitsInStockPerCategory = await session
+            .query({ collection: "products" })
+             // Group by category
+            .groupBy("Category")
+            .selectKey("Category")
+             // Sum the number of units in stock per category
+            .selectSum(new GroupByField("UnitsInStock", "sum"))
+             // Order by the sum value
+            .orderBy("sum", "Long")
+            .all();
+
+        // Results will contain the total number of units in stock per category
+        // ordered by that number in ascending order.
+        //endregion
+    }
+
+    {
+        //region sort_6
+        const products = await session
+            .query({ collection: "products" })
+             // Call 'OrderBy', order by field 'QuantityPerUnit'
+             // Pass a second param, requesting to order the text alphanumerically
+            .orderBy("QuantityPerUnit", "AlphaNumeric")
+            .all();
+        //endregion
+
+        //region sort_6_results
+        // Running the above query on the NorthWind sample data,
+        // would produce the following order for the QuantityPerUnit field:
+        // ================================================================
+        
+        // "1 kg pkg."
+        // "1k pkg."
+        // "2 kg box."
+        // "4 - 450 g glasses"
+        // "5 kg pkg."
+        // ...
+        
+        // While running with the default Lexicographical ordering would have produced:
+        // ============================================================================
+        
+        // "1 kg pkg."
+        // "10 - 200 g glasses"
+        // "10 - 4 oz boxes"
+        // "10 - 500 g pkgs."
+        // "10 - 500 g pkgs."
+        // ...
+        //endregion
+    }
+
+    {
+        //region sort_7
+        const products = await session
+            .query({ collection: "products" })
+            .whereGreaterThan("UnitsInStock", 10)
+             // Apply the primary sort by 'UnitsInStock'
+            .orderByDescending("UnitsInStock", "Long")
+             // Apply a secondary sort by the score
+            .orderByScore()
+             // Apply another sort by 'Name'
+            .orderBy("Name")
+            .all();
+
+        // Results will be sorted by the 'UnitsInStock' value (descending),
+        // then by score,
+        // and then by 'Name' (ascending).
+        //endregion
+    }
+
+    {
+        //region sort_8
+        const products = await session
+            .query({ collection: "products" })
+            .whereGreaterThan("UnitsInStock", 10)
+             // Order by field 'UnitsInStock', pass the name of your custom sorter class
+            .orderBy("UnitsInStock", { sorterName: "MySorter" })
+            .all();
+
+        // Results will be sorted by the 'UnitsInStock' value
+        // according to the logic from 'MySorter' class
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    // orderBy overloads:
+    orderBy(field);
+    orderBy(field, ordering);
+    orderBy(field, options);
+
+    // orderByDescending overloads:
+    orderByDescending(field);
+    orderByDescending(field, ordering);
+    orderByDescending(field, options);
+    //endregion
+}


### PR DESCRIPTION
**Related issue**:
https://issues.hibernatingrhinos.com/issue/RDoc-2523/Update-the-Sorting-articles-with-Corax-details

---

1. In file:
`Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown`
Added Corax info in:
      * Order by score
      * Custom Sorters

  
2. In file:
`Documentation/5.2/Raven.Documentation.Pages/server/configuration/configuration-options.markdown`
Added the "database settings view" option to the "configuration options".

