### PR TITLE
Update Smuggler import/Export data for versions 5.4 and 6.0 (C# only)

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
@@ -1,0 +1,108 @@
+﻿# What is Smuggler
+
+Smuggler gives you the ability to export or import data from or to a database using JSON format.  
+It is exposed via the `DocumentStore.Smuggler` property.
+
+{PANEL:ForDatabase}
+
+By default, the `DocumentStore.Smuggler` works on the default document store database from the `DocumentStore.Database` property. 
+
+In order to switch it to a different database use the `.ForDatabase` method.
+
+{CODE for_database@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+{PANEL/}
+
+{PANEL:Export}
+
+### Syntax
+
+{CODE export_syntax@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerexportoptions). |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
+| **toFile** | `string` | Path to a file where exported data will be written |
+| **token** | `CancellationToken` | Token used to cancel the operation |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerExportOptions
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+
+### Example
+
+{CODE export_example@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+{PANEL/}
+
+{PANEL:Import}
+
+### Syntax
+
+{CODE import_syntax@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerimportoptions). |
+| **stream** | `Stream` | Stream with data to import |
+| **fromFile** | `string` | Path to a file from which data will be imported |
+| **token** | `CancellationToken` | Token used to cancel the operation |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerImportOptions
+
+| Parameters | | |
+| - | - | - |
+| **Collections** | `List<string>` | List specific of collections to import. If empty then all collections will be imported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+
+### Example
+
+{CODE import_example@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+{PANEL/}
+
+{PANEL:TransformScript}
+
+`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+
+Underneath the JavaScript engine is exactly the same as used for [patching operations](../../client-api/operations/patching/single-document) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+
+{CODE-BLOCK:javascript}
+var id = this['@metadata']['@id'];
+if (id === 'orders/999-A')
+    throw 'skip'; // filter-out
+
+this.Freight = 15.3;
+{CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles
+
+### Studio
+
+- [Backup Task](../../studio/database/tasks/backup-task)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
@@ -34,14 +34,14 @@ In order to switch it to a different database use the `.ForDatabase` method.
 
 | Parameters | | |
 | ------------- | ------------- | ----- |
-| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh` |
-| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. <br> Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. <br> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. <br> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. <br> Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. <br> Default: `false` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br> Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. <br> Default: **10000** |
 
 ### Example
 
@@ -70,14 +70,14 @@ In order to switch it to a different database use the `.ForDatabase` method.
 
 | Parameters | | |
 | - | - | - |
-| **Collections** | `List<string>` | List specific of collections to import. If empty then all collections will be imported. Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh` |
-| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **Collections** | `List<string>` | List specific of collections to import. If empty then all collections will be imported. <br> Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. <br> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. <br> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. <br> Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. <br> Default: `false` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br> Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. <br> Default: **10000** |
 
 ### Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.java.markdown
@@ -1,0 +1,105 @@
+﻿# What is Smuggler
+
+Smuggler gives you the ability to export or import data from or to a database using JSON format.  
+It is exposed via the `DocumentStore.smuggler()`.
+
+{PANEL:ForDatabase}
+
+By default, the `IDocumentStore.smuggler` works on the default document store database from the `IDocumentStore.database` property. 
+
+In order to switch it to a different database use the `.forDatabase` method.
+
+{CODE:java for_database@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+{PANEL/}
+
+{PANEL:Export}
+
+### Syntax
+
+{CODE:java export_syntax@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerexportoptions). |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
+| **toFile** | `String` | Path to a file where exported data will be written |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerExportOptions
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **Collections** | `List<String>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **operateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `Identities`, `CompareExchange`, `Subscriptions` |
+| **operateOnDatabaseRecordType** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications` |
+| **includeExpired** | `boolean` | Should expired documents be included in the export. Default: `true` |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `String` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+
+### Example
+
+{CODE:java export_example@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+{PANEL/}
+
+{PANEL:Import}
+
+### Syntax
+
+{CODE:java import_syntax@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerimportoptions). |
+| **stream** | `InputStream` | Stream with data to import |
+| **fromFile** | `String` | Path to a file from which data will be imported |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerImportOptions
+
+| Parameters | | |
+| - | - | - |
+| **Collections** | `List<String>` | List of specific collections to import. If empty, then all collections will be exported. Default: `empty` |
+| **operateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `INDEXES`, `DOCUMENTS`, `REVISION_DOCUMENTS`, `CONFLICTS`, `DATABASE_RECORD`, `IDENTITIES`, `COMPARE_EXCHANGE`, `SUBSCRIPTIONS` |
+| **operateOnDatabaseRecordType** | `DatabaseRecordItemType` | Indicates what should be imported. Default: `CLIENT`, `CONFLICT_SOLVER_CONFIG`, `EXPIRATION`, `EXTERNAL_REPLICATIONS`, `PERIODIC_BACKUPS`, `RAVEN_CONNECTION_STRINGS`, `RAVEN_ETLS`, `REVISIONS`, `SQL_CONNECTION_STRINGS`, `SORTERS`, `SQL_ETLS`, `HUB_PULL_REPLICATIONS`, `SINK_PULL_REPLICATIONS` |
+| **includeExpired** | `boolean` | Should expired documents be included in the import. Default: `true` |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `String` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+
+
+### Example
+
+{CODE:java import_example@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+{PANEL/}
+
+{PANEL:TransformScript}
+
+`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+
+Underneath the JavaScript engine is exactly the same as used for [patching operations](../../client-api/operations/patching/single-document) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+
+{CODE-BLOCK:javascript}
+var id = this['@metadata']['@id'];
+if (id === 'orders/999-A')
+    throw 'skip'; // filter-out
+
+this.Freight = 15.3;
+{CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles
+
+### Studio
+
+- [Backup Task](../../studio/database/tasks/backup-task)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.js.markdown
@@ -1,0 +1,109 @@
+﻿# What is Smuggler
+
+Smuggler gives you the ability to export or import data from or to a database using JSON format.  
+It is exposed via the `DocumentStore.smuggler`.
+
+{PANEL:ForDatabase}
+
+By default, the `DocumentStore.smuggler` works on the default document store database from the `DocumentStore.database` . 
+
+In order to switch it to a different database use the `.forDatabase` method.
+
+{CODE:nodejs for_database@client-api\smuggler\WhatIsSmuggler.js /}
+
+{PANEL/}
+
+{PANEL:Export}
+
+### Usage
+
+{CODE:nodejs export_syntax@client-api\smuggler\WhatIsSmuggler.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerexportoptions). |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
+| **toFile** | `string` | Path to a file where exported data will be written |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerExportOptions
+
+| Parameters | | |
+| - | - | - |
+| **collections** | ` string[]` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **operateOnTypes** | `DatabaseItemType[]` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `Identities`, `CompareExchange`, `Subscriptions` |
+| **operateOnDatabaseRecordTypes** | `DatabaseRecordItemType[]` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications` |
+| **includeExpired** | `boolean` | Should expired documents be included in the export. Default: `true` |
+| **includeArtificial** | `boolean` | ? |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `number` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+| **skipRevisionCreation** | `boolean` | skip revision creation |
+| **encryptionKey** | `string` | Encryption key used for restore |
+
+### Example
+
+{CODE:nodejs export_example@client-api\smuggler\WhatIsSmuggler.js /}
+
+{PANEL/}
+
+{PANEL:Import}
+
+### Usage
+
+{CODE:nodejs import_syntax@client-api\smuggler\WhatIsSmuggler.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerimportoptions). |
+| **stream** | `Stream` | Stream with data to import |
+| **fromFile** | `string` | Path to a file from which data will be imported |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerImportOptions
+
+| Parameters | | |
+| - | - | - |
+| **operateOnTypes** | `DatabaseItemType[]` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `Identities`, `CompareExchange`, `Subscriptions` |
+| **operateOnDatabaseRecordTypes** | `DatabaseRecordItemType[]` | Indicates what should be imported. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications` |
+| **includeExpired** | `boolean` | Should expired documents be included in the import. Default: `true` |
+| **includeArtificial** | `boolean` | ? |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `number` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+| **skipRevisionCreation** | `boolean` | skip revision creation |
+| **encryptionKey** | `string` | Encryption key used for restore |
+
+### Example
+
+{CODE:nodejs import_example@client-api\smuggler\WhatIsSmuggler.js /}
+
+{PANEL/}
+
+{PANEL:TransformScript}
+
+`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+
+Underneath the JavaScript engine is exactly the same as used for [patching operations](../../client-api/operations/patching/single-document) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+
+{CODE-BLOCK:javascript}
+var id = this['@metadata']['@id'];
+if (id === 'orders/999-A')
+    throw 'skip'; // filter-out
+
+this.Freight = 15.3;
+{CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles
+
+### Studio
+
+- [Backup Task](../../studio/database/tasks/backup-task)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Smuggler/WhatIsSmuggler.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Smuggler/WhatIsSmuggler.cs
@@ -1,0 +1,91 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Smuggler;
+
+namespace Raven.Documentation.Samples.ClientApi.Smuggler
+{
+    public class WhatIsSmuggler
+    {
+        private interface IFoo
+        {
+            #region export_syntax
+            Task<Operation> ExportAsync(
+                DatabaseSmugglerExportOptions options,
+                DatabaseSmuggler toDatabase,
+                CancellationToken token = default(CancellationToken));
+
+            Task<Operation> ExportAsync(
+                DatabaseSmugglerExportOptions options,
+                string toFile,
+                CancellationToken token = default(CancellationToken));
+            #endregion
+
+            #region import_syntax
+            Task<Operation> ImportAsync(
+                DatabaseSmugglerImportOptions options,
+                Stream stream,
+                CancellationToken token = default(CancellationToken));
+
+            Task<Operation> ImportAsync(
+                DatabaseSmugglerImportOptions options,
+                string fromFile,
+                CancellationToken token = default(CancellationToken));
+            #endregion
+
+            Task ImportIncrementalAsync(
+                DatabaseSmugglerImportOptions options,
+                string fromDirectory,
+                CancellationToken token = default(CancellationToken));
+
+        }
+
+        public async Task Sample()
+        {
+            var token = new CancellationToken();
+
+            using (var store = new DocumentStore())
+            {
+                #region for_database
+                var northwindSmuggler = store
+                    .Smuggler
+                    .ForDatabase("Northwind");
+                #endregion
+
+                #region export_example
+                // export only Indexes and Documents to a given file
+                var exportOperation = await store
+                    .Smuggler
+                    .ExportAsync(
+                        new DatabaseSmugglerExportOptions
+                        {
+                            OperateOnTypes = DatabaseItemType.Indexes
+                                             | DatabaseItemType.Documents
+                        },
+                        @"C:\ravendb-exports\Northwind.ravendbdump",
+                        token);
+
+                await exportOperation.WaitForCompletionAsync();
+                #endregion
+
+                #region import_example
+                // import only Documents from a given file
+                var importOperation = await store
+                    .Smuggler
+                    .ImportAsync(
+                        new DatabaseSmugglerImportOptions
+                        {
+                            OperateOnTypes = DatabaseItemType.Documents
+                        },
+                        // import the .ravendbdump file that you exported (i.e. in the export example above)
+                        @"C:\ravendb-exports\Northwind.ravendbdump",
+                        token);
+
+                await importOperation.WaitForCompletionAsync();
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Smuggler/WhatIsSmuggler.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Smuggler/WhatIsSmuggler.java
@@ -1,0 +1,63 @@
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.Operation;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.client.documents.smuggler.DatabaseSmuggler;
+import net.ravendb.client.documents.smuggler.*;
+
+import java.io.IOException;
+
+public class SmugglerSample {
+
+    public static void main (String[] args){
+        try (IDocumentStore store = new DocumentStore( new String[]{ "http://localhost:8080" }, "Northwind")) {
+            store.initialize();
+            DatabaseSmugglerExportOptions exportOptions;
+            DatabaseSmugglerImportOptions importOptions;
+            String toFile;
+            DatabaseSmuggler toDatabase;
+            String fromFile;
+
+            try (IDocumentSession session = store.openSession()) {
+                /*
+                Employee employee1 = session.load(Employee.class, "employees/1-A");
+                Employee employee2 = session.load(Employee.class, "employees/1-A");
+                // because NoTracking is set to 'true'
+                // each load will create a new Employee instance
+                Assert.assertNotSame(employee1, employee2);
+                 */
+                //region for_database
+                DatabaseSmuggler northwindSmuggler = store.smuggler().forDatabase("Northwind");
+                //endregion
+
+                DatabaseSmugglerExportOptions smugglerExportOptions = null;
+                exportOptions = null;
+                importOptions = null;
+
+                //region export_syntax
+                //export
+                public Operation exportAsync(DatabaseSmugglerExportOptions options, String toFile);
+
+                public Operation exportAsync(DatabaseSmugglerExportOptions options, DatabaseSmuggler toDatabase);
+                //endregion
+                //region export_example
+                // export only Indexes and Documents to a given file
+                Operation exportOperation = store.smuggler().exportAsync(exportOptions, "C:\\ravendb-exports\\Northwind.ravendbdump");
+                //endregion
+
+                //region import_syntax
+                public Operation importAsync(DatabaseSmugglerImportOptions options, String fromFile);
+                public Operation importAsync(DatabaseSmugglerImportOptions options, InputStream stream);
+                //endregion
+
+                //region import_example
+                Operation importOperation = store.smuggler().importAsync(importOptions, "C:\\ravendb-exports\\Northwind.ravendbdump");
+                //endregion
+
+
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/smuggler/WhatIsSmuggler.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/smuggler/WhatIsSmuggler.js
@@ -1,0 +1,65 @@
+import { IDocumentStore } from "../IDocumentStore";
+import { StringUtil } from "../../Utility/StringUtil";
+import { DatabaseSmugglerImportOptions } from "./DatabaseSmugglerImportOptions";
+import { throwError } from "../../Exceptions";
+import { HttpRequestParameters, HttpResponse } from "../../Primitives/Http";
+import { DatabaseSmugglerExportOptions } from "./DatabaseSmugglerExportOptions";
+import { HttpCache } from "../../Http/HttpCache";
+import { HeadersBuilder } from "../../Utility/HttpUtil";
+import { DatabaseSmugglerOptions } from "./DatabaseSmugglerOptions";
+import * as fs from "fs";
+import * as StreamUtil from "../../Utility/StreamUtil";
+import { LengthUnawareFormData } from "../../Utility/LengthUnawareFormData";
+import * as path from "path";
+import { BackupUtils } from "./BackupUtils";
+import { RequestExecutor } from "../../Http/RequestExecutor";
+import { OperationCompletionAwaiter } from "../Operations/OperationCompletionAwaiter";
+import { GetNextOperationIdCommand } from "../Commands/GetNextOperationIdCommand";
+import { RavenCommand, ResponseDisposeHandling } from "../../Http/RavenCommand";
+import { DocumentConventions } from "../Conventions/DocumentConventions";
+import { ServerNode } from "../../Http/ServerNode";
+import { DatabaseSmuggler } from "../../Http/ServerNode";
+import {DocumentStore} from "ravendb";
+
+//document_store_creation
+const store = new DocumentStore(["http://localhost:8080"], "Northwind2");
+store.initialize();
+    //const session = store.openSession();
+
+const store1 = new DatabaseSmuggler();
+let toDatabase, toFile, fromFile, stream;
+
+
+//region for_database
+const northwindSmuggler = store
+    .smuggler
+    .forDatabase("Northwind");
+//endregion
+
+//region export_syntax
+const operation = await store.smuggler.export(options, toDatabase);
+
+const operation = await store.smuggler.export(options, toFile);
+//endregion
+
+//region export_example
+const options = new DatabaseSmugglerExportOptions();
+options.operateOnTypes = ["Documents"];
+const operation = await store
+    .smuggler
+    .export(options, "C:\\ravendb-exports\\Northwind.ravendbdump");
+await operation.waitForCompletion();
+//endregion
+
+//region import_syntax
+const operation = await store.smuggler.import(options, fromFile);
+
+const operation = await store.smuggler.import(options, stream);
+//endregion 
+
+//region import_example
+const options = new DatabaseSmugglerImportOptions();
+options.operateOnTypes = ["Documents"];
+const operation = await store.smuggler.import(options, "C:\\ravendb-exports\\Northwind.ravendbdump");
+await operation.waitForCompletion();
+//endregion

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
@@ -34,15 +34,15 @@ In order to switch it to a different database use the `.ForDatabase` method.
 
 | Parameters | | |
 | ------------- | ------------- | ----- |
-| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be exported. Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be exported. Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be exported. Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. <br> Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. <br> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. <br> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be exported. <br> Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be exported. <br> Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be exported. <br> Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br> Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: 10000 |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br> Default: **10000** |
 
 ### Example
 
@@ -71,15 +71,15 @@ In order to switch it to a different database use the `.ForDatabase` method.
 
 | Parameters | | |
 | - | - | - |
-| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be imported. Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. <br> Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. <br> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. <br> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. <br> Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. <br> Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be imported. <br> Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br> Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: 10000 |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br> Default: **10000** |
 
 ### Example
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.dotnet.markdown
@@ -1,0 +1,110 @@
+﻿# What is Smuggler
+
+Smuggler gives you the ability to export or import data from or to a database using JSON format.  
+It is exposed via the `DocumentStore.Smuggler` property.
+
+{PANEL:ForDatabase}
+
+By default, the `DocumentStore.Smuggler` works on the default document store database from the `DocumentStore.Database` property. 
+
+In order to switch it to a different database use the `.ForDatabase` method.
+
+{CODE for_database@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+{PANEL/}
+
+{PANEL:Export}
+
+### Syntax
+
+{CODE export_syntax@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerexportoptions). |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
+| **toFile** | `string` | Path to a file where exported data will be written |
+| **token** | `CancellationToken` | Token used to cancel the operation |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerExportOptions
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be exported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be exported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be exported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: 10000 |
+
+### Example
+
+{CODE export_example@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+{PANEL/}
+
+{PANEL:Import}
+
+### Syntax
+
+{CODE import_syntax@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerimportoptions). |
+| **stream** | `Stream` | Stream with data to import |
+| **fromFile** | `string` | Path to a file from which data will be imported |
+| **token** | `CancellationToken` | Token used to cancel the operation |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerImportOptions
+
+| Parameters | | |
+| - | - | - |
+| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be imported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
+| **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: 10000 |
+
+### Example
+
+{CODE import_example@ClientApi\Smuggler\WhatIsSmuggler.cs /}
+
+{PANEL/}
+
+{PANEL:TransformScript}
+
+`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+
+Underneath the JavaScript engine is exactly the same as used for [patching operations](../../client-api/operations/patching/single-document) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+
+{CODE-BLOCK:javascript}
+var id = this['@metadata']['@id'];
+if (id === 'orders/999-A')
+    throw 'skip'; // filter-out
+
+this.Freight = 15.3;
+{CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles
+
+### Studio
+
+- [Backup Task](../../studio/database/tasks/backup-task)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.java.markdown
@@ -1,0 +1,105 @@
+﻿# What is Smuggler
+
+Smuggler gives you the ability to export or import data from or to a database using JSON format.  
+It is exposed via the `DocumentStore.smuggler()`.
+
+{PANEL:ForDatabase}
+
+By default, the `IDocumentStore.smuggler` works on the default document store database from the `IDocumentStore.database` property. 
+
+In order to switch it to a different database use the `.forDatabase` method.
+
+{CODE:java for_database@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+{PANEL/}
+
+{PANEL:Export}
+
+### Syntax
+
+{CODE:java export_syntax@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerexportoptions). |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
+| **toFile** | `String` | Path to a file where exported data will be written |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerExportOptions
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **Collections** | `List<String>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **operateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `Identities`, `CompareExchange`, `Subscriptions` |
+| **operateOnDatabaseRecordType** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications` |
+| **includeExpired** | `boolean` | Should expired documents be included in the export. Default: `true` |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `String` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+
+### Example
+
+{CODE:java export_example@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+{PANEL/}
+
+{PANEL:Import}
+
+### Syntax
+
+{CODE:java import_syntax@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerimportoptions). |
+| **stream** | `InputStream` | Stream with data to import |
+| **fromFile** | `String` | Path to a file from which data will be imported |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerImportOptions
+
+| Parameters | | |
+| - | - | - |
+| **Collections** | `List<String>` | List of specific collections to import. If empty, then all collections will be exported. Default: `empty` |
+| **operateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `INDEXES`, `DOCUMENTS`, `REVISION_DOCUMENTS`, `CONFLICTS`, `DATABASE_RECORD`, `IDENTITIES`, `COMPARE_EXCHANGE`, `SUBSCRIPTIONS` |
+| **operateOnDatabaseRecordType** | `DatabaseRecordItemType` | Indicates what should be imported. Default: `CLIENT`, `CONFLICT_SOLVER_CONFIG`, `EXPIRATION`, `EXTERNAL_REPLICATIONS`, `PERIODIC_BACKUPS`, `RAVEN_CONNECTION_STRINGS`, `RAVEN_ETLS`, `REVISIONS`, `SQL_CONNECTION_STRINGS`, `SORTERS`, `SQL_ETLS`, `HUB_PULL_REPLICATIONS`, `SINK_PULL_REPLICATIONS` |
+| **includeExpired** | `boolean` | Should expired documents be included in the import. Default: `true` |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `String` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `int` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+
+
+### Example
+
+{CODE:java import_example@ClientApi\Smuggler\WhatIsSmuggler.java /}
+
+{PANEL/}
+
+{PANEL:TransformScript}
+
+`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+
+Underneath the JavaScript engine is exactly the same as used for [patching operations](../../client-api/operations/patching/single-document) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+
+{CODE-BLOCK:javascript}
+var id = this['@metadata']['@id'];
+if (id === 'orders/999-A')
+    throw 'skip'; // filter-out
+
+this.Freight = 15.3;
+{CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles
+
+### Studio
+
+- [Backup Task](../../studio/database/tasks/backup-task)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/smuggler/what-is-smuggler.js.markdown
@@ -1,0 +1,109 @@
+﻿# What is Smuggler
+
+Smuggler gives you the ability to export or import data from or to a database using JSON format.  
+It is exposed via the `DocumentStore.smuggler`.
+
+{PANEL:ForDatabase}
+
+By default, the `DocumentStore.smuggler` works on the default document store database from the `DocumentStore.database` . 
+
+In order to switch it to a different database use the `.forDatabase` method.
+
+{CODE:nodejs for_database@client-api\smuggler\WhatIsSmuggler.js /}
+
+{PANEL/}
+
+{PANEL:Export}
+
+### Usage
+
+{CODE:nodejs export_syntax@client-api\smuggler\WhatIsSmuggler.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerexportoptions). |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
+| **toFile** | `string` | Path to a file where exported data will be written |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerExportOptions
+
+| Parameters | | |
+| - | - | - |
+| **collections** | ` string[]` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **operateOnTypes** | `DatabaseItemType[]` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `Identities`, `CompareExchange`, `Subscriptions` |
+| **operateOnDatabaseRecordTypes** | `DatabaseRecordItemType[]` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications` |
+| **includeExpired** | `boolean` | Should expired documents be included in the export. Default: `true` |
+| **includeArtificial** | `boolean` | ? |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `number` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+| **skipRevisionCreation** | `boolean` | skip revision creation |
+| **encryptionKey** | `string` | Encryption key used for restore |
+
+### Example
+
+{CODE:nodejs export_example@client-api\smuggler\WhatIsSmuggler.js /}
+
+{PANEL/}
+
+{PANEL:Import}
+
+### Usage
+
+{CODE:nodejs import_syntax@client-api\smuggler\WhatIsSmuggler.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../client-api/smuggler/what-is-smuggler#databasesmugglerimportoptions). |
+| **stream** | `Stream` | Stream with data to import |
+| **fromFile** | `string` | Path to a file from which data will be imported |
+
+| Return Value | | 
+| ------------- | ----- |
+| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+
+### DatabaseSmugglerImportOptions
+
+| Parameters | | |
+| - | - | - |
+| **operateOnTypes** | `DatabaseItemType[]` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `Identities`, `CompareExchange`, `Subscriptions` |
+| **operateOnDatabaseRecordTypes** | `DatabaseRecordItemType[]` | Indicates what should be imported. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications` |
+| **includeExpired** | `boolean` | Should expired documents be included in the import. Default: `true` |
+| **includeArtificial** | `boolean` | ? |
+| **removeAnalyzers** | `boolean` | Should analyzers be removed from Indexes. Default: `false` |
+| **transformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../client-api/smuggler/what-is-smuggler#transformscript). |
+| **maxStepsForTransformScript** | `number` | Maximum number of steps that transform script can process before failing. Default: 10000 |
+| **skipRevisionCreation** | `boolean` | skip revision creation |
+| **encryptionKey** | `string` | Encryption key used for restore |
+
+### Example
+
+{CODE:nodejs import_example@client-api\smuggler\WhatIsSmuggler.js /}
+
+{PANEL/}
+
+{PANEL:TransformScript}
+
+`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+
+Underneath the JavaScript engine is exactly the same as used for [patching operations](../../client-api/operations/patching/single-document) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+
+{CODE-BLOCK:javascript}
+var id = this['@metadata']['@id'];
+if (id === 'orders/999-A')
+    throw 'skip'; // filter-out
+
+this.Freight = 15.3;
+{CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles
+
+### Studio
+
+- [Backup Task](../../studio/database/tasks/backup-task)

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Smuggler/WhatIsSmuggler.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Smuggler/WhatIsSmuggler.cs
@@ -1,0 +1,91 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Smuggler;
+
+namespace Raven.Documentation.Samples.ClientApi.Smuggler
+{
+    public class WhatIsSmuggler
+    {
+        private interface IFoo
+        {
+            #region export_syntax
+            Task<Operation> ExportAsync(
+                DatabaseSmugglerExportOptions options,
+                DatabaseSmuggler toDatabase,
+                CancellationToken token = default(CancellationToken));
+
+            Task<Operation> ExportAsync(
+                DatabaseSmugglerExportOptions options,
+                string toFile,
+                CancellationToken token = default(CancellationToken));
+            #endregion
+
+            #region import_syntax
+            Task<Operation> ImportAsync(
+                DatabaseSmugglerImportOptions options,
+                Stream stream,
+                CancellationToken token = default(CancellationToken));
+
+            Task<Operation> ImportAsync(
+                DatabaseSmugglerImportOptions options,
+                string fromFile,
+                CancellationToken token = default(CancellationToken));
+            #endregion
+
+            Task ImportIncrementalAsync(
+                DatabaseSmugglerImportOptions options,
+                string fromDirectory,
+                CancellationToken token = default(CancellationToken));
+
+        }
+
+        public async Task Sample()
+        {
+            var token = new CancellationToken();
+
+            using (var store = new DocumentStore())
+            {
+                #region for_database
+                var northwindSmuggler = store
+                    .Smuggler
+                    .ForDatabase("Northwind");
+                #endregion
+
+                #region export_example
+                // export only Indexes and Documents to a given file
+                var exportOperation = await store
+                    .Smuggler
+                    .ExportAsync(
+                        new DatabaseSmugglerExportOptions
+                        {
+                            OperateOnTypes = DatabaseItemType.Indexes
+                                             | DatabaseItemType.Documents
+                        },
+                        @"C:\ravendb-exports\Northwind.ravendbdump",
+                        token);
+
+                await exportOperation.WaitForCompletionAsync();
+                #endregion
+
+                #region import_example
+                // import only Documents from a given file
+                var importOperation = await store
+                    .Smuggler
+                    .ImportAsync(
+                        new DatabaseSmugglerImportOptions
+                        {
+                            OperateOnTypes = DatabaseItemType.Documents
+                        },
+                        // import the .ravendbdump file that you exported (i.e. in the export example above)
+                        @"C:\ravendb-exports\Northwind.ravendbdump",
+                        token);
+
+                await importOperation.WaitForCompletionAsync();
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/Smuggler/WhatIsSmuggler.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/Smuggler/WhatIsSmuggler.java
@@ -1,0 +1,63 @@
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.Operation;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.client.documents.smuggler.DatabaseSmuggler;
+import net.ravendb.client.documents.smuggler.*;
+
+import java.io.IOException;
+
+public class SmugglerSample {
+
+    public static void main (String[] args){
+        try (IDocumentStore store = new DocumentStore( new String[]{ "http://localhost:8080" }, "Northwind")) {
+            store.initialize();
+            DatabaseSmugglerExportOptions exportOptions;
+            DatabaseSmugglerImportOptions importOptions;
+            String toFile;
+            DatabaseSmuggler toDatabase;
+            String fromFile;
+
+            try (IDocumentSession session = store.openSession()) {
+                /*
+                Employee employee1 = session.load(Employee.class, "employees/1-A");
+                Employee employee2 = session.load(Employee.class, "employees/1-A");
+                // because NoTracking is set to 'true'
+                // each load will create a new Employee instance
+                Assert.assertNotSame(employee1, employee2);
+                 */
+                //region for_database
+                DatabaseSmuggler northwindSmuggler = store.smuggler().forDatabase("Northwind");
+                //endregion
+
+                DatabaseSmugglerExportOptions smugglerExportOptions = null;
+                exportOptions = null;
+                importOptions = null;
+
+                //region export_syntax
+                //export
+                public Operation exportAsync(DatabaseSmugglerExportOptions options, String toFile);
+
+                public Operation exportAsync(DatabaseSmugglerExportOptions options, DatabaseSmuggler toDatabase);
+                //endregion
+                //region export_example
+                // export only Indexes and Documents to a given file
+                Operation exportOperation = store.smuggler().exportAsync(exportOptions, "C:\\ravendb-exports\\Northwind.ravendbdump");
+                //endregion
+
+                //region import_syntax
+                public Operation importAsync(DatabaseSmugglerImportOptions options, String fromFile);
+                public Operation importAsync(DatabaseSmugglerImportOptions options, InputStream stream);
+                //endregion
+
+                //region import_example
+                Operation importOperation = store.smuggler().importAsync(importOptions, "C:\\ravendb-exports\\Northwind.ravendbdump");
+                //endregion
+
+
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/Documentation/6.0/Samples/nodejs/client-api/smuggler/WhatIsSmuggler.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/smuggler/WhatIsSmuggler.js
@@ -1,0 +1,65 @@
+import { IDocumentStore } from "../IDocumentStore";
+import { StringUtil } from "../../Utility/StringUtil";
+import { DatabaseSmugglerImportOptions } from "./DatabaseSmugglerImportOptions";
+import { throwError } from "../../Exceptions";
+import { HttpRequestParameters, HttpResponse } from "../../Primitives/Http";
+import { DatabaseSmugglerExportOptions } from "./DatabaseSmugglerExportOptions";
+import { HttpCache } from "../../Http/HttpCache";
+import { HeadersBuilder } from "../../Utility/HttpUtil";
+import { DatabaseSmugglerOptions } from "./DatabaseSmugglerOptions";
+import * as fs from "fs";
+import * as StreamUtil from "../../Utility/StreamUtil";
+import { LengthUnawareFormData } from "../../Utility/LengthUnawareFormData";
+import * as path from "path";
+import { BackupUtils } from "./BackupUtils";
+import { RequestExecutor } from "../../Http/RequestExecutor";
+import { OperationCompletionAwaiter } from "../Operations/OperationCompletionAwaiter";
+import { GetNextOperationIdCommand } from "../Commands/GetNextOperationIdCommand";
+import { RavenCommand, ResponseDisposeHandling } from "../../Http/RavenCommand";
+import { DocumentConventions } from "../Conventions/DocumentConventions";
+import { ServerNode } from "../../Http/ServerNode";
+import { DatabaseSmuggler } from "../../Http/ServerNode";
+import {DocumentStore} from "ravendb";
+
+//document_store_creation
+const store = new DocumentStore(["http://localhost:8080"], "Northwind2");
+store.initialize();
+    //const session = store.openSession();
+
+const store1 = new DatabaseSmuggler();
+let toDatabase, toFile, fromFile, stream;
+
+
+//region for_database
+const northwindSmuggler = store
+    .smuggler
+    .forDatabase("Northwind");
+//endregion
+
+//region export_syntax
+const operation = await store.smuggler.export(options, toDatabase);
+
+const operation = await store.smuggler.export(options, toFile);
+//endregion
+
+//region export_example
+const options = new DatabaseSmugglerExportOptions();
+options.operateOnTypes = ["Documents"];
+const operation = await store
+    .smuggler
+    .export(options, "C:\\ravendb-exports\\Northwind.ravendbdump");
+await operation.waitForCompletion();
+//endregion
+
+//region import_syntax
+const operation = await store.smuggler.import(options, fromFile);
+
+const operation = await store.smuggler.import(options, stream);
+//endregion 
+
+//region import_example
+const options = new DatabaseSmugglerImportOptions();
+options.operateOnTypes = ["Documents"];
+const operation = await store.smuggler.import(options, "C:\\ravendb-exports\\Northwind.ravendbdump");
+await operation.waitForCompletion();
+//endregion


### PR DESCRIPTION
Related issues: 
[RDoc-2568](https://issues.hibernatingrhinos.com/issue/RDoc-2568/Document-the-API-for-including-index-history-in-smuggler-Export)
[RDoc-2410](https://issues.hibernatingrhinos.com/issue/RDoc-2410/Smuggler-page-Add-missing-info)