### PR TITLE
RDoc-2551 Update article Http Configuration

### DIFF
--- a/Documentation/5.1/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
@@ -3,7 +3,7 @@
 
 {NOTE: }
 
-* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which an HTTP web server built on ASP.NET Core.
+* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which is an HTTP web server built on ASP.NET Core.
 
 * You can set Kestrel's properties via the following RavenDB configuration keys.
 

--- a/Documentation/5.1/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
@@ -1,0 +1,188 @@
+# Configuration: HTTP
+---
+
+{NOTE: }
+
+* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which an HTTP web server built on ASP.NET Core.
+
+* You can set Kestrel's properties via the following RavenDB configuration keys.
+
+* In this page:
+  * [Http.MinDataRateBytesPerSec](../../server/configuration/http-configuration#http.mindataratebytespersec)
+  * [Http.MinDataRateGracePeriodInSec](../../server/configuration/http-configuration#http.mindatarategraceperiodinsec)
+  * [Http.MaxRequestBufferSizeInKb](../../server/configuration/http-configuration#http.maxrequestbuffersizeinkb)
+  * [Http.MaxRequestLineSizeInKb](../../server/configuration/http-configuration#http.maxrequestlinesizeinkb)
+  * [Http.UseResponseCompression](../../server/configuration/http-configuration#http.useresponsecompression)
+  * [Http.AllowResponseCompressionOverHttps](../../server/configuration/http-configuration#http.allowresponsecompressionoverhttps)
+  * [Http.GzipResponseCompressionLevel](../../server/configuration/http-configuration#http.gzipresponsecompressionlevel)
+  * [Http.DeflateResponseCompressionLevel](../../server/configuration/http-configuration#http.deflateresponsecompressionlevel)
+  * [Http.StaticFilesResponseCompressionLevel](../../server/configuration/http-configuration#http.staticfilesresponsecompressionlevel)
+  * [Http.Protocols](../../server/configuration/http-configuration#http.protocols)
+  * [Http.AllowSynchronousIO](../../server/configuration/http-configuration#http.allowsynchronousio)
+
+{NOTE/}
+
+---
+
+{PANEL: Http.MinDataRateBytesPerSec}
+
+* Set Kestrel's minimum required data rate in bytes per second.  
+
+* This option must be configured together with [Http.MinDataRateGracePeriod](../../server/configuration/http-configuration#http.mindatarategraceperiodinsec).  
+
+---
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel's properties**:
+    - [MinResponseDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minresponsedatarate?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-minresponsedatarate)
+    - [MinRequestBodyDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minrequestbodydatarate?view=aspnetcore-8.0)
+
+{PANEL/}
+
+{PANEL: Http.MinDataRateGracePeriodInSec}
+
+* Set Kestrel's allowed request and response grace period in seconds.  
+  This option must be configured together with [Http.MinDataRateBytesPerSec](../../server/configuration/http-configuration#http.mindataratebytespersec)
+
+* Kestrel checks every second if data is coming in at the specified rate in bytes/second.  
+  If the rate drops below the minimum set by _MinResponseDataRate_, the connection is timed out.
+
+* The grace period _Http.MinDataRateGracePeriodInSec_ is the amount of time that Kestrel gives the client to increase its send rate up to the minimum. The rate is not checked during that time. 
+  The grace period helps avoid dropping connections that are initially sending data at a slow rate due to TCP slow-start.
+
+* When set to `null` then rates are unlimited, no minimum data rate will be enforced.
+
+---
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel's properties**:
+    - [MinResponseDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minresponsedatarate?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-minresponsedatarate)
+    - [MinRequestBodyDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minrequestbodydatarate?view=aspnetcore-8.0)
+
+{WARNING: }
+If __either__ one of _Http.MinDataRateBytesPerSec_ or _Http.MinDataRateGracePeriodInSec_ is Not set or set to `null`,  
+then __both__ Kestrel's properties ( _MinResponseDataRate_ & _MinRequestBodyDataRate_ ) will be set to `null`.
+{WARNING/}
+
+{PANEL/}
+
+{PANEL: Http.MaxRequestBufferSizeInKb}
+
+* Set the maximum size of the response buffer before write calls begin to block or return tasks that don't complete until the buffer size drops below the configured limit.
+  
+* If not set, or set to `null`, then the size of the request buffer is unlimited.
+
+---
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [MaxRequestBufferSize](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.maxrequestbuffersize?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-maxrequestbuffersize)
+
+{PANEL/}
+
+{PANEL: Http.MaxRequestLineSizeInKb}
+
+Sets the maximum allowed size for the HTTP request line.
+
+- **Type**: `int`
+- **Default**: `16`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [MaxRequestLineSize](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.maxrequestlinesize?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-maxrequestlinesize)
+
+{PANEL/}
+
+{PANEL: Http.UseResponseCompression}
+
+* Set whether Raven's HTTP server should compress its responses.
+
+* Using compression lowers the network bandwidth usage.   
+  However, setting to `false` is needed in order to debug or view the response via sniffer tools.
+
+---
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Http.AllowResponseCompressionOverHttps}
+
+* Set whether Raven's HTTP server should allow response compression to happen when HTTPS is enabled.
+
+* Please see http://breachattack.com/ before enabling this.
+
+---
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [EnableForHttps](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.responsecompressionoptions.enableforhttps?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-responsecompressionoptions-enableforhttps)
+
+{PANEL/}
+
+{PANEL: Http.GzipResponseCompressionLevel}
+
+Set the compression level to be used when compressing HTTP responses with GZip.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Fastest`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [Level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions.level?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-gzipcompressionprovideroptions-level)
+
+{PANEL/}
+
+{PANEL: Http.DeflateResponseCompressionLevel}
+
+Set the compression level to be used when compressing HTTP responses with Deflate.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Fastest`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [Level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions.level?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-gzipcompressionprovideroptions-level)
+
+{PANEL/}
+
+{PANEL: Http.StaticFilesResponseCompressionLevel}
+
+Set the compression level to be used when compressing static files.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Optimal`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Http.Protocols}
+
+* Set HTTP protocols that should be supported by the server.
+
+* By default, the HTTP protocol is set by the constructor of class `HttpConfiguration`  
+  (that is what is meant by the value `"DefaultValueSetInConstructor"`).
+
+* If the platform running RavenDB is either Windows 10 or higher, Windows Server 2016 or newer, or POSIX,  
+  the constructor sets Http.Protocols to `Http1AndHttp2`. Otherwise, it is set to `Http1`.
+
+---
+
+- **Type**: `enum HttpProtocols` ( `None`, `Http1`, `Http2`, `Http1AndHttp2`, `Http3`, `Http1AndHttp2AndHttp3`)
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Http.AllowSynchronousIO}
+
+Set a value that controls whether synchronous IO is allowed for the Request and Response.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [AllowSynchronousIO](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserveroptions.allowsynchronousio?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserveroptions-allowsynchronousio)
+
+{PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
@@ -12,6 +12,9 @@
   * [Http.MinDataRateGracePeriodInSec](../../server/configuration/http-configuration#http.mindatarategraceperiodinsec)
   * [Http.MaxRequestBufferSizeInKb](../../server/configuration/http-configuration#http.maxrequestbuffersizeinkb)
   * [Http.MaxRequestLineSizeInKb](../../server/configuration/http-configuration#http.maxrequestlinesizeinkb)
+  * [Http.Http2.KeepAlivePingTimeoutInSec](../../server/configuration/http-configuration#http.http2.keepalivepingtimeoutinsec)
+  * [Http.Http2.KeepAlivePingDelayInSec](../../server/configuration/http-configuration#http.http2.keepalivepingdelayinsec)
+  * [Http.Http2.MaxStreamsPerConnection](../../server/configuration/http-configuration#http.http2.maxstreamsperconnection)
   * [Http.UseResponseCompression](../../server/configuration/http-configuration#http.useresponsecompression)
   * [Http.AllowResponseCompressionOverHttps](../../server/configuration/http-configuration#http.allowresponsecompressionoverhttps)
   * [Http.GzipResponseCompressionLevel](../../server/configuration/http-configuration#http.gzipresponsecompressionlevel)
@@ -93,6 +96,44 @@ Set the maximum allowed size for the HTTP request line.
 - **Default**: `16`
 - **Scope**: Server-wide only
 - **Used for setting Kestrel property**: [MaxRequestLineSize](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.maxrequestlinesize?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-maxrequestlinesize)
+
+{PANEL/}
+
+{PANEL: Http.Http2.KeepAlivePingTimeoutInSec}
+
+Set Kestrel's HTTP2 keep alive ping timeout.
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [KeepAlivePingTimeout](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.keepalivepingtimeout?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-keepalivepingtimeout)
+
+{PANEL/}
+
+{PANEL: Http.Http2.KeepAlivePingDelayInSec}
+
+Set Kestrel's HTTP2 keep alive ping delay.
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [KeepAlivePingDelay](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.keepalivepingdelay?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-keepalivepingdelay)
+
+{PANEL/}
+
+{PANEL: Http.Http2.MaxStreamsPerConnection}
+
+* Set Kestrel's HTTP2 max streams per connection.  
+
+* This limits the number of concurrent request streams per HTTP/2 connection.  
+  Excess streams will be refused.
+
+---
+
+- **Type**: `int`
+- **Default**: `int.MaxValue` (no limit)
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [MaxStreamsPerConnection](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.maxstreamsperconnection?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-maxstreamsperconnection)
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
@@ -3,7 +3,7 @@
 
 {NOTE: }
 
-* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which an HTTP web server built on ASP.NET Core.
+* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which is an HTTP web server built on ASP.NET Core.
 
 * You can set Kestrel's properties via the following RavenDB configuration keys.
 
@@ -128,10 +128,13 @@ Set Kestrel's HTTP2 keep alive ping delay.
 * This limits the number of concurrent request streams per HTTP/2 connection.  
   Excess streams will be refused.
 
+* When _Http.Http2.MaxStreamsPerConnection_ is `null` or not set,  
+  RavenDB assigns _int.MaxValue_ to _MaxStreamsPerConnection_.
+
 ---
 
 - **Type**: `int`
-- **Default**: `int.MaxValue` (no limit)
+- **Default**: `null` (no limit)
 - **Scope**: Server-wide only
 - **Used for setting Kestrel property**: [MaxStreamsPerConnection](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.maxstreamsperconnection?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-maxstreamsperconnection)
 

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/.docs.json
@@ -1,169 +1,175 @@
 [
-  {
-    "Path": "configuration-options.markdown",
-    "Name": "Configuration Overview",
-    "DiscussionId": "5b02dc18-9f71-44c2-91e1-db773e67ee62",
-    "Mappings": []
-  },
-  {
-    "Path": "command-line-arguments.markdown",
-    "Name": "Command Line Arguments",
-    "DiscussionId": "9814a466-00e6-4457-b9c5-6688c65766a5",
-    "Mappings": []
-  },
-  {
-    "Path": "backup-configuration.markdown",
-    "Name": "Backup Options",
-    "DiscussionId": "dbee505a-ac58-4e24-9993-c4e822a47916",
-    "Mappings": []
-  },
-  {
-    "Path": "cluster-configuration.markdown",
-    "Name": "Cluster Configuration",
-    "DiscussionId": "35d5b815-0e93-4986-b5eb-05ba66ba154c",
-    "Mappings": []
-  },
-  {
-    "Path": "core-configuration.markdown",
-    "Name": "Core Configuration",
-    "DiscussionId": "64bf1f6e-6646-449b-b4ca-3df90c568ae4",
-    "Mappings": []
-  },
-  {
-    "Path": "database-configuration.markdown",
-    "Name": "Database Configuration",
-    "DiscussionId": "21bc3dc1-eb28-4806-99e4-ee3f8a8d2f60",
-    "Mappings": []
-  },
-  {
-    "Path": "etl-configuration.markdown",
-    "Name": "ETL Configuration",
-    "DiscussionId": "c98467b2-7072-4ca0-ac72-b775dc8ac67f",
-    "Mappings": []
-  },
-  {
-    "Path": "queue-sink-configuration.markdown",
-    "Name": "Queue Sink Configuration",
-    "DiscussionId": "c98467b2-7072-4ca0-ac72-b775dc8ac67f",
-    "Mappings": []
-  },
-  {
-    "Path": "embedded-configuration.markdown",
-    "Name": "Embedded Configuration",
-    "DiscussionId": "a6a148d2-c4fa-47c6-aa1c-3fad81e64000",
-    "Mappings": [
-      {
-        "Version": 4.0,
-        "Key": "server/configuration/testing-configuration"
-      }
-    ]
-  },
-  {
-    "Path": "http-configuration.markdown",
-    "Name": "HTTP Configuration",
-    "DiscussionId": "21f4f4d1-cb21-40f0-9c65-af4cfb761cb9",
-    "Mappings": []
-  },
-  {
-    "Path": "indexing-configuration.markdown",
-    "Name": "Indexing Configuration",
-    "DiscussionId": "40464303-54d4-44f4-95c0-a69e0de985a2",
-    "Mappings": []
-  },
-  {
-    "Path": "license-configuration.markdown",
-    "Name": "License Configuration",
-    "DiscussionId": "f96e07fc-5344-4ba6-ab5c-d4263ee8be6b",
-    "Mappings": []
-  },
-  {
-    "Path": "logs-configuration.markdown",
-    "Name": "Logs Configuration",
-    "DiscussionId": "9b1ea3ed-c951-408f-acf4-74ca775ccba5",
-    "Mappings": []
-  },
-  {
-    "Path": "memory-configuration.markdown",
-    "Name": "Memory Configuration",
-    "DiscussionId": "d01a45fe-4356-4fc3-998c-718c62fe89b7",
-    "Mappings": []
-  },
-  {
-    "Path": "monitoring-configuration.markdown",
-    "Name": "Monitoring Configuration",
-    "DiscussionId": "c7ac2756-7486-4c98-bf3d-dedeed45784e",
-    "Mappings": []
-  },
-  {
-    "Path": "patching-configuration.markdown",
-    "Name": "Patching Configuration",
-    "DiscussionId": "0b15dc07-fcf0-4e03-9fc4-4e50eab7eeab",
-    "Mappings": []
-  },
-  {
-    "Path": "performance-hints-configuration.markdown",
-    "Name": "Performance Hints Configuration",
-    "DiscussionId": "8b22654a-e212-4601-ba8a-d5ababe2f730",
-    "Mappings": []
-  },
-  {
-    "Path": "query-configuration.markdown",
-    "Name": "Query Configuration",
-    "DiscussionId": "a70af9a0-53cd-4d98-9cff-a592d0ceca86",
-    "Mappings": []
-  },
-  {
-    "Path": "replication-configuration.markdown",
-    "Name": "Replication Configuration",
-    "DiscussionId": "b47bdf7d-69f2-4bc9-aad5-879311007d33",
-    "Mappings": []
-  },
-  {
-    "Path": "security-configuration.markdown",
-    "Name": "Security Configuration",
-    "DiscussionId": "84c7d92d-d009-4f2c-b2ca-d56afaaac2f8",
-    "Mappings": []
-  },
-  {
-    "Path": "server-configuration.markdown",
-    "Name": "Server Configuration",
-    "DiscussionId": "79df0789-13d6-43c1-ae47-563550cc291c",
-    "Mappings": []
-  },
-  {
-    "Path": "storage-configuration.markdown",
-    "Name": "Storage Configuration",
-    "DiscussionId": "76f2a9ab-56d7-42d1-80e0-38cdbd4147bb",
-    "Mappings": []
-  },
-  {
-    "Path": "studio-configuration.markdown",
-    "Name": "Studio Configuration",
-    "DiscussionId": "d13bd568-a7df-477e-9708-588307fba47a",
-    "Mappings": []
-  },
-  {
-    "Path": "subscription-configuration.markdown",
-    "Name": "Subscription Configuration",
-    "DiscussionId": "04e3284b-d599-4479-b75a-ae7d6920cd6e",
-    "Mappings": []
-  },
-  {
-    "Path": "tombstone-configuration.markdown",
-    "Name": "Tombstone Configuration",
-    "DiscussionId": "65ca6661-dd2f-4833-8978-c642828aa25a",
-    "Mappings": []
-  },
-  {
-    "Path": "transaction-merger-configuration.markdown",
-    "Name": "Transaction Merger Configuration",
-    "DiscussionId": "7b64f734-8147-4e84-815a-3c1aabfc7e68",
-    "Mappings": []
-  },
-  {
-    "Path": "updates-configuration.markdown",
-    "Name": "Updates Configuration",
-    "DiscussionId": "7852f306-898f-4fb4-adbd-c7b21934393d",
-    "Mappings": []
-  }
+    {
+        "Path": "configuration-options.markdown",
+        "Name": "Configuration Overview",
+        "DiscussionId": "5b02dc18-9f71-44c2-91e1-db773e67ee62",
+        "Mappings": []
+    },
+    {
+        "Path": "command-line-arguments.markdown",
+        "Name": "Command Line Arguments",
+        "DiscussionId": "9814a466-00e6-4457-b9c5-6688c65766a5",
+        "Mappings": []
+    },
+    {
+        "Path": "backup-configuration.markdown",
+        "Name": "Backup Options",
+        "DiscussionId": "dbee505a-ac58-4e24-9993-c4e822a47916",
+        "Mappings": []
+    },
+    {
+        "Path": "cluster-configuration.markdown",
+        "Name": "Cluster Configuration",
+        "DiscussionId": "35d5b815-0e93-4986-b5eb-05ba66ba154c",
+        "Mappings": []
+    },
+    {
+        "Path": "core-configuration.markdown",
+        "Name": "Core Configuration",
+        "DiscussionId": "64bf1f6e-6646-449b-b4ca-3df90c568ae4",
+        "Mappings": []
+    },
+    {
+        "Path": "database-configuration.markdown",
+        "Name": "Database Configuration",
+        "DiscussionId": "21bc3dc1-eb28-4806-99e4-ee3f8a8d2f60",
+        "Mappings": []
+    },
+    {
+        "Path": "etl-configuration.markdown",
+        "Name": "ETL Configuration",
+        "DiscussionId": "c98467b2-7072-4ca0-ac72-b775dc8ac67f",
+        "Mappings": []
+    },
+    {
+        "Path": "queue-sink-configuration.markdown",
+        "Name": "Queue Sink Configuration",
+        "DiscussionId": "c98467b2-7072-4ca0-ac72-b775dc8ac67f",
+        "Mappings": []
+    },
+    {
+        "Path": "embedded-configuration.markdown",
+        "Name": "Embedded Configuration",
+        "DiscussionId": "a6a148d2-c4fa-47c6-aa1c-3fad81e64000",
+        "Mappings": [
+            {
+                "Version": 4.0,
+                "Key": "server/configuration/testing-configuration"
+            }
+        ]
+    },
+    {
+        "Path": "http-configuration.markdown",
+        "Name": "HTTP Configuration",
+        "DiscussionId": "21f4f4d1-cb21-40f0-9c65-af4cfb761cb9",
+        "Mappings": []
+    },
+    {
+        "Path": "indexing-configuration.markdown",
+        "Name": "Indexing Configuration",
+        "DiscussionId": "40464303-54d4-44f4-95c0-a69e0de985a2",
+        "Mappings": []
+    },
+    {
+        "Path": "license-configuration.markdown",
+        "Name": "License Configuration",
+        "DiscussionId": "f96e07fc-5344-4ba6-ab5c-d4263ee8be6b",
+        "Mappings": []
+    },
+    {
+        "Path": "logs-configuration.markdown",
+        "Name": "Logs Configuration",
+        "DiscussionId": "9b1ea3ed-c951-408f-acf4-74ca775ccba5",
+        "Mappings": []
+    },
+    {
+        "Path": "memory-configuration.markdown",
+        "Name": "Memory Configuration",
+        "DiscussionId": "d01a45fe-4356-4fc3-998c-718c62fe89b7",
+        "Mappings": []
+    },
+    {
+        "Path": "monitoring-configuration.markdown",
+        "Name": "Monitoring Configuration",
+        "DiscussionId": "c7ac2756-7486-4c98-bf3d-dedeed45784e",
+        "Mappings": []
+    },
+    {
+        "Path": "patching-configuration.markdown",
+        "Name": "Patching Configuration",
+        "DiscussionId": "0b15dc07-fcf0-4e03-9fc4-4e50eab7eeab",
+        "Mappings": []
+    },
+    {
+        "Path": "performance-hints-configuration.markdown",
+        "Name": "Performance Hints Configuration",
+        "DiscussionId": "8b22654a-e212-4601-ba8a-d5ababe2f730",
+        "Mappings": []
+    },
+    {
+        "Path": "query-configuration.markdown",
+        "Name": "Query Configuration",
+        "DiscussionId": "a70af9a0-53cd-4d98-9cff-a592d0ceca86",
+        "Mappings": []
+    },
+    {
+        "Path": "replication-configuration.markdown",
+        "Name": "Replication Configuration",
+        "DiscussionId": "b47bdf7d-69f2-4bc9-aad5-879311007d33",
+        "Mappings": []
+    },
+    {
+        "Path": "security-configuration.markdown",
+        "Name": "Security Configuration",
+        "DiscussionId": "84c7d92d-d009-4f2c-b2ca-d56afaaac2f8",
+        "Mappings": []
+    },
+    {
+        "Path": "server-configuration.markdown",
+        "Name": "Server Configuration",
+        "DiscussionId": "79df0789-13d6-43c1-ae47-563550cc291c",
+        "Mappings": []
+    },
+    {
+        "Path": "storage-configuration.markdown",
+        "Name": "Storage Configuration",
+        "DiscussionId": "76f2a9ab-56d7-42d1-80e0-38cdbd4147bb",
+        "Mappings": []
+    },
+    {
+        "Path": "studio-configuration.markdown",
+        "Name": "Studio Configuration",
+        "DiscussionId": "d13bd568-a7df-477e-9708-588307fba47a",
+        "Mappings": []
+    },
+    {
+        "Path": "subscription-configuration.markdown",
+        "Name": "Subscription Configuration",
+        "DiscussionId": "04e3284b-d599-4479-b75a-ae7d6920cd6e",
+        "Mappings": []
+    },
+    {
+        "Path": "tombstone-configuration.markdown",
+        "Name": "Tombstone Configuration",
+        "DiscussionId": "65ca6661-dd2f-4833-8978-c642828aa25a",
+        "Mappings": []
+    },
+    {
+        "Path": "traffic-watch-configuration.markdown",
+        "Name": "Traffic Watch Configuration",
+        "DiscussionId": "7b64f734-8147-4e84-815a-3c1aabfc7e68",
+        "Mappings": []
+    },
+    {
+        "Path": "transaction-merger-configuration.markdown",
+        "Name": "Transaction Merger Configuration",
+        "DiscussionId": "7b64f734-8147-4e84-815a-3c1aabfc7e68",
+        "Mappings": []
+    },
+    {
+        "Path": "updates-configuration.markdown",
+        "Name": "Updates Configuration",
+        "DiscussionId": "7852f306-898f-4fb4-adbd-c7b21934393d",
+        "Mappings": []
+    }
 ]

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
@@ -19,7 +19,6 @@
   * [Http.AllowResponseCompressionOverHttps](../../server/configuration/http-configuration#http.allowresponsecompressionoverhttps)
   * [Http.GzipResponseCompressionLevel](../../server/configuration/http-configuration#http.gzipresponsecompressionlevel)
   * [Http.DeflateResponseCompressionLevel](../../server/configuration/http-configuration#http.deflateresponsecompressionlevel)
-  * [Http.BrotliResponseCompressionLevel](../../server/configuration/http-configuration#http.brotliresponsecompressionlevel)
   * [Http.ZstdResponseCompressionLevel](../../server/configuration/http-configuration#http.zstdresponsecompressionlevel)
   * [Http.StaticFilesResponseCompressionLevel](../../server/configuration/http-configuration#http.staticfilesresponsecompressionlevel)
   * [Http.Protocols](../../server/configuration/http-configuration#http.protocols)
@@ -186,17 +185,6 @@ Set the compression level to be used when compressing HTTP responses with GZip.
 {PANEL: Http.DeflateResponseCompressionLevel}
 
 Set the compression level to be used when compressing HTTP responses with Deflate.
-
-- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
-- **Default**: `Fastest`
-- **Scope**: Server-wide only
-- **Used for setting Kestrel property**: [Level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions.level?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-gzipcompressionprovideroptions-level)
-
-{PANEL/}
-
-{PANEL: Http.BrotliResponseCompressionLevel}
-
-Set the compression level to be used when compressing HTTP responses with Brotli.
 
 - **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
 - **Default**: `Fastest`

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
@@ -3,7 +3,7 @@
 
 {NOTE: }
 
-* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which an HTTP web server built on ASP.NET Core.
+* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which is an HTTP web server built on ASP.NET Core.
 
 * You can set Kestrel's properties via the following RavenDB configuration keys.
 
@@ -130,10 +130,13 @@ Set Kestrel's HTTP2 keep alive ping delay.
 * This limits the number of concurrent request streams per HTTP/2 connection.  
   Excess streams will be refused.
 
+* When _Http.Http2.MaxStreamsPerConnection_ is `null` or not set,  
+  RavenDB assigns _int.MaxValue_ to _MaxStreamsPerConnection_.
+
 ---
 
 - **Type**: `int`
-- **Default**: `int.MaxValue` (no limit)
+- **Default**: `null` (no limit)
 - **Scope**: Server-wide only
 - **Used for setting Kestrel property**: [MaxStreamsPerConnection](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.maxstreamsperconnection?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-maxstreamsperconnection)
 

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/http-configuration.markdown
@@ -1,0 +1,253 @@
+# Configuration: HTTP
+---
+
+{NOTE: }
+
+* RavenDB uses [Kestrel](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel?view=aspnetcore-8.0), which an HTTP web server built on ASP.NET Core.
+
+* You can set Kestrel's properties via the following RavenDB configuration keys.
+
+* In this page:
+  * [Http.MinDataRateBytesPerSec](../../server/configuration/http-configuration#http.mindataratebytespersec)
+  * [Http.MinDataRateGracePeriodInSec](../../server/configuration/http-configuration#http.mindatarategraceperiodinsec)
+  * [Http.MaxRequestBufferSizeInKb](../../server/configuration/http-configuration#http.maxrequestbuffersizeinkb)
+  * [Http.MaxRequestLineSizeInKb](../../server/configuration/http-configuration#http.maxrequestlinesizeinkb)
+  * [Http.Http2.KeepAlivePingTimeoutInSec](../../server/configuration/http-configuration#http.http2.keepalivepingtimeoutinsec)
+  * [Http.Http2.KeepAlivePingDelayInSec](../../server/configuration/http-configuration#http.http2.keepalivepingdelayinsec)
+  * [Http.Http2.MaxStreamsPerConnection](../../server/configuration/http-configuration#http.http2.maxstreamsperconnection)
+  * [Http.UseResponseCompression](../../server/configuration/http-configuration#http.useresponsecompression)
+  * [Http.AllowResponseCompressionOverHttps](../../server/configuration/http-configuration#http.allowresponsecompressionoverhttps)
+  * [Http.GzipResponseCompressionLevel](../../server/configuration/http-configuration#http.gzipresponsecompressionlevel)
+  * [Http.DeflateResponseCompressionLevel](../../server/configuration/http-configuration#http.deflateresponsecompressionlevel)
+  * [Http.BrotliResponseCompressionLevel](../../server/configuration/http-configuration#http.brotliresponsecompressionlevel)
+  * [Http.ZstdResponseCompressionLevel](../../server/configuration/http-configuration#http.zstdresponsecompressionlevel)
+  * [Http.StaticFilesResponseCompressionLevel](../../server/configuration/http-configuration#http.staticfilesresponsecompressionlevel)
+  * [Http.Protocols](../../server/configuration/http-configuration#http.protocols)
+  * [Http.AllowSynchronousIO](../../server/configuration/http-configuration#http.allowsynchronousio)
+
+{NOTE/}
+
+---
+
+{PANEL: Http.MinDataRateBytesPerSec}
+
+* Set Kestrel's minimum required data rate in bytes per second.  
+
+* This option must be configured together with [Http.MinDataRateGracePeriod](../../server/configuration/http-configuration#http.mindatarategraceperiodinsec).  
+
+---
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel's properties**:
+    - [MinResponseDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minresponsedatarate?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-minresponsedatarate)
+    - [MinRequestBodyDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minrequestbodydatarate?view=aspnetcore-8.0)
+
+{PANEL/}
+
+{PANEL: Http.MinDataRateGracePeriodInSec}
+
+* Set Kestrel's allowed request and response grace period in seconds.  
+  This option must be configured together with [Http.MinDataRateBytesPerSec](../../server/configuration/http-configuration#http.mindataratebytespersec)
+
+* Kestrel checks every second if data is coming in at the specified rate in bytes/second.  
+  If the rate drops below the minimum set by _MinResponseDataRate_, the connection is timed out.
+
+* The grace period _Http.MinDataRateGracePeriodInSec_ is the amount of time that Kestrel gives the client to increase its send rate up to the minimum. The rate is not checked during that time. 
+  The grace period helps avoid dropping connections that are initially sending data at a slow rate due to TCP slow-start.
+
+* When set to `null` then rates are unlimited, no minimum data rate will be enforced.
+
+---
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel's properties**:
+    - [MinResponseDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minresponsedatarate?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-minresponsedatarate)
+    - [MinRequestBodyDataRate](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.minrequestbodydatarate?view=aspnetcore-8.0)
+
+{WARNING: }
+If __either__ one of _Http.MinDataRateBytesPerSec_ or _Http.MinDataRateGracePeriodInSec_ is Not set or set to `null`,  
+then __both__ Kestrel's properties ( _MinResponseDataRate_ & _MinRequestBodyDataRate_ ) will be set to `null`.
+{WARNING/}
+
+{PANEL/}
+
+{PANEL: Http.MaxRequestBufferSizeInKb}
+
+* Set the maximum size of the response buffer before write calls begin to block or return tasks that don't complete until the buffer size drops below the configured limit.
+  
+* If not set, or set to `null`, then the size of the request buffer is unlimited.
+
+---
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [MaxRequestBufferSize](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.maxrequestbuffersize?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-maxrequestbuffersize)
+
+{PANEL/}
+
+{PANEL: Http.MaxRequestLineSizeInKb}
+
+Set the maximum allowed size for the HTTP request line.
+
+- **Type**: `int`
+- **Default**: `16`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [MaxRequestLineSize](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.maxrequestlinesize?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserverlimits-maxrequestlinesize)
+
+{PANEL/}
+
+{PANEL: Http.Http2.KeepAlivePingTimeoutInSec}
+
+Set Kestrel's HTTP2 keep alive ping timeout.
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [KeepAlivePingTimeout](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.keepalivepingtimeout?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-keepalivepingtimeout)
+
+{PANEL/}
+
+{PANEL: Http.Http2.KeepAlivePingDelayInSec}
+
+Set Kestrel's HTTP2 keep alive ping delay.
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [KeepAlivePingDelay](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.keepalivepingdelay?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-keepalivepingdelay)
+
+{PANEL/}
+
+{PANEL: Http.Http2.MaxStreamsPerConnection}
+
+* Set Kestrel's HTTP2 max streams per connection.  
+
+* This limits the number of concurrent request streams per HTTP/2 connection.  
+  Excess streams will be refused.
+
+---
+
+- **Type**: `int`
+- **Default**: `int.MaxValue` (no limit)
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [MaxStreamsPerConnection](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.maxstreamsperconnection?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-maxstreamsperconnection)
+
+{PANEL/}
+
+{PANEL: Http.UseResponseCompression}
+
+* Set whether Raven's HTTP server should compress its responses.
+
+* Using compression lowers the network bandwidth usage.   
+  However, setting to `false` is needed in order to debug or view the response via sniffer tools.
+
+---
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Http.AllowResponseCompressionOverHttps}
+
+* Set whether Raven's HTTP server should allow response compression to happen when HTTPS is enabled.
+
+* Please see http://breachattack.com/ before enabling this.
+
+---
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [EnableForHttps](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.responsecompressionoptions.enableforhttps?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-responsecompressionoptions-enableforhttps)
+
+{PANEL/}
+
+{PANEL: Http.GzipResponseCompressionLevel}
+
+Set the compression level to be used when compressing HTTP responses with GZip.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Fastest`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [Level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions.level?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-gzipcompressionprovideroptions-level)
+
+{PANEL/}
+
+{PANEL: Http.DeflateResponseCompressionLevel}
+
+Set the compression level to be used when compressing HTTP responses with Deflate.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Fastest`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [Level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions.level?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-gzipcompressionprovideroptions-level)
+
+{PANEL/}
+
+{PANEL: Http.BrotliResponseCompressionLevel}
+
+Set the compression level to be used when compressing HTTP responses with Brotli.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Fastest`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [Level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions.level?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-gzipcompressionprovideroptions-level)
+
+{PANEL/}
+
+{PANEL: Http.ZstdResponseCompressionLevel}
+
+Set the compression level to be used when compressing HTTP responses with Zstd.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Fastest`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [Level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions.level?view=aspnetcore-8.0#microsoft-aspnetcore-responsecompression-gzipcompressionprovideroptions-level)
+
+{PANEL/}
+
+{PANEL: Http.StaticFilesResponseCompressionLevel}
+
+Set the compression level to be used when compressing static files.
+
+- **Type**: `enum CompressionLevel` (`Optimal`, `Fastest`, `NoCompression`, `SmallestSize`)
+- **Default**: `Optimal`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Http.Protocols}
+
+* Set HTTP protocols that should be supported by the server.
+
+* By default, the HTTP protocol is set by the constructor of class `HttpConfiguration`  
+  (that is what is meant by the value `"DefaultValueSetInConstructor"`).
+
+* If the platform running RavenDB is either Windows 10 or higher, Windows Server 2016 or newer, or POSIX,  
+  the constructor sets Http.Protocols to `Http1AndHttp2`. Otherwise, it is set to `Http1`.
+
+---
+
+- **Type**: `enum HttpProtocols` ( `None`, `Http1`, `Http2`, `Http1AndHttp2`, `Http3`, `Http1AndHttp2AndHttp3`)
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Http.AllowSynchronousIO}
+
+Set a value that controls whether synchronous IO is allowed for the Request and Response.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+- **Used for setting Kestrel property**: [AllowSynchronousIO](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserveroptions.allowsynchronousio?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-kestrelserveroptions-allowsynchronousio)
+
+{PANEL/}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2551/Document-AllowSynchronousIO-Update-file-Http-Configuration

---

**Added in 5.1:**
```
Http.AllowSynchronousIO
```

**Remove from 5.1:**
```
Http.UseLibuv
```

**Added in 5.4:**
```
Http.Http2.KeepAlivePingTimeoutInSec
Http.Http2.KeepAlivePingDelayInSec
Http.Http2.MaxStreamsPerConnection
```

**Added in 6.0:**
```
Http.BrotliResponseCompressionLevel
Http.ZstdResponseCompressionLevel
```