### PR TITLE
Clarify that an incremental time series' Get results include unique values

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.markdown
@@ -82,7 +82,7 @@ In LINQ, aggregations are performed using the `GroupBy()` method. It takes
 the time period over which to aggregate, either in the form of a `string`, or 
 as an `Action<ITimePeriodBuilder>`.  
 
-{CODE GroupBy@DocumentExtensions\TimeSeries\Querying\AggregationAndProjections.cs /}
+{CODE GroupBy_Switch@DocumentExtensions\TimeSeries\Querying\AggregationAndProjections.cs /}
 
 The `ITimePeriodBuilder` class just contains one property for each of the time 
 period units from milliseconds to years.  

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/timeseries/incremental-time-series/client-api/operations/get.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/timeseries/incremental-time-series/client-api/operations/get.markdown
@@ -48,11 +48,12 @@ public class TimeSeriesRangeResult
         public DateTime From, To;
         public TimeSeriesEntry[] Entries;
         
-        // The actual number of values
+        // The number of unique values
         public long? TotalResults; 
         
-  {CODE-BLOCK/}
-  {CODE-BLOCK:csharp}
+    {CODE-BLOCK/}
+
+    {CODE-BLOCK:csharp}
 public class TimeSeriesEntry 
     {
         public DateTime Timestamp { get; set; }
@@ -62,16 +63,17 @@ public class TimeSeriesEntry
         
         // The nodes distribution per each entry
         public Dictionary<string, double[]> NodeValues { get; set; } 
-   {CODE-BLOCK/}
+    {CODE-BLOCK/}
 
-     {NOTE: }
-
-      * Requesting a time series that doesn't exist will return `null`.  
-      * Requesting an entries range that doesn't exist will return a `TimeSeriesRangeResult` object 
-        with an empty `Entries` property.  
-
-     {NOTE/}
-
+     * `TimeSeriesRangeResult.TotalResults` will contain the number of **unique** values.  
+       If the time series contains entries with multiple values (remember 
+       that since this is an incremental time series this means duplications 
+       of the same number at the same timestamp) all values will be aggregated 
+       in `TotalResults` to a single unique value.  
+     * Requesting a time series that doesn't exist will return `null`.  
+     * Requesting an entries range that doesn't exist will return a `TimeSeriesRangeResult` object 
+       with an empty `Entries` property.  
+ 
 * **Exceptions**  
   Exceptions are not generated.  
 

--- a/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/incremental-time-series/client-api/operations/get.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/incremental-time-series/client-api/operations/get.markdown
@@ -48,11 +48,12 @@ public class TimeSeriesRangeResult
         public DateTime From, To;
         public TimeSeriesEntry[] Entries;
         
-        // The actual number of values
+        // The number of unique values
         public long? TotalResults; 
         
-  {CODE-BLOCK/}
-  {CODE-BLOCK:csharp}
+    {CODE-BLOCK/}
+
+    {CODE-BLOCK:csharp}
 public class TimeSeriesEntry 
     {
         public DateTime Timestamp { get; set; }
@@ -62,15 +63,16 @@ public class TimeSeriesEntry
         
         // The nodes distribution per each entry
         public Dictionary<string, double[]> NodeValues { get; set; } 
-   {CODE-BLOCK/}
+    {CODE-BLOCK/}
 
-     {NOTE: }
-
-      * Requesting a time series that doesn't exist will return `null`.  
-      * Requesting an entries range that doesn't exist will return a `TimeSeriesRangeResult` object 
-        with an empty `Entries` property.  
-
-     {NOTE/}
+     * `TimeSeriesRangeResult.TotalResults` will contain the number of **unique** values.  
+       If the time series contains entries with multiple values (remember 
+       that since this is an incremental time series this means duplications 
+       of the same number at the same timestamp) all values will be aggregated 
+       in `TotalResults` to a single unique value.  
+     * Requesting a time series that doesn't exist will return `null`.  
+     * Requesting an entries range that doesn't exist will return a `TimeSeriesRangeResult` object 
+       with an empty `Entries` property.  
 
 * **Exceptions**  
   Exceptions are not generated.  


### PR DESCRIPTION
Related issue: [RDoc-2570](https://issues.hibernatingrhinos.com/issue/RDoc-2570/Document-StatefulTimestampValue-reflecting-unique-values)