### PR TITLE
RDoc-2606 - `Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved` default value

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -3,7 +3,7 @@
 
 {NOTE: }
 
-* The following __indexing configuration keys__ can modified via either of the following options:
+* The below **indexing configuration keys** can be modified via any of the following methods:
     * As explained in the [Config overview](../../server/configuration/configuration-options) article
     * Set a custom configuration per index from the [Client API](../../indexes/creating-and-deploying#creating-an-index-with-custom-configuration)
     * Set a custom configuration per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -843,7 +843,7 @@ When sorting in descending order, null dates are returned at the end with this o
 - **Type**: `bool`
 - **Default**: `true`
   {NOTE: }
-  **Note** that the default value for this configuration key was changed in version 6.0 from `false` to `true` 
+  **Note** that the default value for this configuration key has changed in version 6.0 from `false` to `true` 
   {NOTE/}
 - **Scope**: Server-wide, or per database, or per index
 

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/indexing-configuration.markdown
@@ -3,7 +3,7 @@
 
 {NOTE: }
 
-* The following __indexing configuration keys__ can modified via either of the following options:
+* The below **indexing configuration keys** can be modified via any of the following methods:
     * As explained in the [Config overview](../../server/configuration/configuration-options) article
     * Set a custom configuration per index from the [Client API](../../indexes/creating-and-deploying#creating-an-index-with-custom-configuration)
     * Set a custom configuration per index from the [Studio](../../studio/database/indexes/create-map-index#configuration)
@@ -841,7 +841,10 @@ Sort by ticks when field contains dates.
 When sorting in descending order, null dates are returned at the end with this option enabled.
 
 - **Type**: `bool`
-- **Default**: `false`
+- **Default**: `true`
+  {NOTE: }
+  **Note** that the default value for this configuration key was changed in version 6.0 from `false` to `true` 
+  {NOTE/}
 - **Scope**: Server-wide, or per database, or per index
 
 {PANEL/}


### PR DESCRIPTION
Related issues:
[RDoc-2605](https://issues.hibernatingrhinos.com/issue/RDoc-2605/Document-ordering-by-ticks-when-field-contains-dates) - `Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved`
[RDoc-2606](https://issues.hibernatingrhinos.com/issue/RDoc-2606/Document-changing-Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved-default-value-to-true) - Document breaking change in default value