### PR TITLE
RDoc-2514 Explain Boosting options + Update indexing configuration

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
@@ -36,7 +36,7 @@
 {CODE-TAB:csharp:DocumentQuery boost_3@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
 from "Employees" where
-(search(Notes, "English") or boost(search(Notes, "Italian"), 10))
+search(Notes, "English") or boost(search(Notes, "Italian"), 10)
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
@@ -1,0 +1,304 @@
+# Sort Query Results
+
+---
+
+{NOTE: }
+
+* When making a query, the server will return the results __sorted__ only if explicitly requested by the query.  
+  If no sorting method is specified when issuing the query then results will not be sorted.
+  
+    * Note: An exception to the above rule is when [Boosting](../../../indexes/boosting) is involved in the query.  
+      Learn more in [Automatic score-based ordering](../../../indexes/boosting#automatic-score-based-ordering).  
+
+* Sorting is applied by the server after the query filtering stage.  
+  Applying filtering is recommended as it reduces the number of results RavenDB needs to sort  
+  when querying a large dataset.
+
+* Multiple sorting actions can be chained.
+
+* This article provides examples of sorting query results when making a __dynamic-query__.  
+  For sorting results when querying a __static-index__ see [sort index query results](../../../indexes/querying/sorting).
+
+* In this page:
+    * [Order by field value](../../../client-api/session/querying/sort-query-results#order-by-field-value) 
+  
+    * [Order by score](../../../client-api/session/querying/sort-query-results#order-by-score)  
+        * [Get resulting score](../../../client-api/session/querying/sort-query-results#get-resulting-score)
+     
+    * [Order by random](../../../client-api/session/querying/sort-query-results#order-by-rando)   
+     
+    * [Order by spatial](../../../client-api/session/querying/sort-query-results#order-by-spatial)
+     
+    * [Order by count (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-count-(aggregation-query))
+     
+    * [Order by sum (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-sum-(aggregation-query))
+     
+    * [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type)
+     
+    * [Chain ordering](../../../client-api/session/querying/sort-query-results#chain-ordering)
+     
+    * [Custom sorters](../../../client-api/session/querying/sort-query-results#custom-sorters)
+     
+    * [Syntax](../../../client-api/session/querying/sort-query-results#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Order by field value}
+
+* Use `OrderBy` or `OrderByDescending` to order the results by the specified document-field.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_1@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_2@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_3@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+__Ordering Type__:
+
+* By default, the `OrderBy` methods will determine the `OrderingType` from the property path expression  
+  and specify that ordering type in the generated RQL that is sent to the server.  
+
+* E.g. in the above example, ordering by `x => x.UnitsInStock` will result in `OrderingType.Long`  
+  because that property data type is an integer.
+
+* Different ordering can be forced - see [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type) below.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by score}
+
+* When querying with some filtering conditions, a basic score is calculated for each item in the results  
+  by the underlying indexing engine. (Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html)).
+
+* The higher the score value the better the match.  
+
+* Use `OrderByScore` or `OrderByScoreDescending` to order the query results by this score.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_4@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_5@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_6@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock < 5 or Discontinued == true
+order by score()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+#### Get resulting score:
+
+---
+
+The score details can be retrieved by either:  
+ 
+  * __Request to include explanations__:  
+    You can get the score details and see how it was calculated by requesting to include explanations in the query. 
+    Currently, this is only available when using Lucene as the underlying indexing engine.  
+    Learn more in [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
+   
+  * __Get score from metadata__:  
+    The score is available in the `@index-score` metadata property within each result.  
+    The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:
+
+    {CODE:csharp get_score_from_metadata@ClientApi\Session\Querying\SortQueryResults.cs /}
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by random}
+
+* Use `RandomOrdering` to randomize the order of the query results.
+
+* An optional seed parameter can be passed.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_7@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_8@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_9@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by random()
+// order by random(someSeed)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by spatial}
+
+* If your data contains geographical locations,  
+  spatial query results can be sorted based on their distance from a specific point.
+
+* See detailed explanation in [Spatial Sorting](../../../client-api/session/querying/how-to-make-a-spatial-query#spatial-sorting).
+
+{PANEL/}
+
+{PANEL: Order by count (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `Count` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_10@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_11@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_12@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by count() as long
+select key() as "Category", count()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by sum (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `Sum` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_13@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_14@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_15@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by Sum as long
+select key() as 'Category', sum(UnitsInStock) as Sum
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Force ordering type}
+
+* By default, the `OrderBy` methods will determine the `OrderingType` from the property path expression  
+  and specify that ordering type in the generated RQL that is sent to the server.
+
+* A different ordering can be forced by passing the ordering type explicitly to `OrderBy` or `OrderByDescending`.
+
+* The following ordering types are available:
+
+    * `OrderingType.Long`
+    * `OrderingType.Double`
+    * `OrderingType.AlphaNumeric`
+    * `OrderingType.String` (lexicographic ordering)
+
+* When using RQL directly, if no ordering type is specified, then the server defaults to lexicographic ordering.
+
+{NOTE: }
+
+__Using alphanumeric ordering example__:
+
+* When ordering mixed-character strings by the default lexicographical ordering  
+  then comparison is done character by character based on the Unicode values.  
+  For example, "Abc9" will come after "Abc10" since 9 is greater than 1.
+
+* If you want the digit characters to be ordered as numbers then use alphanumeric ordering  
+  where "Abc10" will result after "Abc9".
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_16@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_17@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_18@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+order by QuantityPerUnit as alphanumeric
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{CODE sort_16_results@ClientApi\Session\Querying\SortQueryResults.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Chain ordering}
+
+* It is possible to chain multiple orderings in the query.  
+  Any combination of secondary sorting is possible as the fields are indexed independently of one another.
+
+* There is no limit on the number of sorting actions that can be chained.
+  
+* This is achieved by using the `ThenBy` (`ThenByDescending`) and `ThenByScore` (`ThenByScoreDescending`) methods.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_19@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_20@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_21@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long desc, score(), Name
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Custom sorters }
+
+* The Lucene indexing engine allows you to create your own custom sorters.  
+  Custom sorters can be deployed to the server by either:  
+
+     * Sending the [Put Sorters Operation](../../../client-api/operations/maintenance/sorters/put-sorter) from your code.
+  
+     * Uploading a custom sorter from Studio, see [Custom Sorters View](../../../studio/database/settings/custom-sorters).
+
+* Once the custom sorter is deployed, you can sort the query results with it.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query sort_22@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:Query_async sort_23@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB:csharp:DocumentQuery sort_24@ClientApi\Session\Querying\SortQueryResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by custom(UnitsInStock, "MySorter")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\Querying\SortQueryResults.cs /}
+
+| Parameter      | Type                          | Description                                                                                                                                                                |
+|----------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| __path__       | `string`                      | The name of the field to sort by                                                                                                                                           |
+| __path__       | `Expression<Func<T, object>>` | A lambda expression to the field by which to sort                                                                                                                          |
+| __ordering__   | `QueryStatistics`             | The ordering type that will be used to sort the results:<br>`OrderingType.Long`<br>`OrderingType.Double`<br>`OrderingType.AlphaNumeric`<br>`OrderingType.String` (default) |
+| __sorterName__ | `string`                      | The name of your custom sorter class                                                                                                                                       |
+
+{PANEL/}
+
+## Related Articles
+
+#### Client API
+
+- [Query Overview](../../../client-api/session/querying/how-to-query)
+
+### Querying
+
+- [Customize query](../../../client-api/session/querying/how-to-customize-query)
+- [Group by query](../../../client-api/session/querying/how-to-perform-group-by-query)
+- [Spatial query](../../../client-api/session/querying/how-to-make-a-spatial-query)
+- [Full-text search](../../../client-api/session/querying/text-search/full-text-search)
+
+### Indexes
+
+- [Sort index query results](../../../indexes/querying/sorting)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
@@ -1,0 +1,280 @@
+# Sort Query Results
+
+---
+
+{NOTE: }
+
+* When making a query, the server will return the results __sorted__ only if explicitly requested by the query.  
+  If no sorting method is specified when issuing the query then results will not be sorted.
+
+    * Note: An exception to the above rule is when [Boosting](../../../indexes/boosting) is involved in the query.  
+      Learn more in [Automatic score-based ordering](../../../indexes/boosting#automatic-score-based-ordering).
+
+* Sorting is applied by the server after the query filtering stage.  
+  Applying filtering is recommended as it reduces the number of results RavenDB needs to sort  
+  when querying a large dataset.
+
+* Multiple sorting actions can be chained.
+
+* This article provides examples of sorting query results when making a __dynamic-query__.  
+  For sorting results when querying a __static-index__ see [sort index query results](../../../indexes/querying/sorting).
+
+* In this page:
+    * [Order by field value](../../../client-api/session/querying/sort-query-results#order-by-field-value)
+ 
+    * [Order by score](../../../client-api/session/querying/sort-query-results#order-by-score)
+        * [Get resulting score](../../../client-api/session/querying/sort-query-results#get-resulting-score)
+  
+    * [Order by random](../../../client-api/session/querying/sort-query-results#order-by-random)
+   
+    * [Order by spatial](../../../client-api/session/querying/sort-query-results#order-by-spatial)
+     
+    * [Order by count (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-count-(aggregation-query))
+  
+    * [Order by sum (aggregation query)](../../../client-api/session/querying/sort-query-results#order-by-sum-(aggregation-query))
+
+    * [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type)
+
+    * [Chain ordering](../../../client-api/session/querying/sort-query-results#chain-ordering)
+
+    * [Custom sorters](../../../client-api/session/querying/sort-query-results#custom-sorters) 
+
+    * [Syntax](../../../client-api/session/querying/sort-query-results#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Order by field value}
+
+* Use `orderBy` or `orderByDescending` to order the results by the specified document-field.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_1@ClientApi\Session\Querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+__Ordering Type__:
+
+* If no ordering type is specified in the query then the server will apply the default lexicographical ordering.
+
+* In the above example, the ordering type was set to `Long`.
+
+* Different ordering can be forced - see [Force ordering type](../../../client-api/session/querying/sort-query-results#force-ordering-type) below.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by score}
+
+* When querying with some filtering conditions, a basic score is calculated for each item in the results  
+  by the underlying indexing engine. (Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html)).
+
+* The higher the score value the better the match.  
+
+* Use `orderByScore` or `orderByScoreDescending` to order by this score.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_2@ClientApi\Session\Querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock < 5 or Discontinued == true
+order by score()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{INFO: }
+
+#### Get resulting score:
+
+---
+
+The score details can be retrieved by either:
+
+* __Request to include explanations__:  
+  You can get the score details and see how it was calculated by requesting to include explanations in the query. 
+  Currently, this is only available when using Lucene as the underlying indexing engine.  
+  Learn more in [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
+
+* __Get score from metadata__:  
+  The score is available in the `@index-score` metadata property within each result.  
+  The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:
+
+  {CODE:nodejs get_score_from_metadata@ClientApi\Session\Querying\sortQueryResults.js /}
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Order by random}
+
+* Use `randomOrdering` to randomize the order of the query results.
+
+* An optional seed parameter can be passed.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_3@ClientApi\Session\Querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by random()
+// order by random(someSeed)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by spatial}
+
+* If your data contains geographical locations,  
+  spatial query results can be sorted based on their distance from a specific point.
+
+* See detailed explanation in [Spatial Sorting](../../../client-api/session/querying/how-to-make-a-spatial-query#spatial-sorting).
+
+{PANEL/}
+
+{PANEL: Order by count (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `count` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_4@ClientApi\Session\Querying\SortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by count() as long
+select key() as "Category", count()
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Order by sum (aggregation query)}
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query) can be sorted by the `sum` aggregation operation used in the query.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_5@ClientApi\Session\Querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+group by Category
+order by sum as long
+select key() as 'Category', sum(UnitsInStock) as sum
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Force ordering type}
+
+* If no ordering type is specified in the query then the server will apply the default lexicographical ordering.
+
+* A different ordering can be forced by passing the ordering type explicitly to `orderBy` or `orderByDescending`.
+
+* The following ordering types are available:
+
+    * `Long`
+    * `Double`
+    * `AlphaNumeric`
+    * `String` (lexicographic ordering)
+
+{NOTE: }
+
+__Using alphanumeric ordering example__:
+
+* When ordering mixed-character strings by the default lexicographical ordering  
+  then comparison is done character by character based on the Unicode values.  
+  For example, "Abc9" will come after "Abc10" since 9 is greater than 1.
+
+* If you want the digit characters to be ordered as numbers then use alphanumeric ordering  
+  where "Abc10" will result after "Abc9".
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_6@ClientApi\Session\Querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+order by QuantityPerUnit as alphanumeric
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{CODE:nodejs sort_6_results@ClientApi\Session\Querying\sortQueryResults.js /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Chain ordering}
+
+* It is possible to chain multiple orderings in the query.  
+  Any combination of secondary sorting is possible as the fields are indexed independently of one another.
+
+* There is no limit on the number of sorting actions that can be chained.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_7@ClientApi\Session\Querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by UnitsInStock as long desc, score(), Name
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Custom sorters }
+
+* The Lucene indexing engine allows you to create your own custom sorters.  
+  Custom sorters can be deployed to the server by either:  
+
+     * Sending the [Put Sorters Operation](../../../client-api/operations/maintenance/sorters/put-sorter) from your code.
+  
+     * Uploading a custom sorter from Studio, see [Custom Sorters View](../../../studio/database/settings/custom-sorters).
+
+* Once the custom sorter is deployed, you can sort the query results with it.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query sort_8@ClientApi\Session\Querying\sortQueryResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Products"
+where UnitsInStock > 10
+order by custom(UnitsInStock, "MySorter")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Session\Querying\sortQueryResults.js /}
+
+| Parameter    | Type     | Description                                                                                                            |
+|--------------|----------|------------------------------------------------------------------------------------------------------------------------|
+| __field__    | `string` | The name of the field to sort by                                                                                       |
+| __ordering__ | `string` | The ordering type that will be used to sort the results:<br>`Long`<br>`Double`<br>`AlphaNumeric`<br>`String` (default) |
+| __options__  | `object` | An object that specifies the custom `sorterName`                                                                       |
+
+{PANEL/}
+
+## Related Articles
+
+#### Client API
+
+- [Query Overview](../../../client-api/session/querying/how-to-query)
+
+### Querying
+
+- [Customize query](../../../client-api/session/querying/how-to-customize-query)
+- [Group by query](../../../client-api/session/querying/how-to-perform-group-by-query)
+- [Spatial query](../../../client-api/session/querying/how-to-make-a-spatial-query)
+- [Full-text search](../../../client-api/session/querying/text-search/full-text-search)
+
+### Indexes
+
+- [Sort index query results](../../../indexes/querying/sorting)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
@@ -1,0 +1,104 @@
+﻿# Boost Search Results
+
+---
+
+{NOTE: }
+
+* When querying with some filtering conditions,  
+  a basic score is calculated for each document in the results by the underlying engine.
+
+* Providing a boost value to some fields allows you to prioritize the resulting documents.  
+  The boost value is integrated with the basic score, making the document rank higher.  
+
+* Boosting can be achieved in the following ways:  
+
+    * __At query time__:  
+      Apply a boost factor to searched terms at query time - as described in this article.
+
+    * __Via index definition__:  
+      Apply a boost factor in your index definition - see this [boosting](../../../../indexes/boosting) article in under indexes.
+
+* The automatic ordering of the results by the score is now configurable.  
+  Learn more in section [automatic score-based ordering](../../../../indexes/boosting#automatic-score-based-ordering).
+
+* In this page:
+
+  * [Boost results - when making a full-text search](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-making-a-full-text-search)
+  * [Boost results - when querying with where clause](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-querying-with-where-clause)  
+  * [Get resulting score](../../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score)
+
+{NOTE/}
+
+---
+
+{PANEL: Boost results - when making a full-text search}
+
+* When making a full-text search with the `Search()` method then boosting can be applied  
+  to both `Query` and `DocumentQuery`.
+
+{NOTE: }
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query boost_1@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
+{CODE-TAB:csharp:Query_async boost_2@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
+{CODE-TAB:csharp:DocumentQuery boost_3@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Employees" where
+(search(Notes, "English") or boost(search(Notes, "Italian"), 10))
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Boost results - when querying with where clause}
+
+* When querying with `Where` clauses (using an OR condition in between) then boosting can be applied  
+  only with `DocuemtQuery`.
+
+{NOTE: }
+
+{CODE-TABS}
+{CODE-TAB:csharp:DocumentQuery boost_4@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
+{CODE-TAB:csharp:DocumentQuery_async boost_5@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies" where
+boost(startsWith(Name, "O"), 10) or
+boost(startsWith(Name, "P"), 50) or
+boost(endsWith(Name, "OP"), 90)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Get resulting score}
+
+* The score can be retrieved by either:
+
+   * Request to __include explanations__ when making the query.  
+     See [include query explanations](../../../../client-api/session/querying/debugging/include-explanations).
+
+   * __Get the metadata__ of the resulting entities that were loaded to the session.  
+     See example below.  
+
+{NOTE: }
+
+{CODE:csharp boost_6@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [Query overview](../../../../client-api/session/querying/how-to-query)
+- [Full-text search](../../../../client-api/session/querying/text-search/full-text-search)
+
+### Indexes
+
+- [Full-text search with index](../../../../indexes/querying/searching)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
@@ -46,7 +46,7 @@
 {CODE-TAB:csharp:DocumentQuery boost_3@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
 from "Employees" where
-(search(Notes, "English") or boost(search(Notes, "Italian"), 10))
+search(Notes, "English") or boost(search(Notes, "Italian"), 10)
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.dotnet.markdown
@@ -21,11 +21,13 @@
 * The automatic ordering of the results by the score is now configurable.  
   Learn more in section [automatic score-based ordering](../../../../indexes/boosting#automatic-score-based-ordering).
 
+* The calculated score details of the results can be retrieved if needed.  
+  Learn more in section [get resulting score](../../../../client-api/session/querying/sort-query-results#get-resulting-score).
+
 * In this page:
 
   * [Boost results - when making a full-text search](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-making-a-full-text-search)
   * [Boost results - when querying with where clause](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-querying-with-where-clause)  
-  * [Get resulting score](../../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score)
 
 {NOTE/}
 
@@ -69,24 +71,6 @@ boost(startsWith(Name, "P"), 50) or
 boost(endsWith(Name, "OP"), 90)
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
-
-{NOTE/}
-
-{PANEL/}
-
-{PANEL: Get resulting score}
-
-* The score can be retrieved by either:
-
-   * Request to __include explanations__ when making the query.  
-     See [include query explanations](../../../../client-api/session/querying/debugging/include-explanations).
-
-   * __Get the metadata__ of the resulting entities that were loaded to the session.  
-     See example below.  
-
-{NOTE: }
-
-{CODE:csharp boost_6@ClientApi\Session\Querying\TextSearch\BoostResults.cs /}
 
 {NOTE/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.js.markdown
@@ -21,11 +21,13 @@
 * The automatic ordering of the results by the score is now configurable.  
   Learn more in section [automatic score-based ordering](../../../../indexes/boosting#automatic-score-based-ordering).
 
+* The calculated score details of the results can be retrieved if needed.  
+  Learn more in section [get resulting score](../../../../client-api/session/querying/sort-query-results#get-resulting-score).
+
 * In this page:
 
   * [Boost results - when making a full-text search](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-making-a-full-text-search)
   * [Boost results - when querying with where clause](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-querying-with-where-clause)  
-  * [Get resulting score](../../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score)
 
 {NOTE/}
 
@@ -61,24 +63,6 @@ boost(startsWith(Name, "P"), 50) or
 boost(endsWith(Name, "OP"), 90)
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
-
-{NOTE/}
-
-{PANEL/}
-
-{PANEL: Get resulting score}
-
-* The score can be retrieved by either:
-
-    * Request to __include explanations__ when making the query.  
-      See [include query explanations](../../../../client-api/session/querying/debugging/include-explanations).
-
-    * __Get the metadata__ of the resulting entities that were loaded to the session.  
-      See example below.
-
-{NOTE: }
-
-{CODE:nodejs boost_3@ClientApi\Session\Querying\TextSearch\boostResults.js /}
 
 {NOTE/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/querying/text-search/boost-search-results.js.markdown
@@ -1,0 +1,96 @@
+﻿# Boost Search Results
+
+---
+
+{NOTE: }
+
+* When querying with some filtering conditions,  
+  a basic score is calculated for each document in the results by the underlying engine.
+
+* Providing a boost value to some fields allows you to prioritize the resulting documents.  
+  The boost value is integrated with the basic score, making the document rank higher.
+
+* Boosting can be achieved in the following ways:
+
+    * __At query time__:  
+      Apply a boost factor to searched terms at query time - as described in this article.
+
+    * __Via index definition__:  
+      Apply a boost factor in your index definition - see this [boosting](../../../../indexes/boosting) article in under indexes.
+
+* The automatic ordering of the results by the score is now configurable.  
+  Learn more in section [automatic score-based ordering](../../../../indexes/boosting#automatic-score-based-ordering).
+
+* In this page:
+
+  * [Boost results - when making a full-text search](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-making-a-full-text-search)
+  * [Boost results - when querying with where clause](../../../../client-api/session/querying/text-search/boost-search-results#boost-results---when-querying-with-where-clause)  
+  * [Get resulting score](../../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score)
+
+{NOTE/}
+
+---
+
+{PANEL: Boost results - when making a full-text search}
+
+{NOTE: }
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query boost_1@ClientApi\Session\Querying\TextSearch\boostResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Employees" where
+search(Notes, "English") or boost(search(Notes, "Italian"), 10)
+{"p0":"English","p1":"Italian"}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Boost results - when querying with where clause}
+
+{NOTE: }
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query boost_2@ClientApi\Session\Querying\TextSearch\boostResults.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies" where
+boost(startsWith(Name, "O"), 10) or
+boost(startsWith(Name, "P"), 50) or
+boost(endsWith(Name, "OP"), 90)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Get resulting score}
+
+* The score can be retrieved by either:
+
+    * Request to __include explanations__ when making the query.  
+      See [include query explanations](../../../../client-api/session/querying/debugging/include-explanations).
+
+    * __Get the metadata__ of the resulting entities that were loaded to the session.  
+      See example below.
+
+{NOTE: }
+
+{CODE:nodejs boost_3@ClientApi\Session\Querying\TextSearch\boostResults.js /}
+
+{NOTE/}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [Query overview](../../../../client-api/session/querying/how-to-query)
+- [Full-text search](../../../../client-api/session/querying/text-search/full-text-search)
+
+### Indexes
+
+- [Full-text search with index](../../../../indexes/querying/searching)

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
@@ -1,0 +1,109 @@
+# Indexes: Boosting
+---
+
+{NOTE: }
+
+* When querying with some filtering conditions,  
+  a basic score is calculated for each document in the results by the underlying engine.
+
+* Providing a boost value to some fields allows you to prioritize the resulting documents.  
+  The boost value is integrated with the basic score, making the document rank higher.  
+  The ordering of the results by the score is [configurable](../indexes/boosting#automatic-score-based-ordering). 
+
+* Boosting can be achieved in the following ways:
+
+    * __At query time__:  
+      Apply a boost factor to searched terms at query time - see article [Boost search results](../client-api/session/querying/text-search/boost-search-results).
+
+    * __Via index definition__:  
+      Apply a boost factor in your index definition - as described in this article.
+ 
+* In this page:
+    * [Assign a boost factor to an index-field](../indexes/boosting#assign-a-boost-factor-to-an-index-field)
+    * [Assign a boost factor to the index-entry](../indexes/boosting#assign-a-boost-factor-to-the-index-entry)
+    * [Automatic score-based ordering](../indexes/boosting#automatic-score-based-ordering)
+
+{NOTE/}
+
+---
+
+{PANEL: Assign a boost factor to an index-field}
+
+Applying a boost value to an index-field allows you to prioritize matching documents based on an index-field.
+
+---
+
+
+##### The index:
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ-index index_1@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:JavaScript-index index_1_js@Indexes\Boosting.cs /}
+{CODE-TABS/}
+
+##### The query:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_1@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:Query_async query_2@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:DocumentQuery query_3@Indexes\Boosting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Orders/ByCountries/BoostByField"
+where ShipToCountry == "poland" or CompanyCountry == "portugal"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Assign a boost factor to the index-entry}
+
+Applying a boost value to the whole index-entry allows you to prioritize matching documents by content from the document.
+
+---
+
+##### The index:
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ-index index_2@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:JavaScript-index index_2_js@Indexes\Boosting.cs /}
+{CODE-TABS/}
+
+##### The query:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_4@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:Query_async query_5@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:DocumentQuery query_6@Indexes\Boosting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Orders/ByCountries/BoostByIndexEntry"
+where ShipToCountry == "poland" or CompanyCountry == "portugal"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Automatic score-based ordering}
+
+* By default, whenever boosting is involved, either via a dynamic query or when querying an index that has a boosting factor in its definition,
+  the results will be automatically ordered by the score.
+
+* This behavior can be modified using the [OrderByScoreAutomaticallyWhenBoostingIsInvolved](../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)    
+  configuration key.
+
+* Refer to section [Get resulting score](../client-api/session/querying/text-search/boost-search-results#get-resulting-score) to learn how to retrieve the calculated score of each result.
+
+{PANEL/}
+
+## Related Articles
+
+### Querying
+
+- [Full-text search](../client-api/session/querying/text-search/full-text-search)
+- [Boost search results](../client-api/session/querying/text-search/boost-search-results)
+
+### Indexes
+
+- [Analyzers](../indexes/using-analyzers)
+- [Storing Data in Index](../indexes/storing-data-in-index)
+- [Term Vectors](../indexes/using-term-vectors)
+- [Dynamic Fields](../indexes/using-dynamic-fields)

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
@@ -90,7 +90,7 @@ where ShipToCountry == "poland" or CompanyCountry == "portugal"
 * This behavior can be modified using the [OrderByScoreAutomaticallyWhenBoostingIsInvolved](../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)    
   configuration key.
 
-* Refer to section [Get resulting score](../client-api/session/querying/text-search/boost-search-results#get-resulting-score) to learn how to retrieve the calculated score of each result.
+* Refer to section [Get resulting score](../client-api/session/querying/sort-query-results#get-resulting-score) to learn how to retrieve the calculated score of each result.
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
@@ -6,9 +6,9 @@
 * When querying with some filtering conditions,  
   a basic score is calculated for each document in the results by the underlying engine.
 
-* Providing a boost value to some fields allows you to prioritize the resulting documents.  
+* Providing a __boost value__ to some fields allows you to prioritize the resulting documents.  
   The boost value is integrated with the basic score, making the document rank higher.  
-  The ordering of the results by the score is [configurable](../indexes/boosting#automatic-score-based-ordering). 
+  Automatic ordering of the results by the score is [configurable](../indexes/boosting#automatic-score-based-ordering). 
 
 * Boosting can be achieved in the following ways:
 

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.java.markdown
@@ -1,10 +1,18 @@
 # Indexes: Boosting
 
-A feature that RavenDB leverages from Lucene is called Boosting. This feature gives you the ability to manually tune the relevance level of matching documents when performing a query. 
+When querying with some filtering conditions,  
+a basic score is calculated for each document in the results by the underlying engine.
 
-From the index perspective we can associate to an index entry a boosting factor. The higher value it has, the more relevant term will be. To do this, we must use the `Boost` method.
+Providing a __boost value__ to some fields allows you to prioritize the resulting documents.  
+The boost value is integrated with the basic score, making the document rank higher.  
+Automatic ordering of the results by the score is [configurable](../indexes/boosting#automatic-score-based-ordering).
 
-Let's jump straight into the example. To perform the query that will return employees where either `FirstName` or `LastName` is equal to _Bob_, and to promote employees (move them to the top of the results) where `FirstName` matches the phrase, we must first create an index with boosted entry.
+From the index perspective we can associate to an index entry a boosting factor.  
+The higher value it has, the more relevant term will be. To do this, we must use the `Boost` method.
+
+Let's jump straight into the example.  
+To perform the query that will return employees where either `FirstName` or `LastName` is equal to _Bob_,  
+and to promote employees (move them to the top of the results) where `FirstName` matches the phrase, we must first create an index with boosted entry.
 
 {CODE-TABS}
 {CODE-TAB:java:AbstractIndexCreationTask boosting_2@Indexes\Boosting.java /}
@@ -18,6 +26,18 @@ The next step is to perform a query against that index:
 ## Remarks
 
 {INFO Boosting is also available at the query level. /}
+
+{NOTE: }
+
+#### Automatic score-based ordering
+
+* By default, whenever boosting is involved, either via a dynamic query or when querying an index that has a boosting factor in its definition,
+  the results will be automatically ordered by the score.
+
+* This behavior can be modified using the [OrderByScoreAutomaticallyWhenBoostingIsInvolved](../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)    
+  configuration key.
+
+{NOTE/}
 
 ## Related Articles
 

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.java.markdown
@@ -1,0 +1,29 @@
+# Indexes: Boosting
+
+A feature that RavenDB leverages from Lucene is called Boosting. This feature gives you the ability to manually tune the relevance level of matching documents when performing a query. 
+
+From the index perspective we can associate to an index entry a boosting factor. The higher value it has, the more relevant term will be. To do this, we must use the `Boost` method.
+
+Let's jump straight into the example. To perform the query that will return employees where either `FirstName` or `LastName` is equal to _Bob_, and to promote employees (move them to the top of the results) where `FirstName` matches the phrase, we must first create an index with boosted entry.
+
+{CODE-TABS}
+{CODE-TAB:java:AbstractIndexCreationTask boosting_2@Indexes\Boosting.java /}
+{CODE-TAB:java:Operation boosting_4@Indexes\Boosting.java /}
+{CODE-TABS/}
+
+The next step is to perform a query against that index:
+
+{CODE:java boosting_3@Indexes\Boosting.java /}
+
+## Remarks
+
+{INFO Boosting is also available at the query level. /}
+
+## Related Articles
+
+### Indexes
+
+- [Analyzers](../indexes/using-analyzers)
+- [Storing Data in Index](../indexes/storing-data-in-index)
+- [Term Vectors](../indexes/using-term-vectors)
+- [Dynamic Fields](../indexes/using-dynamic-fields)

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/boosting.js.markdown
@@ -36,17 +36,12 @@ Applying a boost value to an index-field allows you to prioritize matching docum
 
 ##### The index:
 
-{CODE-TABS}
-{CODE-TAB:csharp:LINQ_index index_1@Indexes\Boosting.cs /}
-{CODE-TAB:csharp:JavaScript_index index_1_js@Indexes\Boosting.cs /}
-{CODE-TABS/}
+{CODE:nodejs index_1@Indexes\boosting.js /}
 
 ##### The query:
 
 {CODE-TABS}
-{CODE-TAB:csharp:Query query_1@Indexes\Boosting.cs /}
-{CODE-TAB:csharp:Query_async query_2@Indexes\Boosting.cs /}
-{CODE-TAB:csharp:DocumentQuery query_3@Indexes\Boosting.cs /}
+{CODE-TAB:nodejs:Query query_1@Indexes\boosting.js /}
 {CODE-TAB-BLOCK:sql:RQL}
 from index "Orders/ByCountries/BoostByField"
 where ShipToCountry == "poland" or CompanyCountry == "portugal"
@@ -63,17 +58,12 @@ Applying a boost value to the whole index-entry allows you to prioritize matchin
 
 ##### The index:
 
-{CODE-TABS}
-{CODE-TAB:csharp:LINQ_index index_2@Indexes\Boosting.cs /}
-{CODE-TAB:csharp:JavaScript_index index_2_js@Indexes\Boosting.cs /}
-{CODE-TABS/}
+{CODE:nodejs index_2@Indexes\boosting.js /}
 
 ##### The query:
 
 {CODE-TABS}
-{CODE-TAB:csharp:Query query_4@Indexes\Boosting.cs /}
-{CODE-TAB:csharp:Query_async query_5@Indexes\Boosting.cs /}
-{CODE-TAB:csharp:DocumentQuery query_6@Indexes\Boosting.cs /}
+{CODE-TAB:nodejs:Query query_2@Indexes\boosting.js /}
 {CODE-TAB-BLOCK:sql:RQL}
 from index "Orders/ByCountries/BoostByIndexEntry"
 where ShipToCountry == "poland" or CompanyCountry == "portugal"

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -737,7 +737,8 @@ Require database `Admin` [clearance](../../server/security/authorization/securit
 
 {PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
 
-Order by score automatically when boosting is used inside an index definition or a query.
+Set whether query results will be automatically ordered by score when a boost factor is involved in the query.  
+(A boost factor may be [assigned inside an index definition](../../indexes/boosting) or can be [applied at query time](../../client-api/session/querying/text-search/boost-search-results)).
 
 - **Type**: `bool`
 - **Default**: `true`

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -1,212 +1,356 @@
 # Configuration: Indexing
 ---
 
-{PANEL:Indexing.RunInMemory}
+{NOTE: }
 
-Set if indexes should run purely in memory.
+* The following __indexing configuration keys__ can modified via either of the following options:
+    * As explained in the [Config overview](../../server/configuration/configuration-options) article
+    * Set a custom configuration per index from the [Client API](../../indexes/creating-and-deploying#creating-an-index-with-custom-configuration)
+    * Set a custom configuraiton per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)
+
+{NOTE/}
+
+{NOTE: }
+
+* In this page:  
+  [Indexing.RunInMemory](../../server/configuration/indexing-configuration#indexing.runinmemory)  
+  [Indexing.Disable](../../server/configuration/indexing-configuration#indexing.disable)  
+  [Indexing.Static.DeploymentMode](../../server/configuration/indexing-configuration#indexing.static.deploymentmode)  
+  [Indexing.Auto.DeploymentMode](../../server/configuration/indexing-configuration#indexing.auto.deploymentmode)  
+  [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)  
+  [Indexing.TempPath](../../server/configuration/indexing-configuration#indexing.temppath)  
+  [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
+  [Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec](../../server/configuration/indexing-configuration#indexing.timebeforedeletionofsupersededautoindexinsec)  
+  [Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin](../../server/configuration/indexing-configuration#indexing.timetowaitbeforemarkingautoindexasidleinmin)  
+  [Indexing.DisableQueryOptimizerGeneratedIndexes](../../server/configuration/indexing-configuration#indexing.disablequeryoptimizergeneratedindexes)  
+  [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration#indexing.timetowaitbeforedeletingautoindexmarkedasidleinhrs)  
+  [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)  
+  [Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.numberofconcurrentstoppedbatchesifrunninglowonmemory)  
+  [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
+  [Indexing.QueryClauseCache.SizeInMb](../../server/configuration/indexing-configuration#indexing.queryclausecache.sizeinmb)  
+  [Indexing.QueryClauseCache.Disabled](../../server/configuration/indexing-configuration#indexing.queryclausecache.disabled)  
+  [Indexing.QueryClauseCache.ExpirationScanFrequencyInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.expirationscanfrequencyinsec)  
+  [Indexing.QueryClauseCache.RepeatedQueriesCount](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriescount)  
+  [Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriestimeframeinsec)  
+  [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
+  [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
+  [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
+  [Indexing.CleanupIntervalInMin](../../server/configuration/indexing-configuration#indexing.cleanupintervalinmin)  
+  [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
+  [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
+  [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
+  [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
+  [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
+  [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
+  [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch)  
+  [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
+  [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
+  [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
+  [Indexing.ScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.scratchspacelimitinmb)  
+  [Indexing.GlobalScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.globalscratchspacelimitinmb)  
+  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenexceedingscratchspacelimitinsec)  
+  [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
+  [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
+  [Indexing.ErrorIndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.errorindexstartupbehavior)  
+  [Indexing.IndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.indexstartupbehavior)  
+  [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
+  [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
+  [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
+  [Indexing.NuGetAllowPreleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowpreleasepackages)  
+  [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
+  [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
+  [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
+  [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
+  [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
+  [Indexing.Auto.SearchEngineType](../../server/configuration/indexing-configuration#indexing.auto.searchenginetype)  
+  [Indexing.Static.SearchEngineType](../../server/configuration/indexing-configuration#indexing.static.searchenginetype)  
+  [Indexing.SkipDatabaseIdValidationOnIndexOpening](../../server/configuration/indexing-configuration#indexing.skipdatabaseidvalidationonindexopening)  
+  [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
+  [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../server/configuration/indexing-configuration#indexing.static.requireadmintodeployjavascriptindexes)  
+  [Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved](../../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)  
+  [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)  
+  [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
+  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
+  [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)  
+  [Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved](../../server/configuration/indexing-configuration#indexing.orderbyticksautomaticallywhendatesareinvolved)  
+  [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
+
+{NOTE/}
+
+---
+
+{PANEL: Indexing.RunInMemory}
+
+* Set if indexes should run purely in memory.
+
+* When running in memory:
+  * No index data is written to the disk, and if the server is restarted, all index data will be lost.
+  * Note that the index definition itself is kept on disk and remains unaffected by server restarts.
+  * This is mostly useful for testing or faster, non-persistent indexing.
+
+* If _Indexing.RunInMemory_ is not set explicitly,  
+  then this configuration key will take the value of the core configuration key [RunInMemory](../../server/configuration/core-configuration#runinmemory).
+
+---
 
 - **Type**: `bool`
-- **Default**: `null`
-- **Scope**: Server-wide or per database
+- **Default**: `false` 
+- **Scope**: Server-wide, or per database
 
-When running in memory, the index information is not written to disk and if the server is restarted all 
-indexing data will be lost. This is mostly useful for testing or faster non-persistent indexing.
- 
-If not set or set to **null** - indexing will run in memory if core settings *RunInMemory* is set to true.
+Optional values:
 
- Values:
- 
- * `null` - use the value set in core configuration *RunInMemory*
- * `true` - run indexing in memory
- * `false` - store information on the disk
+ * `true` - indexing is run only in memory
+ * `false` - the index data is stored on disk
 
 {PANEL/}
 
-{PANEL:Indexing.Disable}
+{PANEL: Indexing.Disable}
 
-Disable indexing.
+Set whether to disable all indexes in the database.  
+All indexes in the database will be disabled when set to `true`.
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.TempPath}
+{PANEL: Indexing.Static.DeploymentMode}
 
-Use this setting to specify a different path for the indexes' temporary files.  
-By default, temporary files are created under the `Temp` directory inside the index data directory.  
-Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
+Set the default deployment mode for static indexes.
+
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Auto.DeploymentMode}
+
+Set the default deployment mode for auto indexes.
+
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Metrics.Enabled}
+
+Set whether indexing performance metrics will be gathered.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.TempPath}
+
+* Use this setting to specify a different path for the indexes' temporary files.
+
+* By default, temporary files are created under the `Temp` directory inside the index data directory.  
+  Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
+
+---
 
 - **Type**: `string`
 - **Default**: `null`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+{PANEL: Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
 
-Set how many indexes can run concurrently to prevent overwhelming system resources and slow indexing.
-
-- **Type**: `int`
-- **Default**: `null` No limit
-- **MinValue**: 1
-- **Scope**: Server-wide only (can be configured only in the settings.json file located in your RavenDB executable folder)
-
-{PANEL/}
-
-{PANEL:Indexing.IndexStartupBehaviorType}
-
-Manipulate index startup behavior on database load with the following options:  
-(This method can prevent slow index startup behavior in scenarios where many indexes open and 
-start processing concurrently, which would cause IO usage to max out system resources.)
-
-- **Type**: `string`
-- **Default**: Each index starts as soon as it is opened.  
-  - **Immediate**: Same as default.
-  - **Pause**: Opens all indexes, but they are paused until manually started.
-  - **Delay**: Delays starting index processes until all indexes are open.  
-- **Scope**: Server-wide or per database
-
-{PANEL/}
-
-{PANEL:Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
-
-Set how many seconds indexing will keep document transaction open when indexing.
+Set how many seconds indexing will keep document transaction open when indexing.  
+When triggered, transaction will be closed and a new one will be opened.  
 
 - **Type**: `int`
 - **Default**: `15`
-- **Scope**: Server-wide or per database
-
-When triggered, transaction will be closed and a new one will be opened
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
+{PANEL: Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
 
-Set how many seconds to keep a superseded auto index.
+Set the number of seconds to keep a superseded auto index.
 
 - **Type**: `int`
 - **Default**: `15`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
+{PANEL: Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
 
-Set how many minutes to wait before deep cleaning an idle index.  
-Deep cleanup reduces the cost of idle indexes.  
-It might slow the first query after the deep cleanup, thereafter queries return to normal performance.  
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide or per database or per index
-
-{PANEL/}
-
-{PANEL:Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
-
-Set how many minutes to wait before marking auto index as idle.
+Set the number of minutes to wait before marking an auto index as idle.
 
 - **Type**: `int`
 - **Default**: `30`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.DisableQueryOptimizerGeneratedIndexes}
+{PANEL: Indexing.DisableQueryOptimizerGeneratedIndexes}
 
-Disable query optimizer generated indexes (Auto Indexes).
+EXPERT ONLY:  
+Disable query optimizer generated indexes (auto-indexes). Dynamic queries will not be supported.  
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
-
-{WARNING Use with caution. /}
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
+{PANEL: Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
 
-Set how many hours the database should wait before deleting an auto index with the idle flag.
+Set the number of hours the database should wait before deleting an auto-index that is marked as idle.
 
 - **Type**: `int`
 - **Default**: `72`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
+{PANEL: Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
 
-Set minimum number of map attempts after which batch will be canceled if running low on memory.
+EXPERT ONLY:  
+Set minimum number of map attempts after which the batch will be canceled if running low on memory.
 
 - **Type**: `int`
 - **Default**: `512`
-- **Scope**: Server-wide or per database
-
-{WARNING Use with caution. /}
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
+{PANEL: Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
 
+EXPERT ONLY:  
 Number of concurrent stopped batches if running low on memory.
 
 - **Type**: `int`
-- **Default**: `3`
-- **Scope**: Server-wide or per database
-
-{WARNING Use with caution. /}
-
-{PANEL/}
-
-{PANEL:Indexing.History.NumberOfRevisions}
-
-Number of index history revisions to keep per index.  
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide or per database
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
 {PANEL:Indexing.MapTimeoutInSec}
 
-Number of seconds after which mapping will end even if there is more to map.
+Number of seconds after which mapping will end even if there is more to map.  
+Using the default value of `-1` will map everything possible in a single batch.  
 
 - **Type**: `int`
 - **Default**: `-1`
-- **Scope**: Server-wide or per database
-
-Value of *-1* for map as much as possible in single batch.
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.MapTimeoutAfterEtagReachedInMin}
+{PANEL: Indexing.QueryClauseCache.SizeInMb}
 
-Number of minutes after which mapping will end even if there is more to map. This will only be applied if we pass the last etag in collection that we saw when batch was started.
+EXPERT ONLY:  
+
+* Maximum size that the query clause cache will utilize for caching partial query clauses,  
+  defaulting to 10% of the system memory on 64-bit machines.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.Disabled}
+
+EXPERT ONLY:  
+
+* Disable the query clause cache for a server, database, or a single index.
+
+* The default value is set by the constructor of class `IndexingConfiguration`.  
+  It will be `true` if your core configuration key [Features.Availability](../../server/configuration/core-configuration#features.availability) is Not set to 'Experimental'. 
+
+---
+
+- **Type**: `bool`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.ExpirationScanFrequencyInSec}
+
+EXPERT ONLY:  
+The frequency by which to scan the query clause cache for expired values.
+
+- **Type**: `int`
+- **Default**: `180`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.RepeatedQueriesCount}
+
+EXPERT ONLY:  
+The number of recent queries that we will keep to identify repeated queries, relevant for caching.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide only
+ 
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec}
+
+EXPERT ONLY:  
+Queries that repeat within this time frame will be considered worth caching.
+
+- **Type**: `int`
+- **Default**: `300`
+- **Scope**: Server-wide, or per database, or per index
+ 
+{PANEL/}
+
+{PANEL: Indexing.MapBatchSize}
+
+Maximum number of documents to be processed by the index per indexing batch.
+
+- **Type**: `int?`
+- **Default**: `null` (no limit)
+- **MinValue**: `128`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MapTimeoutAfterEtagReachedInMin}
+
+* Number of minutes after which mapping will end even if there is more to map.  
+
+* This will only be applied if we pass the last etag we saw in the collection when the batch was started.
+
+---
 
 - **Type**: `int`
 - **Default**: `15`
-- **Scope**: Server-wide or per database
-
-This will only be applied if we pass the last etag in collection that we saw when batch was started.
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.MaxStepsForScript}
+{PANEL: Indexing.MaxStepsForScript}
 
 The maximum number of steps in the script execution of a JavaScript index.
 
 - **Type**: `int`
-- **Default**: `10000`
-- **Scope**: Server-wide or per database
+- **Default**: `10_000`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.CleanupIntervalInMin}
+{PANEL: Indexing.CleanupIntervalInMin}
 
 Time (in minutes) between auto index cleanup.
+Time (in minutes) between index cleanup"
 
 - **Type**: `int`
 - **Default**: `10`
@@ -214,39 +358,160 @@ Time (in minutes) between auto index cleanup.
 
 {PANEL/}
 
-{PANEL:Indexing.TransactionSizeLimitInMb}
+{PANEL: Indexing.Analyzers.NGram.MinGram}
+
+Smallest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Analyzers.NGram.MaxGram}
+
+Largest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `6`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
+
+{PANEL/}
+
+{PANEL: Indexing.ManagedAllocationsBatchSizeLimitInMb}
+
+Managed allocations limit in an indexing batch after which the batch will complete and an index will continue by starting a new one.
+
+- **Type**: `int`
+- **Default**: `2048`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaximumSizePerSegmentInMb}
+
+EXPERT ONLY:  
+
+* The maximum size in MB that we'll consider for segments merging.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
+ 
+{PANEL/}
+
+{PANEL: Indexing.MergeFactor}
+
+EXPERT ONLY:  
+
+* Set how often index segments are merged into larger ones.  
+  The merge process will start when the number of segments in an index reaches this number.  
+ 
+* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
+
+---
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MergeFactor`
+
+{PANEL/}
+
+{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
+
+EXPERT ONLY:  
+
+* The definition of a large segment in MB.  
+  We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.  
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
+
+{PANEL/}
+
+{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
+
+EXPERT ONLY:  
+Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../) to merge in a single batch.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
+
+EXPERT ONLY:  
+How long will we let merges to run before we close the transaction.
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
+
+{PANEL/}
+
+{PANEL: Indexing.TransactionSizeLimitInMb}
 
 Transaction size limit in megabytes after which an index will stop and complete the current batch.
 
 - **Type**: `int`
 - **Default**: `null` (no limit)
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
 {PANEL:Indexing.Encrypted.TransactionSizeLimitInMb}
 
-Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
+* Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
 
 - **Type**: `int`
-- **Default**: `64`
-- **Scope**: Server-wide or per database
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.ScratchSpaceLimitInMb}
+{PANEL: Indexing.ScratchSpaceLimitInMb}
 
-Amount of scratch space in megabytes that we allow to use for the index storage. After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
+* Amount of scratch space in megabytes that we allow to use for the index storage.
+
+* After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
+
+---
 
 - **Type**: `int`
 - **Default**: `null` (no limit)
-- **Scope**: Server-wide only or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.GlobalScratchSpaceLimitInMb}
+{PANEL: Indexing.GlobalScratchSpaceLimitInMb}
 
-Maximum amount of scratch space in megabytes that we allow to use for all index storages per server. After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
+* Maximum amount of scratch space in megabytes that we allow to use for all index storages per server.  
+
+* After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
+
+---
 
 - **Type**: `int`
 - **Default**: `null` (no limit)
@@ -254,64 +519,126 @@ Maximum amount of scratch space in megabytes that we allow to use for all index 
 
 {PANEL/}
 
-{PANEL:Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit}
+{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec}
 
 Max time to wait in seconds when forcing the storage environment flush and sync after exceeding the scratch space limit.
 
 - **Type**: `int`
 - **Default**: `30`
 - **Scope**: Server-wide only
+- **Alias:** `Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit`
 
 {PANEL/}
 
-{PANEL:Indexing.IndexMissingFieldsAsNull}
+{PANEL: Indexing.IndexMissingFieldsAsNull}
 
-Indicates if missing fields should be indexed same as 'null' values or not.
+* Set how the indexing process should handle fields that are missing.
+
+* When set to `true`, missing fields will be indexed with a `null` value.
+
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.IndexEmptyEntries}
+{PANEL: Indexing.IndexEmptyEntries}
 
-Indicates if empty index entries should be indexed by static indexes.
+* Set how the indexing process should handle documents that are missing fields.
+
+* When set to `true`, the indexing process will index documents even if they lack the fields that are supposed to be indexed.
+
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.MapBatchSize}
+{PANEL: Indexing.ErrorIndexStartupBehavior}
 
-Maximum number of documents to be processed by the index per indexing batch.
+Set how faulty indexes should behave on database startup when they are loaded.  
+By default they are not started.  
 
-- **Type**: `int`
-- **Default**: `null` (no limit)
-- **MinValue**: `128` 
-- **Scope**: Server-wide or per database
-
-{PANEL/}
-
-{PANEL:Indexing.MaxGram}
-
-Largest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers) is used.
-
-- **Type**: `int`
-- **Default**: `6`
-- **Scope**: Server-wide or per database
+- **Type**: `enum ErrorIndexStartupBehaviorType` (`Default`, `Start`, `ResetAndStart`)
+- **Default**: `Default`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.MinGram}
+{PANEL: Indexing.IndexStartupBehavior}
 
-Smallest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers) is used.
+* Set how indexes should behave on database startup when they are loaded.  
+  By default they are started immediately.
+
+* Setting this param can prevent slow index startup behavior in scenarios where many indexes open and start processing concurrently, which may cause IO usage to max out system resources.
+
+---
+
+- **Type**: `enum IndexStartupBehaviorType` (`Default`, `Immediate`, `Pause`, `Delay`)
+- **Default**: `Default`  
+- **Scope**: Server-wide, or per database
+
+Optional values:
+
+  - `Default`: Each index starts as soon as it is loaded.
+  - `Immediate`: Same as Default.
+  - `Pause`: Loads all indexes, but they are paused until manually started.
+  - `Delay`: Delays starting index processes until all indexes are loaded.
+
+{PANEL/}
+
+{PANEL: Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+
+Set how many indexes can run concurrently on the server to prevent overwhelming system resources and slow indexing.
 
 - **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide or per database
+- **Default**: `null` (No limit)
+- **MinValue**: 1
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackagesPath}
+
+Location of NuGet packages cache.
+
+- **Type**: `string`
+- **Default**: `Packages/NuGet`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackageSourceUrl}
+
+Default NuGet source URL.
+
+- **Type**: `string`
+- **Default**: `https://api.nuget.org/v3/index.json`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetAllowPreleasePackages}
+
+Allow installation of NuGet prerelease packages.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL:Indexing.History.NumberOfRevisions}
+
+Number of index history revisions to keep per index.
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
@@ -335,7 +662,7 @@ Smallest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers)
 
 {PANEL/}
 
-{PANEL:Indexing.Analyzers.Search.Default}
+{PANEL: Indexing.Analyzers.Search.Default}
 
 [Default analyzer](../../indexes/using-analyzers#ravendb) that will be used for search fields.
 
@@ -345,47 +672,140 @@ Smallest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers)
 
 {PANEL/}
 
-{PANEL:Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
+{PANEL: Indexing.Throttling.TimeIntervalInMs}
 
-Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) 
-to deploy [JavaScript indexes](../../indexes/javascript-indexes).
+How long the index should delay processing after new work is detected in milliseconds.
 
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide or per database
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.Auto.SearchEngineType}
+{PANEL: Indexing.Auto.SearchEngineType}
 
-Select the search engine to be used with auto indexes.  
+Set the search engine to be used with auto-indexes.
 
-- **Type**: `enum`
-  {CODE-BLOCK: csharp}
-   public enum SearchEngineType
-{
-    Corax, 
-    Lucene
-}
-  {CODE-BLOCK/}
-- **Default**: `SearchEngineType.Lucene`
-- **Scope**: Server-wide or per database
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
 {PANEL:Indexing.Static.SearchEngineType}
 
-Select the search engine to be used with static indexes.  
+Set the search engine to be used with static indexes.
 
-- **Type**: `enum`
-  {CODE-BLOCK: csharp}
-   public enum SearchEngineType
-{
-    Corax, 
-    Lucene
-}
-  {CODE-BLOCK/}
-- **Default**: `SearchEngineType.Lucene`
-- **Scope**: Server-wide, per database, or per index
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database, or per index
 
+{PANEL/}
+
+{PANEL: Indexing.SkipDatabaseIdValidationOnIndexOpening}
+
+EXPERT ONLY:  
+Allow to open an index without checking if current Database ID matched the one for which index was created.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
+
+Set how many minutes to wait before deep cleaning an idle index.  
+Deep cleanup reduces the cost of idle indexes.  
+It might slow the first query after the deep cleanup, thereafter queries return to normal performance.
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
+
+Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) to deploy [JavaScript indexes](../../indexes/javascript-indexes).
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
+
+Order by score automatically when boosting is used inside an index definition or a query.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.UseCompoundFileInMerging}
+
+EXPERT ONLY:  
+Use compound file in merging.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `ndexing.Lucene.UseCompoundFileInMergingt`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.IndexInputType}
+
+Lucene index input
+
+- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
+- **Default**: `Buffered`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec}
+
+Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.
+
+- **Type**: `int`
+- **Default**: `30`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb}
+
+Minimum total size of journals to run flush and sync when replacing side by side index in megabytes.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved}
+
+Sort by ticks when field contains dates.  
+When sorting in descending order, null dates are returned at the end with this option enabled.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.ReaderTermsIndexDivisor}
+
+EXPERT ONLY:  
+Control how many terms we'll keep in the cache for each field.  
+Higher values reduce the memory usage at the expense of increased search time for each term.
+
+- **Type**: `int`
+- **Default**: `1`
+- **Scope**: Server-wide, or per database, or per index
+ 
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -56,7 +56,7 @@
   [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
   [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
   [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
-  [Indexing.NuGetAllowPreleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowpreleasepackages)  
+  [Indexing.NuGetAllowPreReleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowprereleasepackages)  
   [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
   [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
   [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
@@ -622,13 +622,14 @@ Default NuGet source URL.
 
 {PANEL/}
 
-{PANEL: Indexing.NuGetAllowPreleasePackages}
+{PANEL: Indexing.NuGetAllowPreReleasePackages}
 
 Allow installation of NuGet prerelease packages.
 
 - **Type**: `bool`
 - **Default**: `false`
 - **Scope**: Server-wide only
+- **Alias:** `Indexing.NuGetAllowPreleasePackages`
 
 {PANEL/}
 
@@ -754,7 +755,7 @@ Use compound file in merging.
 - **Type**: `bool`
 - **Default**: `true`
 - **Scope**: Server-wide, or per database, or per index
-- **Alias:** `ndexing.Lucene.UseCompoundFileInMergingt`
+- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -407,7 +407,11 @@ Set the number of minutes to wait before marking an auto index as idle.
 
 {PANEL: Indexing.Analyzers.NGram.MaxGram}
 
-Largest n-gram to generate when NGram analyzer is used.
+* This configuration applies only to the Lucene indexing engine.
+
+* Largest n-gram to generate when NGram analyzer is used.
+
+---
 
 - **Type**: `int`
 - **Default**: `6`
@@ -418,7 +422,11 @@ Largest n-gram to generate when NGram analyzer is used.
 
 {PANEL: Indexing.Analyzers.NGram.MinGram}
 
-Smallest n-gram to generate when NGram analyzer is used.
+* This configuration applies only to the Lucene indexing engine.
+
+* Smallest n-gram to generate when NGram analyzer is used.
+
+---
 
 - **Type**: `int`
 - **Default**: `2`
@@ -482,6 +490,8 @@ Smallest n-gram to generate when NGram analyzer is used.
 {PANEL: Indexing.LargeSegmentSizeToMergeInMb}
 
 EXPERT ONLY:
+ 
+* This configuration applies only to the Lucene indexing engine.
 
 * The definition of a large segment in MB.  
   We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.
@@ -588,8 +598,13 @@ When triggered, transaction will be closed and a new one will be opened.
 
 {PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
 
-EXPERT ONLY:  
-How long will we let merges to run before we close the transaction.
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* How long will we let merges to run before we close the transaction.
+
+---
 
 - **Type**: `int`
 - **Default**: `15`
@@ -612,6 +627,8 @@ Max time to wait when forcing the storage environment flush and sync when replac
 
 EXPERT ONLY:
 
+* This configuration applies only to the Lucene indexing engine.
+
 * The maximum size in MB that we'll consider for segments merging.
 
 * The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
@@ -628,6 +645,8 @@ EXPERT ONLY:
 {PANEL: Indexing.MergeFactor}
 
 EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
 
 * Set how often index segments are merged into larger ones.  
   The merge process will start when the number of segments in an index reaches this number.
@@ -687,8 +706,13 @@ Number of concurrent stopped batches if running low on memory.
 
 {PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
 
-EXPERT ONLY:  
-Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+EXPERT ONLY: 
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+
+---
 
 - **Type**: `int`
 - **Default**: `2`
@@ -806,11 +830,16 @@ Transaction size limit in megabytes after which an index will stop and complete 
 {PANEL: Indexing.UseCompoundFileInMerging}
 
 EXPERT ONLY:  
-Use compound file in merging.
+
+* This configuration applies only to the Lucene indexing engine.
+ 
+* Use compound file in merging.
+
+---
 
 - **Type**: `bool`
 - **Default**: `true`
 - **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
+- **Alias:** `Indexing.Lucene.UseCompoundFileInMerging`
 
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -446,7 +446,7 @@ EXPERT ONLY:
 {PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
 
 EXPERT ONLY:  
-Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../) to merge in a single batch.
+Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
 
 - **Type**: `int`
 - **Default**: `2`

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -6,276 +6,157 @@
 * The following __indexing configuration keys__ can modified via either of the following options:
     * As explained in the [Config overview](../../server/configuration/configuration-options) article
     * Set a custom configuration per index from the [Client API](../../indexes/creating-and-deploying#creating-an-index-with-custom-configuration)
-    * Set a custom configuraiton per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)
+    * Set a custom configuration per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)
 
 {NOTE/}
 
 {NOTE: }
 
-* In this page:  
-  [Indexing.RunInMemory](../../server/configuration/indexing-configuration#indexing.runinmemory)  
-  [Indexing.Disable](../../server/configuration/indexing-configuration#indexing.disable)  
-  [Indexing.Static.DeploymentMode](../../server/configuration/indexing-configuration#indexing.static.deploymentmode)  
-  [Indexing.Auto.DeploymentMode](../../server/configuration/indexing-configuration#indexing.auto.deploymentmode)  
-  [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)  
-  [Indexing.TempPath](../../server/configuration/indexing-configuration#indexing.temppath)  
-  [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
-  [Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec](../../server/configuration/indexing-configuration#indexing.timebeforedeletionofsupersededautoindexinsec)  
-  [Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin](../../server/configuration/indexing-configuration#indexing.timetowaitbeforemarkingautoindexasidleinmin)  
-  [Indexing.DisableQueryOptimizerGeneratedIndexes](../../server/configuration/indexing-configuration#indexing.disablequeryoptimizergeneratedindexes)  
-  [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration#indexing.timetowaitbeforedeletingautoindexmarkedasidleinhrs)  
-  [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)  
-  [Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.numberofconcurrentstoppedbatchesifrunninglowonmemory)  
-  [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
-  [Indexing.QueryClauseCache.SizeInMb](../../server/configuration/indexing-configuration#indexing.queryclausecache.sizeinmb)  
-  [Indexing.QueryClauseCache.Disabled](../../server/configuration/indexing-configuration#indexing.queryclausecache.disabled)  
-  [Indexing.QueryClauseCache.ExpirationScanFrequencyInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.expirationscanfrequencyinsec)  
-  [Indexing.QueryClauseCache.RepeatedQueriesCount](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriescount)  
-  [Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriestimeframeinsec)  
-  [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
-  [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
-  [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
-  [Indexing.CleanupIntervalInMin](../../server/configuration/indexing-configuration#indexing.cleanupintervalinmin)  
-  [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
-  [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
-  [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
-  [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
-  [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
-  [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
-  [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch)  
-  [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
-  [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
-  [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
-  [Indexing.ScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.scratchspacelimitinmb)  
-  [Indexing.GlobalScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.globalscratchspacelimitinmb)  
-  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenexceedingscratchspacelimitinsec)  
-  [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
-  [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
-  [Indexing.ErrorIndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.errorindexstartupbehavior)  
-  [Indexing.IndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.indexstartupbehavior)  
-  [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
-  [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
-  [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
-  [Indexing.NuGetAllowPreReleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowprereleasepackages)  
-  [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
-  [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
-  [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
-  [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
-  [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
-  [Indexing.Auto.SearchEngineType](../../server/configuration/indexing-configuration#indexing.auto.searchenginetype)  
-  [Indexing.Static.SearchEngineType](../../server/configuration/indexing-configuration#indexing.static.searchenginetype)  
-  [Indexing.SkipDatabaseIdValidationOnIndexOpening](../../server/configuration/indexing-configuration#indexing.skipdatabaseidvalidationonindexopening)  
-  [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
-  [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../server/configuration/indexing-configuration#indexing.static.requireadmintodeployjavascriptindexes)  
-  [Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved](../../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)  
-  [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)  
-  [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
-  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
-  [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)  
-  [Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved](../../server/configuration/indexing-configuration#indexing.orderbyticksautomaticallywhendatesareinvolved)  
-  [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
+* In this page:
+    * Server-wide scope:  
+      [Indexing.CleanupIntervalInMin](../../server/configuration/indexing-configuration#indexing.cleanupintervalinmin)  
+      [Indexing.GlobalScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.globalscratchspacelimitinmb)  
+      [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
+      [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenexceedingscratchspacelimitinsec)  
+      [Indexing.NuGetAllowPreReleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowprereleasepackages)  
+      [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
+      [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
+      [Indexing.QueryClauseCache.ExpirationScanFrequencyInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.expirationscanfrequencyinsec)  
+      [Indexing.QueryClauseCache.RepeatedQueriesCount](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriescount)  
+      [Indexing.QueryClauseCache.SizeInMb](../../server/configuration/indexing-configuration#indexing.queryclausecache.sizeinmb)
+    * Server-wide, or database scope:  
+      [Indexing.Auto.DeploymentMode](../../server/configuration/indexing-configuration#indexing.auto.deploymentmode)  
+      [Indexing.Auto.SearchEngineType](../../server/configuration/indexing-configuration#indexing.auto.searchenginetype)  
+      [Indexing.Disable](../../server/configuration/indexing-configuration#indexing.disable)  
+      [Indexing.DisableQueryOptimizerGeneratedIndexes](../../server/configuration/indexing-configuration#indexing.disablequeryoptimizergeneratedindexes)  
+      [Indexing.ErrorIndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.errorindexstartupbehavior)  
+      [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
+      [Indexing.IndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.indexstartupbehavior)  
+      [Indexing.RunInMemory](../../server/configuration/indexing-configuration#indexing.runinmemory)  
+      [Indexing.SkipDatabaseIdValidationOnIndexOpening](../../server/configuration/indexing-configuration#indexing.skipdatabaseidvalidationonindexopening)  
+      [Indexing.Static.DeploymentMode](../../server/configuration/indexing-configuration#indexing.static.deploymentmode)  
+      [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../server/configuration/indexing-configuration#indexing.static.requireadmintodeployjavascriptindexes)  
+      [Indexing.TempPath](../../server/configuration/indexing-configuration#indexing.temppath)  
+      [Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec](../../server/configuration/indexing-configuration#indexing.timebeforedeletionofsupersededautoindexinsec)  
+      [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration#indexing.timetowaitbeforedeletingautoindexmarkedasidleinhrs)  
+      [Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin](../../server/configuration/indexing-configuration#indexing.timetowaitbeforemarkingautoindexasidleinmin)
+    * Server-wide, or database, or per index:  
+      [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
+      [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
+      [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
+      [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
+      [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
+      [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
+      [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
+      [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
+      [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
+      [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
+      [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
+      [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
+      [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
+      [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
+      [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
+      [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
+      [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
+      [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
+      [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
+      [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
+      [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
+      [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)   
+      [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)   
+      [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)
+      [Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.numberofconcurrentstoppedbatchesifrunninglowonmemory)   
+      [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch)  
+      [Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved](../../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)  
+      [Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved](../../server/configuration/indexing-configuration#indexing.orderbyticksautomaticallywhendatesareinvolved)  
+      [Indexing.QueryClauseCache.Disabled](../../server/configuration/indexing-configuration#indexing.queryclausecache.disabled)  
+      [Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriestimeframeinsec)  
+      [Indexing.ScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.scratchspacelimitinmb)  
+      [Indexing.Static.SearchEngineType](../../server/configuration/indexing-configuration#indexing.static.searchenginetype)  
+      [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
+      [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
+      [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
+      [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)
 
 {NOTE/}
 
 ---
 
-{PANEL: Indexing.RunInMemory}
+{PANEL: Indexing.CleanupIntervalInMin}
 
-* Set if indexes should run purely in memory.
-
-* When running in memory:
-  * No index data is written to the disk, and if the server is restarted, all index data will be lost.
-  * Note that the index definition itself is kept on disk and remains unaffected by server restarts.
-  * This is mostly useful for testing or faster, non-persistent indexing.
-
-* If _Indexing.RunInMemory_ is not set explicitly,  
-  then this configuration key will take the value of the core configuration key [RunInMemory](../../server/configuration/core-configuration#runinmemory).
-
----
-
-- **Type**: `bool`
-- **Default**: `false` 
-- **Scope**: Server-wide, or per database
-
-Optional values:
-
- * `true` - indexing is run only in memory
- * `false` - the index data is stored on disk
-
-{PANEL/}
-
-{PANEL: Indexing.Disable}
-
-Set whether to disable all indexes in the database.  
-All indexes in the database will be disabled when set to `true`.
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Static.DeploymentMode}
-
-Set the default deployment mode for static indexes.
-
-- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
-- **Default**: `Parallel`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Auto.DeploymentMode}
-
-Set the default deployment mode for auto indexes.
-
-- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
-- **Default**: `Parallel`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Metrics.Enabled}
-
-Set whether indexing performance metrics will be gathered.
-
-- **Type**: `bool`
-- **Default**: `true`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.TempPath}
-
-* Use this setting to specify a different path for the indexes' temporary files.
-
-* By default, temporary files are created under the `Temp` directory inside the index data directory.  
-  Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
-
----
-
-- **Type**: `string`
-- **Default**: `null`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
-
-Set how many seconds indexing will keep document transaction open when indexing.  
-When triggered, transaction will be closed and a new one will be opened.  
+Time (in minutes) between auto index cleanup.
+Time (in minutes) between index cleanup"
 
 - **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
-
-Set the number of seconds to keep a superseded auto index.
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
-
-Set the number of minutes to wait before marking an auto index as idle.
-
-- **Type**: `int`
-- **Default**: `30`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.DisableQueryOptimizerGeneratedIndexes}
-
-EXPERT ONLY:  
-Disable query optimizer generated indexes (auto-indexes). Dynamic queries will not be supported.  
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
-
-Set the number of hours the database should wait before deleting an auto-index that is marked as idle.
-
-- **Type**: `int`
-- **Default**: `72`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
-
-EXPERT ONLY:  
-Set minimum number of map attempts after which the batch will be canceled if running low on memory.
-
-- **Type**: `int`
-- **Default**: `512`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
-
-EXPERT ONLY:  
-Number of concurrent stopped batches if running low on memory.
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL:Indexing.MapTimeoutInSec}
-
-Number of seconds after which mapping will end even if there is more to map.  
-Using the default value of `-1` will map everything possible in a single batch.  
-
-- **Type**: `int`
-- **Default**: `-1`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.QueryClauseCache.SizeInMb}
-
-EXPERT ONLY:  
-
-* Maximum size that the query clause cache will utilize for caching partial query clauses,  
-  defaulting to 10% of the system memory on 64-bit machines.
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
+- **Default**: `10`
 - **Scope**: Server-wide only
 
 {PANEL/}
 
-{PANEL: Indexing.QueryClauseCache.Disabled}
+{PANEL: Indexing.GlobalScratchSpaceLimitInMb}
 
-EXPERT ONLY:  
+* Maximum amount of scratch space in megabytes that we allow to use for all index storages per server.
 
-* Disable the query clause cache for a server, database, or a single index.
-
-* The default value is set by the constructor of class `IndexingConfiguration`.  
-  It will be `true` if your core configuration key [Features.Availability](../../server/configuration/core-configuration#features.availability) is Not set to 'Experimental'. 
+* After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
 
 ---
 
+- **Type**: `int`
+- **Default**: `null` (no limit)
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+
+Set how many indexes can run concurrently on the server to prevent overwhelming system resources and slow indexing.
+
+- **Type**: `int`
+- **Default**: `null` (No limit)
+- **MinValue**: 1
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec}
+
+Max time to wait in seconds when forcing the storage environment flush and sync after exceeding the scratch space limit.
+
+- **Type**: `int`
+- **Default**: `30`
+- **Scope**: Server-wide only
+- **Alias:** `Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit`
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetAllowPreReleasePackages}
+
+Allow installation of NuGet prerelease packages.
+
 - **Type**: `bool`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
+- **Default**: `false`
+- **Scope**: Server-wide only
+- **Alias:** `Indexing.NuGetAllowPreleasePackages`
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackageSourceUrl}
+
+Default NuGet source URL.
+
+- **Type**: `string`
+- **Default**: `https://api.nuget.org/v3/index.json`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackagesPath}
+
+Location of NuGet packages cache.
+
+- **Type**: `string`
+- **Default**: `Packages/NuGet`
+- **Scope**: Server-wide only
 
 {PANEL/}
 
@@ -298,103 +179,15 @@ The number of recent queries that we will keep to identify repeated queries, rel
 - **Type**: `int`
 - **Default**: `512`
 - **Scope**: Server-wide only
- 
-{PANEL/}
-
-{PANEL: Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec}
-
-EXPERT ONLY:  
-Queries that repeat within this time frame will be considered worth caching.
-
-- **Type**: `int`
-- **Default**: `300`
-- **Scope**: Server-wide, or per database, or per index
- 
-{PANEL/}
-
-{PANEL: Indexing.MapBatchSize}
-
-Maximum number of documents to be processed by the index per indexing batch.
-
-- **Type**: `int?`
-- **Default**: `null` (no limit)
-- **MinValue**: `128`
-- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL: Indexing.MapTimeoutAfterEtagReachedInMin}
+{PANEL: Indexing.QueryClauseCache.SizeInMb}
 
-* Number of minutes after which mapping will end even if there is more to map.  
+EXPERT ONLY:
 
-* This will only be applied if we pass the last etag we saw in the collection when the batch was started.
-
----
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MaxStepsForScript}
-
-The maximum number of steps in the script execution of a JavaScript index.
-
-- **Type**: `int`
-- **Default**: `10_000`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.CleanupIntervalInMin}
-
-Time (in minutes) between auto index cleanup.
-Time (in minutes) between index cleanup"
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide only
-
-{PANEL/}
-
-{PANEL: Indexing.Analyzers.NGram.MinGram}
-
-Smallest n-gram to generate when NGram analyzer is used.
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
-
-{PANEL/}
-
-{PANEL: Indexing.Analyzers.NGram.MaxGram}
-
-Largest n-gram to generate when NGram analyzer is used.
-
-- **Type**: `int`
-- **Default**: `6`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
-
-{PANEL/}
-
-{PANEL: Indexing.ManagedAllocationsBatchSizeLimitInMb}
-
-Managed allocations limit in an indexing batch after which the batch will complete and an index will continue by starting a new one.
-
-- **Type**: `int`
-- **Default**: `2048`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MaximumSizePerSegmentInMb}
-
-EXPERT ONLY:  
-
-* The maximum size in MB that we'll consider for segments merging.
+* Maximum size that the query clause cache will utilize for caching partial query clauses,  
+  defaulting to 10% of the system memory on 64-bit machines.
 
 * The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
 
@@ -402,169 +195,69 @@ EXPERT ONLY:
 
 - **Type**: `int`
 - **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
- 
-{PANEL/}
-
-{PANEL: Indexing.MergeFactor}
-
-EXPERT ONLY:  
-
-* Set how often index segments are merged into larger ones.  
-  The merge process will start when the number of segments in an index reaches this number.  
- 
-* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
-
----
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MergeFactor`
-
-{PANEL/}
-
-{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
-
-EXPERT ONLY:  
-
-* The definition of a large segment in MB.  
-  We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.  
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
-
-{PANEL/}
-
-{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
-
-EXPERT ONLY:  
-Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
-
-{PANEL/}
-
-{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
-
-EXPERT ONLY:  
-How long will we let merges to run before we close the transaction.
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
-
-{PANEL/}
-
-{PANEL: Indexing.TransactionSizeLimitInMb}
-
-Transaction size limit in megabytes after which an index will stop and complete the current batch.
-
-- **Type**: `int`
-- **Default**: `null` (no limit)
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL:Indexing.Encrypted.TransactionSizeLimitInMb}
-
-* Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.ScratchSpaceLimitInMb}
-
-* Amount of scratch space in megabytes that we allow to use for the index storage.
-
-* After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
-
----
-
-- **Type**: `int`
-- **Default**: `null` (no limit)
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.GlobalScratchSpaceLimitInMb}
-
-* Maximum amount of scratch space in megabytes that we allow to use for all index storages per server.  
-
-* After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
-
----
-
-- **Type**: `int`
-- **Default**: `null` (no limit)
 - **Scope**: Server-wide only
 
 {PANEL/}
 
-{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec}
+{PANEL: Indexing.Auto.DeploymentMode}
 
-Max time to wait in seconds when forcing the storage environment flush and sync after exceeding the scratch space limit.
+Set the default deployment mode for auto indexes.
 
-- **Type**: `int`
-- **Default**: `30`
-- **Scope**: Server-wide only
-- **Alias:** `Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit`
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL: Indexing.IndexMissingFieldsAsNull}
+{PANEL: Indexing.Auto.SearchEngineType}
 
-* Set how the indexing process should handle fields that are missing.
+Set the search engine to be used with auto-indexes.
 
-* When set to `true`, missing fields will be indexed with a `null` value.
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database
 
----
+{PANEL/}
+
+{PANEL: Indexing.Disable}
+
+Set whether to disable all indexes in the database.  
+All indexes in the database will be disabled when set to `true`.
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide, or per database, or per index
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL: Indexing.IndexEmptyEntries}
+{PANEL: Indexing.DisableQueryOptimizerGeneratedIndexes}
 
-* Set how the indexing process should handle documents that are missing fields.
-
-* When set to `true`, the indexing process will index documents even if they lack the fields that are supposed to be indexed.
-
----
+EXPERT ONLY:  
+Disable query optimizer generated indexes (auto-indexes). Dynamic queries will not be supported.
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide, or per database, or per index
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
 {PANEL: Indexing.ErrorIndexStartupBehavior}
 
 Set how faulty indexes should behave on database startup when they are loaded.  
-By default they are not started.  
+By default they are not started.
 
 - **Type**: `enum ErrorIndexStartupBehaviorType` (`Default`, `Start`, `ResetAndStart`)
 - **Default**: `Default`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL:Indexing.History.NumberOfRevisions}
+
+Number of index history revisions to keep per index.
+
+- **Type**: `int`
+- **Default**: `10`
 - **Scope**: Server-wide, or per database
 
 {PANEL/}
@@ -579,66 +272,115 @@ By default they are not started.
 ---
 
 - **Type**: `enum IndexStartupBehaviorType` (`Default`, `Immediate`, `Pause`, `Delay`)
-- **Default**: `Default`  
+- **Default**: `Default`
 - **Scope**: Server-wide, or per database
 
 Optional values:
 
-  - `Default`: Each index starts as soon as it is loaded.
-  - `Immediate`: Same as Default.
-  - `Pause`: Loads all indexes, but they are paused until manually started.
-  - `Delay`: Delays starting index processes until all indexes are loaded.
+- `Default`: Each index starts as soon as it is loaded.
+- `Immediate`: Same as Default.
+- `Pause`: Loads all indexes, but they are paused until manually started.
+- `Delay`: Delays starting index processes until all indexes are loaded.
 
 {PANEL/}
 
-{PANEL: Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+{PANEL: Indexing.RunInMemory}
 
-Set how many indexes can run concurrently on the server to prevent overwhelming system resources and slow indexing.
+* Set if indexes should run purely in memory.
 
-- **Type**: `int`
-- **Default**: `null` (No limit)
-- **MinValue**: 1
-- **Scope**: Server-wide only
+* When running in memory:
+    * No index data is written to the disk, and if the server is restarted, all index data will be lost.
+    * Note that the index definition itself is kept on disk and remains unaffected by server restarts.
+    * This is mostly useful for testing or faster, non-persistent indexing.
 
-{PANEL/}
+* If _Indexing.RunInMemory_ is not set explicitly,  
+  then this configuration key will take the value of the core configuration key [RunInMemory](../../server/configuration/core-configuration#runinmemory).
 
-{PANEL: Indexing.NuGetPackagesPath}
-
-Location of NuGet packages cache.
-
-- **Type**: `string`
-- **Default**: `Packages/NuGet`
-- **Scope**: Server-wide only
-
-{PANEL/}
-
-{PANEL: Indexing.NuGetPackageSourceUrl}
-
-Default NuGet source URL.
-
-- **Type**: `string`
-- **Default**: `https://api.nuget.org/v3/index.json`
-- **Scope**: Server-wide only
-
-{PANEL/}
-
-{PANEL: Indexing.NuGetAllowPreReleasePackages}
-
-Allow installation of NuGet prerelease packages.
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide only
-- **Alias:** `Indexing.NuGetAllowPreleasePackages`
+- **Scope**: Server-wide, or per database
+
+Optional values:
+
+* `true` - indexing is run only in memory
+* `false` - the index data is stored on disk
 
 {PANEL/}
 
-{PANEL:Indexing.History.NumberOfRevisions}
+{PANEL: Indexing.SkipDatabaseIdValidationOnIndexOpening}
 
-Number of index history revisions to keep per index.
+EXPERT ONLY:  
+Allow to open an index without checking if current Database ID matched the one for which index was created.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, per database
+
+{PANEL/}
+
+{PANEL: Indexing.Static.DeploymentMode}
+
+Set the default deployment mode for static indexes.
+
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
+
+Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) to deploy [JavaScript indexes](../../indexes/javascript-indexes).
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TempPath}
+
+* Use this setting to specify a different path for the indexes' temporary files.
+
+* By default, temporary files are created under the `Temp` directory inside the index data directory.  
+  Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
+
+---
+
+- **Type**: `string`
+- **Default**: `null`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
+
+Set the number of seconds to keep a superseded auto index.
 
 - **Type**: `int`
-- **Default**: `10`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
+
+Set the number of hours the database should wait before deleting an auto-index that is marked as idle.
+
+- **Type**: `int`
+- **Default**: `72`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
+
+Set the number of minutes to wait before marking an auto index as idle.
+
+- **Type**: `int`
+- **Default**: `30`
 - **Scope**: Server-wide, or per database
 
 {PANEL/}
@@ -663,6 +405,28 @@ Number of index history revisions to keep per index.
 
 {PANEL/}
 
+{PANEL: Indexing.Analyzers.NGram.MaxGram}
+
+Largest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `6`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Analyzers.NGram.MinGram}
+
+Smallest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
+
+{PANEL/}
+
 {PANEL: Indexing.Analyzers.Search.Default}
 
 [Default analyzer](../../indexes/using-analyzers#ravendb) that will be used for search fields.
@@ -673,89 +437,63 @@ Number of index history revisions to keep per index.
 
 {PANEL/}
 
-{PANEL: Indexing.Throttling.TimeIntervalInMs}
+{PANEL:Indexing.Encrypted.TransactionSizeLimitInMb}
 
-How long the index should delay processing after new work is detected in milliseconds.
+* Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
 
 - **Type**: `int`
-- **Default**: `null`
+- **Default**: `DefaultValueSetInConstructor`
 - **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL: Indexing.Auto.SearchEngineType}
+{PANEL: Indexing.IndexEmptyEntries}
 
-Set the search engine to be used with auto-indexes.
+* Set how the indexing process should handle documents that are missing fields.
 
-- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
-- **Default**: `Lucene`
-- **Scope**: Server-wide, or per database
+* When set to `true`, the indexing process will index documents even if they lack the fields that are supposed to be indexed.
 
-{PANEL/}
-
-{PANEL:Indexing.Static.SearchEngineType}
-
-Set the search engine to be used with static indexes.
-
-- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
-- **Default**: `Lucene`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.SkipDatabaseIdValidationOnIndexOpening}
-
-EXPERT ONLY:  
-Allow to open an index without checking if current Database ID matched the one for which index was created.
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide, per database
-
-{PANEL/}
-
-{PANEL: Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
-
-Set how many minutes to wait before deep cleaning an idle index.  
-Deep cleanup reduces the cost of idle indexes.  
-It might slow the first query after the deep cleanup, thereafter queries return to normal performance.
-
-- **Type**: `int`
-- **Default**: `10`
 - **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL: Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
+{PANEL: Indexing.IndexMissingFieldsAsNull}
 
-Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) to deploy [JavaScript indexes](../../indexes/javascript-indexes).
+* Set how the indexing process should handle fields that are missing.
+
+* When set to `true`, missing fields will be indexed with a `null` value.
+
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
-
-Set whether query results will be automatically ordered by score when a boost factor is involved in the query.  
-(A boost factor may be [assigned inside an index definition](../../indexes/boosting) or can be [applied at query time](../../client-api/session/querying/text-search/boost-search-results)).
-
-- **Type**: `bool`
-- **Default**: `true`
 - **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL: Indexing.UseCompoundFileInMerging}
+{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
 
-EXPERT ONLY:  
-Use compound file in merging.
+EXPERT ONLY:
 
-- **Type**: `bool`
-- **Default**: `true`
+* The definition of a large segment in MB.  
+  We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
 - **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
+- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
 
 {PANEL/}
 
@@ -769,6 +507,97 @@ Lucene index input
 
 {PANEL/}
 
+{PANEL: Indexing.Lucene.ReaderTermsIndexDivisor}
+
+EXPERT ONLY:  
+Control how many terms we'll keep in the cache for each field.  
+Higher values reduce the memory usage at the expense of increased search time for each term.
+
+- **Type**: `int`
+- **Default**: `1`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.ManagedAllocationsBatchSizeLimitInMb}
+
+Managed allocations limit in an indexing batch after which the batch will complete and an index will continue by starting a new one.
+
+- **Type**: `int`
+- **Default**: `2048`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MapBatchSize}
+
+Maximum number of documents to be processed by the index per indexing batch.
+
+- **Type**: `int?`
+- **Default**: `null` (no limit)
+- **MinValue**: `128`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MapTimeoutAfterEtagReachedInMin}
+
+* Number of minutes after which mapping will end even if there is more to map.
+
+* This will only be applied if we pass the last etag we saw in the collection when the batch was started.
+
+---
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL:Indexing.MapTimeoutInSec}
+
+Number of seconds after which mapping will end even if there is more to map.  
+Using the default value of `-1` will map everything possible in a single batch.
+
+- **Type**: `int`
+- **Default**: `-1`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxStepsForScript}
+
+The maximum number of steps in the script execution of a JavaScript index.
+
+- **Type**: `int`
+- **Default**: `10_000`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
+
+Set how many seconds indexing will keep document transaction open when indexing.  
+When triggered, transaction will be closed and a new one will be opened.
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
+
+EXPERT ONLY:  
+How long will we let merges to run before we close the transaction.
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
+
+{PANEL/}
+
 {PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec}
 
 Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.
@@ -779,12 +608,102 @@ Max time to wait when forcing the storage environment flush and sync when replac
 
 {PANEL/}
 
+{PANEL: Indexing.MaximumSizePerSegmentInMb}
+
+EXPERT ONLY:
+
+* The maximum size in MB that we'll consider for segments merging.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
+
+{PANEL/}
+
+{PANEL: Indexing.MergeFactor}
+
+EXPERT ONLY:
+
+* Set how often index segments are merged into larger ones.  
+  The merge process will start when the number of segments in an index reaches this number.
+
+* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
+
+---
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MergeFactor`
+
+{PANEL/}
+
+{PANEL: Indexing.Metrics.Enabled}
+
+Set whether indexing performance metrics will be gathered.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
+
+EXPERT ONLY:  
+Set minimum number of map attempts after which the batch will be canceled if running low on memory.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
 {PANEL: Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb}
 
 Minimum total size of journals to run flush and sync when replacing side by side index in megabytes.
 
 - **Type**: `int`
 - **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
+
+EXPERT ONLY:  
+Number of concurrent stopped batches if running low on memory.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
+
+EXPERT ONLY:  
+Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
+
+{PANEL/}
+
+{PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
+
+Set whether query results will be automatically ordered by score when a boost factor is involved in the query.  
+(A boost factor may be [assigned inside an index definition](../../indexes/boosting) or can be [applied at query time](../../client-api/session/querying/text-search/boost-search-results)).
+
+- **Type**: `bool`
+- **Default**: `true`
 - **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
@@ -800,14 +719,98 @@ When sorting in descending order, null dates are returned at the end with this o
 
 {PANEL/}
 
-{PANEL: Indexing.Lucene.ReaderTermsIndexDivisor}
+{PANEL: Indexing.QueryClauseCache.Disabled}
+
+EXPERT ONLY:
+
+* Disable the query clause cache for a server, database, or a single index.
+
+* The default value is set by the constructor of class `IndexingConfiguration`.  
+  It will be `true` if your core configuration key [Features.Availability](../../server/configuration/core-configuration#features.availability) is Not set to 'Experimental'.
+
+---
+
+- **Type**: `bool`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec}
 
 EXPERT ONLY:  
-Control how many terms we'll keep in the cache for each field.  
-Higher values reduce the memory usage at the expense of increased search time for each term.
+Queries that repeat within this time frame will be considered worth caching.
 
 - **Type**: `int`
-- **Default**: `1`
+- **Default**: `300`
 - **Scope**: Server-wide, or per database, or per index
- 
+
+{PANEL/}
+
+{PANEL: Indexing.ScratchSpaceLimitInMb}
+
+* Amount of scratch space in megabytes that we allow to use for the index storage.
+
+* After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
+
+---
+
+- **Type**: `int`
+- **Default**: `null` (no limit)
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Static.SearchEngineType}
+
+Set the search engine to be used with static indexes.
+
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Throttling.TimeIntervalInMs}
+
+How long the index should delay processing after new work is detected in milliseconds.
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
+
+Set how many minutes to wait before deep cleaning an idle index.  
+Deep cleanup reduces the cost of idle indexes.  
+It might slow the first query after the deep cleanup, thereafter queries return to normal performance.
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.TransactionSizeLimitInMb}
+
+Transaction size limit in megabytes after which an index will stop and complete the current batch.
+
+- **Type**: `int`
+- **Default**: `null` (no limit)
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.UseCompoundFileInMerging}
+
+EXPERT ONLY:  
+Use compound file in merging.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
+
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -43,30 +43,31 @@
     * Server-wide, or database, or per index:  
       [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
       [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
-      [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
-      [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
       [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
       [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
       [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
       [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
-      [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
+      [Indexing.Lucene.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.lucene.analyzers.ngram.maxgram)  
+      [Indexing.Lucene.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.lucene.analyzers.ngram.mingram)  
       [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
+      [Indexing.Lucene.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.lucene.largesegmentsizetomergeinmb)  
+      [Indexing.Lucene.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.lucene.maximumsizepersegmentinmb)  
+      [Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.lucene.maxtimeformergestokeeprunninginsec)  
+      [Indexing.Lucene.MergeFactor](../../server/configuration/indexing-configuration#indexing.lucene.mergefactor)  
+      [Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.lucene.numberoflargesegmentstomergeinsinglebatch)  
       [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
+      [Indexing.Lucene.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.lucene.usecompoundfileinmerging)  
       [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
       [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
       [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
       [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
       [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
       [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
-      [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
       [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
-      [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
-      [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
       [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)   
       [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)   
       [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)
       [Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.numberofconcurrentstoppedbatchesifrunninglowonmemory)   
-      [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch)  
       [Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved](../../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)  
       [Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved](../../server/configuration/indexing-configuration#indexing.orderbyticksautomaticallywhendatesareinvolved)  
       [Indexing.QueryClauseCache.Disabled](../../server/configuration/indexing-configuration#indexing.queryclausecache.disabled)  
@@ -76,7 +77,6 @@
       [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
       [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
       [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
-      [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)
 
 {NOTE/}
 
@@ -405,36 +405,6 @@ Set the number of minutes to wait before marking an auto index as idle.
 
 {PANEL/}
 
-{PANEL: Indexing.Analyzers.NGram.MaxGram}
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Largest n-gram to generate when NGram analyzer is used.
-
----
-
-- **Type**: `int`
-- **Default**: `6`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
-
-{PANEL/}
-
-{PANEL: Indexing.Analyzers.NGram.MinGram}
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Smallest n-gram to generate when NGram analyzer is used.
-
----
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
-
-{PANEL/}
-
 {PANEL: Indexing.Analyzers.Search.Default}
 
 [Default analyzer](../../indexes/using-analyzers#ravendb) that will be used for search fields.
@@ -487,7 +457,47 @@ Set the number of minutes to wait before marking an auto index as idle.
 
 {PANEL/}
 
-{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
+{PANEL: Indexing.Lucene.Analyzers.NGram.MaxGram}
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Largest n-gram to generate when NGram analyzer is used.
+
+---
+
+- **Type**: `int`
+- **Default**: `6`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Analyzers.NGram.MaxGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.Analyzers.NGram.MinGram}
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Smallest n-gram to generate when NGram analyzer is used.
+
+---
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Analyzers.NGram.MinGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.IndexInputType}
+
+Lucene index input
+
+- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
+- **Default**: `Buffered`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.LargeSegmentSizeToMergeInMb}
 
 EXPERT ONLY:
  
@@ -503,17 +513,80 @@ EXPERT ONLY:
 - **Type**: `int`
 - **Default**: `DefaultValueSetInConstructor`
 - **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
+- **Alias:** `Indexing.LargeSegmentSizeToMergeInMb`
 
 {PANEL/}
 
-{PANEL: Indexing.Lucene.IndexInputType}
+{PANEL: Indexing.Lucene.MaximumSizePerSegmentInMb}
 
-Lucene index input
+EXPERT ONLY:
 
-- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
-- **Default**: `Buffered`
+* This configuration applies only to the Lucene indexing engine.
+
+* The maximum size in MB that we'll consider for segments merging.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
 - **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.MaximumSizePerSegmentInMb`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* How long will we let merges to run before we close the transaction.
+
+---
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.MaxTimeForMergesToKeepRunningInSec`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.MergeFactor}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Set how often index segments are merged into larger ones.  
+  The merge process will start when the number of segments in an index reaches this number.
+
+* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
+
+---
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.MergeFactor`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+
+---
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.NumberOfLargeSegmentsToMergeInSingleBatch`
 
 {PANEL/}
 
@@ -526,6 +599,23 @@ Higher values reduce the memory usage at the expense of increased search time fo
 - **Type**: `int`
 - **Default**: `1`
 - **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.UseCompoundFileInMerging}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Use compound file in merging.
+
+---
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.UseCompoundFileInMerging`
 
 {PANEL/}
 
@@ -596,23 +686,6 @@ When triggered, transaction will be closed and a new one will be opened.
 
 {PANEL/}
 
-{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* How long will we let merges to run before we close the transaction.
-
----
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
-
-{PANEL/}
-
 {PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec}
 
 Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.
@@ -620,45 +693,6 @@ Max time to wait when forcing the storage environment flush and sync when replac
 - **Type**: `int`
 - **Default**: `30`
 - **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MaximumSizePerSegmentInMb}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* The maximum size in MB that we'll consider for segments merging.
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
-
-{PANEL/}
-
-{PANEL: Indexing.MergeFactor}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Set how often index segments are merged into larger ones.  
-  The merge process will start when the number of segments in an index reaches this number.
-
-* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
-
----
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MergeFactor`
 
 {PANEL/}
 
@@ -701,23 +735,6 @@ Number of concurrent stopped batches if running low on memory.
 - **Type**: `int`
 - **Default**: `2`
 - **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
-
-EXPERT ONLY: 
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
-
----
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
 
 {PANEL/}
 
@@ -824,22 +841,5 @@ Transaction size limit in megabytes after which an index will stop and complete 
 - **Type**: `int`
 - **Default**: `null` (no limit)
 - **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.UseCompoundFileInMerging}
-
-EXPERT ONLY:  
-
-* This configuration applies only to the Lucene indexing engine.
- 
-* Use compound file in merging.
-
----
-
-- **Type**: `bool`
-- **Default**: `true`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.UseCompoundFileInMerging`
 
 {PANEL/}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/SortQueryResults.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/SortQueryResults.cs
@@ -1,0 +1,538 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Documentation.Samples.Orders;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents.Session;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Querying
+{
+    public class SortQueryResults
+    {
+        public async Task CanOrderResults()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    // Order by document field
+                    // =======================
+                    
+                    #region sort_1
+                    List<Product> products = session
+                         // Make a dynamic query on the Products collection    
+                        .Query<Product>()
+                         // Apply filtering (optional)
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'OrderBy', pass the document-field by which to order the results
+                        .OrderBy(x => x.UnitsInStock)
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value in ascending order,
+                    // with smaller values listed first.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_2
+                    List<Product> products = await asyncSession
+                         // Make a dynamic query on the Products collection    
+                        .Query<Product>()
+                         // Apply filtering (optional)
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'OrderBy', pass the document-field by which to order the results
+                        .OrderBy(x => x.UnitsInStock)
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value in ascending order,
+                    // with smaller values listed first.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_3
+                    List<Product> products = session.Advanced
+                         // Make a DocumentQuery on the Products collection    
+                        .DocumentQuery<Product>()
+                         // Apply filtering (optional)
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Call 'OrderBy', pass the document-field by which to order the results
+                        .OrderBy(x => x.UnitsInStock)
+                        .ToList();
+
+                    // Results will be sorted by the 'UnitsInStock' value in ascending order,
+                    // with smaller values listed first.
+                    #endregion
+                }
+                
+                // Order by score
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_4
+                    List<Product> products = session
+                        .Query<Product>()
+                         // Apply filtering
+                        .Where(x => x.UnitsInStock < 5 || x.Discontinued)
+                         // Call 'OrderByScore'
+                        .OrderByScore()
+                        .ToList();
+                    
+                    // Results will be sorted by the score value
+                    // with best matching documents (higher score values) listed first.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_5
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                         // Apply filtering
+                        .Where(x => x.UnitsInStock < 5 || x.Discontinued)
+                         // Call 'OrderByScore'
+                        .OrderByScore()
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the score value
+                    // with best matching documents (higher score values) listed first.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_6
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Apply filtering
+                        .WhereLessThan(x => x.UnitsInStock, 5)
+                        .OrElse()
+                        .WhereEquals(x => x.Discontinued, true)
+                         // Call 'OrderByScore'
+                        .OrderByScore()
+                        .ToList();
+                    
+                    // Results will be sorted by the score value
+                    // with best matching documents (higher score values) listed first.
+                    #endregion
+                }
+                
+                // Order by random
+                // ===============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_7
+                    List<Product> products = session
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'Customize' with 'RandomOrdering'
+                        .Customize(x => x.RandomOrdering())
+                         // An optional seed can be passed, e.g.:
+                         // .Customize(x => x.RandomOrdering('someSeed'))
+                        .ToList();
+                    
+                    // Results will be randomly ordered.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_8
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Call 'Customize' with 'RandomOrdering'
+                        .Customize(x => x.RandomOrdering())
+                         // An optional seed can be passed, e.g.:
+                         // .Customize(x => x.RandomOrdering('someSeed'))
+                        .ToListAsync();
+                    
+                    // Results will be randomly ordered.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_9
+                    List<Product> products = session.Advanced  
+                        .DocumentQuery<Product>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Call 'RandomOrdering'
+                        .RandomOrdering()
+                         // An optional seed can be passed, e.g.:
+                         // .RandomOrdering('someSeed')
+                        .ToList();
+                    
+                    // Results will be randomly ordered.
+                    #endregion
+                }
+                
+                // Order by Count
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_10
+                    var numberOfProductsPerCategory = session
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Count the number of product documents per category
+                            Count = x.Count()
+                        })
+                         // Order by the Count value
+                        .OrderBy(x => x.Count)
+                        .ToList();
+                    
+                    // Results will contain the number of Product documents per category
+                    // ordered by that count in ascending order.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_11
+                    var numberOfProductsPerCategory = await asyncSession
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Count the number of product documents per category
+                            Count = x.Count()
+                        })
+                         // Order by the Count value
+                        .OrderBy(x => x.Count)
+                        .ToListAsync();
+                    
+                    // Results will contain the number of Product documents per category
+                    // ordered by that count in ascending order.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_12
+                    var numberOfProductsPerCategory = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Group by Category
+                        .GroupBy("Category")
+                        .SelectKey("Category")
+                         // Count the number of product documents per category
+                        .SelectCount()
+                         // Order by the Count value
+                         // Here you need to specify the ordering type explicitly 
+                        .OrderBy("Count", OrderingType.Long)
+                        .ToList();
+                    
+                    // Results will contain the number of Product documents per category
+                    // ordered by that count in ascending order.
+                    #endregion
+                }
+                
+                // Order by Sum
+                // ============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_13
+                    var numberOfUnitsInStockPerCategory = session
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Sum the number of units in stock per category
+                            Sum = x.Sum(x => x.UnitsInStock)
+                        })
+                         // Order by the Sum value
+                        .OrderBy(x => x.Sum)
+                        .ToList();
+                    
+                    // Results will contain the total number of units in stock per category
+                    // ordered by that number in ascending order.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_14
+                    var numberOfUnitsInStockPerCategory = await asyncSession
+                        .Query<Product>()
+                         // Make an aggregation query
+                        .GroupBy(x => x.Category)
+                        .Select(x => new
+                        {
+                            // Group by Category
+                            Category = x.Key,
+                            // Sum the number of units in stock per category
+                            Sum = x.Sum(x => x.UnitsInStock)
+                        })
+                         // Order by the Sum value
+                        .OrderBy(x => x.Sum)
+                        .ToListAsync();
+                    
+                    // Results will contain the total number of units in stock per category
+                    // ordered by that number in ascending order.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_15
+                    var numberOfUnitsInStockPerCategory = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Group by Category
+                        .GroupBy("Category")
+                        .SelectKey("Category")
+                         // Sum the number of units in stock per category
+                        .SelectSum(new GroupByField
+                        {
+                            FieldName = "UnitsInStock",
+                            ProjectedName = "Sum"
+                        })
+                         // Order by the Sum value
+                         // Here you need to specify the ordering type explicitly 
+                        .OrderBy("Sum", OrderingType.Long)
+                        .ToList();
+                    
+                    // Results will contain the total number of units in stock per category
+                    // ordered by that number in ascending order.
+                    #endregion
+                }
+                
+                // Force ordering type
+                // ===================
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_16
+                    List<Product> products = session
+                        .Query<Product>()
+                         // Call 'OrderBy', order by field 'QuantityPerUnit'
+                         // Pass a second param, requesting to order the text alphanumerically
+                        .OrderBy(x => x.QuantityPerUnit, OrderingType.AlphaNumeric)
+                        .ToList();
+                    #endregion
+                    
+                    #region sort_16_results
+                    // Running the above query on the NorthWind sample data,
+                    // would produce the following order for the QuantityPerUnit field:
+                    // ================================================================
+                    
+                    // "1 kg pkg."
+                    // "1k pkg."
+                    // "2 kg box."
+                    // "4 - 450 g glasses"
+                    // "5 kg pkg."
+                    // ...
+                    
+                    // While running with the default Lexicographical ordering would have produced:
+                    // ============================================================================
+                    
+                    // "1 kg pkg."
+                    // "10 - 200 g glasses"
+                    // "10 - 4 oz boxes"
+                    // "10 - 500 g pkgs."
+                    // "10 - 500 g pkgs."
+                    // ...
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_17
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                         // Call 'OrderBy', order by field 'QuantityPerUnit'
+                         // Pass a second param, requesting to order the text alphanumerically
+                        .OrderBy(x => x.QuantityPerUnit, OrderingType.AlphaNumeric)
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_18
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                         // Call 'OrderBy', order by field 'QuantityPerUnit'
+                         // Pass a second param, requesting to order the text alphanumerically
+                        .OrderBy(x => x.QuantityPerUnit, OrderingType.AlphaNumeric)
+                        .ToList();
+                    #endregion
+                }
+                
+                // Chain ordering
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_19
+                    List<Product> products = session
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Apply the primary sort by 'UnitsInStock'
+                        .OrderByDescending(x => x.UnitsInStock)
+                         // Apply a secondary sort by the score (for products with the same # of units in stock)
+                        .ThenByScore()
+                         // Apply another sort by 'Name' (for products with same # of units in stock and same score)
+                        .ThenBy(x => x.Name)
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value (descending),
+                    // then by score,
+                    // and then by 'Name' (ascending).
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_20
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Apply the primary sort by 'UnitsInStock'
+                        .OrderByDescending(x => x.UnitsInStock)
+                         // Apply a secondary sort by the score (for products with the same # of units in stock)
+                        .ThenByScore()
+                         // Apply another sort by 'Name' (for products with same # of units in stock and same score)
+                        .ThenBy(x => x.Name)
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value (descending),
+                    // then by score,
+                    // and then by 'Name' (ascending).
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_21
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Apply the primary sort by 'UnitsInStock'
+                        .OrderByDescending(x => x.UnitsInStock)
+                         // Apply a secondary sort by the score
+                        .OrderByScore()
+                         // Apply another sort by 'Name'
+                        .OrderBy(x => x.Name)
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value (descending),
+                    // then by score,
+                    // and then by 'Name' (ascending).
+                    #endregion
+                }
+                
+                // Custom sorters
+                // ==============
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region sort_22
+                    List<Product> products = session
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Order by field 'UnitsInStock', pass the name of your custom sorter class
+                        .OrderBy(x => x.UnitsInStock, "MySorter")
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value
+                    // according to the logic from 'MySorter' class
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region sort_23
+                    List<Product> products = await asyncSession
+                        .Query<Product>()
+                        .Where(x => x.UnitsInStock > 10)
+                         // Order by field 'UnitsInStock', pass the name of your custom sorter class
+                        .OrderBy(x => x.UnitsInStock, "MySorter")
+                        .ToListAsync();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value
+                    // according to the logic from 'MySorter' class
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region sort_24
+                    List<Product> products = session.Advanced
+                        .DocumentQuery<Product>()
+                        .WhereGreaterThan(x => x.UnitsInStock, 10)
+                         // Order by field 'UnitsInStock', pass the name of your custom sorter class
+                        .OrderBy(x => x.UnitsInStock, "MySorter")
+                        .ToList();
+                    
+                    // Results will be sorted by the 'UnitsInStock' value
+                    // according to the logic from 'MySorter' class
+                    #endregion
+                }
+                
+                // Get score from metadata
+                // =======================
+                
+                using (var session = store.OpenSession())
+                {
+                    #region get_score_from_metadata
+                    // Make a query:
+                    // =============
+                    
+                    List<Employee> employees = session
+                        .Query<Employee>()
+                        .Search(x => x.Notes, "English")
+                        .Search(x => x.Notes, "Italian", boost: 10)
+                        .ToList();
+                    
+                    // Get the score:
+                    // ==============
+                    
+                    // Call 'GetMetadataFor', pass an entity from the resulting employees list
+                    var metadata = session.Advanced.GetMetadataFor(employees[0]);
+                    
+                    // Score is available in the '@index-score' metadata property
+                    var score = metadata[Constants.Documents.Metadata.IndexScore];
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo<TResult>
+        {
+            #region syntax
+            // OrderBy overloads:
+            IOrderedQueryable<T> OrderBy<T>(string path, OrderingType ordering);
+            IOrderedQueryable<T> OrderBy<T>(Expression<Func<T, object>> path, OrderingType ordering);
+            IOrderedQueryable<T> OrderBy<T>(string path, string sorterName);
+            IOrderedQueryable<T> OrderBy<T>(Expression<Func<T, object>> path, string sorterName);
+
+            // OrderByDescending overloads:
+            IOrderedQueryable<T> OrderByDescending<T>(string path, OrderingType ordering);
+            IOrderedQueryable<T> OrderByDescending<T>(Expression<Func<T, object>> path, OrderingType ordering);
+            IOrderedQueryable<T> OrderByDescending<T>(string path, string sorterName);
+            IOrderedQueryable<T> OrderByDescending<T>(Expression<Func<T, object>> path, string sorterName);
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/BoostResults.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/BoostResults.cs
@@ -150,29 +150,6 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                     // * Search is case-insensitive.
                     #endregion
                 }
-                
-                using (var session = store.OpenSession())
-                {
-                    #region boost_6
-                    // Make a query:
-                    // =============
-                    
-                    List<Employee> employees = session
-                        .Query<Employee>()
-                        .Search(x => x.Notes, "English")
-                        .Search(x => x.Notes, "Italian", boost: 10)
-                        .ToList();
-                    
-                    // Get the score:
-                    // ==============
-                    
-                    // Call 'GetMetadataFor', pass an entity from the resulting employees list
-                    var metadata = session.Advanced.GetMetadataFor(employees[0]);
-                    
-                    // Score is available in the '@index-score' metadata property
-                    var score = metadata[Constants.Documents.Metadata.IndexScore];
-                    #endregion
-                }
             }
         }
     }

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/BoostResults.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/BoostResults.cs
@@ -1,0 +1,179 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
+{
+    public class BoostResults
+    {
+        public async Task Examples()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region boost_1
+                    List<Employee> employees = session
+                         // Make a dynamic full-text search Query on 'Employees' collection
+                        .Query<Employee>()
+                         // This search predicate will use the default boost value of 1
+                        .Search(x => x.Notes, "English")
+                         // * Pass the boost value using the 'boost' parameter
+                         // * This search predicate will use a boost value of 10
+                        .Search(x => x.Notes, "Italian", boost: 10)
+                        .ToList();
+                    
+                    // * Results will contain all Employee documents that have
+                    //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+                    //
+                    // * Matching documents that contain 'Italian' will get a HIGHER score
+                    //   than those that contain 'English'.
+                    //
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.   
+                    // 
+                    // * Search is case-insensitive.
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region boost_2
+                    List<Employee> employees = await asyncSession
+                         // Make a dynamic full-text search Query on 'Employees' collection
+                        .Query<Employee>()
+                         // This search predicate will use the default boost value of 1
+                        .Search(x => x.Notes, "English")
+                         // * Pass the boost value using the 'boost' parameter
+                         // * This search predicate will use a boost value of 10
+                        .Search(x => x.Notes, "Italian", boost: 10)
+                        .ToListAsync();
+                    
+                    // * Results will contain all Employee documents that have
+                    //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+                    //
+                    // * Matching documents that contain 'Italian' will get a HIGHER score
+                    //   than those that contain 'English'.
+                    //
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.   
+                    // 
+                    // * Search is case-insensitive.
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region boost_3
+                    List<Employee> employees = session.Advanced
+                         // Make a dynamic full-text search DocumentQuery on 'Employees' collection
+                        .DocumentQuery<Employee>()
+                         // This search predicate will use the default boost value of 1
+                        .Search(x => x.Notes, "English")
+                         // This search predicate will use a boost value of 10 
+                        .Search(x => x.Notes, "Italian")
+                         // Call 'Boost' to set the boost value of the previous 'Search' call
+                        .Boost(10)
+                        .ToList();
+                    
+                    // * Results will contain all Employee documents that have
+                    //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+                    //
+                    // * Matching documents that contain 'Italian' will get a HIGHER score
+                    //   than those that contain 'English'.
+                    //
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.   
+                    // 
+                    // * Search is case-insensitive.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region boost_4
+                    List<Company> companies = session.Advanced
+                         // Make a dynamic DocumentQuery on 'Companies' collection
+                        .DocumentQuery<Company>()
+                         // Define a 'Where' condition
+                        .WhereStartsWith(x => x.Name, "O")
+                         // Call 'Boost' to set the boost value of the previous 'Where' predicate
+                        .Boost(10)
+                         // Call 'OrElse' so that OR operator will be used between statements
+                        .OrElse()
+                        .WhereStartsWith(x => x.Name, "P")
+                        .Boost(50)
+                        .OrElse()
+                        .WhereEndsWith(x => x.Name, "OP")
+                        .Boost(90)
+                        .ToList();
+                    
+                    // * Results will contain all Company documents that either
+                    //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field.
+                    //
+                    // * Matching documents that end-with 'OP' will get the HIGHEST scores.
+                    //   Matching documents that start-with 'O' will get the LOWEST scores. 
+                    //
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.
+                    //
+                    // * Search is case-insensitive.
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region boost_5
+                    List<Company> companies = await asyncSession.Advanced
+                         // Make a dynamic DocumentQuery on 'Companies' collection
+                        .AsyncDocumentQuery<Company>()
+                         // Define a 'Where' condition
+                        .WhereStartsWith(x => x.Name, "O")
+                         // Call 'Boost' to set the boost value of the previous 'Where' predicate
+                        .Boost(10)
+                         // Call 'OrElse' so that OR operator will be used between statements
+                        .OrElse()
+                        .WhereStartsWith(x => x.Name, "P")
+                        .Boost(50)
+                        .OrElse()
+                        .WhereEndsWith(x => x.Name, "OP")
+                        .Boost(90)
+                        .ToListAsync();
+                    
+                    // * Results will contain all Company documents that either
+                    //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field.
+                    //
+                    // * Matching documents that end-with 'OP' will get the HIGHEST scores.
+                    //   Matching documents that start-with 'O' will get the LOWEST scores. 
+                    //
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.
+                    //
+                    // * Search is case-insensitive.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region boost_6
+                    // Make a query:
+                    // =============
+                    
+                    List<Employee> employees = session
+                        .Query<Employee>()
+                        .Search(x => x.Notes, "English")
+                        .Search(x => x.Notes, "Italian", boost: 10)
+                        .ToList();
+                    
+                    // Get the score:
+                    // ==============
+                    
+                    // Call 'GetMetadataFor', pass an entity from the resulting employees list
+                    var metadata = session.Advanced.GetMetadataFor(employees[0]);
+                    
+                    // Score is available in the '@index-score' metadata property
+                    var score = metadata[Constants.Documents.Metadata.IndexScore];
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/BoostResults.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/TextSearch/BoostResults.cs
@@ -27,14 +27,12 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                         .ToList();
                     
                     // * Results will contain all Employee documents that have
-                    //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+                    //   EITHER 'English' OR 'Italian' in their 'Notes' field (case-insensitive).
                     //
                     // * Matching documents that contain 'Italian' will get a HIGHER score
                     //   than those that contain 'English'.
                     //
-                    // * Unless configured otherwise, the resulting documents will be ordered by their score.   
-                    // 
-                    // * Search is case-insensitive.
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.  
                     #endregion
                 }
 
@@ -52,14 +50,12 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                         .ToListAsync();
                     
                     // * Results will contain all Employee documents that have
-                    //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+                    //   EITHER 'English' OR 'Italian' in their 'Notes' field (case-insensitive).
                     //
                     // * Matching documents that contain 'Italian' will get a HIGHER score
                     //   than those that contain 'English'.
                     //
-                    // * Unless configured otherwise, the resulting documents will be ordered by their score.   
-                    // 
-                    // * Search is case-insensitive.
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.  
                     #endregion
                 }
 
@@ -78,14 +74,12 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                         .ToList();
                     
                     // * Results will contain all Employee documents that have
-                    //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+                    //   EITHER 'English' OR 'Italian' in their 'Notes' field (case-insensitive).
                     //
                     // * Matching documents that contain 'Italian' will get a HIGHER score
                     //   than those that contain 'English'.
                     //
-                    // * Unless configured otherwise, the resulting documents will be ordered by their score.   
-                    // 
-                    // * Search is case-insensitive.
+                    // * Unless configured otherwise, the resulting documents will be ordered by their score.  
                     #endregion
                 }
                 
@@ -109,14 +103,12 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                         .ToList();
                     
                     // * Results will contain all Company documents that either
-                    //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field.
+                    //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field (case-insensitive).
                     //
                     // * Matching documents that end-with 'OP' will get the HIGHEST scores.
                     //   Matching documents that start-with 'O' will get the LOWEST scores. 
                     //
                     // * Unless configured otherwise, the resulting documents will be ordered by their score.
-                    //
-                    // * Search is case-insensitive.
                     #endregion
                 }
                 
@@ -140,14 +132,12 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying.TextSearch
                         .ToListAsync();
                     
                     // * Results will contain all Company documents that either
-                    //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field.
+                    //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field (case-insensitive).
                     //
                     // * Matching documents that end-with 'OP' will get the HIGHEST scores.
                     //   Matching documents that start-with 'O' will get the LOWEST scores. 
                     //
                     // * Unless configured otherwise, the resulting documents will be ordered by their score.
-                    //
-                    // * Search is case-insensitive.
                     #endregion
                 }
             }

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Indexes/Boosting.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Indexes/Boosting.cs
@@ -1,0 +1,210 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq.Indexing;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.Indexes
+{
+    #region index_1
+    public class Orders_ByCountries_BoostByField : AbstractIndexCreationTask<Order>
+    {
+        public class IndexEntry
+        {
+            // Index-field 'ShipToCountry' will be boosted in the map definition below
+            public string ShipToCountry { get; set; }
+            public string CompanyCountry { get; set; }
+        }
+        
+        public Orders_ByCountries_BoostByField()
+        {
+            Map = orders => from order in orders
+                let company = LoadDocument<Company>(order.Company)
+                
+                // Note: with current server version,
+                // use 'select new' instead of 'select new IndexEntry' for compilation
+                select new 
+                {
+                    // Boost index-field 'ShipToCountry':
+                    // * Use method 'Boost', pass a numeric value to boost by 
+                    // * Documents that match the query criteria for this field will rank higher
+                    ShipToCountry = order.ShipTo.Country.Boost(10), 
+                    CompanyCountry = company.Address.Country
+                };
+        }
+    }
+    #endregion
+    
+    #region index_1_js
+    public class Orders_ByCountries_BoostByField_JS : AbstractJavaScriptIndexCreationTask
+    {
+        public Orders_ByCountries_BoostByField_JS()
+        {
+            Maps = new HashSet<string>()
+            {
+                @"map('orders', function(order) {
+                    let company = load(order.Company, 'Companies')
+                    return {
+                        ShipToCountry: boost(order.ShipTo.Country, 10),
+                        CompanyCountry: company.Address.Country
+                    };
+                })"
+            };
+        }
+    }
+    #endregion
+    
+    #region index_2
+    public class Orders_ByCountries_BoostByIndexEntry : AbstractIndexCreationTask<Order>
+    {
+        public class IndexEntry
+        {
+            public string ShipToCountry { get; set; }
+            public string CompanyCountry { get; set; }
+        }
+        
+        public Orders_ByCountries_BoostByIndexEntry()
+        {
+            Map = orders => from order in orders
+                let company = LoadDocument<Company>(order.Company)
+                
+                select new IndexEntry()
+                {
+                    ShipToCountry = order.ShipTo.Country,
+                    CompanyCountry = company.Address.Country
+                }
+                // Boost the whole index-entry:
+                // * Use method 'Boost'
+                // * Pass a document-field that will set the boost level dynamically per document indexed.  
+                // * The boost level will vary from one document to another based on the value of this field.
+               .Boost((float) order.Freight);
+        }
+    }
+    #endregion
+    
+    #region index_2_js
+    public class Orders_ByCountries_BoostByIndexEntry_JS : AbstractJavaScriptIndexCreationTask
+    {
+        public Orders_ByCountries_BoostByIndexEntry_JS()
+        {
+            Maps = new HashSet<string>()
+            {
+                @"map('orders', function(order) {
+                    let company = load(order.Company, 'Companies')
+                    return boost({
+                        ShipToCountry: order.ShipTo.Country,
+                        CompanyCountry: company.Address.Country
+                    }, order.Freight)
+                })"
+            };
+        }
+    }
+    #endregion
+
+    public class Boosting
+    {
+        public async void Queries()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region query_1
+                    List<Order> orders = session
+                         // Query the index    
+                        .Query<Orders_ByCountries_BoostByField.IndexEntry, Orders_ByCountries_BoostByField>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
+                        .ToList();
+                    
+                    // Because index-field 'ShipToCountry' was boosted (inside the index definition),
+                    // then documents containing 'Poland' in their 'ShipTo.Country' field will get a higher score than
+                    // documents containing a company that is located in 'Portugal'.
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region query_2
+                    List<Order> orders = await asyncSession
+                         // Query the index    
+                        .Query<Orders_ByCountries_BoostByField.IndexEntry, Orders_ByCountries_BoostByField>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
+                        .ToListAsync();
+                    
+                    // Because index-field 'ShipToCountry' was boosted (inside the index definition),
+                    // then documents containing 'Poland' in their 'ShipTo.Country' field will get a higher score than
+                    // documents containing a company that is located in 'Portugal'.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region query_3
+                    List<Order> orders = session.Advanced
+                         // Query the index 
+                        .DocumentQuery<Orders_ByCountries_BoostByField.IndexEntry, Orders_ByCountries_BoostByField>()
+                        .WhereEquals(x => x.ShipToCountry, "Poland")
+                        .OrElse()
+                        .WhereEquals(x => x.CompanyCountry, "Portugal")
+                        .OfType<Order>()
+                        .ToList();
+                    
+                    // Because index-field 'ShipToCountry' was boosted (inside the index definition),
+                    // then documents containing 'Poland' in their 'ShipTo.Country' field will get a higher score than
+                    // documents containing a company that is located in 'Portugal'.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region query_4
+                    List<Order> orders = session
+                         // Query the index  
+                        .Query<Orders_ByCountries_BoostByIndexEntry.IndexEntry, Orders_ByCountries_BoostByIndexEntry>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
+                        .ToList();
+                    
+                    // The resulting score per matching document is affected by the value of the document-field 'Freight'. 
+                    // Documents with a higher 'Freight' value will rank higher.
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region query_5
+                    List<Order> orders = await asyncSession
+                         // Query the index  
+                        .Query<Orders_ByCountries_BoostByIndexEntry.IndexEntry, Orders_ByCountries_BoostByIndexEntry>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
+                        .ToListAsync();
+                    
+                    // The resulting score per matching document is affected by the value of the document-field 'Freight'. 
+                    // Documents with a higher 'Freight' value will rank higher.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region query_6
+                    List<Order> orders = session.Advanced
+                         // Query the index  
+                        .DocumentQuery<Orders_ByCountries_BoostByIndexEntry.IndexEntry, Orders_ByCountries_BoostByIndexEntry>()
+                        .WhereEquals(x => x.ShipToCountry, "Poland")
+                        .OrElse()
+                        .WhereEquals(x => x.CompanyCountry, "Portugal")
+                        .OfType<Order>()
+                        .ToList();
+                    
+                    // The resulting score per matching document is affected by the value of the document-field 'Freight'. 
+                    // Documents with a higher 'Freight' value will rank higher.
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Northwind.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Northwind.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Raven.Documentation.Samples
+{
+    namespace Orders
+    {
+        #region northwind
+        public class Company
+        {
+            public string Id { get; set; }
+            public string ExternalId { get; set; }
+            public string Name { get; set; }
+            public Contact Contact { get; set; }
+            public Address Address { get; set; }
+            public string Phone { get; set; }
+            public string Fax { get; set; }
+        }
+
+        public class Address
+        {
+            public string Line1 { get; set; }
+            public string Line2 { get; set; }
+            public string City { get; set; }
+            public string Region { get; set; }
+            public string PostalCode { get; set; }
+            public string Country { get; set; }
+            public Location Location { get; set; }
+        }
+
+        public class Location
+        {
+            public double Latitude { get; set; }
+            public double Longitude { get; set; }
+        }
+
+        public class Contact
+        {
+            public string Name { get; set; }
+            public string Title { get; set; }
+        }
+
+        public class Category
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+        }
+
+        public class Order
+        {
+            public string Id { get; set; }
+            public string Company { get; set; }
+            public string Employee { get; set; }
+            public DateTime OrderedAt { get; set; }
+            public DateTime RequireAt { get; set; }
+            public DateTime? ShippedAt { get; set; }
+            public Address ShipTo { get; set; }
+            public string ShipVia { get; set; }
+            public decimal Freight { get; set; }
+            public List<OrderLine> Lines { get; set; }
+        }
+
+        public class OrderLine
+        {
+            public string Product { get; set; }
+            public string ProductName { get; set; }
+            public decimal PricePerUnit { get; set; }
+            public int Quantity { get; set; }
+            public decimal Discount { get; set; }
+        }
+
+        public class Product
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Supplier { get; set; }
+            public string Category { get; set; }
+            public string QuantityPerUnit { get; set; }
+            public decimal PricePerUnit { get; set; }
+            public int UnitsInStock { get; set; }
+            public int UnitsOnOrder { get; set; }
+            public bool Discontinued { get; set; }
+            public int ReorderLevel { get; set; }
+        }
+
+        public class Supplier
+        {
+            public string Id { get; set; }
+            public Contact Contact { get; set; }
+            public string Name { get; set; }
+            public Address Address { get; set; }
+            public string Phone { get; set; }
+            public string Fax { get; set; }
+            public string HomePage { get; set; }
+        }
+
+        public class Employee
+        {
+            public string Id { get; set; }
+            public string LastName { get; set; }
+            public string FirstName { get; set; }
+            public string Title { get; set; }
+            public Address Address { get; set; }
+            public DateTime HiredAt { get; set; }
+            public DateTime Birthday { get; set; }
+            public string HomePhone { get; set; }
+            public string Extension { get; set; }
+            public string ReportsTo { get; set; }
+            public List<string> Notes { get; set; }
+            public List<string> Territories { get; set; }
+        }
+
+        public class Region
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public List<Territory> Territories { get; set; }
+        }
+
+        public class Territory
+        {
+            public string Code { get; set; }
+            public string Name { get; set; }
+            public string Area { get; set; }
+        }
+
+        public class Shipper
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Phone { get; set; }
+        }
+        #endregion
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Indexes/Boosting.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Indexes/Boosting.java
@@ -1,0 +1,57 @@
+package net.ravendb.Indexes;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.IndexDefinition;
+import net.ravendb.client.documents.operations.indexes.PutIndexesOperation;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Boosting {
+
+    //region boosting_2
+    public class Employees_ByFirstAndLastName extends AbstractIndexCreationTask {
+        public Employees_ByFirstAndLastName() {
+            map = "docs.Employees.Select(employee => new {" +
+                "    FirstName = employee.FirstName.Boost(10)," +
+                "    LastName = employee.LastName" +
+                "})";
+        }
+    }
+    //endregion
+
+    private static class Employee {
+
+    }
+
+    public Boosting() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region boosting_3
+                // employees with 'firstName' equal to 'Bob'
+                // will be higher in results
+                // than the ones with 'lastName' match
+                List<Employee> results = session.query(Employee.class, Employees_ByFirstAndLastName.class)
+                    .whereEquals("FirstName", "Bob")
+                    .whereEquals("LastName", "Bob")
+                    .toList();
+                //endregion
+            }
+
+            //region boosting_4
+            IndexDefinition indexDefinition = new IndexDefinition();
+            indexDefinition.setName("Employees/ByFirstAndLastName");
+            indexDefinition.setMaps(Collections.singleton(
+                "docs.Employees.Select(employee => new {" +
+                "    FirstName = employee.FirstName.Boost(10)," +
+                "    LastName = employee.LastName" +
+                "})"));
+
+            store.maintenance().send(new PutIndexesOperation(indexDefinition));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/TextSearch/boostResults.js
+++ b/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/TextSearch/boostResults.js
@@ -58,27 +58,4 @@ async function boostResults() {
         // * Search is case-insensitive.
         //endregion
     }
-
-    {
-        //region boost_3
-        // Make a query:
-        // =============
-        
-        const employees = await session
-            .query({ collection: "Employees"})
-            .search('Notes', 'English')
-            .search('Notes', 'Italian')
-            .boost(10)
-            .all();
-
-        // Get the score:
-        // ==============
-
-        // Call 'getMetadataFor', pass an entity from the resulting employees list
-        const metadata = session.advanced.getMetadataFor(employees[0]);
-
-        // Score is available in the '@index-score' metadata property
-        const score = metadata[CONSTANTS.Documents.Metadata.INDEX_SCORE];
-        //endregion
-    }
 }

--- a/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/TextSearch/boostResults.js
+++ b/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/TextSearch/boostResults.js
@@ -18,14 +18,12 @@ async function boostResults() {
             .all();
 
         // * Results will contain all Employee documents that have
-        //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+        //   EITHER 'English' OR 'Italian' in their 'Notes' field (case-insensitive).
         //
         // * Matching documents that contain 'Italian' will get a HIGHER score
         //   than those that contain 'English'.
         //
-        // * Unless configured otherwise, the resulting documents will be ordered by their score.   
-        // 
-        // * Search is case-insensitive.
+        // * Unless configured otherwise, the resulting documents will be ordered by their score.  
         //endregion
     }
 
@@ -48,14 +46,12 @@ async function boostResults() {
             .all();
 
         // * Results will contain all Company documents that either
-        //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field.
+        //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field (case-insensitive). 
         //
         // * Matching documents that end-with 'OP' will get the HIGHEST scores.
         //   Matching documents that start-with 'O' will get the LOWEST scores. 
         //
         // * Unless configured otherwise, the resulting documents will be ordered by their score.
-        //
-        // * Search is case-insensitive.
         //endregion
     }
 }

--- a/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/TextSearch/boostResults.js
+++ b/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/TextSearch/boostResults.js
@@ -1,0 +1,84 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function boostResults() {
+    {
+        //region boost_1
+        const employees = await session
+             // Make a dynamic full-text search Query on 'Employees' collection
+            .query({ collection: "Employees"})
+             // This search predicate will use the default boost value of 1
+            .search('Notes', 'English')
+             // This search predicate will use a boost value of 10 
+            .search('Notes', 'Italian')
+             // Call 'boost' to set the boost value of the previous 'search' call
+            .boost(10)
+            .all();
+
+        // * Results will contain all Employee documents that have
+        //   EITHER 'English' OR 'Italian' in their 'Notes' field.
+        //
+        // * Matching documents that contain 'Italian' will get a HIGHER score
+        //   than those that contain 'English'.
+        //
+        // * Unless configured otherwise, the resulting documents will be ordered by their score.   
+        // 
+        // * Search is case-insensitive.
+        //endregion
+    }
+
+    {
+        //region boost_2
+        const companies = await session
+             // Make a dynamic DocumentQuery on 'Companies' collection
+            .query({ collection: "Companies"})
+             // Define a 'where' condition
+            .whereStartsWith("Name", "O")
+             // Call 'boost' to set the boost value of the previous 'where' predicate
+            .boost(10)
+             // Call 'orElse' so that OR operator will be used between statements
+            .orElse()
+            .whereStartsWith("Name", "P")
+            .boost(50)
+            .orElse()
+            .whereEndsWith("Name", "OP")
+            .boost(90)
+            .all();
+
+        // * Results will contain all Company documents that either
+        //   (start-with 'O') OR (start-with 'P') OR (end-with 'OP') in their 'Name' field.
+        //
+        // * Matching documents that end-with 'OP' will get the HIGHEST scores.
+        //   Matching documents that start-with 'O' will get the LOWEST scores. 
+        //
+        // * Unless configured otherwise, the resulting documents will be ordered by their score.
+        //
+        // * Search is case-insensitive.
+        //endregion
+    }
+
+    {
+        //region boost_3
+        // Make a query:
+        // =============
+        
+        const employees = await session
+            .query({ collection: "Employees"})
+            .search('Notes', 'English')
+            .search('Notes', 'Italian')
+            .boost(10)
+            .all();
+
+        // Get the score:
+        // ==============
+
+        // Call 'getMetadataFor', pass an entity from the resulting employees list
+        const metadata = session.advanced.getMetadataFor(employees[0]);
+
+        // Score is available in the '@index-score' metadata property
+        const score = metadata[CONSTANTS.Documents.Metadata.INDEX_SCORE];
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/sortQueryResults.js
+++ b/Documentation/5.4/Samples/nodejs/ClientApi/Session/Querying/sortQueryResults.js
@@ -1,0 +1,195 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function sortQueryResults() {
+    {
+        //region sort_1
+        const products = await session
+             // Make a dynamic query on the 'products' collection    
+            .query({ collection: "products" })
+             // Apply filtering (optional)
+            .whereGreaterThan("UnitsInStock", 10)
+             // Call 'orderBy'
+             // Pass the document-field by which to order the results and the ordering type
+            .orderBy("UnitsInStock", "Long")
+            .all(); 
+
+        // Results will be sorted by the 'UnitsInStock' value in ascending order,
+        // with smaller values listed first.
+        //endregion
+    }
+
+    {
+        //region sort_2
+        const products = await session
+            .query({ collection: "products" })
+             // Apply filtering
+            .whereLessThan("UnitsInStock", 5)
+            .orElse()
+            .whereEquals("Discontinued", true)
+             // Call 'orderByScore'
+            .orderByScore()
+            .all();
+
+        // Results will be sorted by the score value
+        // with best matching documents (higher score values) listed first.
+        //endregion
+    }
+
+    {
+        //region sort_3
+        const products = await session
+            .query({ collection: "products" })
+            .whereGreaterThan("UnitsInStock", 10)
+             // Call 'randomOrdering'
+            .randomOrdering()
+             // An optional seed can be passed, e.g.:
+             // .randomOrdering("someSeed")
+            .all();
+
+        // Results will be randomly ordered.
+        //endregion
+    }
+
+    {
+        //region sort_4
+        const numberOfProductsPerCategory = await session
+            .query({ collection: "products" })
+             // Group by category
+            .groupBy("Category")
+            .selectKey("Category")
+             // Count the number of product documents per category
+            .selectCount()
+             // Order by the count value
+            .orderBy("count", "Long")
+            .all();
+
+        // Results will contain the number of Product documents per category
+        // ordered by that count in ascending order.
+        //endregion
+    }
+
+    {
+        //region sort_5
+        const numberOfUnitsInStockPerCategory = await session
+            .query({ collection: "products" })
+             // Group by category
+            .groupBy("Category")
+            .selectKey("Category")
+             // Sum the number of units in stock per category
+            .selectSum(new GroupByField("UnitsInStock", "sum"))
+             // Order by the sum value
+            .orderBy("sum", "Long")
+            .all();
+
+        // Results will contain the total number of units in stock per category
+        // ordered by that number in ascending order.
+        //endregion
+    }
+
+    {
+        //region sort_6
+        const products = await session
+            .query({ collection: "products" })
+             // Call 'OrderBy', order by field 'QuantityPerUnit'
+             // Pass a second param, requesting to order the text alphanumerically
+            .orderBy("QuantityPerUnit", "AlphaNumeric")
+            .all();
+        //endregion
+
+        //region sort_6_results
+        // Running the above query on the NorthWind sample data,
+        // would produce the following order for the QuantityPerUnit field:
+        // ================================================================
+        
+        // "1 kg pkg."
+        // "1k pkg."
+        // "2 kg box."
+        // "4 - 450 g glasses"
+        // "5 kg pkg."
+        // ...
+        
+        // While running with the default Lexicographical ordering would have produced:
+        // ============================================================================
+        
+        // "1 kg pkg."
+        // "10 - 200 g glasses"
+        // "10 - 4 oz boxes"
+        // "10 - 500 g pkgs."
+        // "10 - 500 g pkgs."
+        // ...
+        //endregion
+    }
+
+    {
+        //region sort_7
+        const products = await session
+            .query({ collection: "products" })
+            .whereGreaterThan("UnitsInStock", 10)
+             // Apply the primary sort by 'UnitsInStock'
+            .orderByDescending("UnitsInStock", "Long")
+             // Apply a secondary sort by the score
+            .orderByScore()
+             // Apply another sort by 'Name'
+            .orderBy("Name")
+            .all();
+
+        // Results will be sorted by the 'UnitsInStock' value (descending),
+        // then by score,
+        // and then by 'Name' (ascending).
+        //endregion
+    }
+
+    {
+        //region sort_8
+        const products = await session
+            .query({ collection: "products" })
+            .whereGreaterThan("UnitsInStock", 10)
+             // Order by field 'UnitsInStock', pass the name of your custom sorter class
+            .orderBy("UnitsInStock", { sorterName: "MySorter" })
+            .all();
+
+        // Results will be sorted by the 'UnitsInStock' value
+        // according to the logic from 'MySorter' class
+        //endregion
+    }
+
+    {
+        //region get_score_from_metadata
+        // Make a query:
+        // =============
+
+        const employees = await session
+            .query({ collection: "Employees"})
+            .search('Notes', 'English')
+            .search('Notes', 'Italian')
+            .boost(10)
+            .all();
+
+        // Get the score:
+        // ==============
+
+        // Call 'getMetadataFor', pass an entity from the resulting employees list
+        const metadata = session.advanced.getMetadataFor(employees[0]);
+
+        // Score is available in the '@index-score' metadata property
+        const score = metadata[CONSTANTS.Documents.Metadata.INDEX_SCORE];
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    // orderBy overloads:
+    orderBy(field);
+    orderBy(field, ordering);
+    orderBy(field, options);
+
+    // orderByDescending overloads:
+    orderByDescending(field);
+    orderByDescending(field, ordering);
+    orderByDescending(field, options);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/indexes/boosting.js
+++ b/Documentation/5.4/Samples/nodejs/indexes/boosting.js
@@ -1,0 +1,77 @@
+import { DocumentStore, AbstractCsharpIndexCreationTask } from "ravendb";
+
+const store = new DocumentStore();
+
+//region index_1
+class Orders_ByCountries_BoostByField extends AbstractCsharpIndexCreationTask {
+    constructor() {
+        super();
+
+        this.map = `from order in docs.Orders
+             let company = LoadDocument(order.Company, "Companies")
+             select new {
+             
+                 // Boost index-field 'ShipToCountry':
+                 // * Use method 'Boost', pass a numeric value to boost by 
+                 // * Documents that match the query criteria for this field will rank higher
+                
+                 ShipToCountry = order.ShipTo.Country.Boost(10),
+                 CompanyCountry = company.Address.Country
+             }`;
+    }
+}
+//endregion
+
+//region index_2
+class Orders_ByCountries_BoostByIndexEntry extends AbstractCsharpIndexCreationTask {
+    constructor() {
+        super();
+
+        this.map = `from order in docs.Orders
+             let company = LoadDocument(order.Company, "Companies")
+             select new {
+                 ShipToCountry = order.ShipTo.Country,
+                 CompanyCountry = company.Address.Country
+             }
+             
+             // Boost the whole index-entry:
+             // * Use method 'Boost'
+             // * Pass a document-field that will set the boost level dynamically per document indexed.  
+             // * The boost level will vary from one document to another based on the value of this field.
+            
+             .Boost(order.Freight)`;
+    }
+}
+//endregion
+
+async function boosting() {
+    
+    {
+        const session = store.openSession();
+
+        //region query_1
+        const orders = await session
+            .query({ indexName: "Orders/ByCountries/BoostByField" })
+            .whereEquals("ShipToCountry", "Poland")
+            .orElse()
+            .whereEquals("CompanyCountry", "Portugal")
+            .all();
+
+        // Because index-field 'ShipToCountry' was boosted (inside the index definition),
+        // then documents containing 'Poland' in their 'ShipTo.Country' field will get a higher score than
+        // documents containing a company that is located in 'Portugal'.
+        //endregion
+
+        //region query_2
+        const orders = await session
+            .query({ indexName: "Orders/ByCountries/BoostByIndexEntry" })
+            .whereEquals("ShipToCountry", "Poland")
+            .orElse()
+            .whereEquals("CompanyCountry", "Portugal")
+            .all();
+
+        // The resulting score per matching document is affected by the value of the document-field 'Freight'. 
+        // Documents with a higher 'Freight' value will rank higher.
+        //endregion
+    }
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-make-a-spatial-query.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-make-a-spatial-query.dotnet.markdown
@@ -234,8 +234,8 @@ order by spatial.distance(
 
     * When using __Corax__:  
       In order to enhance performance, this property is not included in the results by default.  
-      To get this metadata property you must set the [Indexing.Corax.IncludeSpatialDistance](../../../server/configuration/indexing-configuration#indexing.corax.includespatialdistance) configuration value to _true_.
-      Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+      To get this metadata property you must set the [Indexing.Corax.IncludeSpatialDistance](../../../server/configuration/indexing-configuration#indexing.corax.includespatialdistance) configuration value to _true_.  
+      Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../server/configuration/indexing-configuration) article.
 
 {CODE spatial_4_getDistance@ClientApi\Session\Querying\MakeSpatialQuery.cs /}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-make-a-spatial-query.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/how-to-make-a-spatial-query.js.markdown
@@ -222,8 +222,8 @@ order by spatial.distance(
 
     * When using __Corax__:  
       In order to enhance performance, this property is not included in the results by default.  
-      To get this metadata property you must set the [Indexing.Corax.IncludeSpatialDistance](../../../server/configuration/indexing-configuration#indexing.corax.includespatialdistance) configuration value to _true_.
-      Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+      To get this metadata property you must set the [Indexing.Corax.IncludeSpatialDistance](../../../server/configuration/indexing-configuration#indexing.corax.includespatialdistance) configuration value to _true_.  
+      Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../server/configuration/indexing-configuration) article.
 
 {CODE:nodejs spatial_4_getDistance@client-api\session\querying\makeSpatialQuery.js /}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
@@ -115,13 +115,13 @@ The score details can be retrieved by either:
       Note the following difference between the underlying indexing engines:
 
       * When using __Lucene__:  
-          The `@index-score` metadata property is always available in the results.  
+          This metadata property is always available in the results.  
           Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
 
       * When using __Corax__:  
-          In order to enhance performance, this property is Not included in the results by default.  
-          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_.
-          Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+          In order to enhance performance, this metadata property is Not included in the results by default.  
+          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_.  
+          Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../server/configuration/indexing-configuration) article.
 
     * The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:  
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.dotnet.markdown
@@ -7,6 +7,9 @@
 * When making a query, the server will return the results __sorted__ only if explicitly requested by the query.  
   If no sorting method is specified when issuing the query then results will not be sorted.
 
+    * Note: An exception to the above rule is when [Boosting](../../../indexes/boosting) is involved in the query.  
+      Learn more in [Automatic score-based ordering](../../../indexes/boosting#automatic-score-based-ordering).
+
 * Sorting is applied by the server after the query filtering stage.  
   Applying filtering is recommended as it reduces the number of results RavenDB needs to sort  
   when querying a large dataset.
@@ -20,6 +23,7 @@
     * [Order by field value](../../../client-api/session/querying/sort-query-results#order-by-field-value)
  
     * [Order by score](../../../client-api/session/querying/sort-query-results#order-by-score)
+        * [Get resulting score](../../../client-api/session/querying/sort-query-results#get-resulting-score)
   
     * [Order by random](../../../client-api/session/querying/sort-query-results#order-by-random)
    
@@ -94,30 +98,35 @@ order by score()
 
 {INFO: }
 
-__Get resulting score__:
+#### Get resulting score:
 
 ---
 
-* __@Index-score metadata property__:  
-  The score is available in the `@index-score` metadata property within each result.  
-  Learn how to retrieve the resulting score from the metadata in [Get resulting score](../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score).  
-  <br>
-  Note the following difference between the underlying indexing engines:
+The score details can be retrieved by either:
 
-    * When using __Lucene__:  
-      This metadata property is always available in the results.
-      Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
+* __Request to include explanations__:  
+  You can get the score details and see how it was calculated by requesting to include explanations in the query.
+  Currently, this is only available when using Lucene as the underlying indexing engine.  
+  Learn more in [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
 
-    * When using __Corax__:  
-      In order to enhance performance, this property is not included in the results by default.  
-      To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_.
-      Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+* __Get score from metadata__:    
 
-* __Include explanations__:  
-  Another option to get the score details and see how it was calculated is to request to include explanations in the query.
-  Currently, this is only available when using Lucene.  
-  See [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
+    * The score is available in the `@index-score` metadata property within each result.  
+      Note the following difference between the underlying indexing engines:
 
+      * When using __Lucene__:  
+          The `@index-score` metadata property is always available in the results.  
+          Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
+
+      * When using __Corax__:  
+          In order to enhance performance, this property is Not included in the results by default.  
+          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_.
+          Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+
+    * The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:  
+
+      {CODE:csharp get_score_from_metadata@ClientApi\Session\Querying\SortQueryResults.cs /}
+ 
 {INFO/}
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
@@ -109,13 +109,13 @@ The score details can be retrieved by either:
       Note the following difference between the underlying indexing engines:
 
         * When using __Lucene__:  
-          The `@index-score` metadata property is always available in the results.  
+          This metadata property is always available in the results.  
           Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
 
         * When using __Corax__:  
-          In order to enhance performance, this property is Not included in the results by default.  
-          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_.
-          Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+          In order to enhance performance, this metadata property is Not included in the results by default.  
+          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_.  
+          Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../server/configuration/indexing-configuration) article.
 
     * The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/sort-query-results.js.markdown
@@ -7,6 +7,9 @@
 * When making a query, the server will return the results __sorted__ only if explicitly requested by the query.  
   If no sorting method is specified when issuing the query then results will not be sorted.
 
+    * Note: An exception to the above rule is when [Boosting](../../../indexes/boosting) is involved in the query.  
+      Learn more in [Automatic score-based ordering](../../../indexes/boosting#automatic-score-based-ordering).
+
 * Sorting is applied by the server after the query filtering stage.  
   Applying filtering is recommended as it reduces the number of results RavenDB needs to sort  
   when querying a large dataset.
@@ -20,6 +23,7 @@
     * [Order by field value](../../../client-api/session/querying/sort-query-results#order-by-field-value)
  
     * [Order by score](../../../client-api/session/querying/sort-query-results#order-by-score)
+        * [Get resulting score](../../../client-api/session/querying/sort-query-results#get-resulting-score)
   
     * [Order by random](../../../client-api/session/querying/sort-query-results#order-by-random)
    
@@ -88,29 +92,34 @@ order by score()
 
 {INFO: }
 
-__Get resulting score__:
+#### Get resulting score:
 
 ---
 
-* __@Index-score metadata property__:  
-  The score is available in the `@index-score` metadata property within each result.  
-  Learn how to retrieve the resulting score from the metadata in [Get resulting score](../../../client-api/session/querying/text-search/boost-search-results#get-resulting-score).  
-  <br>
-  Note the following difference between the underlying indexing engines:
+The score details can be retrieved by either:
 
-  * When using __Lucene__:  
-    This metadata property is always available in the results. 
-    Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
-  
-  * When using __Corax__:  
-    In order to enhance performance, this property is not included in the results by default.  
-    To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_. 
-    Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).    
+* __Request to include explanations__:  
+  You can get the score details and see how it was calculated by requesting to include explanations in the query.
+  Currently, this is only available when using Lucene as the underlying indexing engine.  
+  Learn more in [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
 
-* __Include explanations__:  
-  Another option to get the score details and see how it was calculated is to request to include explanations in the query. 
-  Currently, this is only available when using Lucene.  
-  See [Include query explanations](../../../client-api/session/querying/debugging/include-explanations).
+* __Get score from metadata__:
+
+    * The score is available in the `@index-score` metadata property within each result.  
+      Note the following difference between the underlying indexing engines:
+
+        * When using __Lucene__:  
+          The `@index-score` metadata property is always available in the results.  
+          Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
+
+        * When using __Corax__:  
+          In order to enhance performance, this property is Not included in the results by default.  
+          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore) configuration value to _true_.
+          Learn how to set configuration values in this [Configuration overview](../../../server/configuration/configuration-options).
+
+    * The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:
+
+      {CODE:nodejs get_score_from_metadata@client-api\session\querying\sortQueryResults.js /}
 
 {INFO/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
@@ -1,33 +1,114 @@
 # Indexes: Boosting
-
-A feature that RavenDB leverages from Lucene is called Boosting. This feature gives you the ability to manually tune the relevance level of matching documents when performing a query. 
-
-From the index perspective we can associate to an index entry a boosting factor. The higher value it has, the more relevant term will be. To do this, we must use the `Boost` extension method from the `Raven.Client.Documents.Linq.Indexing` namespace.
-
-Let's jump straight into the example. To perform the query that will return employees where either `FirstName` or `LastName` is equal to _Bob_, and to promote employees (move them to the top of the results) where `FirstName` matches the phrase, we must first create an index with boosted entry.
-
-{CODE-TABS}
-{CODE-TAB:csharp:AbstractIndexCreationTask boosting_2@Indexes\Boosting.cs /}
-{CODE-TAB:csharp:Operation boosting_4@Indexes\Boosting.cs /}
-{CODE-TABS/}
-
-The next step is to perform a query against that index:
-
-{CODE boosting_3@Indexes\Boosting.cs /}
-
-## Remarks
-
-{INFO Boosting is also available at the query level. You can read more about it [here](../client-api/session/querying/text-search/boost-search-results). /}
+---
 
 {NOTE: }
-When using [Corax](../indexes/search-engine/corax) as the search engine:  
 
-* [indexing-time boosting](../indexes/search-engine/corax#supported-features) 
-  is available for documents, but not for document fields.  
-* Corax ranks search results using the [BM25 algorithm](https://en.wikipedia.org/wiki/Okapi_BM25).  
-  Other search engines, e.g. Lucene, may use a different ranking algorithm and return different search results.  
+* When querying with some filtering conditions,  
+  a basic score is calculated for each document in the results by the underlying engine.
+
+* Providing a __boost value__ to some fields allows you to prioritize the resulting documents.  
+  The boost value is integrated with the basic score, making the document rank higher.  
+  Automatic ordering of the results by the score is [configurable](../indexes/boosting#automatic-score-based-ordering).
+
+* Boosting can be achieved in the following ways:
+
+    * __At query time__:  
+      Apply a boost factor to searched terms at query time - see article [Boost search results](../client-api/session/querying/text-search/boost-search-results).
+
+    * __Via index definition__:  
+      Apply a boost factor in your index definition - as described in this article.
+
+* In this page:
+    * [Assign a boost factor to an index-field](../indexes/boosting#assign-a-boost-factor-to-an-index-field)
+    * [Assign a boost factor to the index-entry](../indexes/boosting#assign-a-boost-factor-to-the-index-entry)
+    * [Automatic score-based ordering](../indexes/boosting#automatic-score-based-ordering)
+    * [Corax vs Lucene: boosting differences](../indexes/boosting#automatic-score-based-ordering)
 
 {NOTE/}
+
+---
+
+{PANEL: Assign a boost factor to an index-field}
+
+Applying a boost value to an index-field allows you to prioritize matching documents based on an index-field.
+
+---
+
+
+##### The index:
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ_index index_1@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:JavaScript_index index_1_js@Indexes\Boosting.cs /}
+{CODE-TABS/}
+
+##### The query:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_1@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:Query_async query_2@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:DocumentQuery query_3@Indexes\Boosting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Orders/ByCountries/BoostByField"
+where ShipToCountry == "poland" or CompanyCountry == "portugal"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Assign a boost factor to the index-entry}
+
+Applying a boost value to the whole index-entry allows you to prioritize matching documents by content from the document.
+
+---
+
+##### The index:
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ_index index_2@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:JavaScript_index index_2_js@Indexes\Boosting.cs /}
+{CODE-TABS/}
+
+##### The query:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_4@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:Query_async query_5@Indexes\Boosting.cs /}
+{CODE-TAB:csharp:DocumentQuery query_6@Indexes\Boosting.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Orders/ByCountries/BoostByIndexEntry"
+where ShipToCountry == "poland" or CompanyCountry == "portugal"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Automatic score-based ordering}
+
+* By default, whenever boosting is involved, either via a dynamic query or when querying an index that has a boosting factor in its definition,
+  the results will be automatically ordered by the score.
+
+* This behavior can be modified using the [OrderByScoreAutomaticallyWhenBoostingIsInvolved](../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)    
+  configuration key.
+
+* Refer to section [Get resulting score](../client-api/session/querying/sort-query-results#get-resulting-score) to learn how to retrieve the calculated score of each result.
+
+{PANEL/}
+
+{PANEL: Corax vs Lucene: boosting differences}
+
+* __Boosting features available:__  
+
+  * When using __Corax__ as the underlying indexing engine, you can only [assign a boost factor to the index-entry](../indexes/boosting#assign-a-boost-factor-to-the-index-entry).  
+    Applying a boost factor to an index-field is Not supported.  
+  
+  * When using __Lucene__, you can assign a boost factor to both the index-field and the whole index-entry.  
+
+* __Algorithm used__:  
+  Corax ranks search results using the [BM25 algorithm](https://en.wikipedia.org/wiki/Okapi_BM25).   
+  Other search engines, e.g. Lucene, may use a different ranking algorithm and return different search results.
+
+{PANEL/}
 
 ## Related Articles
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.java.markdown
@@ -1,10 +1,18 @@
 # Indexes: Boosting
 
-A feature that RavenDB leverages from Lucene is called Boosting. This feature gives you the ability to manually tune the relevance level of matching documents when performing a query. 
+When querying with some filtering conditions,  
+a basic score is calculated for each document in the results by the underlying engine.
 
-From the index perspective we can associate to an index entry a boosting factor. The higher value it has, the more relevant term will be. To do this, we must use the `Boost` method.
+Providing a __boost value__ to some fields allows you to prioritize the resulting documents.  
+The boost value is integrated with the basic score, making the document rank higher.  
+Automatic ordering of the results by the score is [configurable](../indexes/boosting#automatic-score-based-ordering).
 
-Let's jump straight into the example. To perform the query that will return employees where either `FirstName` or `LastName` is equal to _Bob_, and to promote employees (move them to the top of the results) where `FirstName` matches the phrase, we must first create an index with boosted entry.
+From the index perspective we can associate to an index entry a boosting factor.  
+The higher value it has, the more relevant term will be. To do this, we must use the `Boost` method. 
+
+Let's jump straight into the example.  
+To perform the query that will return employees where either `FirstName` or `LastName` is equal to _Bob_,  
+and to promote employees (move them to the top of the results) where `FirstName` matches the phrase, we must first create an index with boosted entry.
 
 {CODE-TABS}
 {CODE-TAB:java:AbstractIndexCreationTask boosting_2@Indexes\Boosting.java /}
@@ -20,6 +28,19 @@ The next step is to perform a query against that index:
 {INFO Boosting is also available at the query level. /}
 
 {NOTE: }
+
+#### Automatic score-based ordering
+
+* By default, whenever boosting is involved, either via a dynamic query or when querying an index that has a boosting factor in its definition,
+  the results will be automatically ordered by the score.
+
+* This behavior can be modified using the [OrderByScoreAutomaticallyWhenBoostingIsInvolved](../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)    
+  configuration key.
+
+{NOTE/}
+
+{NOTE: }
+
 When using [Corax](../indexes/search-engine/corax) as the search engine:  
 
 * [indexing-time boosting](../indexes/search-engine/corax#supported-features) 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.js.markdown
@@ -1,33 +1,104 @@
 # Indexes: Boosting
-
-A feature that RavenDB leverages from Lucene is called Boosting. This feature gives you the ability to manually tune the relevance level of matching documents when performing a query. 
-
-From the index perspective we can associate to an index entry a boosting factor. The higher value it has, the more relevant term will be. To do this, we must use the `Boost` method.
-
-Let's jump straight into the example. To perform the query that will return employees where either `FirstName` or `LastName` is equal to _Bob_, and to promote employees (move them to the top of the results) where `FirstName` matches the phrase, we must first create an index with boosted entry.
-
-{CODE-TABS}
-{CODE-TAB:nodejs:AbstractIndexCreationTask boosting_2@indexes\boosting.js /}
-{CODE-TAB:nodejs:Operation boosting_4@indexes\boosting.js /}
-{CODE-TABS/}
-
-The next step is to perform a query against that index:
-
-{CODE:nodejs boosting_3@indexes\boosting.js /}
-
-## Remarks
-
-{INFO Boosting is also available at the query level. You can read more about it [here](../client-api/session/querying/text-search/boost-search-results). /}
+---
 
 {NOTE: }
-When using [Corax](../indexes/search-engine/corax) as the search engine:  
 
-* [indexing-time boosting](../indexes/search-engine/corax#supported-features) 
-  is available for documents, but not for document fields.  
-* Corax ranks search results using the [BM25 algorithm](https://en.wikipedia.org/wiki/Okapi_BM25).  
-  Other search engines, e.g. Lucene, may use a different ranking algorithm and return different search results.  
+* When querying with some filtering conditions,  
+  a basic score is calculated for each document in the results by the underlying engine.
+
+* Providing a __boost value__ to some fields allows you to prioritize the resulting documents.  
+  The boost value is integrated with the basic score, making the document rank higher.  
+  Automatic ordering of the results by the score is [configurable](../indexes/boosting#automatic-score-based-ordering).
+
+* Boosting can be achieved in the following ways:
+
+    * __At query time__:  
+      Apply a boost factor to searched terms at query time - see article [Boost search results](../client-api/session/querying/text-search/boost-search-results).
+
+    * __Via index definition__:  
+      Apply a boost factor in your index definition - as described in this article.
+
+* In this page:
+    * [Assign a boost factor to an index-field](../indexes/boosting#assign-a-boost-factor-to-an-index-field)
+    * [Assign a boost factor to the index-entry](../indexes/boosting#assign-a-boost-factor-to-the-index-entry)
+    * [Automatic score-based ordering](../indexes/boosting#automatic-score-based-ordering)
+    * [Corax vs Lucene: boosting differences](../indexes/boosting#automatic-score-based-ordering)
 
 {NOTE/}
+
+---
+
+{PANEL: Assign a boost factor to an index-field}
+
+Applying a boost value to an index-field allows you to prioritize matching documents based on an index-field.
+
+---
+
+
+##### The index:
+
+{CODE:nodejs index_1@Indexes\boosting.js /}
+
+##### The query:
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_1@Indexes\boosting.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Orders/ByCountries/BoostByField"
+where ShipToCountry == "poland" or CompanyCountry == "portugal"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Assign a boost factor to the index-entry}
+
+Applying a boost value to the whole index-entry allows you to prioritize matching documents by content from the document.
+
+---
+
+##### The index:
+
+{CODE:nodejs index_2@Indexes\boosting.js /}
+
+##### The query:
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_2@Indexes\boosting.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Orders/ByCountries/BoostByIndexEntry"
+where ShipToCountry == "poland" or CompanyCountry == "portugal"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Automatic score-based ordering}
+
+* By default, whenever boosting is involved, either via a dynamic query or when querying an index that has a boosting factor in its definition,
+  the results will be automatically ordered by the score.
+
+* This behavior can be modified using the [OrderByScoreAutomaticallyWhenBoostingIsInvolved](../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)    
+  configuration key.
+
+* Refer to section [Get resulting score](../client-api/session/querying/sort-query-results#get-resulting-score) to learn how to retrieve the calculated score of each result.
+
+{PANEL/}
+
+{PANEL: Corax vs Lucene: boosting differences}
+
+* __Boosting features available:__
+
+    * When using __Corax__ as the underlying indexing engine, you can only [assign a boost factor to the index-entry](../indexes/boosting#assign-a-boost-factor-to-the-index-entry).  
+      Applying a boost factor to an index-field is Not supported.
+
+    * When using __Lucene__, you can assign a boost factor to both the index-field and the whole index-entry.
+
+* __Algorithm used__:  
+  Corax ranks search results using the [BM25 algorithm](https://en.wikipedia.org/wiki/Okapi_BM25).   
+  Other search engines, e.g. Lucene, may use a different ranking algorithm and return different search results.
+
+{PANEL/}
 
 ## Related Articles
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/search-engine/corax.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/search-engine/corax.markdown
@@ -156,13 +156,13 @@ Available values: `SearchEngineType.Lucene`, `SearchEngineType.Corax`.
 
 {PANEL: Unsupported Features}
 
-Below are the features currently not supported by Corax.  
+The below features are currently not supported by Corax.
 
 #### Unsupported during indexing:
 
-* [Boosting](../../indexes/boosting) **document fields** during indexing  
-  Note that boosting **documents** IS supported.  
-* Indexing [WKT shapes](../../indexes/indexing-spatial-data)  
+* Setting a [boost factor on an index-field](../../indexes/boosting#assign-a-boost-factor-to-an-index-field) is not supported.  
+  Note that [boosting the whole index-entry](../../indexes/boosting#assign-a-boost-factor-to-the-index-entry) IS supported.
+* Indexing [WKT shapes](../../indexes/indexing-spatial-data) is not supported.  
   Note that indexing **spatial points** IS supported.  
 * [Custom analyzers](../../studio/database/settings/custom-analyzers)  
 * [Custom Sorters](../../indexes/querying/sorting#creating-a-custom-sorter)  
@@ -182,7 +182,9 @@ Read more about this [below](../../indexes/search-engine/corax#handling-of-compl
 * [lucene()](../../client-api/session/querying/document-query/how-to-use-lucene)  
 * [intersect()](../../indexes/querying/intersection)  
 
-## Unimplemented Methods
+---
+
+### Unimplemented Methods
 
 Trying to use Corax with an unimplemented method (see 
 [Unsupported Features](../../indexes/search-engine/corax#unsupported-features) above) 

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -45,8 +45,6 @@
   * Server-wide, or database, or per index:  
     [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
     [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
-    [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
-    [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
     [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
     [Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation](../../server/configuration/indexing-configuration#indexing.corax.documentslimitforcompressiondictionarycreation)  
     [Indexing.Corax.IncludeDocumentScore](../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore)  
@@ -56,19 +54,23 @@
     [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
     [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
     [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
-    [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
+    [Indexing.Lucene.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.lucene.analyzers.ngram.maxgram)  
+    [Indexing.Lucene.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.lucene.analyzers.ngram.mingram)  
     [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
+    [Indexing.Lucene.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.lucene.largesegmentsizetomergeinmb)  
+    [Indexing.Lucene.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.lucene.maximumsizepersegmentinmb)  
+    [Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.lucene.maxtimeformergestokeeprunninginsec)  
+    [Indexing.Lucene.MergeFactor](../../server/configuration/indexing-configuration#indexing.lucene.mergefactor)  
+    [Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.lucene.numberoflargesegmentstomergeinsinglebatch)  
     [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
+    [Indexing.Lucene.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.lucene.usecompoundfileinmerging)  
     [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
     [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
     [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
     [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
     [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
     [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
-    [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
     [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
-    [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
-    [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
     [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)   
     [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)   
     [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)
@@ -83,7 +85,6 @@
     [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
     [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
     [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
-    [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)  
 
 {NOTE/}
 
@@ -432,36 +433,6 @@ Set the number of minutes to wait before marking an auto index as idle.
 
 {PANEL/}
 
-{PANEL: Indexing.Analyzers.NGram.MaxGram}
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Largest n-gram to generate when NGram analyzer is used.
-
----
-
-- **Type**: `int`
-- **Default**: `6`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
-
-{PANEL/}
-
-{PANEL: Indexing.Analyzers.NGram.MinGram}
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Smallest n-gram to generate when NGram analyzer is used.
-
----
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
-
-{PANEL/}
-
 {PANEL: Indexing.Analyzers.Search.Default}
 
 [Default analyzer](../../indexes/using-analyzers#ravendb) that will be used for search fields.
@@ -572,7 +543,47 @@ The maximum amount of memory in megabytes that Corax can use for memoization dur
 
 {PANEL/}
 
-{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
+{PANEL: Indexing.Lucene.Analyzers.NGram.MaxGram}
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Largest n-gram to generate when NGram analyzer is used.
+
+---
+
+- **Type**: `int`
+- **Default**: `6`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Analyzers.NGram.MaxGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.Analyzers.NGram.MinGram}
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Smallest n-gram to generate when NGram analyzer is used.
+
+---
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Analyzers.NGram.MinGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.IndexInputType}
+
+Lucene index input
+
+- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
+- **Default**: `Buffered`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.LargeSegmentSizeToMergeInMb}
 
 EXPERT ONLY:
 
@@ -588,17 +599,80 @@ EXPERT ONLY:
 - **Type**: `int`
 - **Default**: `DefaultValueSetInConstructor`
 - **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
+- **Alias:** `Indexing.LargeSegmentSizeToMergeInMb`
 
 {PANEL/}
 
-{PANEL: Indexing.Lucene.IndexInputType}
+{PANEL: Indexing.Lucene.MaximumSizePerSegmentInMb}
 
-Lucene index input
+EXPERT ONLY:
 
-- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
-- **Default**: `Buffered`
+* This configuration applies only to the Lucene indexing engine.
+
+* The maximum size in MB that we'll consider for segments merging.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
 - **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.MaximumSizePerSegmentInMb`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* How long will we let merges to run before we close the transaction.
+
+---
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.MaxTimeForMergesToKeepRunningInSec`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.MergeFactor}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Set how often index segments are merged into larger ones.  
+  The merge process will start when the number of segments in an index reaches this number.
+
+* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
+
+---
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.MergeFactor`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+
+---
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.NumberOfLargeSegmentsToMergeInSingleBatch`
 
 {PANEL/}
 
@@ -611,6 +685,23 @@ Higher values reduce the memory usage at the expense of increased search time fo
 - **Type**: `int`
 - **Default**: `1`
 - **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.UseCompoundFileInMerging}
+
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Use compound file in merging.
+
+---
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.UseCompoundFileInMerging`
 
 {PANEL/}
 
@@ -681,23 +772,6 @@ When triggered, transaction will be closed and a new one will be opened.
 
 {PANEL/}
 
-{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* How long will we let merges to run before we close the transaction.
-
----
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
-
-{PANEL/}
-
 {PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec}
 
 Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.
@@ -705,45 +779,6 @@ Max time to wait when forcing the storage environment flush and sync when replac
 - **Type**: `int`
 - **Default**: `30`
 - **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MaximumSizePerSegmentInMb}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* The maximum size in MB that we'll consider for segments merging.
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
-
-{PANEL/}
-
-{PANEL: Indexing.MergeFactor}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Set how often index segments are merged into larger ones.  
-  The merge process will start when the number of segments in an index reaches this number.
-
-* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
-
----
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MergeFactor`
 
 {PANEL/}
 
@@ -786,23 +821,6 @@ Number of concurrent stopped batches if running low on memory.
 - **Type**: `int`
 - **Default**: `2`
 - **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
-
----
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
 
 {PANEL/}
 
@@ -909,22 +927,5 @@ Transaction size limit in megabytes after which an index will stop and complete 
 - **Type**: `int`
 - **Default**: `null` (no limit)
 - **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.UseCompoundFileInMerging}
-
-EXPERT ONLY:
-
-* This configuration applies only to the Lucene indexing engine.
-
-* Use compound file in merging.
-
----
-
-- **Type**: `bool`
-- **Default**: `true`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.UseCompoundFileInMerging`
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -1,224 +1,383 @@
 # Configuration: Indexing
 ---
 
-{PANEL:Indexing.RunInMemory}
+{NOTE: }
 
-Set if indexes should run purely in memory.
+* The following __indexing configuration keys__ can modified via either of the following options:
+    * As explained in the [Config overview](../../server/configuration/configuration-options) article
+    * Set a custom configuration per index from the [Client API](../../indexes/creating-and-deploying#creating-an-index-with-custom-configuration)
+    * Set a custom configuraiton per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)
+
+{NOTE/}
+
+{NOTE: }
+
+* In this page:  
+  [Indexing.RunInMemory](../../server/configuration/indexing-configuration#indexing.runinmemory)  
+  [Indexing.Disable](../../server/configuration/indexing-configuration#indexing.disable)  
+  [Indexing.Static.DeploymentMode](../../server/configuration/indexing-configuration#indexing.static.deploymentmode)  
+  [Indexing.Auto.DeploymentMode](../../server/configuration/indexing-configuration#indexing.auto.deploymentmode)  
+  [Indexing.Auto.ArchivedDataProcessingBehavior](../../server/configuration/indexing-configuration#indexing.auto.archiveddataprocessingbehavior)  
+  [Indexing.Static.ArchivedDataProcessingBehavior](../../server/configuration/indexing-configuration#indexing.static.archiveddataprocessingbehavior)  
+  [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)  
+  [Indexing.TempPath](../../server/configuration/indexing-configuration#indexing.temppath)  
+  [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
+  [Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec](../../server/configuration/indexing-configuration#indexing.timebeforedeletionofsupersededautoindexinsec)  
+  [Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin](../../server/configuration/indexing-configuration#indexing.timetowaitbeforemarkingautoindexasidleinmin)  
+  [Indexing.DisableQueryOptimizerGeneratedIndexes](../../server/configuration/indexing-configuration#indexing.disablequeryoptimizergeneratedindexes)  
+  [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration#indexing.timetowaitbeforedeletingautoindexmarkedasidleinhrs)  
+  [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)  
+  [Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.numberofconcurrentstoppedbatchesifrunninglowonmemory)  
+  [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
+  [Indexing.QueryClauseCache.SizeInMb](../../server/configuration/indexing-configuration#indexing.queryclausecache.sizeinmb)  
+  [Indexing.QueryClauseCache.Disabled](../../server/configuration/indexing-configuration#indexing.queryclausecache.disabled)  
+  [Indexing.QueryClauseCache.ExpirationScanFrequencyInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.expirationscanfrequencyinsec)  
+  [Indexing.QueryClauseCache.RepeatedQueriesCount](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriescount)  
+  [Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriestimeframeinsec)  
+  [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
+  [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
+  [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
+  [Indexing.CleanupIntervalInMin](../../server/configuration/indexing-configuration#indexing.cleanupintervalinmin)  
+  [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
+  [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
+  [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
+  [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
+  [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
+  [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
+  [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch)  
+  [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
+  [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
+  [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
+  [Indexing.ScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.scratchspacelimitinmb)  
+  [Indexing.GlobalScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.globalscratchspacelimitinmb)  
+  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenexceedingscratchspacelimitinsec)  
+  [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
+  [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
+  [Indexing.ErrorIndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.errorindexstartupbehavior)  
+  [Indexing.IndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.indexstartupbehavior)  
+  [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
+  [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
+  [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
+  [Indexing.NuGetAllowPreleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowpreleasepackages)  
+  [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
+  [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
+  [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
+  [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
+  [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
+  [Indexing.Auto.SearchEngineType](../../server/configuration/indexing-configuration#indexing.auto.searchenginetype)  
+  [Indexing.Static.SearchEngineType](../../server/configuration/indexing-configuration#indexing.static.searchenginetype)  
+  [Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation](../../server/configuration/indexing-configuration#indexing.corax.documentslimitforcompressiondictionarycreation)  
+  [Indexing.SkipDatabaseIdValidationOnIndexOpening](../../server/configuration/indexing-configuration#indexing.skipdatabaseidvalidationonindexopening)  
+  [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
+  [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../server/configuration/indexing-configuration#indexing.static.requireadmintodeployjavascriptindexes)  
+  [Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved](../../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)  
+  [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)  
+  [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
+  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
+  [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)  
+  [Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved](../../server/configuration/indexing-configuration#indexing.orderbyticksautomaticallywhendatesareinvolved)  
+  [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
+  [Indexing.Corax.IncludeDocumentScore](../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore)  
+  [Indexing.Corax.IncludeSpatialDistance](../../server/configuration/indexing-configuration#indexing.corax.includespatialdistance)  
+  [Indexing.Corax.MaxMemoizationSizeInMb](../../server/configuration/indexing-configuration#indexing.corax.maxmemoizationsizeinmb)  
+  [Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb](../../server/configuration/indexing-configuration#indexing.corax.maxallocationsatdictionarytraininginmb)  
+
+{NOTE/}
+
+---
+
+{PANEL: Indexing.RunInMemory}
+
+* Set if indexes should run purely in memory.
+
+* When running in memory:
+  * No index data is written to the disk, and if the server is restarted, all index data will be lost.
+  * Note that the index definition itself is kept on disk and remains unaffected by server restarts.
+  * This is mostly useful for testing or faster, non-persistent indexing.
+
+* If _Indexing.RunInMemory_ is not set explicitly,  
+  then this configuration key will take the value of the core configuration key [RunInMemory](../../server/configuration/core-configuration#runinmemory).
+
+---
 
 - **Type**: `bool`
-- **Default**: `null`
-- **Scope**: Server-wide or per database
+- **Default**: `false` 
+- **Scope**: Server-wide, or per database
 
-When running in memory, the index information is not written to disk and if the server is restarted all 
-indexing data will be lost. This is mostly useful for testing or faster non-persistent indexing.
- 
-If not set or set to **null** - indexing will run in memory if core settings *RunInMemory* is set to true.
+Optional values:
 
- Values:
- 
- * `null` - use the value set in core configuration *RunInMemory*
- * `true` - run indexing in memory
- * `false` - store information on the disk
+ * `true` - indexing is run only in memory
+ * `false` - the index data is stored on disk
 
 {PANEL/}
 
-{PANEL:Indexing.Disable}
+{PANEL: Indexing.Disable}
 
-Disable indexing.
+Set whether to disable all indexes in the database.  
+All indexes in the database will be disabled when set to `true`.
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.TempPath}
+{PANEL: Indexing.Static.DeploymentMode}
 
-Use this setting to specify a different path for the indexes' temporary files.  
-By default, temporary files are created under the `Temp` directory inside the index data directory.  
-Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
+Set the default deployment mode for static indexes.
+
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Auto.DeploymentMode}
+
+Set the default deployment mode for auto indexes.
+
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Auto.ArchivedDataProcessingBehavior}
+
+Set the default deployment mode for static indexes.
+
+- **Type**: `enum IndexDeploymentModeArchivedDataProcessingBehavior` (`ExcludeArchived`, `IncludeArchived`, `ArchivedOnly`)
+- **Default**: `ExcludeArchived`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Static.ArchivedDataProcessingBehavior}
+
+Set the default deployment mode for static indexes.
+
+- **Type**: `enum IndexDeploymentModeArchivedDataProcessingBehavior` (`ExcludeArchived`, `IncludeArchived`, `ArchivedOnly`)
+- **Default**: `ExcludeArchived`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Metrics.Enabled}
+
+Set whether indexing performance metrics will be gathered.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.TempPath}
+
+* Use this setting to specify a different path for the indexes' temporary files.
+
+* By default, temporary files are created under the `Temp` directory inside the index data directory.  
+  Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
+
+---
 
 - **Type**: `string`
 - **Default**: `null`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+{PANEL: Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
 
-Set how many indexes can run concurrently to prevent overwhelming system resources and slow indexing.
-
-- **Type**: `int`
-- **Default**: `null` No limit
-- **MinValue**: 1
-- **Scope**: Server-wide only (can be configured only in the settings.json file located in your RavenDB executable folder)
-
-{PANEL/}
-
-{PANEL:Indexing.IndexStartupBehaviorType}
-
-Manipulate index startup behavior on database load with the following options:  
-(This method can prevent slow index startup behavior in scenarios where many indexes open and 
-start processing concurrently, which would cause IO usage to max out system resources.)
-
-- **Type**: `string`
-- **Default**: Each index starts as soon as it is opened.  
-  - **Immediate**: Same as default.
-  - **Pause**: Opens all indexes, but they are paused until manually started.
-  - **Delay**: Delays starting index processes until all indexes are open.  
-- **Scope**: Server-wide or per database
-
-{PANEL/}
-
-{PANEL:Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
-
-Set how many seconds indexing will keep document transaction open when indexing.
+Set how many seconds indexing will keep document transaction open when indexing.  
+When triggered, transaction will be closed and a new one will be opened.  
 
 - **Type**: `int`
 - **Default**: `15`
-- **Scope**: Server-wide or per database
-
-When triggered, transaction will be closed and a new one will be opened
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
+{PANEL: Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
 
-Set how many seconds to keep a superseded auto index.
+Set the number of seconds to keep a superseded auto index.
 
 - **Type**: `int`
 - **Default**: `15`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
+{PANEL: Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
 
-Set how many minutes to wait before deep cleaning an idle index.  
-Deep cleanup reduces the cost of idle indexes.  
-It might slow the first query after the deep cleanup, thereafter queries return to normal performance.  
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide or per database or per index
-
-{PANEL/}
-
-{PANEL:Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
-
-Set how many minutes to wait before marking auto index as idle.
+Set the number of minutes to wait before marking an auto index as idle.
 
 - **Type**: `int`
 - **Default**: `30`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.DisableQueryOptimizerGeneratedIndexes}
+{PANEL: Indexing.DisableQueryOptimizerGeneratedIndexes}
 
-Disable query optimizer generated indexes (Auto Indexes).
+EXPERT ONLY:  
+Disable query optimizer generated indexes (auto-indexes). Dynamic queries will not be supported.  
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
-
-{WARNING Use with caution. /}
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
+{PANEL: Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
 
-Set how many hours the database should wait before deleting an auto index with the idle flag.
+Set the number of hours the database should wait before deleting an auto-index that is marked as idle.
 
 - **Type**: `int`
 - **Default**: `72`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
+{PANEL: Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
 
-Set minimum number of map attempts after which batch will be canceled if running low on memory.
+EXPERT ONLY:  
+Set minimum number of map attempts after which the batch will be canceled if running low on memory.
 
 - **Type**: `int`
 - **Default**: `512`
-- **Scope**: Server-wide or per database
-
-{WARNING Use with caution. /}
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
+{PANEL: Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
 
+EXPERT ONLY:  
 Number of concurrent stopped batches if running low on memory.
 
 - **Type**: `int`
-- **Default**: `3`
-- **Scope**: Server-wide or per database
-
-{WARNING Use with caution. /}
-
-{PANEL/}
-
-{PANEL:Indexing.History.NumberOfRevisions}
-
-Number of index history revisions to keep per index.  
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide or per database
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
 {PANEL:Indexing.MapTimeoutInSec}
 
-Number of seconds after which mapping will end even if there is more to map.
+Number of seconds after which mapping will end even if there is more to map.  
+Using the default value of `-1` will map everything possible in a single batch.  
 
 - **Type**: `int`
 - **Default**: `-1`
-- **Scope**: Server-wide or per database
-
-Value of *-1* for map as much as possible in single batch.
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.MapTimeoutAfterEtagReachedInMin}
+{PANEL: Indexing.QueryClauseCache.SizeInMb}
 
-Number of minutes after which mapping will end even if there is more to map. This will only be applied if we pass the last etag in collection that we saw when batch was started.
+EXPERT ONLY:  
+
+* Maximum size that the query clause cache will utilize for caching partial query clauses,  
+  defaulting to 10% of the system memory on 64-bit machines.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.Disabled}
+
+EXPERT ONLY:  
+
+* Disable the query clause cache for a server, database, or a single index.
+
+* The default value is set by the constructor of class `IndexingConfiguration`.  
+  It will be `true` if your core configuration key [Features.Availability](../../server/configuration/core-configuration#features.availability) is Not set to 'Experimental'. 
+
+---
+
+- **Type**: `bool`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.ExpirationScanFrequencyInSec}
+
+EXPERT ONLY:  
+The frequency by which to scan the query clause cache for expired values.
+
+- **Type**: `int`
+- **Default**: `180`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.RepeatedQueriesCount}
+
+EXPERT ONLY:  
+The number of recent queries that we will keep to identify repeated queries, relevant for caching.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide only
+ 
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec}
+
+EXPERT ONLY:  
+Queries that repeat within this time frame will be considered worth caching.
+
+- **Type**: `int`
+- **Default**: `300`
+- **Scope**: Server-wide, or per database, or per index
+ 
+{PANEL/}
+
+{PANEL: Indexing.MapBatchSize}
+
+Maximum number of documents to be processed by the index per indexing batch.
+
+- **Type**: `int?`
+- **Default**: `null` (no limit)
+- **MinValue**: `128`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MapTimeoutAfterEtagReachedInMin}
+
+* Number of minutes after which mapping will end even if there is more to map.  
+
+* This will only be applied if we pass the last etag we saw in the collection when the batch was started.
+
+---
 
 - **Type**: `int`
 - **Default**: `15`
-- **Scope**: Server-wide or per database
-
-This will only be applied if we pass the last etag in collection that we saw when batch was started.
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.MaxStepsForScript}
+{PANEL: Indexing.MaxStepsForScript}
 
 The maximum number of steps in the script execution of a JavaScript index.
 
 - **Type**: `int`
-- **Default**: `10000`
-- **Scope**: Server-wide or per database
+- **Default**: `10_000`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-
-{PANEL:Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved}
-
-Sort by ticks when field contains dates.  
-When sorting in descending order, `null` dates are returned at the end with this option enabled.  
-
-- **Type**: `bool`
-- **Default**: `true`
-- **Scope**: Server-wide or per database or per index
-
-{PANEL/}
-
-{PANEL:Indexing.CleanupIntervalInMin}
+{PANEL: Indexing.CleanupIntervalInMin}
 
 Time (in minutes) between auto index cleanup.
+Time (in minutes) between index cleanup"
 
 - **Type**: `int`
 - **Default**: `10`
@@ -226,39 +385,160 @@ Time (in minutes) between auto index cleanup.
 
 {PANEL/}
 
-{PANEL:Indexing.TransactionSizeLimitInMb}
+{PANEL: Indexing.Analyzers.NGram.MinGram}
+
+Smallest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Analyzers.NGram.MaxGram}
+
+Largest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `6`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
+
+{PANEL/}
+
+{PANEL: Indexing.ManagedAllocationsBatchSizeLimitInMb}
+
+Managed allocations limit in an indexing batch after which the batch will complete and an index will continue by starting a new one.
+
+- **Type**: `int`
+- **Default**: `2048`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaximumSizePerSegmentInMb}
+
+EXPERT ONLY:  
+
+* The maximum size in MB that we'll consider for segments merging.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
+ 
+{PANEL/}
+
+{PANEL: Indexing.MergeFactor}
+
+EXPERT ONLY:  
+
+* Set how often index segments are merged into larger ones.  
+  The merge process will start when the number of segments in an index reaches this number.  
+ 
+* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
+
+---
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MergeFactor`
+
+{PANEL/}
+
+{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
+
+EXPERT ONLY:  
+
+* The definition of a large segment in MB.  
+  We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.  
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
+
+{PANEL/}
+
+{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
+
+EXPERT ONLY:  
+Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../) to merge in a single batch.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
+
+EXPERT ONLY:  
+How long will we let merges to run before we close the transaction.
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
+
+{PANEL/}
+
+{PANEL: Indexing.TransactionSizeLimitInMb}
 
 Transaction size limit in megabytes after which an index will stop and complete the current batch.
 
 - **Type**: `int`
 - **Default**: `null` (no limit)
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
 {PANEL:Indexing.Encrypted.TransactionSizeLimitInMb}
 
-Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
+* Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
 
 - **Type**: `int`
-- **Default**: `64`
-- **Scope**: Server-wide or per database
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.ScratchSpaceLimitInMb}
+{PANEL: Indexing.ScratchSpaceLimitInMb}
 
-Amount of scratch space in megabytes that we allow to use for the index storage. After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
+* Amount of scratch space in megabytes that we allow to use for the index storage.
+
+* After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
+
+---
 
 - **Type**: `int`
 - **Default**: `null` (no limit)
-- **Scope**: Server-wide only or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.GlobalScratchSpaceLimitInMb}
+{PANEL: Indexing.GlobalScratchSpaceLimitInMb}
 
-Maximum amount of scratch space in megabytes that we allow to use for all index storages per server. After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
+* Maximum amount of scratch space in megabytes that we allow to use for all index storages per server.  
+
+* After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
+
+---
 
 - **Type**: `int`
 - **Default**: `null` (no limit)
@@ -266,64 +546,126 @@ Maximum amount of scratch space in megabytes that we allow to use for all index 
 
 {PANEL/}
 
-{PANEL:Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit}
+{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec}
 
 Max time to wait in seconds when forcing the storage environment flush and sync after exceeding the scratch space limit.
 
 - **Type**: `int`
 - **Default**: `30`
 - **Scope**: Server-wide only
+- **Alias:** `Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit`
 
 {PANEL/}
 
-{PANEL:Indexing.IndexMissingFieldsAsNull}
+{PANEL: Indexing.IndexMissingFieldsAsNull}
 
-Indicates if missing fields should be indexed same as 'null' values or not.
+* Set how the indexing process should handle fields that are missing.
+
+* When set to `true`, missing fields will be indexed with a `null` value.
+
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.IndexEmptyEntries}
+{PANEL: Indexing.IndexEmptyEntries}
 
-Indicates if empty index entries should be indexed by static indexes.
+* Set how the indexing process should handle documents that are missing fields.
+
+* When set to `true`, the indexing process will index documents even if they lack the fields that are supposed to be indexed.
+
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide or per database
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.MapBatchSize}
+{PANEL: Indexing.ErrorIndexStartupBehavior}
 
-Maximum number of documents to be processed by the index per indexing batch.
+Set how faulty indexes should behave on database startup when they are loaded.  
+By default they are not started.  
 
-- **Type**: `int`
-- **Default**: `null` (no limit)
-- **MinValue**: `128` 
-- **Scope**: Server-wide or per database
-
-{PANEL/}
-
-{PANEL:Indexing.MaxGram}
-
-Largest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers) is used.
-
-- **Type**: `int`
-- **Default**: `6`
-- **Scope**: Server-wide or per database
+- **Type**: `enum ErrorIndexStartupBehaviorType` (`Default`, `Start`, `ResetAndStart`)
+- **Default**: `Default`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL:Indexing.MinGram}
+{PANEL: Indexing.IndexStartupBehavior}
 
-Smallest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers) is used.
+* Set how indexes should behave on database startup when they are loaded.  
+  By default they are started immediately.
+
+* Setting this param can prevent slow index startup behavior in scenarios where many indexes open and start processing concurrently, which may cause IO usage to max out system resources.
+
+---
+
+- **Type**: `enum IndexStartupBehaviorType` (`Default`, `Immediate`, `Pause`, `Delay`)
+- **Default**: `Default`  
+- **Scope**: Server-wide, or per database
+
+Optional values:
+
+  - `Default`: Each index starts as soon as it is loaded.
+  - `Immediate`: Same as Default.
+  - `Pause`: Loads all indexes, but they are paused until manually started.
+  - `Delay`: Delays starting index processes until all indexes are loaded.
+
+{PANEL/}
+
+{PANEL: Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+
+Set how many indexes can run concurrently on the server to prevent overwhelming system resources and slow indexing.
 
 - **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide or per database
+- **Default**: `null` (No limit)
+- **MinValue**: 1
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackagesPath}
+
+Location of NuGet packages cache.
+
+- **Type**: `string`
+- **Default**: `Packages/NuGet`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackageSourceUrl}
+
+Default NuGet source URL.
+
+- **Type**: `string`
+- **Default**: `https://api.nuget.org/v3/index.json`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetAllowPreleasePackages}
+
+Allow installation of NuGet prerelease packages.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL:Indexing.History.NumberOfRevisions}
+
+Number of index history revisions to keep per index.
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
@@ -347,7 +689,7 @@ Smallest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers)
 
 {PANEL/}
 
-{PANEL:Indexing.Analyzers.Search.Default}
+{PANEL: Indexing.Analyzers.Search.Default}
 
 [Default analyzer](../../indexes/using-analyzers#ravendb) that will be used for search fields.
 
@@ -357,127 +699,198 @@ Smallest n-gram to generate when [NGram analyzer](../../indexes/using-analyzers)
 
 {PANEL/}
 
-{PANEL:Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
+{PANEL: Indexing.Throttling.TimeIntervalInMs}
 
-Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) 
-to deploy [JavaScript indexes](../../indexes/javascript-indexes).
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide or per database
-
-{PANEL/}
-
-{PANEL:Indexing.Auto.SearchEngineType}
-
-Select the search engine to be used with auto indexes.  
-
-- **Type**: `enum`
-  {CODE-BLOCK: csharp}
-   public enum SearchEngineType
-{
-    Corax, 
-    Lucene
-}
-  {CODE-BLOCK/}
-- **Default**: `SearchEngineType.Lucene`
-- **Scope**: Server-wide or per database
-
-{PANEL/}
-
-{PANEL:Indexing.Static.SearchEngineType}
-
-Select the search engine to be used with static indexes.  
-
-- **Type**: `enum`
-  {CODE-BLOCK: csharp}
-   public enum SearchEngineType
-{
-    Corax, 
-    Lucene
-}
-  {CODE-BLOCK/}
-- **Default**: `SearchEngineType.Lucene`
-- **Scope**: Server-wide, per database, or per index
-
-{PANEL/}
-
-{PANEL:Indexing.Corax.IncludeDocumentScore}
-
-Include score value in document metadata when sorting by score.  
-
-{NOTE: }
-Disabling this option can improve query performance.  
-{NOTE/}
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, per database, or per index
-
-{PANEL/}
-
-{PANEL:Indexing.Corax.IncludeSpatialDistance}
-
-Include spatial information in document metadata when sorting by distance.  
-
-{NOTE: }
-Disabling this option can improve query performance.  
-{NOTE/}
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, per database, or per index
-
-{PANEL/}
-
-{PANEL:Indexing.Corax.MaxMemoizationSizeInMb}
-
-The maximum amount of memory that Corax can use for a memoization clause during query processing.  
-
-- **Type**: `Size`
-- **Default**: `128`
-- **Scope**: Server-wide, per database, or per index
-
-{WARNING: Expert Level Configuration}
-Please configure this option only if you are an expert.
-{WARNING/}
-
-{PANEL/}
-
-{PANEL:Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation}
-
-Set the maximum number of documents that will be used for the training of a Corax index during dictionary creation.  
-Training will stop when it reaches this limit.  
+How long the index should delay processing after new work is detected in milliseconds.
 
 - **Type**: `int`
-- **Default**: `100000`
-- **Scope**: Server-wide, per database, or per index
+- **Default**: `null`
+- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL:Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb}
+{PANEL: Indexing.Auto.SearchEngineType}
 
-Set the maximum amount of memory (in MB) that will be allocated for the training of a Corax index during dictionary creation.  
-Training will stop when it reaches this limit.  
+Set the search engine to be used with auto-indexes.
 
-- **Type**: `SizeUnit.Megabytes`
-- **Default**: 2 GB for 64 bits systems, or 128 MB for 32 bits systems
-- **Scope**: Server-wide, per database, or per index
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-## Related Articles
+{PANEL: Indexing.Static.SearchEngineType}
 
-### Indexes
+Set the search engine to be used with static indexes.
 
-- [Auto Indexes](../../indexes/creating-and-deploying#auto-indexes)  
-- [Static Indexes](../../indexes/creating-and-deploying#static-indexes)  
-- [Boosting](../../indexes/boosting)
-- [Search Enigine: Corax](../../indexes/search-engine/corax#enabling-corax)
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database, or per index
 
-### Studio
-- [Index List View](../../studio/database/indexes/indexes-list-view)  
-- [Database Settings](../../studio/database/settings/database-settings)  
+{PANEL/}
 
-### Configuration
-- [Configuration Options](../../server/configuration/configuration-options)
+{PANEL: Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation}
+
+Corax index compression max documents used for dictionary creation.
+
+- **Type**: `int`
+- **Default**: `100_000`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.SkipDatabaseIdValidationOnIndexOpening}
+
+EXPERT ONLY:  
+Allow to open an index without checking if current Database ID matched the one for which index was created.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
+
+Set how many minutes to wait before deep cleaning an idle index.  
+Deep cleanup reduces the cost of idle indexes.  
+It might slow the first query after the deep cleanup, thereafter queries return to normal performance.
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
+
+Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) to deploy [JavaScript indexes](../../indexes/javascript-indexes).
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
+
+Order by score automatically when boosting is used inside an index definition or a query.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.UseCompoundFileInMerging}
+
+EXPERT ONLY:  
+Use compound file in merging.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `ndexing.Lucene.UseCompoundFileInMergingt`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.IndexInputType}
+
+Lucene index input
+
+- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
+- **Default**: `Buffered`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec}
+
+Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.
+
+- **Type**: `int`
+- **Default**: `30`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb}
+
+Minimum total size of journals to run flush and sync when replacing side by side index in megabytes.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved}
+
+Sort by ticks when field contains dates.  
+When sorting in descending order, null dates are returned at the end with this option enabled.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.ReaderTermsIndexDivisor}
+
+EXPERT ONLY:  
+Control how many terms we'll keep in the cache for each field.  
+Higher values reduce the memory usage at the expense of increased search time for each term.
+
+- **Type**: `int`
+- **Default**: `1`
+- **Scope**: Server-wide, or per database, or per index
+ 
+{PANEL/}
+
+{PANEL: Indexing.Corax.IncludeDocumentScore}
+
+Include score value in the metadata when sorting by score.  
+Disabling this option could enhance query performance.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Corax.IncludeSpatialDistance}
+
+Include spatial information in the metadata when sorting by distance.  
+Disabling this option could enhance query performance.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Corax.MaxMemoizationSizeInMb}
+
+The maximum amount of memory in megabytes that Corax can use for memoization during query processing.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb}
+
+EXPERT ONLY:  
+
+* The maximum amount of megabytes that we'll allocate for training indexing dictionaries.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -6,303 +6,164 @@
 * The following __indexing configuration keys__ can modified via either of the following options:
     * As explained in the [Config overview](../../server/configuration/configuration-options) article
     * Set a custom configuration per index from the [Client API](../../indexes/creating-and-deploying#creating-an-index-with-custom-configuration)
-    * Set a custom configuraiton per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)
+    * Set a custom configuration per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)
 
 {NOTE/}
 
 {NOTE: }
 
 * In this page:  
-  [Indexing.RunInMemory](../../server/configuration/indexing-configuration#indexing.runinmemory)  
-  [Indexing.Disable](../../server/configuration/indexing-configuration#indexing.disable)  
-  [Indexing.Static.DeploymentMode](../../server/configuration/indexing-configuration#indexing.static.deploymentmode)  
-  [Indexing.Auto.DeploymentMode](../../server/configuration/indexing-configuration#indexing.auto.deploymentmode)  
-  [Indexing.Auto.ArchivedDataProcessingBehavior](../../server/configuration/indexing-configuration#indexing.auto.archiveddataprocessingbehavior)  
-  [Indexing.Static.ArchivedDataProcessingBehavior](../../server/configuration/indexing-configuration#indexing.static.archiveddataprocessingbehavior)  
-  [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)  
-  [Indexing.TempPath](../../server/configuration/indexing-configuration#indexing.temppath)  
-  [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
-  [Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec](../../server/configuration/indexing-configuration#indexing.timebeforedeletionofsupersededautoindexinsec)  
-  [Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin](../../server/configuration/indexing-configuration#indexing.timetowaitbeforemarkingautoindexasidleinmin)  
-  [Indexing.DisableQueryOptimizerGeneratedIndexes](../../server/configuration/indexing-configuration#indexing.disablequeryoptimizergeneratedindexes)  
-  [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration#indexing.timetowaitbeforedeletingautoindexmarkedasidleinhrs)  
-  [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)  
-  [Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.numberofconcurrentstoppedbatchesifrunninglowonmemory)  
-  [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
-  [Indexing.QueryClauseCache.SizeInMb](../../server/configuration/indexing-configuration#indexing.queryclausecache.sizeinmb)  
-  [Indexing.QueryClauseCache.Disabled](../../server/configuration/indexing-configuration#indexing.queryclausecache.disabled)  
-  [Indexing.QueryClauseCache.ExpirationScanFrequencyInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.expirationscanfrequencyinsec)  
-  [Indexing.QueryClauseCache.RepeatedQueriesCount](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriescount)  
-  [Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriestimeframeinsec)  
-  [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
-  [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
-  [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
-  [Indexing.CleanupIntervalInMin](../../server/configuration/indexing-configuration#indexing.cleanupintervalinmin)  
-  [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
-  [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
-  [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
-  [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
-  [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
-  [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
-  [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch)  
-  [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
-  [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
-  [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
-  [Indexing.ScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.scratchspacelimitinmb)  
-  [Indexing.GlobalScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.globalscratchspacelimitinmb)  
-  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenexceedingscratchspacelimitinsec)  
-  [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
-  [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
-  [Indexing.ErrorIndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.errorindexstartupbehavior)  
-  [Indexing.IndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.indexstartupbehavior)  
-  [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
-  [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
-  [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
-  [Indexing.NuGetAllowPreReleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowprereleasepackages)  
-  [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
-  [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
-  [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
-  [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
-  [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
-  [Indexing.Auto.SearchEngineType](../../server/configuration/indexing-configuration#indexing.auto.searchenginetype)  
-  [Indexing.Static.SearchEngineType](../../server/configuration/indexing-configuration#indexing.static.searchenginetype)  
-  [Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation](../../server/configuration/indexing-configuration#indexing.corax.documentslimitforcompressiondictionarycreation)  
-  [Indexing.SkipDatabaseIdValidationOnIndexOpening](../../server/configuration/indexing-configuration#indexing.skipdatabaseidvalidationonindexopening)  
-  [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
-  [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../server/configuration/indexing-configuration#indexing.static.requireadmintodeployjavascriptindexes)  
-  [Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved](../../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)  
-  [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)  
-  [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
-  [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
-  [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)  
-  [Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved](../../server/configuration/indexing-configuration#indexing.orderbyticksautomaticallywhendatesareinvolved)  
-  [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
-  [Indexing.Corax.IncludeDocumentScore](../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore)  
-  [Indexing.Corax.IncludeSpatialDistance](../../server/configuration/indexing-configuration#indexing.corax.includespatialdistance)  
-  [Indexing.Corax.MaxMemoizationSizeInMb](../../server/configuration/indexing-configuration#indexing.corax.maxmemoizationsizeinmb)  
-  [Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb](../../server/configuration/indexing-configuration#indexing.corax.maxallocationsatdictionarytraininginmb)  
+  * Server-wide scope:  
+    [Indexing.CleanupIntervalInMin](../../server/configuration/indexing-configuration#indexing.cleanupintervalinmin)  
+    [Indexing.GlobalScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.globalscratchspacelimitinmb)  
+    [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
+    [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenexceedingscratchspacelimitinsec)  
+    [Indexing.NuGetAllowPreReleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowprereleasepackages)  
+    [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
+    [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
+    [Indexing.QueryClauseCache.ExpirationScanFrequencyInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.expirationscanfrequencyinsec)  
+    [Indexing.QueryClauseCache.RepeatedQueriesCount](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriescount)  
+    [Indexing.QueryClauseCache.SizeInMb](../../server/configuration/indexing-configuration#indexing.queryclausecache.sizeinmb)  
+  * Server-wide, or database scope:  
+    [Indexing.Auto.ArchivedDataProcessingBehavior](../../server/configuration/indexing-configuration#indexing.auto.archiveddataprocessingbehavior)  
+    [Indexing.Auto.DeploymentMode](../../server/configuration/indexing-configuration#indexing.auto.deploymentmode)  
+    [Indexing.Auto.SearchEngineType](../../server/configuration/indexing-configuration#indexing.auto.searchenginetype)  
+    [Indexing.Disable](../../server/configuration/indexing-configuration#indexing.disable)  
+    [Indexing.DisableQueryOptimizerGeneratedIndexes](../../server/configuration/indexing-configuration#indexing.disablequeryoptimizergeneratedindexes)  
+    [Indexing.ErrorIndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.errorindexstartupbehavior)  
+    [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
+    [Indexing.IndexStartupBehavior](../../server/configuration/indexing-configuration#indexing.indexstartupbehavior)  
+    [Indexing.RunInMemory](../../server/configuration/indexing-configuration#indexing.runinmemory)  
+    [Indexing.SkipDatabaseIdValidationOnIndexOpening](../../server/configuration/indexing-configuration#indexing.skipdatabaseidvalidationonindexopening)  
+    [Indexing.Static.ArchivedDataProcessingBehavior](../../server/configuration/indexing-configuration#indexing.static.archiveddataprocessingbehavior)  
+    [Indexing.Static.DeploymentMode](../../server/configuration/indexing-configuration#indexing.static.deploymentmode)  
+    [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../server/configuration/indexing-configuration#indexing.static.requireadmintodeployjavascriptindexes)  
+    [Indexing.TempPath](../../server/configuration/indexing-configuration#indexing.temppath)  
+    [Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec](../../server/configuration/indexing-configuration#indexing.timebeforedeletionofsupersededautoindexinsec)  
+    [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration#indexing.timetowaitbeforedeletingautoindexmarkedasidleinhrs)  
+    [Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin](../../server/configuration/indexing-configuration#indexing.timetowaitbeforemarkingautoindexasidleinmin)  
+  * Server-wide, or database, or per index:  
+    [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
+    [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
+    [Indexing.Analyzers.NGram.MaxGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.maxgram)  
+    [Indexing.Analyzers.NGram.MinGram](../../server/configuration/indexing-configuration#indexing.analyzers.ngram.mingram)  
+    [Indexing.Analyzers.Search.Default](../../server/configuration/indexing-configuration#indexing.analyzers.search.default)  
+    [Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation](../../server/configuration/indexing-configuration#indexing.corax.documentslimitforcompressiondictionarycreation)  
+    [Indexing.Corax.IncludeDocumentScore](../../server/configuration/indexing-configuration#indexing.corax.includedocumentscore)  
+    [Indexing.Corax.IncludeSpatialDistance](../../server/configuration/indexing-configuration#indexing.corax.includespatialdistance)  
+    [Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb](../../server/configuration/indexing-configuration#indexing.corax.maxallocationsatdictionarytraininginmb)  
+    [Indexing.Corax.MaxMemoizationSizeInMb](../../server/configuration/indexing-configuration#indexing.corax.maxmemoizationsizeinmb)  
+    [Indexing.Encrypted.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.encrypted.transactionsizelimitinmb)  
+    [Indexing.IndexEmptyEntries](../../server/configuration/indexing-configuration#indexing.indexemptyentries)  
+    [Indexing.IndexMissingFieldsAsNull](../../server/configuration/indexing-configuration#indexing.indexmissingfieldsasnull)  
+    [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb)  
+    [Indexing.Lucene.IndexInputType](../../server/configuration/indexing-configuration#indexing.lucene.indexinputtype)  
+    [Indexing.Lucene.ReaderTermsIndexDivisor](../../server/configuration/indexing-configuration#indexing.lucene.readertermsindexdivisor)  
+    [Indexing.ManagedAllocationsBatchSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.managedallocationsbatchsizelimitinmb)  
+    [Indexing.MapBatchSize](../../server/configuration/indexing-configuration#indexing.mapbatchsize)  
+    [Indexing.MapTimeoutAfterEtagReachedInMin](../../server/configuration/indexing-configuration#indexing.maptimeoutafteretagreachedinmin)  
+    [Indexing.MapTimeoutInSec](../../server/configuration/indexing-configuration#indexing.maptimeoutinsec)  
+    [Indexing.MaxStepsForScript](../../server/configuration/indexing-configuration#indexing.maxstepsforscript)  
+    [Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec](../../server/configuration/indexing-configuration#indexing.maxtimefordocumenttransactiontoremainopeninsec)  
+    [Indexing.MaxTimeForMergesToKeepRunningInSec](../../server/configuration/indexing-configuration#indexing.maxtimeformergestokeeprunninginsec)  
+    [Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec](../../server/configuration/indexing-configuration#indexing.maxtimetowaitafterflushandsyncwhenreplacingsidebysideindexinsec)  
+    [Indexing.MaximumSizePerSegmentInMb](../../server/configuration/indexing-configuration#indexing.maximumsizepersegmentinmb)  
+    [Indexing.MergeFactor](../../server/configuration/indexing-configuration#indexing.mergefactor)  
+    [Indexing.Metrics.Enabled](../../server/configuration/indexing-configuration#indexing.metrics.enabled)   
+    [Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.minnumberofmapattemptsafterwhichbatchwillbecanceledifrunninglowonmemory)   
+    [Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb](../../server/configuration/indexing-configuration#indexing.minimumtotalsizeofjournalstorunflushandsyncwhenreplacingsidebysideindexinmb)
+    [Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory](../../server/configuration/indexing-configuration#indexing.numberofconcurrentstoppedbatchesifrunninglowonmemory)   
+    [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch)  
+    [Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved](../../server/configuration/indexing-configuration#indexing.orderbyscoreautomaticallywhenboostingisinvolved)  
+    [Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved](../../server/configuration/indexing-configuration#indexing.orderbyticksautomaticallywhendatesareinvolved)  
+    [Indexing.QueryClauseCache.Disabled](../../server/configuration/indexing-configuration#indexing.queryclausecache.disabled)  
+    [Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec](../../server/configuration/indexing-configuration#indexing.queryclausecache.repeatedqueriestimeframeinsec)  
+    [Indexing.ScratchSpaceLimitInMb](../../server/configuration/indexing-configuration#indexing.scratchspacelimitinmb)  
+    [Indexing.Static.SearchEngineType](../../server/configuration/indexing-configuration#indexing.static.searchenginetype)  
+    [Indexing.Throttling.TimeIntervalInMs](../../server/configuration/indexing-configuration#indexing.throttling.timeintervalinms)  
+    [Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin](../../server/configuration/indexing-configuration#indexing.timesincelastqueryafterwhichdeepcleanupcanbeexecutedinmin)  
+    [Indexing.TransactionSizeLimitInMb](../../server/configuration/indexing-configuration#indexing.transactionsizelimitinmb)  
+    [Indexing.UseCompoundFileInMerging](../../server/configuration/indexing-configuration#indexing.usecompoundfileinmerging)  
 
 {NOTE/}
 
 ---
 
-{PANEL: Indexing.RunInMemory}
+{PANEL: Indexing.CleanupIntervalInMin}
 
-* Set if indexes should run purely in memory.
-
-* When running in memory:
-  * No index data is written to the disk, and if the server is restarted, all index data will be lost.
-  * Note that the index definition itself is kept on disk and remains unaffected by server restarts.
-  * This is mostly useful for testing or faster, non-persistent indexing.
-
-* If _Indexing.RunInMemory_ is not set explicitly,  
-  then this configuration key will take the value of the core configuration key [RunInMemory](../../server/configuration/core-configuration#runinmemory).
-
----
-
-- **Type**: `bool`
-- **Default**: `false` 
-- **Scope**: Server-wide, or per database
-
-Optional values:
-
- * `true` - indexing is run only in memory
- * `false` - the index data is stored on disk
-
-{PANEL/}
-
-{PANEL: Indexing.Disable}
-
-Set whether to disable all indexes in the database.  
-All indexes in the database will be disabled when set to `true`.
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Static.DeploymentMode}
-
-Set the default deployment mode for static indexes.
-
-- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
-- **Default**: `Parallel`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Auto.DeploymentMode}
-
-Set the default deployment mode for auto indexes.
-
-- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
-- **Default**: `Parallel`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Auto.ArchivedDataProcessingBehavior}
-
-Set the default deployment mode for static indexes.
-
-- **Type**: `enum IndexDeploymentModeArchivedDataProcessingBehavior` (`ExcludeArchived`, `IncludeArchived`, `ArchivedOnly`)
-- **Default**: `ExcludeArchived`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Static.ArchivedDataProcessingBehavior}
-
-Set the default deployment mode for static indexes.
-
-- **Type**: `enum IndexDeploymentModeArchivedDataProcessingBehavior` (`ExcludeArchived`, `IncludeArchived`, `ArchivedOnly`)
-- **Default**: `ExcludeArchived`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Metrics.Enabled}
-
-Set whether indexing performance metrics will be gathered.
-
-- **Type**: `bool`
-- **Default**: `true`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.TempPath}
-
-* Use this setting to specify a different path for the indexes' temporary files.
-
-* By default, temporary files are created under the `Temp` directory inside the index data directory.  
-  Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
-
----
-
-- **Type**: `string`
-- **Default**: `null`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
-
-Set how many seconds indexing will keep document transaction open when indexing.  
-When triggered, transaction will be closed and a new one will be opened.  
+Time (in minutes) between auto index cleanup.
+Time (in minutes) between index cleanup"
 
 - **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
-
-Set the number of seconds to keep a superseded auto index.
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
-
-Set the number of minutes to wait before marking an auto index as idle.
-
-- **Type**: `int`
-- **Default**: `30`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.DisableQueryOptimizerGeneratedIndexes}
-
-EXPERT ONLY:  
-Disable query optimizer generated indexes (auto-indexes). Dynamic queries will not be supported.  
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
-
-Set the number of hours the database should wait before deleting an auto-index that is marked as idle.
-
-- **Type**: `int`
-- **Default**: `72`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
-
-EXPERT ONLY:  
-Set minimum number of map attempts after which the batch will be canceled if running low on memory.
-
-- **Type**: `int`
-- **Default**: `512`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
-
-EXPERT ONLY:  
-Number of concurrent stopped batches if running low on memory.
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL:Indexing.MapTimeoutInSec}
-
-Number of seconds after which mapping will end even if there is more to map.  
-Using the default value of `-1` will map everything possible in a single batch.  
-
-- **Type**: `int`
-- **Default**: `-1`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.QueryClauseCache.SizeInMb}
-
-EXPERT ONLY:  
-
-* Maximum size that the query clause cache will utilize for caching partial query clauses,  
-  defaulting to 10% of the system memory on 64-bit machines.
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
+- **Default**: `10`
 - **Scope**: Server-wide only
 
 {PANEL/}
 
-{PANEL: Indexing.QueryClauseCache.Disabled}
+{PANEL: Indexing.GlobalScratchSpaceLimitInMb}
 
-EXPERT ONLY:  
+* Maximum amount of scratch space in megabytes that we allow to use for all index storages per server.
 
-* Disable the query clause cache for a server, database, or a single index.
-
-* The default value is set by the constructor of class `IndexingConfiguration`.  
-  It will be `true` if your core configuration key [Features.Availability](../../server/configuration/core-configuration#features.availability) is Not set to 'Experimental'. 
+* After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
 
 ---
 
+- **Type**: `int`
+- **Default**: `null` (no limit)
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+
+Set how many indexes can run concurrently on the server to prevent overwhelming system resources and slow indexing.
+
+- **Type**: `int`
+- **Default**: `null` (No limit)
+- **MinValue**: 1
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec}
+
+Max time to wait in seconds when forcing the storage environment flush and sync after exceeding the scratch space limit.
+
+- **Type**: `int`
+- **Default**: `30`
+- **Scope**: Server-wide only
+- **Alias:** `Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit`
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetAllowPreReleasePackages}
+
+Allow installation of NuGet prerelease packages.
+
 - **Type**: `bool`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
+- **Default**: `false`
+- **Scope**: Server-wide only
+- **Alias:** `Indexing.NuGetAllowPreleasePackages`
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackageSourceUrl}
+
+Default NuGet source URL.
+
+- **Type**: `string`
+- **Default**: `https://api.nuget.org/v3/index.json`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL: Indexing.NuGetPackagesPath}
+
+Location of NuGet packages cache.
+
+- **Type**: `string`
+- **Default**: `Packages/NuGet`
+- **Scope**: Server-wide only
 
 {PANEL/}
 
@@ -325,103 +186,15 @@ The number of recent queries that we will keep to identify repeated queries, rel
 - **Type**: `int`
 - **Default**: `512`
 - **Scope**: Server-wide only
- 
-{PANEL/}
-
-{PANEL: Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec}
-
-EXPERT ONLY:  
-Queries that repeat within this time frame will be considered worth caching.
-
-- **Type**: `int`
-- **Default**: `300`
-- **Scope**: Server-wide, or per database, or per index
- 
-{PANEL/}
-
-{PANEL: Indexing.MapBatchSize}
-
-Maximum number of documents to be processed by the index per indexing batch.
-
-- **Type**: `int?`
-- **Default**: `null` (no limit)
-- **MinValue**: `128`
-- **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
 
-{PANEL: Indexing.MapTimeoutAfterEtagReachedInMin}
+{PANEL: Indexing.QueryClauseCache.SizeInMb}
 
-* Number of minutes after which mapping will end even if there is more to map.  
+EXPERT ONLY:
 
-* This will only be applied if we pass the last etag we saw in the collection when the batch was started.
-
----
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MaxStepsForScript}
-
-The maximum number of steps in the script execution of a JavaScript index.
-
-- **Type**: `int`
-- **Default**: `10_000`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.CleanupIntervalInMin}
-
-Time (in minutes) between auto index cleanup.
-Time (in minutes) between index cleanup"
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide only
-
-{PANEL/}
-
-{PANEL: Indexing.Analyzers.NGram.MinGram}
-
-Smallest n-gram to generate when NGram analyzer is used.
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
-
-{PANEL/}
-
-{PANEL: Indexing.Analyzers.NGram.MaxGram}
-
-Largest n-gram to generate when NGram analyzer is used.
-
-- **Type**: `int`
-- **Default**: `6`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
-
-{PANEL/}
-
-{PANEL: Indexing.ManagedAllocationsBatchSizeLimitInMb}
-
-Managed allocations limit in an indexing batch after which the batch will complete and an index will continue by starting a new one.
-
-- **Type**: `int`
-- **Default**: `2048`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MaximumSizePerSegmentInMb}
-
-EXPERT ONLY:  
-
-* The maximum size in MB that we'll consider for segments merging.
+* Maximum size that the query clause cache will utilize for caching partial query clauses,  
+  defaulting to 10% of the system memory on 64-bit machines.
 
 * The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
 
@@ -429,169 +202,79 @@ EXPERT ONLY:
 
 - **Type**: `int`
 - **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
- 
-{PANEL/}
-
-{PANEL: Indexing.MergeFactor}
-
-EXPERT ONLY:  
-
-* Set how often index segments are merged into larger ones.  
-  The merge process will start when the number of segments in an index reaches this number.  
- 
-* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
-
----
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MergeFactor`
-
-{PANEL/}
-
-{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
-
-EXPERT ONLY:  
-
-* The definition of a large segment in MB.  
-  We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.  
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
-
-{PANEL/}
-
-{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
-
-EXPERT ONLY:  
-Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
-
-- **Type**: `int`
-- **Default**: `2`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
-
-{PANEL/}
-
-{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
-
-EXPERT ONLY:  
-How long will we let merges to run before we close the transaction.
-
-- **Type**: `int`
-- **Default**: `15`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
-
-{PANEL/}
-
-{PANEL: Indexing.TransactionSizeLimitInMb}
-
-Transaction size limit in megabytes after which an index will stop and complete the current batch.
-
-- **Type**: `int`
-- **Default**: `null` (no limit)
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL:Indexing.Encrypted.TransactionSizeLimitInMb}
-
-* Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
-
-* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
-
----
-
-- **Type**: `int`
-- **Default**: `DefaultValueSetInConstructor`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.ScratchSpaceLimitInMb}
-
-* Amount of scratch space in megabytes that we allow to use for the index storage.
-
-* After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
-
----
-
-- **Type**: `int`
-- **Default**: `null` (no limit)
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.GlobalScratchSpaceLimitInMb}
-
-* Maximum amount of scratch space in megabytes that we allow to use for all index storages per server.  
-
-* After exceeding this limit the indexes will complete their current indexing batches and force flush and sync storage environments.
-
----
-
-- **Type**: `int`
-- **Default**: `null` (no limit)
 - **Scope**: Server-wide only
 
 {PANEL/}
 
-{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimitInSec}
+{PANEL: Indexing.Auto.ArchivedDataProcessingBehavior}
 
-Max time to wait in seconds when forcing the storage environment flush and sync after exceeding the scratch space limit.
+Set the default deployment mode for static indexes.
 
-- **Type**: `int`
-- **Default**: `30`
-- **Scope**: Server-wide only
-- **Alias:** `Indexing.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit`
+- **Type**: `enum IndexDeploymentModeArchivedDataProcessingBehavior` (`ExcludeArchived`, `IncludeArchived`, `ArchivedOnly`)
+- **Default**: `ExcludeArchived`
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL: Indexing.IndexMissingFieldsAsNull}
+{PANEL: Indexing.Auto.DeploymentMode}
 
-* Set how the indexing process should handle fields that are missing.
+Set the default deployment mode for auto indexes.
 
-* When set to `true`, missing fields will be indexed with a `null` value.
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
 
----
+{PANEL/}
+
+{PANEL: Indexing.Auto.SearchEngineType}
+
+Set the search engine to be used with auto-indexes.
+
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Disable}
+
+Set whether to disable all indexes in the database.  
+All indexes in the database will be disabled when set to `true`.
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide, or per database, or per index
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
-{PANEL: Indexing.IndexEmptyEntries}
+{PANEL: Indexing.DisableQueryOptimizerGeneratedIndexes}
 
-* Set how the indexing process should handle documents that are missing fields.
-
-* When set to `true`, the indexing process will index documents even if they lack the fields that are supposed to be indexed.
-
----
+EXPERT ONLY:  
+Disable query optimizer generated indexes (auto-indexes). Dynamic queries will not be supported.
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide, or per database, or per index
+- **Scope**: Server-wide, or per database
 
 {PANEL/}
 
 {PANEL: Indexing.ErrorIndexStartupBehavior}
 
 Set how faulty indexes should behave on database startup when they are loaded.  
-By default they are not started.  
+By default they are not started.
 
 - **Type**: `enum ErrorIndexStartupBehaviorType` (`Default`, `Start`, `ResetAndStart`)
 - **Default**: `Default`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL:Indexing.History.NumberOfRevisions}
+
+Number of index history revisions to keep per index.
+
+- **Type**: `int`
+- **Default**: `10`
 - **Scope**: Server-wide, or per database
 
 {PANEL/}
@@ -606,66 +289,125 @@ By default they are not started.
 ---
 
 - **Type**: `enum IndexStartupBehaviorType` (`Default`, `Immediate`, `Pause`, `Delay`)
-- **Default**: `Default`  
+- **Default**: `Default`
 - **Scope**: Server-wide, or per database
 
 Optional values:
 
-  - `Default`: Each index starts as soon as it is loaded.
-  - `Immediate`: Same as Default.
-  - `Pause`: Loads all indexes, but they are paused until manually started.
-  - `Delay`: Delays starting index processes until all indexes are loaded.
+- `Default`: Each index starts as soon as it is loaded.
+- `Immediate`: Same as Default.
+- `Pause`: Loads all indexes, but they are paused until manually started.
+- `Delay`: Delays starting index processes until all indexes are loaded.
 
 {PANEL/}
 
-{PANEL: Indexing.MaxNumberOfConcurrentlyRunningIndexes}
+{PANEL: Indexing.RunInMemory}
 
-Set how many indexes can run concurrently on the server to prevent overwhelming system resources and slow indexing.
+* Set if indexes should run purely in memory.
 
-- **Type**: `int`
-- **Default**: `null` (No limit)
-- **MinValue**: 1
-- **Scope**: Server-wide only
+* When running in memory:
+    * No index data is written to the disk, and if the server is restarted, all index data will be lost.
+    * Note that the index definition itself is kept on disk and remains unaffected by server restarts.
+    * This is mostly useful for testing or faster, non-persistent indexing.
 
-{PANEL/}
+* If _Indexing.RunInMemory_ is not set explicitly,  
+  then this configuration key will take the value of the core configuration key [RunInMemory](../../server/configuration/core-configuration#runinmemory).
 
-{PANEL: Indexing.NuGetPackagesPath}
-
-Location of NuGet packages cache.
-
-- **Type**: `string`
-- **Default**: `Packages/NuGet`
-- **Scope**: Server-wide only
-
-{PANEL/}
-
-{PANEL: Indexing.NuGetPackageSourceUrl}
-
-Default NuGet source URL.
-
-- **Type**: `string`
-- **Default**: `https://api.nuget.org/v3/index.json`
-- **Scope**: Server-wide only
-
-{PANEL/}
-
-{PANEL: Indexing.NuGetAllowPreReleasePackages}
-
-Allow installation of NuGet prerelease packages.
+---
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Scope**: Server-wide only
-- **Alias:** `Indexing.NuGetAllowPreleasePackages`
+- **Scope**: Server-wide, or per database
+
+Optional values:
+
+* `true` - indexing is run only in memory
+* `false` - the index data is stored on disk
 
 {PANEL/}
 
-{PANEL:Indexing.History.NumberOfRevisions}
+{PANEL: Indexing.SkipDatabaseIdValidationOnIndexOpening}
 
-Number of index history revisions to keep per index.
+EXPERT ONLY:  
+Allow to open an index without checking if current Database ID matched the one for which index was created.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, per database
+
+{PANEL/}
+
+{PANEL: Indexing.Static.ArchivedDataProcessingBehavior}
+
+Set the default deployment mode for static indexes.
+
+- **Type**: `enum IndexDeploymentModeArchivedDataProcessingBehavior` (`ExcludeArchived`, `IncludeArchived`, `ArchivedOnly`)
+- **Default**: `ExcludeArchived`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Static.DeploymentMode}
+
+Set the default deployment mode for static indexes.
+
+- **Type**: `enum IndexDeploymentMode` (`Parallel`, `Rolling`)
+- **Default**: `Parallel`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
+
+Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) to deploy [JavaScript indexes](../../indexes/javascript-indexes).
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TempPath}
+
+* Use this setting to specify a different path for the indexes' temporary files.
+
+* By default, temporary files are created under the `Temp` directory inside the index data directory.  
+  Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).
+
+---
+
+- **Type**: `string`
+- **Default**: `null`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeBeforeDeletionOfSupersededAutoIndexInSec}
+
+Set the number of seconds to keep a superseded auto index.
 
 - **Type**: `int`
-- **Default**: `10`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs}
+
+Set the number of hours the database should wait before deleting an auto-index that is marked as idle.
+
+- **Type**: `int`
+- **Default**: `72`
+- **Scope**: Server-wide, or per database
+
+{PANEL/}
+
+{PANEL: Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdleInMin}
+
+Set the number of minutes to wait before marking an auto index as idle.
+
+- **Type**: `int`
+- **Default**: `30`
 - **Scope**: Server-wide, or per database
 
 {PANEL/}
@@ -690,42 +432,34 @@ Number of index history revisions to keep per index.
 
 {PANEL/}
 
+{PANEL: Indexing.Analyzers.NGram.MaxGram}
+
+Largest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `6`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MaxGram`
+
+{PANEL/}
+
+{PANEL: Indexing.Analyzers.NGram.MinGram}
+
+Smallest n-gram to generate when NGram analyzer is used.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.Analyzers.NGram.MinGram`
+
+{PANEL/}
+
 {PANEL: Indexing.Analyzers.Search.Default}
 
 [Default analyzer](../../indexes/using-analyzers#ravendb) that will be used for search fields.
 
 - **Type**: `string`
 - **Default**: `RavenStandardAnalyzer`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.Throttling.TimeIntervalInMs}
-
-How long the index should delay processing after new work is detected in milliseconds.
-
-- **Type**: `int`
-- **Default**: `null`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.Auto.SearchEngineType}
-
-Set the search engine to be used with auto-indexes.
-
-- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
-- **Default**: `Lucene`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.Static.SearchEngineType}
-
-Set the search engine to be used with static indexes.
-
-- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
-- **Default**: `Lucene`
 - **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}
@@ -738,115 +472,6 @@ Corax index compression max documents used for dictionary creation.
 - **Default**: `100_000`
 - **Scope**: Server-wide, or per database, or per index
 
-{PANEL/}
-
-{PANEL: Indexing.SkipDatabaseIdValidationOnIndexOpening}
-
-EXPERT ONLY:  
-Allow to open an index without checking if current Database ID matched the one for which index was created.
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, per database
-
-{PANEL/}
-
-{PANEL: Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
-
-Set how many minutes to wait before deep cleaning an idle index.  
-Deep cleanup reduces the cost of idle indexes.  
-It might slow the first query after the deep cleanup, thereafter queries return to normal performance.
-
-- **Type**: `int`
-- **Default**: `10`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.Static.RequireAdminToDeployJavaScriptIndexes}
-
-Require database `Admin` [clearance](../../server/security/authorization/security-clearance-and-permissions) to deploy [JavaScript indexes](../../indexes/javascript-indexes).
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, or per database
-
-{PANEL/}
-
-{PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
-
-Set whether query results will be automatically ordered by score when a boost factor is involved in the query.  
-(A boost factor may be [assigned inside an index definition](../../indexes/boosting) or can be [applied at query time](../../client-api/session/querying/text-search/boost-search-results)).
-
-- **Type**: `bool`
-- **Default**: `true`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.UseCompoundFileInMerging}
-
-EXPERT ONLY:  
-Use compound file in merging.
-
-- **Type**: `bool`
-- **Default**: `true`
-- **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
-
-{PANEL/}
-
-{PANEL: Indexing.Lucene.IndexInputType}
-
-Lucene index input
-
-- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
-- **Default**: `Buffered`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec}
-
-Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.
-
-- **Type**: `int`
-- **Default**: `30`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb}
-
-Minimum total size of journals to run flush and sync when replacing side by side index in megabytes.
-
-- **Type**: `int`
-- **Default**: `512`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved}
-
-Sort by ticks when field contains dates.  
-When sorting in descending order, null dates are returned at the end with this option enabled.
-
-- **Type**: `bool`
-- **Default**: `false`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
-{PANEL: Indexing.Lucene.ReaderTermsIndexDivisor}
-
-EXPERT ONLY:  
-Control how many terms we'll keep in the cache for each field.  
-Higher values reduce the memory usage at the expense of increased search time for each term.
-
-- **Type**: `int`
-- **Default**: `1`
-- **Scope**: Server-wide, or per database, or per index
- 
 {PANEL/}
 
 {PANEL: Indexing.Corax.IncludeDocumentScore}
@@ -871,19 +496,9 @@ Disabling this option could enhance query performance.
 
 {PANEL/}
 
-{PANEL: Indexing.Corax.MaxMemoizationSizeInMb}
-
-The maximum amount of memory in megabytes that Corax can use for memoization during query processing.
-
-- **Type**: `int`
-- **Default**: `512`
-- **Scope**: Server-wide, or per database, or per index
-
-{PANEL/}
-
 {PANEL: Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb}
 
-EXPERT ONLY:  
+EXPERT ONLY:
 
 * The maximum amount of megabytes that we'll allocate for training indexing dictionaries.
 
@@ -894,5 +509,393 @@ EXPERT ONLY:
 - **Type**: `int`
 - **Default**: `DefaultValueSetInConstructor`
 - **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Corax.MaxMemoizationSizeInMb}
+
+The maximum amount of memory in megabytes that Corax can use for memoization during query processing.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL:Indexing.Encrypted.TransactionSizeLimitInMb}
+
+* Transaction size limit in megabytes for _encrypted_ databases, after which an index will stop and complete the current batch.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.IndexEmptyEntries}
+
+* Set how the indexing process should handle documents that are missing fields.
+
+* When set to `true`, the indexing process will index documents even if they lack the fields that are supposed to be indexed.
+
+---
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.IndexMissingFieldsAsNull}
+
+* Set how the indexing process should handle fields that are missing.
+
+* When set to `true`, missing fields will be indexed with a `null` value.
+
+---
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.LargeSegmentSizeToMergeInMb}
+
+EXPERT ONLY:
+
+* The definition of a large segment in MB.  
+  We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.LargeSegmentSizeToMergeInMb`
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.IndexInputType}
+
+Lucene index input
+
+- **Type**: `enum LuceneIndexInputType` (`Standard`, `Buffered`)
+- **Default**: `Buffered`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Lucene.ReaderTermsIndexDivisor}
+
+EXPERT ONLY:  
+Control how many terms we'll keep in the cache for each field.  
+Higher values reduce the memory usage at the expense of increased search time for each term.
+
+- **Type**: `int`
+- **Default**: `1`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.ManagedAllocationsBatchSizeLimitInMb}
+
+Managed allocations limit in an indexing batch after which the batch will complete and an index will continue by starting a new one.
+
+- **Type**: `int`
+- **Default**: `2048`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MapBatchSize}
+
+Maximum number of documents to be processed by the index per indexing batch.
+
+- **Type**: `int?`
+- **Default**: `null` (no limit)
+- **MinValue**: `128`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MapTimeoutAfterEtagReachedInMin}
+
+* Number of minutes after which mapping will end even if there is more to map.
+
+* This will only be applied if we pass the last etag we saw in the collection when the batch was started.
+
+---
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL:Indexing.MapTimeoutInSec}
+
+Number of seconds after which mapping will end even if there is more to map.  
+Using the default value of `-1` will map everything possible in a single batch.
+
+- **Type**: `int`
+- **Default**: `-1`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxStepsForScript}
+
+The maximum number of steps in the script execution of a JavaScript index.
+
+- **Type**: `int`
+- **Default**: `10_000`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec}
+
+Set how many seconds indexing will keep document transaction open when indexing.  
+When triggered, transaction will be closed and a new one will be opened.
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
+
+EXPERT ONLY:  
+How long will we let merges to run before we close the transaction.
+
+- **Type**: `int`
+- **Default**: `15`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec`
+
+{PANEL/}
+
+{PANEL: Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec}
+
+Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.
+
+- **Type**: `int`
+- **Default**: `30`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MaximumSizePerSegmentInMb}
+
+EXPERT ONLY:
+
+* The maximum size in MB that we'll consider for segments merging.
+
+* The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
+
+---
+
+- **Type**: `int`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MaximumSizePerSegmentInMb`
+
+{PANEL/}
+
+{PANEL: Indexing.MergeFactor}
+
+EXPERT ONLY:
+
+* Set how often index segments are merged into larger ones.  
+  The merge process will start when the number of segments in an index reaches this number.
+
+* With smaller values, less RAM is used while indexing, and searches on unoptimized indexes are faster, but indexing speed is slower.
+
+---
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.MergeFactor`
+
+{PANEL/}
+
+{PANEL: Indexing.Metrics.Enabled}
+
+Set whether indexing performance metrics will be gathered.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory}
+
+EXPERT ONLY:  
+Set minimum number of map attempts after which the batch will be canceled if running low on memory.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb}
+
+Minimum total size of journals to run flush and sync when replacing side by side index in megabytes.
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory}
+
+EXPERT ONLY:  
+Number of concurrent stopped batches if running low on memory.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
+
+EXPERT ONLY:  
+Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+
+- **Type**: `int`
+- **Default**: `2`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch`
+
+{PANEL/}
+
+{PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
+
+Set whether query results will be automatically ordered by score when a boost factor is involved in the query.  
+(A boost factor may be [assigned inside an index definition](../../indexes/boosting) or can be [applied at query time](../../client-api/session/querying/text-search/boost-search-results)).
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved}
+
+Sort by ticks when field contains dates.  
+When sorting in descending order, null dates are returned at the end with this option enabled.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.Disabled}
+
+EXPERT ONLY:
+
+* Disable the query clause cache for a server, database, or a single index.
+
+* The default value is set by the constructor of class `IndexingConfiguration`.  
+  It will be `true` if your core configuration key [Features.Availability](../../server/configuration/core-configuration#features.availability) is Not set to 'Experimental'.
+
+---
+
+- **Type**: `bool`
+- **Default**: `DefaultValueSetInConstructor`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec}
+
+EXPERT ONLY:  
+Queries that repeat within this time frame will be considered worth caching.
+
+- **Type**: `int`
+- **Default**: `300`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.ScratchSpaceLimitInMb}
+
+* Amount of scratch space in megabytes that we allow to use for the index storage.
+
+* After exceeding this limit the current indexing batch will complete and the index will force flush and sync storage environment.
+
+---
+
+- **Type**: `int`
+- **Default**: `null` (no limit)
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Static.SearchEngineType}
+
+Set the search engine to be used with static indexes.
+
+- **Type**: `enum SearchEngineType` (`Lucene`, `Corax`)
+- **Default**: `Lucene`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.Throttling.TimeIntervalInMs}
+
+How long the index should delay processing after new work is detected in milliseconds.
+
+- **Type**: `int`
+- **Default**: `null`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin}
+
+Set how many minutes to wait before deep cleaning an idle index.  
+Deep cleanup reduces the cost of idle indexes.  
+It might slow the first query after the deep cleanup, thereafter queries return to normal performance.
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.TransactionSizeLimitInMb}
+
+Transaction size limit in megabytes after which an index will stop and complete the current batch.
+
+- **Type**: `int`
+- **Default**: `null` (no limit)
+- **Scope**: Server-wide, or per database, or per index
+
+{PANEL/}
+
+{PANEL: Indexing.UseCompoundFileInMerging}
+
+EXPERT ONLY:  
+Use compound file in merging.
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide, or per database, or per index
+- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -774,7 +774,8 @@ Require database `Admin` [clearance](../../server/security/authorization/securit
 
 {PANEL: Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved}
 
-Order by score automatically when boosting is used inside an index definition or a query.
+Set whether query results will be automatically ordered by score when a boost factor is involved in the query.  
+(A boost factor may be [assigned inside an index definition](../../indexes/boosting) or can be [applied at query time](../../client-api/session/querying/text-search/boost-search-results)).
 
 - **Type**: `bool`
 - **Default**: `true`

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -58,7 +58,7 @@
   [Indexing.MaxNumberOfConcurrentlyRunningIndexes](../../server/configuration/indexing-configuration#indexing.maxnumberofconcurrentlyrunningindexes)  
   [Indexing.NuGetPackagesPath](../../server/configuration/indexing-configuration#indexing.nugetpackagespath)  
   [Indexing.NuGetPackageSourceUrl](../../server/configuration/indexing-configuration#indexing.nugetpackagesourceurl)  
-  [Indexing.NuGetAllowPreleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowpreleasepackages)  
+  [Indexing.NuGetAllowPreReleasePackages](../../server/configuration/indexing-configuration#indexing.nugetallowprereleasepackages)  
   [Indexing.History.NumberOfRevisions](../../server/configuration/indexing-configuration#indexing.history.numberofrevisions)  
   [Indexing.Analyzers.Default](../../server/configuration/indexing-configuration#indexing.analyzers.default)  
   [Indexing.Analyzers.Exact.Default](../../server/configuration/indexing-configuration#indexing.analyzers.exact.default)  
@@ -649,13 +649,14 @@ Default NuGet source URL.
 
 {PANEL/}
 
-{PANEL: Indexing.NuGetAllowPreleasePackages}
+{PANEL: Indexing.NuGetAllowPreReleasePackages}
 
 Allow installation of NuGet prerelease packages.
 
 - **Type**: `bool`
 - **Default**: `false`
 - **Scope**: Server-wide only
+- **Alias:** `Indexing.NuGetAllowPreleasePackages`
 
 {PANEL/}
 
@@ -791,7 +792,7 @@ Use compound file in merging.
 - **Type**: `bool`
 - **Default**: `true`
 - **Scope**: Server-wide, or per database, or per index
-- **Alias:** `ndexing.Lucene.UseCompoundFileInMergingt`
+- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
 
 {PANEL/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -434,7 +434,11 @@ Set the number of minutes to wait before marking an auto index as idle.
 
 {PANEL: Indexing.Analyzers.NGram.MaxGram}
 
-Largest n-gram to generate when NGram analyzer is used.
+* This configuration applies only to the Lucene indexing engine.
+
+* Largest n-gram to generate when NGram analyzer is used.
+
+---
 
 - **Type**: `int`
 - **Default**: `6`
@@ -445,7 +449,11 @@ Largest n-gram to generate when NGram analyzer is used.
 
 {PANEL: Indexing.Analyzers.NGram.MinGram}
 
-Smallest n-gram to generate when NGram analyzer is used.
+* This configuration applies only to the Lucene indexing engine.
+
+* Smallest n-gram to generate when NGram analyzer is used.
+
+---
 
 - **Type**: `int`
 - **Default**: `2`
@@ -568,6 +576,8 @@ The maximum amount of memory in megabytes that Corax can use for memoization dur
 
 EXPERT ONLY:
 
+* This configuration applies only to the Lucene indexing engine.
+
 * The definition of a large segment in MB.  
   We won't merge more than [Indexing.NumberOfLargeSegmentsToMergeInSingleBatch](../../server/configuration/indexing-configuration#indexing.numberoflargesegmentstomergeinsinglebatch) in a single batch.
 
@@ -673,8 +683,13 @@ When triggered, transaction will be closed and a new one will be opened.
 
 {PANEL: Indexing.MaxTimeForMergesToKeepRunningInSec}
 
-EXPERT ONLY:  
-How long will we let merges to run before we close the transaction.
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* How long will we let merges to run before we close the transaction.
+
+---
 
 - **Type**: `int`
 - **Default**: `15`
@@ -697,6 +712,8 @@ Max time to wait when forcing the storage environment flush and sync when replac
 
 EXPERT ONLY:
 
+* This configuration applies only to the Lucene indexing engine.
+
 * The maximum size in MB that we'll consider for segments merging.
 
 * The default value, which is determined based on your platform details, is set by the constructor of class `IndexingConfiguration`.
@@ -713,6 +730,8 @@ EXPERT ONLY:
 {PANEL: Indexing.MergeFactor}
 
 EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
 
 * Set how often index segments are merged into larger ones.  
   The merge process will start when the number of segments in an index reaches this number.
@@ -772,8 +791,13 @@ Number of concurrent stopped batches if running low on memory.
 
 {PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
 
-EXPERT ONLY:  
-Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
+
+---
 
 - **Type**: `int`
 - **Default**: `2`
@@ -890,12 +914,17 @@ Transaction size limit in megabytes after which an index will stop and complete 
 
 {PANEL: Indexing.UseCompoundFileInMerging}
 
-EXPERT ONLY:  
-Use compound file in merging.
+EXPERT ONLY:
+
+* This configuration applies only to the Lucene indexing engine.
+
+* Use compound file in merging.
+
+---
 
 - **Type**: `bool`
 - **Default**: `true`
 - **Scope**: Server-wide, or per database, or per index
-- **Alias:** `Indexing.Lucene.UseCompoundFileInMergingt`
+- **Alias:** `Indexing.Lucene.UseCompoundFileInMerging`
 
 {PANEL/}

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -473,7 +473,7 @@ EXPERT ONLY:
 {PANEL: Indexing.NumberOfLargeSegmentsToMergeInSingleBatch}
 
 EXPERT ONLY:  
-Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../) to merge in a single batch.
+Number of large segments defined by [Indexing.LargeSegmentSizeToMergeInMb](../../server/configuration/indexing-configuration#indexing.largesegmentsizetomergeinmb) to merge in a single batch.
 
 - **Type**: `int`
 - **Default**: `2`

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/SortQueryResults.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/SortQueryResults.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
 using Raven.Documentation.Samples.Orders;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Client.Documents.Session;
 
 namespace Raven.Documentation.Samples.ClientApi.Session.Querying
@@ -486,6 +487,32 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
                     
                     // Results will be sorted by the 'UnitsInStock' value
                     // according to the logic from 'MySorter' class
+                    #endregion
+                }
+                
+                // Get score from metadata
+                // =======================
+                
+                using (var session = store.OpenSession())
+                {
+                    #region get_score_from_metadata
+                    // Make a query:
+                    // =============
+                    
+                    List<Employee> employees = session
+                        .Query<Employee>()
+                        .Search(x => x.Notes, "English")
+                        .Search(x => x.Notes, "Italian", boost: 10)
+                        .ToList();
+                    
+                    // Get the score:
+                    // ==============
+                    
+                    // Call 'GetMetadataFor', pass an entity from the resulting employees list
+                    var metadata = session.Advanced.GetMetadataFor(employees[0]);
+                    
+                    // Score is available in the '@index-score' metadata property
+                    var score = metadata[Constants.Documents.Metadata.IndexScore];
                     #endregion
                 }
             }

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Boosting.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Boosting.cs
@@ -3,66 +3,207 @@ using System.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq.Indexing;
-using Raven.Client.Documents.Operations.Indexes;
 using Raven.Documentation.Samples.Orders;
-
 
 namespace Raven.Documentation.Samples.Indexes
 {
-    #region boosting_2
-    public class Employees_ByFirstAndLastName : AbstractIndexCreationTask<Employee>
+    #region index_1
+    public class Orders_ByCountries_BoostByField : AbstractIndexCreationTask<Order>
     {
-        public Employees_ByFirstAndLastName()
+        public class IndexEntry
         {
-            Map =
-                employees =>
-                from employee in employees
-                select new
+            // Index-field 'ShipToCountry' will be boosted in the map definition below
+            public string ShipToCountry { get; set; }
+            public string CompanyCountry { get; set; }
+        }
+        
+        public Orders_ByCountries_BoostByField()
+        {
+            Map = orders => from order in orders
+                let company = LoadDocument<Company>(order.Company)
+                
+                // Note: with current server version,
+                // use 'select new' instead of 'select new IndexEntry' for compilation
+                select new 
                 {
-                    FirstName = employee.FirstName.Boost(10),
-                    LastName = employee.LastName
+                    // Boost index-field 'ShipToCountry':
+                    // * Use method 'Boost', pass a numeric value to boost by 
+                    // * Documents that match the query criteria for this field will rank higher
+                    ShipToCountry = order.ShipTo.Country.Boost(10), 
+                    CompanyCountry = company.Address.Country
                 };
         }
     }
-
+    #endregion
+    
+    #region index_1_js
+    public class Orders_ByCountries_BoostByField_JS : AbstractJavaScriptIndexCreationTask
+    {
+        public Orders_ByCountries_BoostByField_JS()
+        {
+            Maps = new HashSet<string>()
+            {
+                @"map('orders', function(order) {
+                    let company = load(order.Company, 'Companies')
+                    return {
+                        ShipToCountry: boost(order.ShipTo.Country, 10),
+                        CompanyCountry: company.Address.Country
+                    };
+                })"
+            };
+        }
+    }
+    #endregion
+    
+    #region index_2
+    public class Orders_ByCountries_BoostByIndexEntry : AbstractIndexCreationTask<Order>
+    {
+        public class IndexEntry
+        {
+            public string ShipToCountry { get; set; }
+            public string CompanyCountry { get; set; }
+        }
+        
+        public Orders_ByCountries_BoostByIndexEntry()
+        {
+            Map = orders => from order in orders
+                let company = LoadDocument<Company>(order.Company)
+                
+                select new IndexEntry()
+                {
+                    ShipToCountry = order.ShipTo.Country,
+                    CompanyCountry = company.Address.Country
+                }
+                // Boost the whole index-entry:
+                // * Use method 'Boost'
+                // * Pass a document-field that will set the boost level dynamically per document indexed.  
+                // * The boost level will vary from one document to another based on the value of this field.
+               .Boost((float) order.Freight);
+        }
+    }
+    #endregion
+    
+    #region index_2_js
+    public class Orders_ByCountries_BoostByIndexEntry_JS : AbstractJavaScriptIndexCreationTask
+    {
+        public Orders_ByCountries_BoostByIndexEntry_JS()
+        {
+            Maps = new HashSet<string>()
+            {
+                @"map('orders', function(order) {
+                    let company = load(order.Company, 'Companies')
+                    return boost({
+                        ShipToCountry: order.ShipTo.Country,
+                        CompanyCountry: company.Address.Country
+                    }, order.Freight)
+                })"
+            };
+        }
+    }
     #endregion
 
     public class Boosting
     {
-        public Boosting()
+        public async void Queries()
         {
             using (var store = new DocumentStore())
             {
                 using (var session = store.OpenSession())
                 {
-                    #region boosting_3
-                    // employees with 'FirstName' equal to 'Bob'
-                    // will be higher in results
-                    // than the ones with 'LastName' match
-                    IList<Employee> results = session
-                        .Query<Employee, Employees_ByFirstAndLastName>()
-                        .Where(x => x.FirstName == "Bob" || x.LastName == "Bob")
+                    #region query_1
+                    List<Order> orders = session
+                         // Query the index    
+                        .Query<Orders_ByCountries_BoostByField.IndexEntry, Orders_ByCountries_BoostByField>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
                         .ToList();
+                    
+                    // Because index-field 'ShipToCountry' was boosted (inside the index definition),
+                    // then documents containing 'Poland' in their 'ShipTo.Country' field will get a higher score than
+                    // documents containing a company that is located in 'Portugal'.
                     #endregion
                 }
 
-                #region boosting_4
-                store
-                    .Maintenance
-                    .Send(new PutIndexesOperation(new IndexDefinition
-                    {
-                        Name = "Employees/ByFirstAndLastName",
-                        Maps =
-                        {
-                            @"from employee in docs.Employees
-                              select new
-                              {
-                                  FirstName = employee.FirstName.Boost(10),
-                                  LastName = employee.LastName
-                              }"
-                        }
-                    }));
-                #endregion
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region query_2
+                    List<Order> orders = await asyncSession
+                         // Query the index    
+                        .Query<Orders_ByCountries_BoostByField.IndexEntry, Orders_ByCountries_BoostByField>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
+                        .ToListAsync();
+                    
+                    // Because index-field 'ShipToCountry' was boosted (inside the index definition),
+                    // then documents containing 'Poland' in their 'ShipTo.Country' field will get a higher score than
+                    // documents containing a company that is located in 'Portugal'.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region query_3
+                    List<Order> orders = session.Advanced
+                         // Query the index 
+                        .DocumentQuery<Orders_ByCountries_BoostByField.IndexEntry, Orders_ByCountries_BoostByField>()
+                        .WhereEquals(x => x.ShipToCountry, "Poland")
+                        .OrElse()
+                        .WhereEquals(x => x.CompanyCountry, "Portugal")
+                        .OfType<Order>()
+                        .ToList();
+                    
+                    // Because index-field 'ShipToCountry' was boosted (inside the index definition),
+                    // then documents containing 'Poland' in their 'ShipTo.Country' field will get a higher score than
+                    // documents containing a company that is located in 'Portugal'.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region query_4
+                    List<Order> orders = session
+                         // Query the index  
+                        .Query<Orders_ByCountries_BoostByIndexEntry.IndexEntry, Orders_ByCountries_BoostByIndexEntry>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
+                        .ToList();
+                    
+                    // The resulting score per matching document is affected by the value of the document-field 'Freight'. 
+                    // Documents with a higher 'Freight' value will rank higher.
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region query_5
+                    List<Order> orders = await asyncSession
+                         // Query the index  
+                        .Query<Orders_ByCountries_BoostByIndexEntry.IndexEntry, Orders_ByCountries_BoostByIndexEntry>()
+                        .Where(x => x.ShipToCountry == "Poland" || x.CompanyCountry == "Portugal")
+                        .OfType<Order>()
+                        .ToListAsync();
+                    
+                    // The resulting score per matching document is affected by the value of the document-field 'Freight'. 
+                    // Documents with a higher 'Freight' value will rank higher.
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region query_6
+                    List<Order> orders = session.Advanced
+                         // Query the index  
+                        .DocumentQuery<Orders_ByCountries_BoostByIndexEntry.IndexEntry, Orders_ByCountries_BoostByIndexEntry>()
+                        .WhereEquals(x => x.ShipToCountry, "Poland")
+                        .OrElse()
+                        .WhereEquals(x => x.CompanyCountry, "Portugal")
+                        .OfType<Order>()
+                        .ToList();
+                    
+                    // The resulting score per matching document is affected by the value of the document-field 'Freight'. 
+                    // Documents with a higher 'Freight' value will rank higher.
+                    #endregion
+                }
             }
         }
     }

--- a/Documentation/6.0/Samples/nodejs/client-api/session/querying/sortQueryResults.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/session/querying/sortQueryResults.js
@@ -155,6 +155,29 @@ async function sortQueryResults() {
         // according to the logic from 'MySorter' class
         //endregion
     }
+
+    {
+        //region get_score_from_metadata
+        // Make a query:
+        // =============
+
+        const employees = await session
+            .query({ collection: "Employees"})
+            .search('Notes', 'English')
+            .search('Notes', 'Italian')
+            .boost(10)
+            .all();
+
+        // Get the score:
+        // ==============
+
+        // Call 'getMetadataFor', pass an entity from the resulting employees list
+        const metadata = session.advanced.getMetadataFor(employees[0]);
+
+        // Score is available in the '@index-score' metadata property
+        const score = metadata[CONSTANTS.Documents.Metadata.INDEX_SCORE];
+        //endregion
+    }
 }
 
 {


### PR DESCRIPTION
**Related issues:**
https://issues.hibernatingrhinos.com/issue/RDoc-2514/Explain-Boosting-options-when-indexing
https://issues.hibernatingrhinos.com/issue/RDoc-2552/Disable-OrderByScore-when-Boosting-is-involved-Update-indexing-configuration-file
https://issues.hibernatingrhinos.com/issue/RDoc-2332/Add-information-about-supporting-document-boost-in-documentation
https://issues.hibernatingrhinos.com/issue/RDoc-2380/Add-missing-indexing-configuration-keys

---

**Work included:**

`../indexing-configuration` files:
Update the indexing-configuration with all missing keys 

`../indexes/boosting` files: 
Explain the 2 ways to apply boosting inside the index definition (on index-field vs index-entry) 
Added Javascript index examples + updated Node.js
 
`../sort-query-results` files:
Organize "how to get the score" in a single location. 

`../boost-search-results` files:
Explain the configurable option to order-by-score when Boosting is involved - in all relevant places
 
---

@ml054 The main **Node.js** files to check in this PR is:
```
Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.js.markdown
Documentation/6.0/Samples/nodejs/indexes/boosting.js
```

---

@maciejaszyk  The main **C#** files to check:
```
Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
Documentation/6.0/Raven.Documentation.Pages/indexes/boosting.dotnet.markdown
Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Boosting.cs
```