### PR TITLE
Explain how to dispose of store certificates

### DIFF
--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
@@ -31,7 +31,7 @@ The following properties can be configured when creating a new Document Store:
     * **Note**: Do not create a Document Store with URLs that point to servers outside of your cluster.  
 
     * **Note**: This list is not binding. You can always modify your cluster later dynamically, add new nodes or remove existing ones as 
-    necessary. Learn more in [Cluster View Operations](../studio/cluster/cluster-view#cluster-view-operations).  
+    necessary. Learn more in [Cluster View Operations](../studio/server/cluster/cluster-view#cluster-view-operations).  
 
 * **[Database](../client-api/setting-up-default-database)** (optional)  
   The default database which the Client will work against.  
@@ -56,8 +56,8 @@ When the store is disposed of, it is advisable to also dispose of any certificat
 to it to [avoid the accumulation of unneeded certificate files](https://snede.net/the-most-dangerous-constructor-in-net/), 
 especially if certificates are added often.  
 
-To dispose of a certificate set an [AfterDispose](../client-api/how-to/subscribe-to-store-events#section-2) 
-store event, triggered when the store is disposed of, and use it to call the `Certificate.Dispose()` method.  
+To dispose of a certificate set an `AfterDispose` store event, triggered when 
+the store is disposed of, and use it to call the `Certificate.Dispose()` method.  
 
 {CODE certificate_cleanup@ClientApi\CreatingDocumentStore.cs /}  
 

--- a/Documentation/4.2/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
@@ -61,6 +61,10 @@ the store is disposed of, and use it to call the `Certificate.Dispose()` method.
 
 {CODE certificate_cleanup@ClientApi\CreatingDocumentStore.cs /}  
 
+{NOTE: }
+Note: In RavenDB `6.x` and on certificate cleanup is automatic and the procedure described here is unnecessary.
+{NOTE/}
+
 {PANEL/}
 
 {PANEL: Creating a Document Store - Example}

--- a/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
+++ b/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
@@ -1,0 +1,98 @@
+﻿namespace Raven.Documentation.Samples.ClientApi
+{
+    using System;
+    using System.Security.Cryptography.X509Certificates;
+    using Client.Documents;
+    using static Raven.Client.Constants;
+
+    public class CreatingDocumentStore
+    {
+
+        #region document_store_holder
+        // The `DocumentStoreHolder` class holds a single Document Store instance.
+        public class DocumentStoreHolder
+        {
+            // Use Lazy<IDocumentStore> to initialize the document store lazily. 
+            // This ensures that it is created only once - when first accessing the public `Store` property.
+            private static Lazy<IDocumentStore> store = new Lazy<IDocumentStore>(CreateStore);
+
+            public static IDocumentStore Store => store.Value;
+            
+            private static IDocumentStore CreateStore()
+            {
+                IDocumentStore store = new DocumentStore()
+                {
+                    // Define the cluster node URLs (required)
+                    Urls = new[] { "http://your_RavenDB_cluster_node", 
+                                   /*some additional nodes of this cluster*/ },
+
+                    // Set conventions as necessary (optional)
+                    Conventions =
+                    {
+                        MaxNumberOfRequestsPerSession = 10,
+                        UseOptimisticConcurrency = true
+                    },
+
+                    // Define a default database (optional)
+                    Database = "your_database_name",
+
+                    // Define a client certificate (optional)
+                    Certificate = new X509Certificate2("C:\\path_to_your_pfx_file\\cert.pfx"),
+
+                    // Initialize the Document Store
+                }.Initialize();
+
+                // When the store is disposed of, the certificate file will be removed as well
+                Store.AfterDispose += (sender, args) => Store.Certificate.Dispose();
+
+                return store;
+            }
+        }
+        #endregion
+    }
+
+    public class CertificateCleanup
+    {
+        // The `DocumentStoreHolder` class holds a single Document Store instance.
+        public class DocumentStoreHolder
+        {
+            // Use Lazy<IDocumentStore> to initialize the document store lazily. 
+            // This ensures that it is created only once - when first accessing the public `Store` property.
+            private static Lazy<IDocumentStore> store = new Lazy<IDocumentStore>(CreateStore);
+
+            public static IDocumentStore Store => store.Value;
+
+            private static IDocumentStore CreateStore()
+            {
+                IDocumentStore store = new DocumentStore()
+                {
+                    // Define the cluster node URLs (required)
+                    Urls = new[] { "http://your_RavenDB_cluster_node", 
+                                   /*some additional nodes of this cluster*/ },
+
+                    // Set conventions as necessary (optional)
+                    Conventions =
+                    {
+                        MaxNumberOfRequestsPerSession = 10,
+                        UseOptimisticConcurrency = true
+                    },
+
+                    // Define a default database (optional)
+                    Database = "your_database_name",
+
+                    // Define a client certificate (optional)
+                    Certificate = new X509Certificate2("C:\\path_to_your_pfx_file\\cert.pfx"),
+
+                    // Initialize the Document Store
+                }.Initialize();
+
+                #region certificate_cleanup
+                // Use the AfterDispose store event to remove the certificate after the store is disposed of
+                Store.AfterDispose += (sender, args) => Store.Certificate.Dispose();
+                #endregion
+
+                return store;
+            }
+        }
+    }
+}

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
@@ -41,9 +41,57 @@
                 // Initialize the Document Store
                 }.Initialize();
 
+                // When the store is disposed of, the certificate file will be removed as well
+                Store.AfterDispose += (sender, args) => Store.Certificate.Dispose();
+
                 return store;
             }
         }
         #endregion
+    }
+
+    public class CertificateCleanup
+    {
+        // The `DocumentStoreHolder` class holds a single Document Store instance.
+        public class DocumentStoreHolder
+        {
+            // Use Lazy<IDocumentStore> to initialize the document store lazily. 
+            // This ensures that it is created only once - when first accessing the public `Store` property.
+            private static Lazy<IDocumentStore> store = new Lazy<IDocumentStore>(CreateStore);
+
+            public static IDocumentStore Store => store.Value;
+
+            private static IDocumentStore CreateStore()
+            {
+                IDocumentStore store = new DocumentStore()
+                {
+                    // Define the cluster node URLs (required)
+                    Urls = new[] { "http://your_RavenDB_cluster_node", 
+                                   /*some additional nodes of this cluster*/ },
+
+                    // Set conventions as necessary (optional)
+                    Conventions =
+                    {
+                        MaxNumberOfRequestsPerSession = 10,
+                        UseOptimisticConcurrency = true
+                    },
+
+                    // Define a default database (optional)
+                    Database = "your_database_name",
+
+                    // Define a client certificate (optional)
+                    Certificate = new X509Certificate2("C:\\path_to_your_pfx_file\\cert.pfx"),
+
+                    // Initialize the Document Store
+                }.Initialize();
+
+                #region certificate_cleanup
+                // Use the AfterDispose store event to remove the certificate after the store is disposed of
+                Store.AfterDispose += (sender, args) => Store.Certificate.Dispose();
+                #endregion
+
+                return store;
+            }
+        }
     }
 }

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -25,6 +25,7 @@
    * [WaitForNonStaleResultsTimeout](../../client-api/configuration/conventions#waitfornonstaleresultstimeout)  
    * [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient)  
    * [HttpClientType](../../client-api/configuration/conventions#httpclienttype)  
+   * [DisposeCertificate](../../client-api/configuration/conventions#disposecertificate)  
 
 {PANEL: Client Conventions}
 
@@ -214,6 +215,12 @@ convention to use a non-default HTTP client, we advise that you also
 set `HttpClientType` so it returns the client type you are actually using.  
 {NOTE/}
 
+## DisposeCertificate
+
+Use the `DisposeCertificate` convention to enable or disable the automatic 
+disposal of X509Certificate2 certificates when the store is disposed of.  
+**Default**: `true`  
+{CODE DisposeCertificate@ClientApi\Configuration\Conventions.cs /}
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
@@ -10,7 +10,6 @@ Creating more than one Document Store may be resource intensive, and one instanc
 
 * In this page:  
   * [Creating a Document Store - Configuration](../client-api/creating-document-store#creating-a-document-store---configuration)  
-     * [Certificate Cleanup](../client-api/creating-document-store#certificate-cleanup)  
   * [Creating a Document Store - Example](../client-api/creating-document-store#creating-a-document-store---example)  
 {NOTE/}
 
@@ -49,21 +48,6 @@ After setting the above configurations as necessary, call `.Initialize()` to beg
 The Document Store is immutable - all above configuration are frozen upon calling .Initialize().  
 Create a new document store object if you need different default configuration values.  
 {WARNING/}
-
-## Certificate Cleanup
-
-When the store is disposed of, it is advisable to also dispose of any certificate attached 
-to it to [avoid the accumulation of unneeded certificate files](https://snede.net/the-most-dangerous-constructor-in-net/), 
-especially if certificates are added often.  
-
-To dispose of a certificate set an [AfterDispose](../client-api/how-to/subscribe-to-store-events#section-2) 
-store event, triggered when the store is disposed of, and use it to call the `Certificate.Dispose()` method.  
-
-{CODE certificate_cleanup@ClientApi\CreatingDocumentStore.cs /}  
-
-{NOTE: }
-Note: In RavenDB `6.x` and on certificate cleanup is automatic and the procedure described here is unnecessary.
-{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.dotnet.markdown
@@ -10,6 +10,7 @@ Creating more than one Document Store may be resource intensive, and one instanc
 
 * In this page:  
   * [Creating a Document Store - Configuration](../client-api/creating-document-store#creating-a-document-store---configuration)  
+     * [Certificate Disposal](../client-api/creating-document-store#certificate-disposal)  
   * [Creating a Document Store - Example](../client-api/creating-document-store#creating-a-document-store---example)  
 {NOTE/}
 
@@ -48,6 +49,16 @@ After setting the above configurations as necessary, call `.Initialize()` to beg
 The Document Store is immutable - all above configuration are frozen upon calling .Initialize().  
 Create a new document store object if you need different default configuration values.  
 {WARNING/}
+
+## Certificate Disposal
+
+Starting with RavenDB `6.x`, disposing of a store automatically removes any X509Certificate2 certificate installed for 
+it, to [prevent the accumulation of unneeded certificate files](https://snede.net/the-most-dangerous-constructor-in-net/).  
+
+To **disable** the automatic disposal of certificates, please use the 
+[DisposeCertificate](../client-api/configuration/conventions#disposecertificate) convention.  
+
+{CODE disable_certificate_cleanup@ClientApi\CreatingDocumentStore.cs /}  
 
 {PANEL/}
 

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
@@ -118,6 +118,11 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                     // The type of HTTP client you are using
                     HttpClientType = typeof(MyHttpClient)
                     #endregion
+                    ,
+                    #region DisposeCertificate
+                    // Disable the automatic disposal of certificates when the store is disposed of
+                    DisposeCertificate = false
+                    #endregion
                 }
             };
             

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
@@ -47,13 +47,10 @@
         #endregion
     }
 
-    public class CertificateCleanup
+    public class DisableAutomaticCertificateCleanup
     {
-        // The `DocumentStoreHolder` class holds a single Document Store instance.
         public class DocumentStoreHolder
         {
-            // Use Lazy<IDocumentStore> to initialize the document store lazily. 
-            // This ensures that it is created only once - when first accessing the public `Store` property.
             private static Lazy<IDocumentStore> store = new Lazy<IDocumentStore>(CreateStore);
 
             public static IDocumentStore Store => store.Value;
@@ -66,12 +63,14 @@
                     Urls = new[] { "http://your_RavenDB_cluster_node", 
                                    /*some additional nodes of this cluster*/ },
 
+                    #region disable_certificate_cleanup
                     // Set conventions as necessary (optional)
                     Conventions =
                     {
-                        MaxNumberOfRequestsPerSession = 10,
-                        UseOptimisticConcurrency = true
+                        // Disable the automatic disposal of certificates when the store is disposed of
+                        DisposeCertificate = false
                     },
+                    #endregion
 
                     // Define a default database (optional)
                     Database = "your_database_name",

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/CreatingDocumentStore.cs
@@ -1,0 +1,89 @@
+﻿namespace Raven.Documentation.Samples.ClientApi
+{
+    using System;
+    using System.Security.Cryptography.X509Certificates;
+    using Client.Documents;
+
+    public class CreatingDocumentStore
+    {
+
+        #region document_store_holder
+        // The `DocumentStoreHolder` class holds a single Document Store instance.
+        public class DocumentStoreHolder
+        {
+            // Use Lazy<IDocumentStore> to initialize the document store lazily. 
+            // This ensures that it is created only once - when first accessing the public `Store` property.
+            private static Lazy<IDocumentStore> store = new Lazy<IDocumentStore>(CreateStore);
+
+            public static IDocumentStore Store => store.Value;
+            
+            private static IDocumentStore CreateStore()
+            {
+                IDocumentStore store = new DocumentStore()
+                {
+                    // Define the cluster node URLs (required)
+                    Urls = new[] { "http://your_RavenDB_cluster_node", 
+                                   /*some additional nodes of this cluster*/ },
+
+                    // Set conventions as necessary (optional)
+                    Conventions =
+                    {
+                        MaxNumberOfRequestsPerSession = 10,
+                        UseOptimisticConcurrency = true
+                    },
+
+                    // Define a default database (optional)
+                    Database = "your_database_name",
+
+                    // Define a client certificate (optional)
+                    Certificate = new X509Certificate2("C:\\path_to_your_pfx_file\\cert.pfx"),
+
+                // Initialize the Document Store
+                }.Initialize();
+
+                return store;
+            }
+        }
+        #endregion
+    }
+
+    public class CertificateCleanup
+    {
+        // The `DocumentStoreHolder` class holds a single Document Store instance.
+        public class DocumentStoreHolder
+        {
+            // Use Lazy<IDocumentStore> to initialize the document store lazily. 
+            // This ensures that it is created only once - when first accessing the public `Store` property.
+            private static Lazy<IDocumentStore> store = new Lazy<IDocumentStore>(CreateStore);
+
+            public static IDocumentStore Store => store.Value;
+
+            private static IDocumentStore CreateStore()
+            {
+                IDocumentStore store = new DocumentStore()
+                {
+                    // Define the cluster node URLs (required)
+                    Urls = new[] { "http://your_RavenDB_cluster_node", 
+                                   /*some additional nodes of this cluster*/ },
+
+                    // Set conventions as necessary (optional)
+                    Conventions =
+                    {
+                        MaxNumberOfRequestsPerSession = 10,
+                        UseOptimisticConcurrency = true
+                    },
+
+                    // Define a default database (optional)
+                    Database = "your_database_name",
+
+                    // Define a client certificate (optional)
+                    Certificate = new X509Certificate2("C:\\path_to_your_pfx_file\\cert.pfx"),
+
+                    // Initialize the Document Store
+                }.Initialize();
+
+                return store;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related issues: 
https://issues.hibernatingrhinos.com/issue/RDoc-1706/DocumentStoreHolder-mention-that-its-possible-to-cleanup-X509Certificate2
https://issues.hibernatingrhinos.com/issue/RDoc-2559/document-DisposeCertificate