### PR TITLE
RDoc-2537 Add operation.Kill + WaitForCompletion overload

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -28,12 +28,16 @@
 
 {PANEL: Why use operations}
 
-* Operations provide __management functionality__ that is Not available in the context of the session, e.g.:  
-  create/delete a database, execute administrative tasks, assign permissions, change server configuration, etc.
+* Operations provide __management functionality__ that is Not available in the context of the session, for example:
+    * Create/delete a database
+    * Execute administrative tasks
+    * Assign permissions
+    * Change server configuration, and more.
 
-* Some operations (e.g. _PatchOperation_) can also be carried out via the session (e.g. _session.Advanced.Patch()_).  
-  However, while a session wraps multiple actions into a single business transaction,  
-  the operation is an __individual action__ that is Not part of the session transaction.
+* The operations are executed on the DocumentStore and are Not part of the session transaction.
+
+* There are some client tasks, such as patching documents, that can be carried out either via the Session ([session.Advanced.Patch()](../../client-api/operations/patching/single-document#array-manipulation))
+  or via an Operation on the DocumentStore ([PatchOperation](../../client-api/operations/patching/single-document#operations-api)).
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -28,12 +28,16 @@
 
 {PANEL: Why use operations}
 
-* Operations provide __management functionality__ that is Not available in the context of the session, e.g.:  
-  create/delete a database, execute administrative tasks, assign permissions, change server configuration, etc.
+* Operations provide __management functionality__ that is Not available in the context of the session, for example:
+    * Create/delete a database
+    * Execute administrative tasks
+    * Assign permissions
+    * Change server configuration, and more.
 
-* Some operations (e.g. _PatchOperation_) can also be carried out via the session (e.g. _session.advanced.patch()_).  
-  However, while a session wraps multiple actions into a single business transaction,  
-  the operation is an __individual action__ that is Not part of the session transaction.
+* The operations are executed on the DocumentStore and are Not part of the session transaction.
+
+* There are some client tasks, such as patching documents, that can be carried out either via the Session ([session.advanced.patch()](../../client-api/operations/patching/single-document#array-manipulation))
+  or via an Operation on the DocumentStore ([PatchOperation](../../client-api/operations/patching/single-document#operations-api)).
 
 {PANEL/}
 

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
@@ -104,7 +104,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations
             };
 
             #region operations_ex
-            // Define operation, e.g.. get all counters info for a document
+            // Define operation, e.g. get all counters info for a document
             IOperation<CountersDetail> getCountersOp = new GetCountersOperation("products/1-A");
             
             // Execute the operation by passing the operation to Operations.Send

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -28,12 +28,16 @@
 
 {PANEL: Why use operations}
 
-* Operations provide __management functionality__ that is Not available in the context of the session, e.g.:  
-  create/delete a database, execute administrative tasks, assign permissions, change server configuration, etc.
+* Operations provide __management functionality__ that is Not available in the context of the session, for example:
+    * Create/delete a database
+    * Execute administrative tasks
+    * Assign permissions
+    * Change server configuration, and more.
 
-* Some operations (e.g. _PatchOperation_) can also be carried out via the session (e.g. _session.Advanced.Patch()_).  
-  However, while a session wraps multiple actions into a single business transaction,  
-  the operation is an __individual action__ that is Not part of the session transaction.
+* The operations are executed on the DocumentStore and are Not part of the session transaction.
+
+* There are some client tasks, such as patching documents, that can be carried out either via the Session ([session.Advanced.Patch()](../../client-api/operations/patching/single-document#array-manipulation))
+  or via an Operation on the DocumentStore ([PatchOperation](../../client-api/operations/patching/single-document#operations-api)).
 
 {PANEL/}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -28,12 +28,16 @@
 
 {PANEL: Why use operations}
 
-* Operations provide __management functionality__ that is Not available in the context of the session, e.g.:  
-  create/delete a database, execute administrative tasks, assign permissions, change server configuration, etc.
+* Operations provide __management functionality__ that is Not available in the context of the session, for example:
+    * Create/delete a database
+    * Execute administrative tasks
+    * Assign permissions
+    * Change server configuration, and more.
 
-* Some operations (e.g. _PatchOperation_) can also be carried out via the session (e.g. _session.advanced.patch()_).  
-  However, while a session wraps multiple actions into a single business transaction,  
-  the operation is an __individual action__ that is Not part of the session transaction.
+* The operations are executed on the DocumentStore and are Not part of the session transaction.
+
+* There are some client tasks, such as patching documents, that can be carried out either via the Session ([session.advanced.patch()](../../client-api/operations/patching/single-document#array-manipulation))
+  or via an Operation on the DocumentStore ([PatchOperation](../../client-api/operations/patching/single-document#operations-api)).
 
 {PANEL/}
 

--- a/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
+++ b/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
@@ -104,7 +104,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations
             };
 
             #region operations_ex
-            // Define operation, e.g.. get all counters info for a document
+            // Define operation, e.g. get all counters info for a document
             IOperation<CountersDetail> getCountersOp = new GetCountersOperation("products/1-A");
             
             // Execute the operation by passing the operation to Operations.Send

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -19,8 +19,10 @@
   * __Operation types__: 
       * [Common operations](../../client-api/operations/what-are-operations#common-operations)  
       * [Maintenance operations](../../client-api/operations/what-are-operations#maintenance-operations)  
-      * [Server-maintenance operations](../../client-api/operations/what-are-operations#server-maintenance-operations)  
-  * [Wait for completion](../../client-api/operations/what-are-operations#wait-for-completion)  
+      * [Server-maintenance operations](../../client-api/operations/what-are-operations#server-maintenance-operations)
+  * [Manage lengthy operations](../../client-api/operations/what-are-operations#manage-lengthy-operations)
+      * [Wait for completion](../../client-api/operations/what-are-operations#waitForCompletion)  
+      * [Kill operation](../../client-api/operations/what-are-operations#killOperation)  
 
 {NOTE/}
 
@@ -399,35 +401,63 @@ __Send syntax__:
 {NOTE/}
 {PANEL/}
 
-{PANEL: Wait for completion}
+{PANEL: Manage lengthy operations}
 
-* Some operations may take a long time to complete.  
-  Those operations will run in the server background and can be awaited for completion.  
-* The response of the inner 'RavenCommand' class for such operations is `OperationIdResult`.  
-* For those operations, the `Send` method will return an `Operation` object that allows waiting on that operation Id.  
+* Some operations that run in the server background may take a long time to complete.  
 
-__Example__:  
+* For Operations that implement an interface with type `OperationIdResult`,  
+  executing the operation via the `Send` method will return an `Operation` object,  
+  which can be __awaited for completion__ or __aborted (killed)__.  
+
+---
+
+{NOTE: }
+
+<a id="waitForCompletion" /> __Wait for completion__:
 
 {CODE-TABS}
-{CODE-TAB:csharp:Sync wait_ex@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async wait_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:With_Timeout wait_timeout_ex@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:With_Timout_async wait_timeout_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:With_CancellationToken wait_token_ex@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:With_CancellationToken_async wait_token_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-__Syntax__:
+##### Syntax:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync waitForCompletion_syntax@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TAB:csharp:Async waitForCompletion_syntax_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-| Parameters | Type | Description |
-| - | - | - |
-| __timeout__ | `TimeSpan` | <ul><li> __When timespan is specified__ - <br>server throws an error if operation has Not completed within the specified time frame. No rollback action will take place.</li><li>`null` - <br>WaitForCompletion will wait for operation to complete forever.</li></ul> |
+| Parameter   | Type                | Description                                                                                                                                                                                                                                                                                                                                           |
+|-------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| __timeout__ | `TimeSpan`          | <ul><li> __When timespan is specified__ - <br>The server will throw a `TimeoutException` if operation has Not completed within the specified time frame.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li><li>`null` - <br>WaitForCompletion will wait for operation to complete forever.</li></ul> |
+| __token__   | `CancellationToken` | <ul><li> __When cancellation token is specified__ - <br>The server will throw a `TimeoutException` if operation has Not completed at cancellation time.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li></ul>                                                                                      |
 
-| Return type | |
-| - | - |
+| Return type        |                               |
+|--------------------|-------------------------------|
 | `IOperationResult` | The operation result content. |
 
+{NOTE/}
+
+{NOTE: }
+
+<a id="killOperation" /> __Kill operation__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Kill kill_ex@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Kill_async kill_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+##### Syntax:
+
+{CODE kill_syntax@ClientApi\Operations\WhatAreOperations.cs /}
+
+| Parameter   | Type                | Description                                                     |
+|-------------|---------------------|-----------------------------------------------------------------|
+| __token__   | `CancellationToken` | Provide a cancellation token if needed to abort the Kill method |
+
+{NOTE/}
 {PANEL/}
 
 ## Related articles

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -453,9 +453,9 @@ __Send syntax__:
 
 {CODE kill_syntax@ClientApi\Operations\WhatAreOperations.cs /}
 
-| Parameter   | Type                | Description                                                     |
-|-------------|---------------------|-----------------------------------------------------------------|
-| __token__   | `CancellationToken` | Provide a cancellation token if needed to abort the Kill method |
+| Parameter   | Type                | Description                                                          |
+|-------------|---------------------|----------------------------------------------------------------------|
+| __token__   | `CancellationToken` | Provide a cancellation token if needed to abort the KillAsync method |
 
 {NOTE/}
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -1,0 +1,442 @@
+# What are Operations
+
+---
+
+{NOTE: }
+
+* The RavenDB Client API is built with the notion of layers.  
+  At the top, and what you will usually interact with, are the **[DocumentStore](../../client-api/what-is-a-document-store)**
+  and the **[Session](../../client-api/session/what-is-a-session-and-how-does-it-work)**.  
+  They in turn are built on top of the lower-level __Operations__ and __RavenCommands__ API.
+
+* __RavenDB provides access to this lower-level API__, so that instead of using the higher session API,  
+  you can generate requests directly to the server by executing operations on the DocumentStore.
+
+* In this page:  
+  * [Why use operations](../../client-api/operations/what-are-operations#why-use-operations)  
+  * [How operations work](../../client-api/operations/what-are-operations#how-operations-work)  
+  <br>
+  * __Operation types__: 
+      * [Common operations](../../client-api/operations/what-are-operations#common-operations)  
+      * [Maintenance operations](../../client-api/operations/what-are-operations#maintenance-operations)  
+      * [Server-maintenance operations](../../client-api/operations/what-are-operations#server-maintenance-operations)  
+  * [Wait for completion](../../client-api/operations/what-are-operations#wait-for-completion)  
+
+{NOTE/}
+
+---
+
+{PANEL: Why use operations}
+
+* Operations provide __management functionality__ that is Not available in the context of the session, for example:
+    * Create/delete a database
+    * Execute administrative tasks
+    * Assign permissions
+    * Change server configuration, and more.
+
+* The operations are executed on the DocumentStore and are Not part of the session transaction.
+
+* There are some client tasks, such as patching documents, that can be carried out either via the Session ([session.Advanced.Patch()](../../client-api/operations/patching/single-document#array-manipulation))
+  or via an Operation on the DocumentStore ([PatchOperation](../../client-api/operations/patching/single-document#operations-api)).
+
+{PANEL/}
+
+{PANEL: How operations work}
+
+* __Sending the request__:  
+  Each Operation is an encapsulation of a `RavenCommand`.  
+  The RavenCommand creates the HTTP request message to be sent to the relevant server endpoint.  
+  The DocumentStore `OperationExecutor` sends the request and processes the results.
+* __Target node__:  
+  By default, the operation will be executed on the server node that is defined by the [client configuration](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, server-maintenance operations can be executed on a specific node by using the [ForNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
+* __Target database__:  
+  By default, operations work on the default database defined in the DocumentStore.  
+  However, common operations & maintenance operations can operate on a different database by using the [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) method.  
+* __Transaction scope__:  
+  Operations execute as a single-node transaction.  
+  If needed, data will then replicate to the other nodes in the database-group.  
+* __Background operations__:  
+  Some operations may take a long time to complete and can be awaited for completion.   
+  Learn more [below](../../client-api/operations/what-are-operations#wait-for-completion).
+
+{PANEL/}
+
+{PANEL: Common operations}
+
+{NOTE: }
+
+* All common operations implement the `IOperation` interface.  
+  The operation is executed within the __database scope__.  
+  Use [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.  
+
+* These operations include set-based operations such as _PatchOperation_, _CounterBatchOperation_,  
+  document-extensions related operations such as getting/putting an attachment, and more.  
+  See all available operations [below](../../client-api/operations/what-are-operations#operations-list).
+
+* To execute a common operation request,  
+  use the `Send` method on the `Operations` property in the DocumentStore.
+
+__Example__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync operations_ex@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async operations_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Send syntax__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync operations_send@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async operations_send_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+<span id="operations-list"> __The following common operations are available:__ </span>
+
+---
+
+* __Attachments__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutAttachmentOperation](../../client-api/operations/attachments/put-attachment)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetAttachmentOperation](../../client-api/operations/attachments/get-attachment)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteAttachmentOperation](../../client-api/operations/attachments/delete-attachment)  
+
+* __Counters__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CounterBatchOperation](../../client-api/operations/counters/counter-batch)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCountersOperation](../../client-api/operations/counters/get-counters)  
+
+* __Time series__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; TimeSeriesBatchOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetMultipleTimeSeriesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTimeSeriesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTimeSeriesStatisticsOperation  
+
+* __Revisions__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetRevisionsOperation](../../document-extensions/revisions/client-api/operations/get-revisions)  
+
+* __Patching__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PatchOperation](../../client-api/operations/patching/single-document)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PatchByQueryOperation](../../client-api/operations/patching/set-based)  
+
+* __Delete by query__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteByQueryOperation](../../client-api/operations/delete-by-query)   
+
+* __Compare-exchange__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutCompareExchangeValueOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetCompareExchangeValueOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetCompareExchangeValuesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteCompareExchangeValueOperation  
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Maintenance operations}
+
+{NOTE: }
+
+* All maintenance operations implement the `IMaintenanceOperation` interface.  
+  The operation is executed within the __database scope__.  
+  Use [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.
+
+* These operations include database management operations such as setting client configuration,  
+  managing indexes & ongoing-tasks operations, getting stats, and more.  
+  See all available maintenance operations [below](../../client-api/operations/what-are-operations#maintenance-list).
+ 
+* To execute a maintenance operation request,  
+  use the `Send` method on the `Maintenance` property in the DocumentStore.
+
+__Example__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync maintenance_ex@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async maintenance_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Send syntax__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync maintenance_send@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async maintenance_send_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+<span id="maintenance-list"> __The following maintenance operations are available:__ </span>
+
+---
+
+* __Statistics__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-database-stats)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDetailedStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCollectionStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-collection-stats)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDetailedCollectionStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+
+* __Client Configuration__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutClientConfigurationOperation](../../client-api/operations/maintenance/configuration/put-client-configuration)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetClientConfigurationOperation](../../client-api/operations/maintenance/configuration/get-client-configuration)  
+
+* __Indexes__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutIndexesOperation](../../client-api/operations/maintenance/indexes/put-indexes)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SetIndexesLockOperation](../../client-api/operations/maintenance/indexes/set-index-lock)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SetIndexesPriorityOperation](../../client-api/operations/maintenance/indexes/set-index-priority)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexErrorsOperation](../../client-api/operations/maintenance/indexes/get-index-errors)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexOperation](../../client-api/operations/maintenance/indexes/get-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexesOperation](../../client-api/operations/maintenance/indexes/get-indexes)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetTermsOperation](../../client-api/operations/maintenance/indexes/get-terms)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexPerformanceStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexesStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexingStatusOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexStalenessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexNamesOperation](../../client-api/operations/maintenance/indexes/get-index-names)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StartIndexOperation](../../client-api/operations/maintenance/indexes/start-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StartIndexingOperation](../../client-api/operations/maintenance/indexes/start-indexing)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StopIndexOperation](../../client-api/operations/maintenance/indexes/stop-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StopIndexingOperation](../../client-api/operations/maintenance/indexes/stop-indexing)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ResetIndexOperation](../../client-api/operations/maintenance/indexes/reset-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteIndexOperation](../../client-api/operations/maintenance/indexes/delete-index)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteIndexErrorsOperation](../../client-api/operations/maintenance/indexes/delete-index-errors)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DisableIndexOperation](../../client-api/operations/maintenance/indexes/disable-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [EnableIndexOperation](../../client-api/operations/maintenance/indexes/enable-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [IndexHasChangedOperation](../../client-api/operations/maintenance/indexes/index-has-changed)   
+
+* __Analyzers__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutAnalyzersOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteAnalyzerOperation  
+
+* __Ongoing tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetOngoingTaskInfoOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteOngoingTaskOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ToggleOngoingTaskStateOperation  
+
+* __ETL tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; AddEtlOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateEtlOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ResetEtlOperation](../../client-api/operations/maintenance/etl/reset-etl)
+
+* __Replication tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutPullReplicationAsHubOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetPullReplicationTasksInfoOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetReplicationHubAccessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetReplicationPerformanceStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RegisterReplicationHubAccessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UnregisterReplicationHubAccessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateExternalReplicationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdatePullReplicationAsSinkOperation
+
+* __Backup__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; BackupOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetPeriodicBackupStatusOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StartBackupOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdatePeriodicBackupOperation  
+
+* __Connection strings__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutConnectionStringOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RemoveConnectionStringOperation  
+
+* __Transaction recording__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StartTransactionsRecordingOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StopTransactionsRecordingOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplayTransactionsRecordingOperation  
+
+* __Database settings__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)  
+
+* __Identities__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [NextIdentityForOperation](../../client-api/operations/maintenance/identities/increment-next-identity)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SeedIdentityForOperation](../../client-api/operations/maintenance/identities/seed-identity)
+
+* __Time series__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesPolicyOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesValueNamesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RemoveTimeSeriesPolicyOperation  
+
+* __Revisions__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ConfigureRevisionsOperation](../../document-extensions/revisions/client-api/operations/configure-revisions)  
+
+* __Sorters__:   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutSortersOperation](../../client-api/operations/maintenance/sorters/put-sorter)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteSorterOperation  
+
+* __Misc__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureExpirationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureRefreshOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateDocumentsCompressionConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DatabaseHealthCheckOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetOperationStateOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; CreateSampleDataOperation  
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Server-maintenance operations}
+
+{NOTE: }
+
+* All server-maintenance operations implement the `IServerOperation` interface.  
+  The operation is executed within the __server scope__.   
+  Use [ForNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) to operate on a specific node other than the default defined in the client configuration.
+
+* These operations include server management and configuration operations.  
+  See all available operations [below](../../client-api/operations/what-are-operations#server-list).
+
+* To execute a server-maintenance operation request,  
+  use the `Send` method on the `Maintenance.Server` property in the DocumentStore.
+
+__Example__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync server_ex@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async server_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Send syntax__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync server_send@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async server_send_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+<span id="server-list"> __The following server-maintenance operations are available:__ </span>
+
+---
+
+* __Client certificates__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutClientCertificateOperation](../../client-api/operations/server-wide/certificates/put-client-certificate)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CreateClientCertificateOperation](../../client-api/operations/server-wide/certificates/create-client-certificate)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCertificatesOperation](../../client-api/operations/server-wide/certificates/get-certificates)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteCertificateOperation](../../client-api/operations/server-wide/certificates/delete-certificate)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; EditClientCertificateOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetCertificateMetadataOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplaceClusterCertificateOperation  
+
+* __Server-wide client configuration__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutServerWideClientConfigurationOperation](../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetServerWideClientConfigurationOperation](../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)   
+
+* __Database management__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CreateDatabaseOperation](../../client-api/operations/server-wide/create-database)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteDatabasesOperation](../../client-api/operations/server-wide/delete-database)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ToggleDatabasesStateOperation](../../client-api/operations/server-wide/toggle-databases-state)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseNamesOperation](../../client-api/operations/server-wide/get-database-names)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [AddDatabaseNodeOperation](../../client-api/operations/server-wide/add-database-node)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PromoteDatabaseNodeOperation](../../client-api/operations/server-wide/promote-database-node)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ReorderDatabaseMembersOperation](../../client-api/operations/server-wide/reorder-database-members)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CompactDatabaseOperation](../../client-api/operations/server-wide/compact-database)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetDatabaseRecordOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; SetDatabasesLockOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; CreateDatabaseOperationWithoutNameValidation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; SetDatabaseDynamicDistributionOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ModifyDatabaseTopologyOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateDatabaseOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateUnusedDatabasesOperation  
+
+* __Server-wide ongoing tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideTaskOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ToggleServerWideTaskStateOperation  
+
+* __Server-wide replication tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideExternalReplicationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideExternalReplicationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideExternalReplicationsOperation  
+
+* __Server-wide backup tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideBackupConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideBackupConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideBackupConfigurationsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RestoreBackupOperation  
+
+* __Server-wide analyzers__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideAnalyzersOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideAnalyzerOperation  
+
+* __Server-wide sorters__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutServerWideSortersOperation](../../client-api/operations/server-wide/sorters/put-sorter-server-wide)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideSorterOperation  
+
+* __Logs & debug__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; SetLogsConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetLogsConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetClusterDebugInfoPackageOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetBuildNumberOperation](../../client-api/operations/server-wide/get-build-number)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideOperationStateOperation  
+
+* __Traffic watch__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutTrafficWatchConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTrafficWatchConfigurationOperation
+
+* __Revisions__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ConfigureRevisionsForConflictsOperation](../../document-extensions/revisions/client-api/operations/conflict-revisions-configuration)  
+
+* __Misc__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ModifyConflictSolverOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OfflineMigrationOperation  
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Wait for completion}
+
+* Some operations may take a long time to complete.  
+  Those operations will run in the server background and can be awaited for completion.  
+* The response of the inner 'RavenCommand' class for such operations is `OperationIdResult`.  
+* For those operations, the `Send` method will return an `Operation` object that allows waiting on that operation Id.  
+
+__Example__:  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync wait_ex@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async wait_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+__Syntax__:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync waitForCompletion_syntax@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TAB:csharp:Async waitForCompletion_syntax_async@ClientApi\Operations\WhatAreOperations.cs /}
+{CODE-TABS/}
+
+| Parameters | Type | Description |
+| - | - | - |
+| __timeout__ | `TimeSpan` | <ul><li> __When timespan is specified__ - <br>server throws an error if operation has Not completed within the specified time frame. No rollback action will take place.</li><li>`null` - <br>WaitForCompletion will wait for operation to complete forever.</li></ul> |
+
+| Return type | |
+| - | - |
+| `IOperationResult` | The operation result content. |
+
+{PANEL/}
+
+## Related articles
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)
+
+### Operations
+
+- [How to Switch Operations to a Different Database](../../client-api/operations/how-to/switch-operations-to-a-different-database)
+- [How to Switch Operations to a Different Node](../../client-api/operations/how-to/switch-operations-to-a-different-node)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.java.markdown
@@ -1,0 +1,145 @@
+# What are Operations
+
+The RavenDB client API is built with the notion of layers. At the top, and what you will usually interact with, are the **[DocumentStore](../../client-api/what-is-a-document-store)** and the **[DocumentSession](../../client-api/session/what-is-a-session-and-how-does-it-work)**.
+
+They in turn, are built on top of the notion of Operations and Commands.
+
+Operations are an encapsulation of a set of low level commands which are used to manipulate data, execute administrative tasks, and change the configuration on a server.  
+
+They are available in the DocumentStore under the **operations**, **maintenance**, and **maintenance().server** methods.
+
+{PANEL:Common Operations}
+
+Common operations include set based operations for [Patching](../../client-api/operations/patching/set-based) or removal of documents by using queries (more can be read [here](../../client-api/operations/delete-by-query)).  
+There is also the ability to handle distributed [Compare Exchange](../../client-api/operations/compare-exchange/overview) operations and manage [Attachments](../../client-api/operations/attachments/get-attachment) and [Counters](../../client-api/operations/counters/counter-batch).
+
+### How to Send an Operation
+
+In order to execute an operation, you will need to use the `send` or `sendAsync` methods. Available overloads are:
+{CODE-TABS}
+{CODE-TAB:java:Sync Client_Operations_api@ClientApi\Operations\WhatAreOperations.java /}
+{CODE-TAB:java:Async Client_Operations_api_async@ClientApi\Operations\WhatAreOperations.java /}
+{CODE-TABS/}
+
+### The following operations are available:
+
+#### Compare Exchange
+
+* [CompareExchange](../../client-api/operations/compare-exchange/overview)   
+
+#### Attachments
+
+* [GetAttachmentOperation](../../client-api/operations/attachments/get-attachment)
+* [PutAttachmentOperation](../../client-api/operations/attachments/put-attachment)
+* [DeleteAttachmentOperation](../../client-api/operations/attachments/delete-attachment)
+
+#### Patching
+
+* [PatchByQueryOperation](../../client-api/operations/patching/set-based)   
+* [PatchOperation](../../client-api/operations/patching/single-document)   
+
+
+#### Counters
+
+* [CounterBatchOperation](../../client-api/operations/counters/counter-batch)   
+* [GetCountersOperation](../../client-api/operations/counters/get-counters)   
+
+
+#### Misc
+
+* [DeleteByQueryOperation](../../client-api/operations/delete-by-query)   
+
+### Example - Get Attachment
+
+{CODE:java Client_Operations_1@ClientApi\Operations\WhatAreOperations.java /}
+
+{PANEL/}
+
+{PANEL:Maintenance Operations}
+
+Maintenance operations include operations for changing the configuration at runtime and for management of index operations.
+
+### How to Send an Operation
+
+{CODE:java Maintenance_Operations_api@ClientApi\Operations\WhatAreOperations.java /}
+
+### The following maintenance operations are available:
+
+#### Client Configuration
+
+* [PutClientConfigurationOperation](../../client-api/operations/maintenance/configuration/put-client-configuration)   
+* [GetClientConfigurationOperation](../../client-api/operations/maintenance/configuration/get-client-configuration)   
+
+#### Indexing
+
+* [DeleteIndexOperation](../../client-api/operations/maintenance/indexes/delete-index)   
+* [DisableIndexOperation](../../client-api/operations/maintenance/indexes/disable-index)   
+* [EnableIndexOperation](../../client-api/operations/maintenance/indexes/enable-index)   
+* [ResetIndexOperation](../../client-api/operations/maintenance/indexes/reset-index)   
+* [SetIndexesLockOperation](../../client-api/operations/maintenance/indexes/set-index-lock)   
+* [SetIndexesPriorityOperation](../../client-api/operations/maintenance/indexes/set-index-priority)  
+* [StartIndexOperation](../../client-api/operations/maintenance/indexes/start-index)   
+* [StartIndexingOperation](../../client-api/operations/maintenance/indexes/start-indexing)   
+* [StopIndexOperation](../../client-api/operations/maintenance/indexes/stop-index)   
+* [StopIndexingOperation](../../client-api/operations/maintenance/indexes/stop-indexing)   
+* [GetIndexErrorsOperation](../../client-api/operations/maintenance/indexes/get-index-errors)   
+* [GetIndexOperation](../../client-api/operations/maintenance/indexes/get-index)   
+* [GetIndexesOperation](../../client-api/operations/maintenance/indexes/get-indexes)   
+* [GetTermsOperation](../../client-api/operations/maintenance/indexes/get-terms)   
+* [IndexHasChangedOperation](../../client-api/operations/maintenance/indexes/index-has-changed)   
+* [PutIndexesOperation](../../client-api/operations/maintenance/indexes/put-indexes)   
+
+#### Misc
+
+* [GetCollectionStatisticsOperation](../../client-api/operations/maintenance/get-stats)   
+* [GetStatisticsOperation](../../client-api/operations/maintenance/get-stats)     
+* [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)   
+
+### Example - Stop Index
+
+{CODE:java Maintenance_Operations_1@ClientApi\Operations\WhatAreOperations.java /}
+
+{PANEL/}
+
+{PANEL:Server Operations}
+
+These type of operations contain various administrative and miscellaneous configuration operations.
+
+### How to Send an Operation
+
+{CODE-TABS}
+{CODE-TAB:java:Sync Server_Operations_api@ClientApi\Operations\WhatAreOperations.java /}
+{CODE-TAB:java:Async Server_Operations_api_async@ClientApi\Operations\WhatAreOperations.java /}
+{CODE-TABS/}
+
+### The following server-wide operations are available:
+
+
+#### Cluster Management
+
+* [CreateDatabaseOperation](../../client-api/operations/server-wide/create-database)   
+* [DeleteDatabasesOperation](../../client-api/operations/server-wide/delete-database)   
+
+#### Miscellaneous
+
+* [GetDatabaseNamesOperation](../../client-api/operations/server-wide/get-database-names)   
+
+### Example - Get Build Number
+
+{CODE:java Server_Operations_1@ClientApi\Operations\WhatAreOperations.java /}
+
+{PANEL/}
+
+## Remarks
+
+{NOTE By default, operations available in `store.operations` or `store.maintenance` are working on a default database that was setup for that store. To switch operations to a different database that is available on that server use the **[forDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database)** method. /}
+
+## Related articles
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)
+
+### Operations
+
+- [How to Switch Operations to a Different Database](../../client-api/operations/how-to/switch-operations-to-a-different-database)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -15,12 +15,14 @@
 * In this page:  
   * [Why use operations](../../client-api/operations/what-are-operations#why-use-operations)  
   * [How operations work](../../client-api/operations/what-are-operations#how-operations-work)  
-<br>
+  <br>
   * __Operation types__: 
       * [Common operations](../../client-api/operations/what-are-operations#common-operations)  
       * [Maintenance operations](../../client-api/operations/what-are-operations#maintenance-operations)  
       * [Server-maintenance operations](../../client-api/operations/what-are-operations#server-maintenance-operations)  
-  * [Wait for completion](../../client-api/operations/what-are-operations#wait-for-completion)  
+  * [Manage lengthy operations](../../client-api/operations/what-are-operations#manage-lengthy-operations)
+      * [Wait for completion](../../client-api/operations/what-are-operations#waitForCompletion)
+      * [Kill operation](../../client-api/operations/what-are-operations#killOperation)
 
 {NOTE/}
 
@@ -380,20 +382,39 @@ __Send syntax__:
 {NOTE/}
 {PANEL/}
 
-{PANEL: Wait for completion}
+{PANEL: Manage lengthy operations}
 
-* Some operations may take a long time to complete.  
-  Those operations will run in the server background and can be awaited for completion.  
-* Those operations implement an interface with result type `OperationIdResult`.  
-* For those operations, the `send` method returns a promise for an object that can be awaited on that Id.  
+* Some operations that run in the server background may take a long time to complete.
 
-__Example__:  
+* For Operations that implement an interface with type `OperationIdResult`,  
+  executing the operation via the `send` method will return a promise for `OperationCompletionAwaiter` object,  
+  which can then be __awaited for completion__ or __aborted (killed)__.
+
+---
+
+{NOTE: }
+
+<a id="waitForCompletion" /> __Wait for completion__:
 
 {CODE:nodejs wait_ex@client-api\operations\whatAreOperations.js /}
 
-__Syntax__:
+{NOTE/}
 
-{CODE:nodejs waitForCompletion_syntax@client-api\operations\whatAreOperations.js /}
+{NOTE: }
+
+<a id="killOperation" /> __Kill operation__:
+
+{CODE:nodejs kill_ex@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+##### Syntax:
+
+{CODE:nodejs wait_kill_syntax@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -1,0 +1,409 @@
+# What are Operations
+
+---
+
+{NOTE: }
+
+* The RavenDB Client API is built with the notion of layers.  
+  At the top, and what you will usually interact with, are the **[DocumentStore](../../client-api/what-is-a-document-store)**
+  and the **[Session](../../client-api/session/what-is-a-session-and-how-does-it-work)**.  
+  They in turn are built on top of the lower-level __Operations__ and __RavenCommands__ API.
+
+* __RavenDB provides access to this lower-level API__, so that instead of using the higher session API,  
+  you can generate requests directly to the server by executing operations on the DocumentStore.
+
+* In this page:  
+  * [Why use operations](../../client-api/operations/what-are-operations#why-use-operations)  
+  * [How operations work](../../client-api/operations/what-are-operations#how-operations-work)  
+<br>
+  * __Operation types__: 
+      * [Common operations](../../client-api/operations/what-are-operations#common-operations)  
+      * [Maintenance operations](../../client-api/operations/what-are-operations#maintenance-operations)  
+      * [Server-maintenance operations](../../client-api/operations/what-are-operations#server-maintenance-operations)  
+  * [Wait for completion](../../client-api/operations/what-are-operations#wait-for-completion)  
+
+{NOTE/}
+
+---
+
+{PANEL: Why use operations}
+
+* Operations provide __management functionality__ that is Not available in the context of the session, for example:
+    * Create/delete a database
+    * Execute administrative tasks
+    * Assign permissions
+    * Change server configuration, and more.
+
+* The operations are executed on the DocumentStore and are Not part of the session transaction.
+
+* There are some client tasks, such as patching documents, that can be carried out either via the Session ([session.advanced.patch()](../../client-api/operations/patching/single-document#array-manipulation))
+  or via an Operation on the DocumentStore ([PatchOperation](../../client-api/operations/patching/single-document#operations-api)).
+
+{PANEL/}
+
+{PANEL: How operations work}
+
+* __Sending the request__:  
+  Each Operation creates an HTTP request message to be sent to the relevant server endpoint.  
+  The DocumentStore `OperationExecutor` sends the request and processes the results.
+* __Target node__:  
+  By default, the operation will be executed on the server node that is defined by the [client configuration](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, server-maintenance operations can be executed on a specific node by using the [forNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
+* __Target database__:  
+  By default, operations work on the default database defined in the DocumentStore.  
+  However, common operations & maintenance operations can operate on a different database by using the [forDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) method.  
+* __Transaction scope__:  
+  Operations execute as a single-node transaction.  
+  If needed, data will then replicate to the other nodes in the database-group.
+* __Background operations__:  
+  Some operations may take a long time to complete and can be awaited for completion.   
+  Learn more [below](../../client-api/operations/what-are-operations#wait-for-completion).
+
+{PANEL/}
+
+{PANEL: Common operations}
+
+{NOTE: }
+
+* All common operations implement the `IOperation` interface.  
+  The operation is executed within the __database scope__.  
+  Use [forDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.  
+
+* These operations include set-based operations such as _PatchOperation_, _CounterBatchOperation_,  
+  document-extensions related operations such as getting/putting an attachment, and more.  
+  See all available operations [below](../../client-api/operations/what-are-operations#operations-list).
+
+* To execute a common operation request,  
+  use the `send` method on the `operations` property in the DocumentStore.
+
+__Example__:
+
+{CODE:nodejs operations_ex@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Send syntax__:
+
+{CODE:nodejs operations_send@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+<span id="operations-list"> __The following common operations are available:__ </span>
+
+---
+
+* __Attachments__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutAttachmentOperation](../../client-api/operations/attachments/put-attachment)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetAttachmentOperation](../../client-api/operations/attachments/get-attachment)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteAttachmentOperation](../../client-api/operations/attachments/delete-attachment)  
+
+* __Counters__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CounterBatchOperation](../../client-api/operations/counters/counter-batch)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCountersOperation](../../client-api/operations/counters/get-counters)  
+
+* __Time series__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; TimeSeriesBatchOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetMultipleTimeSeriesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTimeSeriesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTimeSeriesStatisticsOperation  
+
+* __Revisions__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetRevisionsOperation](../../document-extensions/revisions/client-api/operations/get-revisions)  
+
+* __Patching__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PatchOperation](../../client-api/operations/patching/single-document)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PatchByQueryOperation](../../client-api/operations/patching/set-based)  
+
+* __Delete by query__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteByQueryOperation](../../client-api/operations/delete-by-query)   
+
+* __Compare-exchange__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutCompareExchangeValueOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetCompareExchangeValueOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetCompareExchangeValuesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteCompareExchangeValueOperation  
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Maintenance operations}
+
+{NOTE: }
+
+* All maintenance operations implement the `IMaintenanceOperation` interface.  
+  The operation is executed within the __database scope__.  
+  Use [forDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.
+
+* These operations include database management operations such as setting client configuration,  
+  managing indexes & ongoing-tasks operations, getting stats, and more.  
+  See all available maintenance operations [below](../../client-api/operations/what-are-operations#maintenance-list).
+ 
+* To execute a maintenance operation request,  
+  use the `send` method on the `maintenance` property in the DocumentStore.
+
+__Example__:
+
+{CODE:nodejs maintenance_ex@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Send syntax__:
+
+{CODE:nodejs maintenance_send@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+<span id="maintenance-list"> __The following maintenance operations are available:__ </span>
+
+---
+
+* __Statistics__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-database-stats)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDetailedStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCollectionStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-collection-stats)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDetailedCollectionStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+
+* __Client Configuration__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutClientConfigurationOperation](../../client-api/operations/maintenance/configuration/put-client-configuration)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetClientConfigurationOperation](../../client-api/operations/maintenance/configuration/get-client-configuration)  
+
+* __Indexes__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutIndexesOperation](../../client-api/operations/maintenance/indexes/put-indexes)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SetIndexesLockOperation](../../client-api/operations/maintenance/indexes/set-index-lock)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SetIndexesPriorityOperation](../../client-api/operations/maintenance/indexes/set-index-priority)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexErrorsOperation](../../client-api/operations/maintenance/indexes/get-index-errors)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexOperation](../../client-api/operations/maintenance/indexes/get-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexesOperation](../../client-api/operations/maintenance/indexes/get-indexes)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetTermsOperation](../../client-api/operations/maintenance/indexes/get-terms)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexPerformanceStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexesStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexingStatusOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetIndexStalenessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIndexNamesOperation](../../client-api/operations/maintenance/indexes/get-index-names)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StartIndexOperation](../../client-api/operations/maintenance/indexes/start-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StartIndexingOperation](../../client-api/operations/maintenance/indexes/start-indexing)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StopIndexOperation](../../client-api/operations/maintenance/indexes/stop-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [StopIndexingOperation](../../client-api/operations/maintenance/indexes/stop-indexing)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ResetIndexOperation](../../client-api/operations/maintenance/indexes/reset-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteIndexOperation](../../client-api/operations/maintenance/indexes/delete-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteIndexErrorsOperation](../../client-api/operations/maintenance/indexes/delete-index-errors)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DisableIndexOperation](../../client-api/operations/maintenance/indexes/disable-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [EnableIndexOperation](../../client-api/operations/maintenance/indexes/enable-index)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [IndexHasChangedOperation](../../client-api/operations/maintenance/indexes/index-has-changed)   
+
+* __Analyzers__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutAnalyzersOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteAnalyzerOperation  
+
+* __Ongoing tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetOngoingTaskInfoOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteOngoingTaskOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ToggleOngoingTaskStateOperation  
+
+* __ETL tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; AddEtlOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateEtlOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ResetEtlOperation](../../client-api/operations/maintenance/etl/reset-etl)
+
+* __Replication tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutPullReplicationAsHubOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetPullReplicationTasksInfoOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetReplicationHubAccessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetReplicationPerformanceStatisticsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RegisterReplicationHubAccessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UnregisterReplicationHubAccessOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateExternalReplicationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdatePullReplicationAsSinkOperation
+
+* __Backup__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; BackupOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetPeriodicBackupStatusOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StartBackupOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdatePeriodicBackupOperation  
+
+* __Connection strings__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutConnectionStringOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RemoveConnectionStringOperation  
+
+* __Transaction recording__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StartTransactionsRecordingOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StopTransactionsRecordingOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplayTransactionsRecordingOperation  
+
+* __Database settings__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)  
+
+* __Identities__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [NextIdentityForOperation](../../client-api/operations/maintenance/identities/increment-next-identity)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SeedIdentityForOperation](../../client-api/operations/maintenance/identities/seed-identity)
+
+* __Time series__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesPolicyOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesValueNamesOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RemoveTimeSeriesPolicyOperation  
+
+* __Revisions__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ConfigureRevisionsOperation](../../document-extensions/revisions/client-api/operations/configure-revisions)  
+
+* __Sorters__:   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutSortersOperation](../../client-api/operations/maintenance/sorters/put-sorter)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteSorterOperation  
+
+* __Misc__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureExpirationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureRefreshOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateDocumentsCompressionConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DatabaseHealthCheckOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetOperationStateOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; CreateSampleDataOperation  
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Server-maintenance operations}
+
+{NOTE: }
+
+* All server-maintenance operations implement the `IServerOperation` interface.  
+  The operation is executed within the __server scope__.   
+  Use [forNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) to operate on a specific node other than the default defined in the client configuration.
+
+* These operations include server management and configuration operations.  
+  See all available operations [below](../../client-api/operations/what-are-operations#server-list).
+
+* To execute a server-maintenance operation request,  
+  use the `send` method on the `maintenance.server` property in the DocumentStore.   
+
+__Example__:
+
+{CODE:nodejs server_ex@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Send syntax__:
+
+{CODE:nodejs server_send@client-api\operations\whatAreOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+<span id="server-list"> __The following server-maintenance operations are available:__ </span>
+
+---
+
+* __Client certificates__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutClientCertificateOperation](../../client-api/operations/server-wide/certificates/put-client-certificate)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CreateClientCertificateOperation](../../client-api/operations/server-wide/certificates/create-client-certificate)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCertificatesOperation](../../client-api/operations/server-wide/certificates/get-certificates)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteCertificateOperation](../../client-api/operations/server-wide/certificates/delete-certificate)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; EditClientCertificateOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetCertificateMetadataOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplaceClusterCertificateOperation  
+
+* __Server-wide client configuration__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutServerWideClientConfigurationOperation](../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetServerWideClientConfigurationOperation](../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)   
+
+* __Database management__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CreateDatabaseOperation](../../client-api/operations/server-wide/create-database)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteDatabasesOperation](../../client-api/operations/server-wide/delete-database)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ToggleDatabasesStateOperation](../../client-api/operations/server-wide/toggle-databases-state)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseNamesOperation](../../client-api/operations/server-wide/get-database-names)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [AddDatabaseNodeOperation](../../client-api/operations/server-wide/add-database-node)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PromoteDatabaseNodeOperation](../../client-api/operations/server-wide/promote-database-node)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ReorderDatabaseMembersOperation](../../client-api/operations/server-wide/reorder-database-members)   
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CompactDatabaseOperation](../../client-api/operations/server-wide/compact-database)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetDatabaseRecordOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; SetDatabasesLockOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; CreateDatabaseOperationWithoutNameValidation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; SetDatabaseDynamicDistributionOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ModifyDatabaseTopologyOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateDatabaseOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateUnusedDatabasesOperation  
+
+* __Server-wide ongoing tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideTaskOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ToggleServerWideTaskStateOperation  
+
+* __Server-wide replication tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideExternalReplicationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideExternalReplicationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideExternalReplicationsOperation  
+
+* __Server-wide backup tasks__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideBackupConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideBackupConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideBackupConfigurationsOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RestoreBackupOperation
+
+* __Server-wide analyzers__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideAnalyzersOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideAnalyzerOperation
+
+* __Server-wide sorters__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutServerWideSortersOperation](../../client-api/operations/server-wide/sorters/put-sorter-server-wide)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideSorterOperation
+
+* __Logs & debug__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; SetLogsConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetLogsConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetClusterDebugInfoPackageOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetBuildNumberOperation](../../client-api/operations/server-wide/get-build-number)  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideOperationStateOperation
+
+* __Traffic watch__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutTrafficWatchConfigurationOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTrafficWatchConfigurationOperation
+
+* __Revisions__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ConfigureRevisionsForConflictsOperation](../../document-extensions/revisions/client-api/operations/conflict-revisions-configuration)  
+
+* __Misc__:  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ModifyConflictSolverOperation  
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OfflineMigrationOperation
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Wait for completion}
+
+* Some operations may take a long time to complete.  
+  Those operations will run in the server background and can be awaited for completion.  
+* Those operations implement an interface with result type `OperationIdResult`.  
+* For those operations, the `send` method returns a promise for an object that can be awaited on that Id.  
+
+__Example__:  
+
+{CODE:nodejs wait_ex@client-api\operations\whatAreOperations.js /}
+
+__Syntax__:
+
+{CODE:nodejs waitForCompletion_syntax@client-api\operations\whatAreOperations.js /}
+
+{PANEL/}
+
+## Related articles
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)
+
+### Operations
+
+- [How to Switch Operations to a Different Database](../../client-api/operations/how-to/switch-operations-to-a-different-database)
+- [How to Switch Operations to a Different Node](../../client-api/operations/how-to/switch-operations-to-a-different-node)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
@@ -166,10 +166,6 @@ namespace Raven.Documentation.Samples.ClientApi.Operations
             
             // Call 'Kill' to abort operation
             operation.Kill();
-            
-            // Assert that operation is no longer running
-            Assert.Throws<TaskCanceledException>(() => 
-                operation.WaitForCompletion(TimeSpan.FromSeconds(30)));
             #endregion
         }
         

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Counters;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations
+{
+    public class WhatAreOperations
+    {
+        public interface ISendSyntax
+        {
+            #region operations_send
+            // Available overloads:
+            void Send(IOperation operation, SessionInfo sessionInfo = null);
+            TResult Send<TResult>(IOperation<TResult> operation, SessionInfo sessionInfo = null);
+            Operation Send(IOperation<OperationIdResult> operation, SessionInfo sessionInfo = null);
+            
+            PatchStatus Send(PatchOperation operation);
+            PatchOperation.Result<TEntity> Send<TEntity>(PatchOperation<TEntity> operation);
+            #endregion
+
+            #region operations_send_async
+            // Available overloads:
+            Task SendAsync(IOperation operation,
+                CancellationToken token = default(CancellationToken), SessionInfo sessionInfo = null);
+            Task<TResult> SendAsync<TResult>(IOperation<TResult> operation,
+                CancellationToken token = default(CancellationToken), SessionInfo sessionInfo = null);
+            Task<Operation> SendAsync(IOperation<OperationIdResult> operation,
+                CancellationToken token = default(CancellationToken), SessionInfo sessionInfo = null);
+            
+            Task<PatchStatus> SendAsync(PatchOperation operation,
+                CancellationToken token = default(CancellationToken));
+            Task<PatchOperation.Result<TEntity>> SendAsync<TEntity>(PatchOperation<TEntity> operation,
+                CancellationToken token = default(CancellationToken));
+            #endregion
+
+            #region maintenance_send
+            // Available overloads:
+            void Send(IMaintenanceOperation operation);
+            TResult Send<TResult>(IMaintenanceOperation<TResult> operation);
+            Operation Send(IMaintenanceOperation<OperationIdResult> operation);
+            #endregion
+
+            #region maintenance_send_async
+            // Available overloads:
+            Task SendAsync(IMaintenanceOperation operation,
+                CancellationToken token = default(CancellationToken));
+            Task<TResult> SendAsync<TResult>(IMaintenanceOperation<TResult> operation,
+                CancellationToken token = default(CancellationToken));
+            Task<Operation> SendAsync(IMaintenanceOperation<OperationIdResult> operation,
+                CancellationToken token = default(CancellationToken));
+            #endregion
+
+            #region server_send
+            // Available overloads:
+            void Send(IServerOperation operation);
+            TResult Send<TResult>(IServerOperation<TResult> operation);
+            Operation Send(IServerOperation<OperationIdResult> operation);
+            #endregion
+
+            #region server_send_async
+            // Available overloads:
+            Task SendAsync(IServerOperation operation,
+                CancellationToken token = default(CancellationToken));
+            Task<TResult> SendAsync<TResult>(IServerOperation<TResult> operation,
+                CancellationToken token = default(CancellationToken));
+            Task<Operation> SendAsync(IServerOperation<OperationIdResult> operation,
+                CancellationToken token = default(CancellationToken));
+            #endregion
+              
+            /*
+            #region waitForCompletion_syntax
+            // Available overloads:
+            public IOperationResult WaitForCompletion(TimeSpan? timeout = null)
+            
+            public TResult WaitForCompletion<TResult>(TimeSpan? timeout = null)
+                where TResult : IOperationResult
+            #endregion
+            */
+
+            /*
+            #region waitForCompletion_syntax_async
+            // Available overloads:
+            public Task<IOperationResult> WaitForCompletionAsync(TimeSpan? timeout = null)
+            
+            public async Task<TResult> WaitForCompletionAsync<TResult>(TimeSpan? timeout = null)
+                where TResult : IOperationResult
+            #endregion
+            */
+        }
+
+        public void Examples()
+        {
+            using var documentStore = new DocumentStore
+            {
+                Urls = new[] { "http://localhost:8080" },
+                Database = "Northwind"
+            };
+
+            #region operations_ex
+            // Define operation, e.g.. get all counters info for a document
+            IOperation<CountersDetail> getCountersOp = new GetCountersOperation("products/1-A");
+            
+            // Execute the operation by passing the operation to Operations.Send
+            CountersDetail allCountersResult = documentStore.Operations.Send(getCountersOp);
+            
+            // Access the operation result
+            int numberOfCounters = allCountersResult.Counters.Count;
+            #endregion
+
+            #region maintenance_ex
+            // Define operation, e.g. stop an index 
+            IMaintenanceOperation stopIndexOp = new StopIndexOperation("Orders/ByCompany");
+                
+            // Execute the operation by passing the operation to Maintenance.Send
+            documentStore.Maintenance.Send(stopIndexOp);
+            
+            // This specific operation returns void
+            // You can send another operation to verify the index running status
+            IMaintenanceOperation<IndexStats> indexStatsOp = new GetIndexStatisticsOperation("Orders/ByCompany");
+            IndexStats indexStats =  documentStore.Maintenance.Send(indexStatsOp);
+            IndexRunningStatus status = indexStats.Status; // will be "Paused"
+            #endregion
+
+            #region server_ex
+            // Define operation, e.g. get the server build number
+            IServerOperation<BuildNumber> getBuildNumberOp = new GetBuildNumberOperation();
+                
+            // Execute the operation by passing the operation to Maintenance.Server.Send
+            BuildNumber buildNumberResult = documentStore.Maintenance.Server.Send(getBuildNumberOp);
+
+            // Access the operation result
+            int version = buildNumberResult.BuildVersion;
+            #endregion
+            
+            #region wait_ex
+            // Define operation, e.g. delete all discontinued products 
+            // Note: This operation implements: 'IOperation<OperationIdResult>'
+            IOperation<OperationIdResult> deleteByQueryOp =
+                new DeleteByQueryOperation("from Products where Discontinued = true");
+                
+            // Execute the operation
+            // Send returns an 'Operation' object that can be awaited on
+            Operation operation = documentStore.Operations.Send(deleteByQueryOp);
+            
+            // Call method 'WaitForCompletion' to wait for operation completion 
+            BulkOperationResult result = (BulkOperationResult)operation.WaitForCompletion(TimeSpan.FromMinutes(2));
+            
+            // Access the operation result
+            long numberOfItemsDeleted = result.Total;
+            #endregion
+        }
+        
+        public async Task ExamplesAsync()
+        {
+            using var documentStore = new DocumentStore
+            {
+                Urls = new[] { "http://localhost:8080" },
+                Database = "Northwind"
+            };
+
+            #region operations_ex_async
+            // Define operation, e.g. get all counters info for a document
+            IOperation<CountersDetail> getCountersOp = new GetCountersOperation("products/1-A");
+                
+            // Execute the operation by passing the operation to Operations.Send
+            CountersDetail allCountersResult = await documentStore.Operations.SendAsync(getCountersOp);
+            
+            // Access the operation result
+            int numberOfCounters = allCountersResult.Counters.Count;
+            #endregion
+
+            #region maintenance_ex_async
+            // Define operation, e.g. stop an index 
+            IMaintenanceOperation stopIndexOp = new StopIndexOperation("Orders/ByCompany");
+            
+            // Execute the operation by passing the operation to Maintenance.Send
+            await documentStore.Maintenance.SendAsync(stopIndexOp);
+            
+            // This specific operation returns void
+            // You can send another operation to verify the index running status
+            IMaintenanceOperation<IndexStats> indexStatsOp = new GetIndexStatisticsOperation("Orders/ByCompany");
+            IndexStats indexStats =  await documentStore.Maintenance.SendAsync(indexStatsOp);
+            IndexRunningStatus status = indexStats.Status; // will be "Paused"
+            #endregion
+
+            #region server_ex_async
+            // Define operation, e.g. get the server build number
+            IServerOperation<BuildNumber> getBuildNumberOp = new GetBuildNumberOperation();
+                
+            // Execute the operation by passing the operation to Maintenance.Server.Send
+            BuildNumber buildNumberResult = await documentStore.Maintenance.Server.SendAsync(getBuildNumberOp);
+            
+            // Access the operation result
+            int version = buildNumberResult.BuildVersion;
+            #endregion
+            
+            #region wait_ex_async
+            // Define operation, e.g. delete all discontinued products
+            // Note: This operation implements: 'IOperation<OperationIdResult>'
+            IOperation<OperationIdResult> deleteByQueryOp =
+                new DeleteByQueryOperation("from Products where Discontinued = true");
+                
+            // Execute the operation
+            // SendAsync returns an 'Operation' object that can be awaited on
+            Operation operation = await documentStore.Operations.SendAsync(deleteByQueryOp);
+            
+            // Call method 'WaitForCompletionAsync' to wait for operation completion 
+            BulkOperationResult result = 
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(2))
+                               .ConfigureAwait(false) as BulkOperationResult;
+            
+            // Access the operation result
+            long numberOfItemsDeleted = result.Total;
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/WhatAreOperations.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/WhatAreOperations.java
@@ -1,0 +1,101 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.attachments.AttachmentType;
+import net.ravendb.client.documents.operations.CompactDatabaseOperation;
+import net.ravendb.client.documents.operations.DeleteByQueryOperation;
+import net.ravendb.client.documents.operations.Operation;
+import net.ravendb.client.documents.operations.attachments.CloseableAttachmentResult;
+import net.ravendb.client.documents.operations.attachments.GetAttachmentOperation;
+import net.ravendb.client.documents.operations.configuration.GetClientConfigurationOperation;
+import net.ravendb.client.documents.operations.indexes.StopIndexOperation;
+import net.ravendb.client.documents.queries.IndexQuery;
+import net.ravendb.client.serverwide.CompactSettings;
+
+public class WhatAreOperations {
+
+    private interface IFoo<TResult, TEntity> {
+        /*
+        //region Client_Operations_api
+        public void send(IVoidOperation operation)
+
+        public void send(IVoidOperation operation, SessionInfo sessionInfo)
+
+        public <TResult> TResult send(IOperation<TResult> operation)
+
+        public <TResult> TResult send(IOperation<TResult> operation, SessionInfo sessionInfo)
+
+        public PatchStatus send(PatchOperation operation, SessionInfo sessionInfo)
+
+        public <TEntity> PatchOperation.Result<TEntity> send(Class<TEntity> entityClass, PatchOperation operation, SessionInfo sessionInfo)
+        //endregion
+
+        //region Client_Operations_api_async
+        public Operation sendAsync(IOperation<OperationIdResult> operation)
+
+        public Operation sendAsync(IOperation<OperationIdResult> operation, SessionInfo sessionInfo)
+        //endregion
+
+        //region Maintenance_Operations_api
+        public void send(IVoidMaintenanceOperation operation)
+
+        public <TResult> TResult send(IMaintenanceOperation<TResult> operation)
+        //endregion
+
+        //region Maintenance_Operations_api_async
+        public Operation sendAsync(IMaintenanceOperation<OperationIdResult> operation)
+        //endregion
+
+        //region Server_Operations_api
+        public void send(IVoidServerOperation operation)
+
+        public <TResult> TResult send(IServerOperation<TResult> operation)
+        //endregion
+
+        //region Server_Operations_api_async
+        public Operation sendAsync(IServerOperation<OperationIdResult> operation)
+        //endregion
+        */
+    }
+
+    public WhatAreOperations() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region Client_Operations_1
+            try (CloseableAttachmentResult fetchedAttachment = store
+                .operations()
+                .send(new GetAttachmentOperation("users/1", "file.txt", AttachmentType.DOCUMENT, null))) {
+                // do stuff with the attachment stream --> fetchedAttachment.data
+            }
+            //endregion
+
+            {
+                //region Client_Operations_1_async
+                IndexQuery indexQuery = new IndexQuery();
+                indexQuery.setQuery("from users where Age == 5");
+                DeleteByQueryOperation operation = new DeleteByQueryOperation(indexQuery);
+                Operation asyncOp = store.operations().sendAsync(operation);
+                //endregion
+            }
+
+            //region Maintenance_Operations_1
+            store.maintenance().send(new StopIndexOperation("Orders/ByCompany"));
+            //endregion
+
+            //region Server_Operations_1
+            GetClientConfigurationOperation.Result result
+                = store.maintenance().send(new GetClientConfigurationOperation());
+            //endregion
+
+            {
+                //region Server_Operations_1_async
+                CompactSettings settings = new CompactSettings();
+                settings.setDocuments(true);
+                settings.setDatabaseName("Northwind");
+                Operation operation = store.maintenance().server().sendAsync(new CompactDatabaseOperation(settings));
+                operation.waitForCompletion();
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/whatAreOperations.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/whatAreOperations.js
@@ -1,0 +1,79 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function operations() {
+    //region operations_ex
+    // Define operation, e.g. get all counters info for a document
+    const getCountersOp = new GetCountersOperation("products/1-A");
+
+    // Execute the operation by passing the operation to operations.send
+    const allCountersResult = await documentStore.operations.send(getCountersOp);
+
+    // Access the operation result
+    const numberOfCounters = allCountersResult.counters.length;
+    //endregion
+
+    //region maintenance_ex
+    // Define operation, e.g. stop an index 
+    const stopIndexOp = new StopIndexOperation("Orders/ByCompany");
+
+    // Execute the operation by passing the operation to maintenance.send
+    await documentStore.maintenance.send(stopIndexOp);
+
+    // This specific operation returns void
+    // You can send another operation to verify the index running status
+    const indexStatsOp = new GetIndexStatisticsOperation("Orders/ByCompany");
+    const indexStats = await documentStore.maintenance.send(indexStatsOp);
+    const status = indexStats.status; // will be "Paused"
+    //endregion
+
+    //region server_ex
+    // Define operation, e.g. get the server build number
+    const getBuildNumberOp = new GetBuildNumberOperation();
+
+    // Execute the operation by passing the operation to maintenance.server.send
+    const buildNumberResult = await documentStore.maintenance.server.send(getBuildNumberOp);
+
+    // Access the operation result
+    const version = buildNumberResult.buildVersion;
+    //endregion
+
+    //region wait_ex
+    // Define operation, e.g. delete all discontinued products 
+    // Note: This operation implements: 'IOperation<OperationIdResult>'
+    const deleteByQueryOp = new DeleteByQueryOperation("from Products where Discontinued = true");
+
+    // Execute the operation
+    // 'send' returns an object that can be awaited on
+    const asyncOperation = await documentStore.operations.send(deleteByQueryOp);
+
+    // Call method 'waitForCompletion' to wait for operation completion 
+    await asyncOperation.waitForCompletion();
+    //endregion
+}
+
+{
+    //region operations_send
+    // Available overloads:
+    await send(operation);
+    await send(operation, sessionInfo);
+    await send(operation, sessionInfo, documentType);
+
+    await send(patchOperaton);
+    await send(patchOperation, sessionInfo);
+    await send(patchOperation, sessionInfo, resultType);
+    //endregion
+
+    //region maintenance_send
+    await send(operation);
+    //endregion
+
+    //region server_send
+    await send(operation);
+    //endregion
+
+    //region waitForCompletion_syntax
+    await waitForCompletion();
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/whatAreOperations.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/whatAreOperations.js
@@ -41,15 +41,28 @@ async function operations() {
 
     //region wait_ex
     // Define operation, e.g. delete all discontinued products 
-    // Note: This operation implements: 'IOperation<OperationIdResult>'
+    // Note: This operation implements interface: 'IOperation<OperationIdResult>'
     const deleteByQueryOp = new DeleteByQueryOperation("from Products where Discontinued = true");
 
     // Execute the operation
     // 'send' returns an object that can be awaited on
     const asyncOperation = await documentStore.operations.send(deleteByQueryOp);
 
-    // Call method 'waitForCompletion' to wait for operation completion 
+    // Call method 'waitForCompletion' to wait for the operation to complete 
     await asyncOperation.waitForCompletion();
+    //endregion
+
+    //region kill_ex
+    // Define operation, e.g. delete all discontinued products 
+    // Note: This operation implements interface: 'IOperation<OperationIdResult>'
+    const deleteByQueryOp = new DeleteByQueryOperation("from Products where Discontinued = true");
+
+    // Execute the operation
+    // 'send' returns an object that can be 'killed'
+    const asyncOperation = await documentStore.operations.send(deleteByQueryOp);
+
+    // Call method 'kill' to abort operation
+    await asyncOperation.kill();
     //endregion
 }
 
@@ -73,7 +86,8 @@ async function operations() {
     await send(operation);
     //endregion
 
-    //region waitForCompletion_syntax
+    //region wait_kill_syntax
     await waitForCompletion();
+    await kill()
     //endregion
 }


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2537/Add-operation.Kill-WaitForCompletion-overload

---

**C#:**
* Fixed 'why use operation' text
* Added `operation.kill`
* Added `operation.WaitForCompletion` with cancellation token
* @haludi - pls review files:
  ```
  Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
  Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/WhatAreOperations.cs
  ```


**Node.js:**
* Fixed 'why use operation' text
* Added `operation.kill`
* @ml054 - pls review files:
   ```
  Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
  Documentation/5.4/Samples/nodejs/client-api/operations/whatAreOperations.js
  ```