### PR TITLE
RDoc-2337  Streaming query with WaitForNonStaleResults is not supported

### DIFF
--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.dotnet.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.dotnet.markdown
@@ -20,8 +20,10 @@
 * The stream results are a __snapshot of the data__ at the time when the query is computed by the server.  
   Results that match the query after it was already processed are not streamed to the client.
 
-* Streaming query results does not support using [include](../../../client-api/session/loading-entities#load-with-includes).  
-  Learn how to __stream related documents__ here [below](../../../client-api/session/querying/how-to-stream-query-results#stream-related-documents).
+* Streaming query results does Not support the following:  
+  * Requesting the query to [WaitForNonStaleResults](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults).  
+  * Using [Include](../../../client-api/how-to/handle-document-relationships#includes) to load a related document to the session while querying.  
+    Learn how to __stream related documents__ here [below](../../../client-api/session/querying/how-to-stream-query-results#stream-related-documents).  
 
 * To stream results, use the `Stream` method from the `Advanced` session operations.
 
@@ -94,7 +96,7 @@
 __Why streaming query results does not support 'include'__:
 
 * A document can reference [related documents](../../../indexes/indexing-related-documents#what-are-related-documents).
-* An [include](../../../client-api/session/loading-entities#load-with-includes) clause in a non-streamed query loads these related documents to the session  
+* An [Include](../../../client-api/how-to/handle-document-relationships#includes) clause in a non-streamed query loads these related documents to the session  
   so that they can be accessed without an additional query to the server.
 * Those included documents are sent to the client at the end of the query results.  
   This does not mesh well with streaming, which is designed to allow transferring massive amounts of data,  

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.java.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.java.markdown
@@ -1,6 +1,12 @@
 # Stream Query Results
 
-Query results can be streamed using the `stream` method from the `advanced` session operations. The query can be issued using either a static index, or it can be a dynamic one where it will be handled by an auto index.
+Query results can be streamed using the `stream` method from the `advanced` session operations.   
+The query can be issued using either a static index, or it can be a dynamic one where it will be handled by an auto index.
+
+Streaming query results does Not support the following:  
+
+   * Requesting the query to [WaitForNonStaleResults](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults).  
+   * Using [Include](../../../client-api/session/loading-entities#load-with-includes) to load a related document to the session while querying.  
 
 ## Syntax
 

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.js.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/session/querying/how-to-stream-query-results.js.markdown
@@ -20,8 +20,10 @@
 * The stream results are a __snapshot of the data__ at the time when the query is computed by the server.  
   Results that match the query after it was already processed are not streamed to the client.
 
-* Streaming query results does not support using [include](../../../client-api/session/loading-entities#load-with-includes).  
-  Learn how to __stream related documents__ here [below](../../../client-api/session/querying/how-to-stream-query-results#stream-related-documents).
+* Streaming query results does Not support the following:  
+    * Requesting the query to [waitForNonStaleResults](../../../client-api/session/querying/how-to-customize-query#waitfornonstaleresults).  
+    * Using [include](../../../client-api/session/loading-entities#load-with-includes) to load a related document to the session while querying.  
+      Learn how to __stream related documents__ here [below](../../../client-api/session/querying/how-to-stream-query-results#stream-related-documents).
 
 * To stream results, use the `stream` method from the `advanced` session operations.
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.dotnet.markdown
@@ -331,6 +331,9 @@ __Syntax__
 
 * A `TimeoutException` will be thrown if the query is not able to return non-stale results within the specified  
   (or default) timeout.
+ 
+* Note: This feature is Not available when [streaming the query results](../../../client-api/session/querying/how-to-stream-query-results).  
+  Calling _WaitForNonStaleResults_ with a streaming query will throw an exception.  
 
 * Learn more about stale results in [stale indexes](../../../indexes/stale-indexes).
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.java.markdown
@@ -164,6 +164,9 @@ To order results randomly, use the `randomOrdering` method.
 Queries can be 'instructed' to wait for non-stale results for a specified amount of time using the `waitForNonStaleResults` method. If the query won't be able to return 
 non-stale results within the specified (or default) timeout, then a `TimeoutException` is thrown.
 
+Note: This feature is Not available when [streaming the query results](../../../client-api/session/querying/how-to-stream-query-results).  
+Calling _waitForNonStaleResults_ with a streaming query will throw an exception.
+
 {NOTE: Cutoff Point}
 If a query sent to the server specifies that it needs to wait for non-stale results, then RavenDB sets the cutoff Etag for the staleness check.
 It is the Etag of the last document (or document tombstone), from the collection(s) processed by the index, as of the query arrived to the server.

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/querying/how-to-customize-query.js.markdown
@@ -267,6 +267,9 @@ __Syntax__
 * A `TimeoutException` will be thrown if the query is not able to return non-stale results within the specified  
   (or default) timeout.
 
+* Note: This feature is Not available when [streaming the query results](../../../client-api/session/querying/how-to-stream-query-results).  
+  Calling _waitForNonStaleResults_ with a streaming query will throw an exception.
+
 * Learn more about stale results in [stale indexes](../../../indexes/stale-indexes).
 
 {NOTE: }


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2337/Explain-that-streaming-query-with-WaitForNonStaleResults-is-not-supported