### PR TITLE
RDoc-2567 + RDoc-2595 Configuration Conventions

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -1,218 +1,758 @@
 # Conventions
 
-* **Conventions** are adjustable RavenDB settings that users 
-  can configure to modify client behaviors by their preferences.  
-* Access conventions through the `DocumentStore` object 
-  `Conventions` property.  
+{NOTE: }
 
+* __Conventions__ in RavenDB are customizable settings that users can configure to tailor client behaviors according to their preferences.
+ 
 * In this page:  
-   * [Client Conventions](../../client-api/configuration/conventions#client-conventions)  
-   * [MaxHttpCacheSize](../../client-api/configuration/conventions#maxhttpcachesize)  
-   * [MaxNumberOfRequestsPerSession](../../client-api/configuration/conventions#maxnumberofrequestspersession)  
-   * [UseOptimisticConcurrency](../../client-api/configuration/conventions#useoptimisticconcurrency)  
-   * [RequestTimeout](../../client-api/configuration/conventions#requesttimeout)  
-   * [DisableTopologyUpdates](../../client-api/configuration/conventions#disabletopologyupdates)  
-   * [SaveEnumsAsIntegers](../../client-api/configuration/conventions#saveenumsasintegers)  
-   * [UseCompression](../../client-api/configuration/conventions#usecompression)  
-   * [OperationStatusFetchMode](../../client-api/configuration/conventions#operationstatusfetchmode)  
-   * [Change fields/properties Naming Convention](../../client-api/configuration/conventions#change-fieldsproperties-naming-convention)  
-   * [IdentityPartsSeparator](../../client-api/configuration/conventions#identitypartsseparator)  
-   * [TopologyCacheLocation](../../client-api/configuration/conventions#topologycachelocation)  
-   * [AddIdFieldToDynamicObjects](../../client-api/configuration/conventions#addidfieldtodynamicobjects)  
-   * [ShouldIgnoreEntityChanges](../../client-api/configuration/conventions#shouldignoreentitychanges)  
-   * [WaitForIndexesAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforindexesaftersavechangestimeout)  
-   * [WaitForReplicationAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforreplicationaftersavechangestimeout)  
-   * [WaitForNonStaleResultsTimeout](../../client-api/configuration/conventions#waitfornonstaleresultstimeout)  
-   * [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient)  
-   * [HttpClientType](../../client-api/configuration/conventions#httpclienttype)  
+  * [How to set conventions](../../client-api/configuration/conventions#how-to-set-conventions)  
+  * [Conventions:](../../client-api/configuration/conventions#conventions:)  
+      [AddIdFieldToDynamicObjects](../../client-api/configuration/conventions#addidfieldtodynamicobjects)  
+      [AggressiveCache.Duration](../../client-api/configuration/conventions#aggressivecache.duration)  
+      [AggressiveCache.Mode](../../client-api/configuration/conventions#aggressivecache.mode)  
+      [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient)  
+      [DisableAtomicDocumentWritesInClusterWideTransaction](../../client-api/configuration/conventions#disableatomicdocumentwritesinclusterwidetransaction)  
+      [DisableTcpCompression](../../client-api/configuration/conventions#disabletcpcompression)  
+      [DisableTopologyCache](../../client-api/configuration/conventions#disabletopologycache)  
+      [DisableTopologyUpdates](../../client-api/configuration/conventions#disabletopologyupdates)  
+      [FindClrType](../../client-api/configuration/conventions#findclrtype)  
+      [FindClrTypeName](../../client-api/configuration/conventions#findclrtypename)  
+      [FindClrTypeNameForDynamic](../../client-api/configuration/conventions#findclrtypenamefordynamic)  
+      [FindCollectionName](../../client-api/configuration/conventions#findcollectionname)  
+      [FindCollectionNameForDynamic](../../client-api/configuration/conventions#findcollectionnamefordynamic)  
+      [FindIdentityProperty](../../client-api/configuration/conventions#findidentityproperty)  
+      [FindIdentityPropertyNameFromCollectionName](../../client-api/configuration/conventions#findidentitypropertynamefromcollectionname)  
+      [FindProjectedPropertyNameForIndex](../../client-api/configuration/conventions#findprojectedpropertynameforindex)  
+      [FindPropertyNameForDynamicIndex](../../client-api/configuration/conventions#findpropertynamefordynamicindex)  
+      [FindPropertyNameForIndex](../../client-api/configuration/conventions#findpropertynameforindex)  
+      [FirstBroadcastAttemptTimeout](../../client-api/configuration/conventions#firstbroadcastattempttimeout)  
+      [HttpClientType](../../client-api/configuration/conventions#httpclienttype)  
+      [HttpVersion](../../client-api/configuration/conventions#httpversion)  
+      [IdentityPartsSeparator](../../client-api/configuration/conventions#identitypartsseparator)  
+      [LoadBalanceBehavior](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [LoadBalancerContextSeed](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [LoadBalancerPerSessionContextSelector](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [MaxHttpCacheSize](../../client-api/configuration/conventions#maxhttpcachesize)  
+      [MaxNumberOfRequestsPerSession](../../client-api/configuration/conventions#maxnumberofrequestspersession)  
+      [Modify serialization of property name](../../client-api/configuration/conventions#modify-serialization-of-property-name)  
+      [OperationStatusFetchMode](../../client-api/configuration/conventions#operationstatusfetchmode)  
+      [PreserveDocumentPropertiesNotFoundOnModel](../../client-api/configuration/conventions#preservedocumentpropertiesnotfoundonmodel)  
+      [ReadBalanceBehavior](../../client-api/configuration/conventions#readbalancebehavior)  
+      [RequestTimeout](../../client-api/configuration/conventions#requesttimeout)  
+      [ResolveTypeFromClrTypeName](../../client-api/configuration/conventions#resolvetypefromclrtypename)  
+      [SaveEnumsAsIntegers](../../client-api/configuration/conventions#saveenumsasintegers)  
+      [SecondBroadcastAttemptTimeout](../../client-api/configuration/conventions#secondbroadcastattempttimeout)  
+      [SendApplicationIdentifier](../../client-api/configuration/conventions#sendapplicationidentifier)  
+      [ShouldIgnoreEntityChanges](../../client-api/configuration/conventions#shouldignoreentitychanges)  
+      [ThrowIfQueryPageSizeIsNotSet](../../client-api/configuration/conventions#throwifquerypagesizeisnotset)  
+      [TopologyCacheLocation](../../client-api/configuration/conventions#topologycachelocation)  
+      [TransformTypeCollectionNameToDocumentIdPrefix](../../client-api/configuration/conventions#transformtypecollectionnametodocumentidprefix)  
+      [UseCompression](../../client-api/configuration/conventions#usecompression)  
+      [UseOptimisticConcurrency](../../client-api/configuration/conventions#useoptimisticconcurrency)  
+      [WaitForIndexesAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforindexesaftersavechangestimeout)  
+      [WaitForNonStaleResultsTimeout](../../client-api/configuration/conventions#waitfornonstaleresultstimeout)  
+      [WaitForReplicationAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforreplicationaftersavechangestimeout)  
 
-{PANEL: Client Conventions}
+{NOTE/}
 
-Access conventions via the `Conventions` property of the 
-`DocumentStore` object.  
+---
+
+{PANEL: How to set conventions}
+
+* Access the conventions via the `Conventions` property of the `DocumentStore` object.
+
+* The conventions set on a Document Store will apply to ALL [sessions](../../client-api/session/what-is-a-session-and-how-does-it-work) and [operations](../../client-api/operations/what-are-operations) associated with that store.
+ 
+* Customizing the conventions can only be set __before__ calling `DocumentStore.Initialize()`.  
+  Trying to do so after calling _Initialize()_ will throw an exception.
+
 {CODE conventions_1@ClientApi\Configuration\Conventions.cs /}
 
+{PANEL/}
+
+{PANEL: Conventions:}
+
 {NOTE: }
-Customize conventions **before** `DocumentStore.Initialize()` is called. 
+
+#### AddIdFieldToDynamicObjects
+
+---
+
+* Use the `AddIdFieldToDynamicObjects` convention to determine whether an `Id` field is automatically added  
+  to [dynamic objects](../../https://learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/interop/using-type-dynamic) when [storing new entities](../../client-api/session/storing-entities) via the session.
+ 
+* DEFAULT: `true`  
+
+{CODE AddIdFieldToDynamicObjectsSyntax@ClientApi\Configuration\Conventions.cs /}
+
 {NOTE/}
+{NOTE: }
 
-## MaxHttpCacheSize
+#### AggressiveCache.Duration
 
-Use `MaxHttpCacheSize` as follows to modify the maximum HTTP cache size.  
-{CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
+---
 
-**Default**:
+* Use the `AggressiveCache.Duration` convention to define the [aggressive cache](../../client-api/how-to/setup-aggressive-caching) duration period.
 
-| System | Usable Memory | Default Value |
-| -------| ------------- | ------------- |
-| 64-bit | Lower than or equal to 3GB <br> Greater than 3GB and Lower than or equal to 6GB <br> Greater than 6GB | 64MB <br> 128MB <br> 512MB |
-| 32-bit | | 32MB |
+* DEFAULT: `1 day`
 
-* Caching is set **per database**.  
-* **Disabling Caching**:  
-  To disable caching globally, set `MaxHttpCacheSize` to zero.
+{CODE AggressiveCacheDurationSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### AggressiveCache.Mode
+
+---
+
+* Use the `AggressiveCache.Mode` convention to define the [aggressive cache](../../client-api/how-to/setup-aggressive-caching) mode.  
+  (`AggressiveCacheMode.TrackChanges` or `AggressiveCacheMode.DoNotTrackChanges`)
+
+* DEFAULT: `AggressiveCacheMode.TrackChanges`
+
+{CODE AggressiveCacheModeSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### CreateHttpClient
+
+---
+
+* Use the `CreateHttpClient` convention to modify the HTTP client your client application uses.  
+ 
+* For example, implementing your own HTTP client can be useful when you'd like your clients to provide the server with tracing info.  
+
+* If you override the default `CreateHttpClient` convention we advise that you also set the HTTP client type  
+  correctly using the [HttpClientType](../../client-api/configuration/conventions#httpclienttype) convention.
+
+{CODE CreateHttpClient@ClientApi\Configuration\Conventions.cs /}
+{CODE CreateHttpClientSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableAtomicDocumentWritesInClusterWideTransaction
+
+---
+
+* EXPERT ONLY:   
+  Use the `DisableAtomicDocumentWritesInClusterWideTransaction` convention disable automatic  
+  atomic writes with cluster write transactions.
+
+* When set to `true`, will only consider explicitly added compare exchange values to validate cluster wide transactions.
+
+* DEFAULT: `false`
+
+{CODE DisableAtomicDocumentWritesInClusterWideTransactionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableTcpCompression
+
+---
+
+* When setting the `DisableTcpCompression` convention to `true`, TCP data will not be compressed.
+
+* DEFAULT: `false`
+
+{CODE DisableTcpCompressionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableTopologyCache
+
+---
+ 
+* When setting the `DisableTopologyCache` convention to `true`, the topology cache usage will be disabled.  
+  Even if the client is configured to receive topology updates from the server, no topology files will be saved on disk, 
+  thus preventing `*.raven-cluster-topology` files from piling up.  
+ 
+* In addition, when set to _true_, the client will not try to load the topology from the cache upon failing to connect to the server.
+ 
+* DEFAULT: `false`
+
+{CODE DisableTopologyCacheSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableTopologyUpdates
+
+---
+
+* When setting the `DisableTopologyUpdates` convention to `true`,  
+  no database topology updates will be sent from the server to the client (e.g. adding or removing a node).
+ 
+* DEFAULT: `false`
+
+{CODE DisableTopologyUpdatesSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindClrType
+
+---
+
+* Use the `FindClrType` convention to define a function that finds the CLR type of a document.  
+
+* DEFAULT:  
+  The CLR type is retrieved from the `Raven-Clr-Type` property under the `@metdata` key in the document. 
+
+{CODE FindClrType@ClientApi\Configuration\Conventions.cs /}
+{CODE FindClrTypeSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindClrTypeName
+
+---
+
+* Use the `FindClrTypeName` convention to define a function that returns the CLR type name from a given type.
+ 
+* DEFAULT: The entity's full name with the assembly name is returned.
+
+{CODE FindClrTypeNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindClrTypeNameForDynamic
+
+---
+
+* Use the `FindClrTypeNameForDynamic` convention to define a function that returns the CLR type name  
+  from a dynamic entity.
+
+* DEFAULT: The dynamic entity type is returned.
+
+{CODE FindClrTypeNameForDynamic@ClientApi\Configuration\Conventions.cs /}
+{CODE FindClrTypeNameForDynamicSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindCollectionName
+
+---
+
+* Use the `FindCollectionName` convention to define a function that will customize the collection name  
+  from given type.
+
+* DEFAULT: The collection name will be the plural form of the type name.
+
+{CODE FindCollectionName@ClientApi\Configuration\Conventions.cs /}
+{CODE FindCollectionNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindCollectionNameForDynamic
+
+---
+
+* Use the `FindCollectionNameForDynamic` convention to define a function that will customize the  
+  collection name from a dynamic type.
+
+* DEFAULT: The collection name will be the entity's type.
+
+{CODE FindCollectionNameForDynamic@ClientApi\Configuration\Conventions.cs /}
+{CODE FindCollectionNameForDynamicSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindIdentityProperty
+
+---
+
+* Use the `FindIdentityProperty` convention to define a function that finds the specified ID property  
+  in the entity.
+ 
+* DEFAULT: The entity's `Id` property serves as the ID property.
+
+{CODE FindIdentityProperty@ClientApi\Configuration\Conventions.cs /}
+{CODE FindIdentityPropertySyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindIdentityPropertyNameFromCollectionName
+
+---
+
+* Use the `FindIdentityPropertyNameFromCollectionName` convention to define a function that customizes  
+  the entity's ID property from the collection name.
+
+* DEFAULT: Will use the `Id` property.
+
+{CODE FindIdentityPropertyNameFromCollectionName@ClientApi\Configuration\Conventions.cs /}
+{CODE FindIdentityPropertyNameFromCollectionNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindProjectedPropertyNameForIndex
+
+---
+
+* Use the `FindProjectedPropertyNameForIndex` convention to define a function that customizes the  
+  projected fields names that will be used in the RQL sent to the server when querying an index.
+
+* Given input: The indexed document type, the index name, the current path, and the property path  
+  that is used in a query.
+
+* DEFAULT: `null`
+
+{CODE FindProjectedPropertyNameForIndexSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindPropertyNameForDynamicIndex
+
+---
+
+* Use the `FindPropertyNameForDynamicIndex` convention to define a function that customizes the  
+  property name that will be used in the RQL sent to the server when making a dynamic query.
+
+* Given input: The indexed document type, the index name, the current path, and the property path  
+  that is used in a query predicate.
+
+{CODE FindPropertyNameForDynamicIndex@ClientApi\Configuration\Conventions.cs /}
+{CODE FindPropertyNameForDynamicIndexSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindPropertyNameForIndex
+
+---
+
+* Use the `FindPropertyNameForIndex` convention to define a function that customizes the name of the  
+  index-field property that will be used in the RQL sent to the server when querying an index. 
+
+* Given input: The indexed document type, the index name, the current path, and the property path  
+  that is used in a query predicate.
+
+* DEFAULT: `[].` & `.` are replaced by `_`
+
+{CODE FindPropertyNameForIndex@ClientApi\Configuration\Conventions.cs /}
+{CODE FindPropertyNameForIndexSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FirstBroadcastAttemptTimeout
+
+---
+
+* Use the `FirstBroadcastAttemptTimeout` convention to set the timeout for the first broadcast attempt.  
+ 
+* In the first attempt, the request executor will send a single request to the selected node.  
+  Learn about the "selected node" in: [Client logic for choosing a node](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+ 
+* A [second attempt](../../client-api/configuration/conventions#secondbroadcastattempttimeout) will be held upon failure.
+ 
+* DEFAULT: `5 seconds`
+
+{CODE FirstBroadcastAttemptTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE FirstBroadcastAttemptTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### HttpClientType
+
+---
+
+* Use the `HttpClientType` convention to set the type of HTTP client you're using.
+ 
+* RavenDB uses the HTTP type internally to manage its cache.  
+ 
+* If you override the [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient) convention to use a non-default HTTP client,  
+  we advise that you also set `HttpClientType` so it returns the client type you are actually using.
+
+{CODE HttpClientType@ClientApi\Configuration\Conventions.cs /}
+{CODE HttpClientTypeSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### HttpVersion
+
+---
+
+* Use the `HttpVersion` convention to set the Http version the client will use when communicating  
+  with the server.
+
+* DEFAULT: `System.Net.HttpVersion.Version11` (HTTP 1.1)
+
+{CODE HttpVersionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### IdentityPartsSeparator
+
+---
+
+* Use the `IdentityPartsSeparator` convention to set the default **ID separator** for automatically-generated document IDs.
+ 
+* DEFAULT: `/` (forward slash)  
+ 
+* The value can be any `char` except `|` (pipe).
+ 
+* Changing the separator affects these ID generation strategies:  
+  * [Server-Side ID](../../server/kb/document-identifier-generation#strategy--2)
+  * [Identity](../../server/kb/document-identifier-generation#strategy--3)
+  * [HiLo Algorithm](../../server/kb/document-identifier-generation#strategy--4)
+
+{CODE IdentityPartsSeparatorSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### LoadBalanceBehavior
+#### LoadBalancerPerSessionContextSelector
+#### LoadBalancerContextSeed
+
+---
+
+* Configure the __load balance behavior__ by setting the following conventions:
+  * `LoadBalanceBehavior`
+  * `LoadBalancerPerSessionContextSelector`
+  * `LoadBalancerContextSeed`
+
+* Learn more in the dedicated [Load balance behavior](../../client-api/configuration/load-balance/load-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### MaxHttpCacheSize
+
+---
+
+* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.
+ 
+* This setting will affect all the databases accessed by the Document Store.
+ 
+* DEFAULT:  
+ 
+    | System    | Usable Memory                                                                                         | Default Value              |
+    |-----------|-------------------------------------------------------------------------------------------------------|----------------------------|
+    | 64-bit    | Lower than or equal to 3GB <br> Greater than 3GB and Lower than or equal to 6GB <br> Greater than 6GB | 64MB <br> 128MB <br> 512MB |
+    | 32-bit    |                                                                                                       | 32MB                       |
+
+* __Disabling Caching__:  
+
+    * To disable caching globally, set `MaxHttpCacheSize` to zero.  
+  
+    * Note: When caching is disabled, ALL data requests are sent to the server.
+
+  {CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
   {CODE disable_cache@ClientApi\Configuration\Conventions.cs /}
-  {WARNING: }
-  Please be aware that if cache is disabled **ALL** data requests will be sent to the server.  
-  {WARNING/}
+  {CODE MaxHttpCacheSizeSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## MaxNumberOfRequestsPerSession
-
-Use `MaxNumberOfRequestsPerSession` to get or set the maximum number of GET requests per session.  
-**Default**: `30`  
-{CODE MaxNumberOfRequestsPerSession@ClientApi\Configuration\Conventions.cs /}
-
-## UseOptimisticConcurrency
-
-Use `UseOptimisticConcurrency` to control whether optimistic 
-concurrency is set to true by default for all future sessions.  
-**Default**: `false`  
-{CODE UseOptimisticConcurrency@ClientApi\Configuration\Conventions.cs /}
-
-## RequestTimeout
-
-Use `RequestTimeout` to define the global request timeout 
-value for all `RequestExecutors` created per database.  
-**Default**: `null`
-{CODE RequestTimeout@ClientApi\Configuration\Conventions.cs /}
-
-## DisableTopologyUpdates
-
-Use `DisableTopologyUpdates` to disable database topology updates.  
-**Default**: `false`  
-{CODE DisableTopologyUpdates@ClientApi\Configuration\Conventions.cs /}
-
-## SaveEnumsAsIntegers
-
-`SaveEnumsAsIntegers` determines whether C# `enum` types should be saved as 
-integers or strings and instructs the LINQ provider to query enums as integer values.  
-**Default**: `false`  
-{CODE SaveEnumsAsIntegers@ClientApi\Configuration\Conventions.cs /}
-
-## UseCompression
-
-`UseCompression` determines if the client would send the 
-server headers indicating whether compression is to be used.  
-**Default**: `true`  
-{CODE UseCompression@ClientApi\Configuration\Conventions.cs /}
-
-## OperationStatusFetchMode
-
-`OperationStatusFetchMode` changes the way the operation is 
-fetching the operation status when waiting for completion.  
-{NOTE: }
-**By default**, the value is set to `ChangesApi` which uses the WebSocket 
-protocol underneath when a connection is established with the server.  
-On some older systems like Windows 7 the WebSocket protocol might not 
-be available due to the OS and .NET Framework limitations. To bypass 
-this issue, the value can be changed to `Polling`.  
 {NOTE/}
+{NOTE: }
+
+#### MaxNumberOfRequestsPerSession
+
+---
+
+* Use the `MaxNumberOfRequestsPerSession` convention to set the maximum number of requests per session.
+ 
+* DEFAULT: `30`
+ 
+{CODE MaxNumberOfRequestsPerSessionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### Modify serialization of property name
+
+---
+
+* Different clients use different casing conventions for entity field names. For example:  
+
+    | Language   | Default casing  | Example    |
+    |------------|-----------------|------------|
+    | C#         | PascalCase      | OrderLines |
+    | Java       | camelCase       | orderLines |
+    | JavaScript | camelCase       | orderLines |
+
+* By default, when saving an entity, the naming convention used by the client is reflected in the JSON document properties on the server-side.  
+  This default serialization behavior can be customized to facilitate language interoperability.
+ 
+* __Example__:  
+    
+    Set `CustomizeJsonSerializer` and `PropertyNameConverter` to serialize an entity's properties as camelCase from a C# client:
+
+    {CODE PropertyCasing@ClientApi\Configuration\Conventions.cs /}
+    {CODE FirstChar@ClientApi\Configuration\Conventions.cs /}
+    {CODE SerializationSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### OperationStatusFetchMode
+
+---
+
+* Use the `OperationStatusFetchMode` convention to set the way an [operation](../../client-api/operations/what-are-operations) is getting its status when [waiting for completion](../../client-api/operations/what-are-operations#wait-for-completion).
+ 
+* DEFAULT:  
+  By default, the value is set to `ChangesApi` which uses the WebSocket protocol underneath when a connection is established with the server.  
+ 
+* On some older systems like Windows 7 the WebSocket protocol might not be available due to the OS and .NET Framework limitations. 
+  To bypass this issue, the value can be changed to `Polling`.  
+
 {CODE OperationStatusFetchMode@ClientApi\Configuration\Conventions.cs /}
+{CODE OperationStatusFetchModeSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## Change fields/properties Naming Convention
-
-Different clients may use different casing conventions for entity field names.  
-E.g., here are the field naming defaults for clients of a few languages.  
-
-| Language | Default convention | Example |
-| ------------- | ----- | --- |
-| C# | PascalCase | OrderLines |
-| Java | camelCase | orderLines |
-| JavaScript | camelCase | orderLines |
-
-Whatever naming convention a client uses, is by default reflected on the server-side.  
-These defauls can be customized, e.g. to allow inter-language operability.  
-
-### Example: Using camelCase by a C# client
-
-Make a C# client use camelCase by setting `CustomizeJsonSerializer` and `PropertyNameConverter `.  
-
-{CODE FirstChar@ClientApi\Configuration\Conventions.cs /}
-{CODE PropertyCasing@ClientApi\Configuration\Conventions.cs /}
-
-## IdentityPartsSeparator
-
-Use the `IdentityPartsSeparator` convention to change the default 
-**ID (Identity) separator** for automatically-generated document IDs.  
-**Default**: `/` (forward slash)  
-{CODE IdentityPartsSeparator@ClientApi\Configuration\Conventions.cs /}
-
-* The value can be any `char` except `|` (pipe).  
-
-{NOTE: }
-Changing the separator affects these ID generation strategies:  
-
-* [Server-Side ID](../../server/kb/document-identifier-generation#strategy--2)
-* [Identity](../../server/kb/document-identifier-generation#strategy--3)
-* [HiLo Algorithm](../../server/kb/document-identifier-generation#strategy--4)
 {NOTE/}
+{NOTE: }
 
-## TopologyCacheLocation
+#### PreserveDocumentPropertiesNotFoundOnModel
 
-Use `TopologyCacheLocation` to change the location of topology cache files.  
-Setting this value will check directory existance and writing permissions.  
-**Default**: The application's base directory (`AppContext.BaseDirectory`)
+---
+
+* When setting the `PreserveDocumentPropertiesNotFoundOnModel` convention to `true`,  
+  the client can report (via [whatChanged](../../lient-api/session/how-to/check-if-there-are-any-changes-on-a-session#get-session-changes) method) the missing properties on the model when loading a document.
+
+* DEFAULT: `true`
+
+{CODE PreserveDocumentPropertiesNotFoundOnModelSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### ReadBalanceBehavior
+
+---
+
+* Configure the __read request behavior__ by setting the `ReadBalanceBehavior` convention.
+
+* Learn more in the dedicated [Read balance behavior](../../client-api/configuration/load-balance/read-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### RequestTimeout
+
+---
+
+* Use the `RequestTimeout` convention to define the global request timeout value for all `RequestExecutors` created per database.
+ 
+* DEFAULT: `null` (the default HTTP client timout will be applied - 12h)
+
+{CODE RequestTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE RequestTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### ResolveTypeFromClrTypeName
+
+---
+
+* Use the `ResolveTypeFromClrTypeName` convention to define a function that resolves the CLR type  
+  from the CLR type name.
+
+* DEFAULT: The type is returned.
+
+{CODE ResolveTypeFromClrTypeName@ClientApi\Configuration\Conventions.cs /}
+{CODE ResolveTypeFromClrTypeNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### SaveEnumsAsIntegers
+
+---
+
+* When setting the `SaveEnumsAsIntegers` convention to `true`,  
+  C# `enum` types will be stored and queried as integers, rather than their string representations.  
+ 
+* DEFAULT: `false` (save as strings)
+
+{CODE SaveEnumsAsIntegersSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### SecondBroadcastAttemptTimeout
+
+---
+
+* Use the `SecondBroadcastAttemptTimeout` convention to set the timeout for the second broadcast attempt.
+ 
+* Upon failure of the [first attempt](../../client-api/configuration/conventions#firstbroadcastattempttimeout) the request executor will resend the command to all nodes simultaneously.
+ 
+* DEFAULT: `30 seconds`
+
+{CODE SecondBroadcastAttemptTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE SecondBroadcastAttemptTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### SendApplicationIdentifier
+
+---
+
+* Use the `SendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
+
+* Setting tp _true_ allows the server to issue performance hint notifications to the client, 
+  e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
+
+* DEFAULT: `true`
+
+{CODE SendApplicationIdentifierSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### ShouldIgnoreEntityChanges
+
+---
+
+* Set the `ShouldIgnoreEntityChanges` convention to disable entity tracking for certain entities.  
+ 
+* Learn more in [Customize tracking in conventions](../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions).
+
+{NOTE/}
+{NOTE: }
+
+#### ThrowIfQueryPageSizeIsNotSet
+
+---
+
+* When setting the `ThrowIfQueryPageSizeIsNotSet` convention to `true`,  
+  an exception will be thrown if a query is performed without explicitly setting a page size.
+
+* This can be useful during development to identify potential performance bottlenecks
+  since there is no limitation on the number of results returned from the server.
+
+* DEFAULT: `false`
+
+{CODE ThrowIfQueryPageSizeIsNotSetSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### TopologyCacheLocation
+
+---
+
+* Use the `TopologyCacheLocation` convention to change the location of the topology cache files   
+  (`*.raven-database-topology` & `*.raven-cluster-topology`).  
+ 
+* Directory existence and writing permissions will be checked when setting this value.
+ 
+* DEFAULT: `AppContext.BaseDirectory` (The application's base directory)
 
 {CODE TopologyCacheLocation@ClientApi\Configuration\Conventions.cs /}
+{CODE TopologyCacheLocationSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## AddIdFieldToDynamicObjects
+{NOTE/}
+{NOTE: }
 
-Use `AddIdFieldToDynamicObjects` to determine whether an Id field is automatically added to dynamic objects.  
-**Default**: `true`  
-{CODE AddIdFieldToDynamicObjects@ClientApi\Configuration\Conventions.cs /}
+#### TransformTypeCollectionNameToDocumentIdPrefix
 
-## ShouldIgnoreEntityChanges
+---
 
-Configure this function to disable entity tracking for certain entities.  
-Learn more in [Customize tracking in conventions](../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions).
+* Use the `TransformTypeCollectionNameToDocumentIdPrefix` convention to define a function that will  
+  customize the document ID prefix from the the collection name.
+ 
+* DEFAULT:  
+  By default, the document id prefix is determined as follows:  
+ 
+| Number of uppercase letters in collection name   | Document ID prefix                                          |
+|--------------------------------------------------|-------------------------------------------------------------|
+| `<= 1`                                           | Use the collection name with all lowercase letters          |
+| `> 1`                                            | Use the collection name as is, preserving the original case |
 
-## WaitForIndexesAfterSaveChangesTimeout
+{CODE TransformTypeCollectionNameToDocumentIdPrefixSyntax@ClientApi\Configuration\Conventions.cs /}
 
-Use `WaitForIndexesAfterSaveChangesTimeout` to set the default timeout 
-for the DocumentSession.Advanced.WaitForIndexesAfterSaveChanges method.  
-**Default**: 15 Seconds  
+{NOTE/}
+{NOTE: }
+
+#### UseCompression
+
+---
+
+* Set the `UseCompression` convention to true to in order to use compression when sending and receiving content of HTTP request. 
+ 
+* DEFAULT: `true`  
+
+{CODE UseCompressionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### UseOptimisticConcurrency
+
+---
+
+* When setting the `UseOptimisticConcurrency` convention to `true`,  
+  Optimistic Concurrency checks will be applied for all sessions opened from the Document Store. 
+ 
+* DEFAULT: `false`  
+
+{CODE UseOptimisticConcurrencySyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### WaitForIndexesAfterSaveChangesTimeout
+
+---
+
+* Use the `WaitForIndexesAfterSaveChangesTimeout` convention to set the default timeout for the 
+  `DocumentSession.Advanced.WaitForIndexesAfterSaveChanges` method.  
+ 
+* DEFAULT: 15 Seconds
+
 {CODE WaitForIndexesAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE WaitForIndexesAfterSaveChangesTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## WaitForReplicationAfterSaveChangesTimeout
+{NOTE/}
+{NOTE: }
 
-Use `WaitForReplicationAfterSaveChangesTimeout` to set the default timeout 
-for the DocumentSession.Advanced.WaitForReplicationAfterSaveChanges method.  
-**Default**: 15 Seconds  
-{CODE WaitForReplicationAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+#### WaitForNonStaleResultsTimeout
 
-## WaitForNonStaleResultsTimeout
+---
 
-Use `WaitForNonStaleResultsTimeout` to set the default timeout WaitForNonStaleResults 
-methods used when querying.  
-**Default**: 15 Seconds  
+* Use the `WaitForNonStaleResultsTimeout` convention to set the default timeout used by the  
+  `WaitForNonStaleResults` method when querying.  
+ 
+* DEFAULT: 15 Seconds  
+
 {CODE WaitForNonStaleResultsTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE WaitForNonStaleResultsTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## CreateHttpClient
-
-Use the `CreateHttpClient` convention to modify the HTTP client your 
-client application uses.  
-Implementing your own  HTTP client can be useful when, for example, 
-you'd like your clients to provide the server with tracing info.  
-{CODE CreateHttpClient@ClientApi\Configuration\Conventions.cs /}
-
-{NOTE: }
-If you override the default `CreateHttpClient` convention we advise 
-that you also set the HTTP client type correctly using the 
-[HttpClientType](../../client-api/configuration/conventions#httpclienttype) convention.  
 {NOTE/}
-
-## HttpClientType
-
-Use `HttpClientType` to get or set the type of HTTP client you're using.  
-{CODE HttpClientType@ClientApi\Configuration\Conventions.cs /}
-
 {NOTE: }
-RavenDB uses the HTTP type internally to manage its cache. If you 
-override the [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient) 
-convention to use a non-default HTTP client, we advise that you also 
-set `HttpClientType` so it returns the client type you are actually using.  
-{NOTE/}
 
+#### WaitForReplicationAfterSaveChangesTimeout
+
+---
+
+* Use the `WaitForReplicationAfterSaveChangesTimeout` convention to set the default timeout for the  
+  `DocumentSession.Advanced.WaitForReplicationAfterSaveChanges`method.  
+ 
+* DEFAULT: 15 Seconds  
+
+{CODE WaitForReplicationAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE WaitForReplicationAfterSaveChangesTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -165,12 +165,17 @@
 #### DisableTopologyCache
 
 ---
- 
-* When setting the `DisableTopologyCache` convention to `true`, the topology cache usage will be disabled.  
-  Even if the client is configured to receive topology updates from the server, no topology files will be saved on disk, 
-  thus preventing `*.raven-cluster-topology` files from piling up.  
- 
-* In addition, when set to _true_, the client will not try to load the topology from the cache upon failing to connect to the server.
+
+* By default, the client caches the cluster's topology in `*.raven-cluster-topology` files on disk.  
+  When all servers provided in the `DocumentStore.Urls` property are down or unavailable, 
+  the client will load the topology from the latest file and try to connect to nodes that are not listed in the URL property.
+
+* This behavior can be disabled when setting the `DisableTopologyCache` convention to `true`.  
+  In such a case:
+
+   * The client will not load the topology from the cache upon failing to connect to a server.  
+   * Even if the client is configured to [receive topology updates](../../client-api/configuration/conventions#disabletopologyupdates) from the server, no topology files will be saved on disk,  
+     thus preventing the accumulation of these files.
  
 * DEFAULT: `false`
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -687,7 +687,9 @@
 
 ---
 
-* Set the `UseCompression` convention to true to in order to use compression when sending and receiving content of HTTP request. 
+* Set the `UseCompression` convention to true to in order to accept the __response__ in compressed format and the automatic decompression of the HTTP response content.
+
+* A gzip compression is always applied when sending content in an HTTP request.
  
 * DEFAULT: `true`  
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -137,7 +137,7 @@
 ---
 
 * EXPERT ONLY:   
-  Use the `DisableAtomicDocumentWritesInClusterWideTransaction` convention disable automatic  
+  Use the `DisableAtomicDocumentWritesInClusterWideTransaction` convention to disable automatic  
   atomic writes with cluster write transactions.
 
 * When set to `true`, will only consider explicitly added compare exchange values to validate cluster wide transactions.
@@ -522,8 +522,13 @@
 
 ---
 
-* When setting the `PreserveDocumentPropertiesNotFoundOnModel` convention to `true`,  
-  the client can report (via [whatChanged](../../lient-api/session/how-to/check-if-there-are-any-changes-on-a-session#get-session-changes) method) the missing properties on the model when loading a document.
+* Loading a document using a different model will result in the removal of the missing model properties  
+  from the loaded entity, and no exception is thrown.
+
+* Setting the `PreserveDocumentPropertiesNotFoundOnModel` convention to `true`  
+  allows the client to check (via [whatChanged](../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session#get-session-changes) 
+  or via [WhatChangedFor](../../client-api/session/how-to/check-if-entity-has-changed#get-entity-changes) methods) 
+  for the missing properties on the entity after loading the document.
 
 * DEFAULT: `true`
 
@@ -687,7 +692,7 @@
 
 ---
 
-* Set the `UseCompression` convention to true to in order to accept the __response__ in compressed format and the automatic decompression of the HTTP response content.
+* Set the `UseCompression` convention to true in order to accept the __response__ in compressed format and the automatic decompression of the HTTP response content.
 
 * A gzip compression is always applied when sending content in an HTTP request.
  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -205,7 +205,7 @@
 * Use the `FindClrType` convention to define a function that finds the CLR type of a document.  
 
 * DEFAULT:  
-  The CLR type is retrieved from the `Raven-Clr-Type` property under the `@metdata` key in the document. 
+  The CLR type is retrieved from the `Raven-Clr-Type` property under the `@metadata` key in the document. 
 
 {CODE FindClrType@ClientApi\Configuration\Conventions.cs /}
 {CODE FindClrTypeSyntax@ClientApi\Configuration\Conventions.cs /}
@@ -442,9 +442,8 @@
 
 ---
 
-* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.
- 
-* This setting will affect all the databases accessed by the Document Store.
+* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.  
+  This setting will affect all the databases accessed by the Document Store.
  
 * DEFAULT:  
  
@@ -456,12 +455,14 @@
 * __Disabling Caching__:  
 
     * To disable caching globally, set `MaxHttpCacheSize` to zero.  
-  
-    * Note: When caching is disabled, ALL data requests are sent to the server.
+    * To disable caching per session, see: [Disable caching per session](../../client-api/session/configuration/how-to-disable-caching).   
 
-  {CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
-  {CODE disable_cache@ClientApi\Configuration\Conventions.cs /}
-  {CODE MaxHttpCacheSizeSyntax@ClientApi\Configuration\Conventions.cs /}
+* Note: RavenDB also supports Aggressive Caching.  
+  Learn more about that in article [Setup aggressive caching](../../client-api/how-to/setup-aggressive-caching). 
+
+{CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
+{CODE disable_cache@ClientApi\Configuration\Conventions.cs /}
+{CODE MaxHttpCacheSizeSyntax@ClientApi\Configuration\Conventions.cs /}
 
 {NOTE/}
 {NOTE: }
@@ -618,7 +619,7 @@
 
 * Use the `SendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
 
-* Setting tp _true_ allows the server to issue performance hint notifications to the client, 
+* Setting to _true_ allows the server to issue performance hint notifications to the client, 
   e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
 
 * DEFAULT: `true`
@@ -714,7 +715,10 @@
 
 * When setting the `UseOptimisticConcurrency` convention to `true`,  
   Optimistic Concurrency checks will be applied for all sessions opened from the Document Store. 
- 
+  
+* Learn more about Optimistic Concurrency and the various ways to enable it in article  
+  [how to enable optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency).  
+
 * DEFAULT: `false`  
 
 {CODE UseOptimisticConcurrencySyntax@ClientApi\Configuration\Conventions.cs /}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -395,7 +395,9 @@
 * Use the `HttpVersion` convention to set the Http version the client will use when communicating  
   with the server.
 
-* DEFAULT: `System.Net.HttpVersion.Version11` (HTTP 1.1)
+* DEFAULT:  
+    * When this convention is explicitly set to `null`, the default HTTP version provided by your .NET framework is used.
+    * Otherwise, the default HTTP version is set to `System.Net.HttpVersion.Version11` (HTTP 1.1).
 
 {CODE HttpVersionSyntax@ClientApi\Configuration\Conventions.cs /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
@@ -1,0 +1,484 @@
+# Conventions
+
+{NOTE: }
+
+* __Conventions__ in RavenDB are customizable settings that users can configure to tailor client behaviors according to their preferences.
+ 
+* In this page:  
+  * [How to set conventions](../../client-api/configuration/conventions#how-to-set-conventions)  
+  * [Conventions:](../../client-api/configuration/conventions#conventions:)  
+      [customFetch](../../client-api/configuration/conventions#customfetch)  
+      [disableAtomicDocumentWritesInClusterWideTransaction](../../client-api/configuration/conventions#disableatomicdocumentwritesinclusterwidetransaction)  
+      [disableTopologyUpdates](../../client-api/configuration/conventions#disabletopologyupdates)  
+      [findCollectionName](../../client-api/configuration/conventions#findcollectionname)  
+      [findJsType](../../client-api/configuration/conventions#_findjstype)  
+      [findJsTypeName](../../client-api/configuration/conventions#_findjstypeName)  
+      [firstBroadcastAttemptTimeout](../../client-api/configuration/conventions#firstbroadcastattempttimeout)  
+      [identityPartsSeparator](../../client-api/configuration/conventions#identitypartsseparator)  
+      [loadBalanceBehavior](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [loadBalancerContextSeed](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [loadBalancerPerSessionContextSelector](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [maxHttpCacheSize](../../client-api/configuration/conventions#maxhttpcachesize)  
+      [maxNumberOfRequestsPerSession](../../client-api/configuration/conventions#maxnumberofrequestspersession)  
+      [readBalanceBehavior](../../client-api/configuration/conventions#readbalancebehavior)  
+      [requestTimeout](../../client-api/configuration/conventions#requesttimeout)  
+      [secondBroadcastAttemptTimeout](../../client-api/configuration/conventions#secondbroadcastattempttimeout)  
+      [sendApplicationIdentifier](../../client-api/configuration/conventions#sendapplicationidentifier)  
+      [shouldIgnoreEntityChanges](../../client-api/configuration/conventions#shouldignoreentitychanges)  
+      [storeDatesInUtc](../../client-api/configuration/conventions#storedatesinutc)  
+      [storeDatesWithTimezoneInfo](../../client-api/configuration/conventions#storedateswithtimezoneinfo)  
+      [syncJsonParseLimit](../../client-api/configuration/conventions#syncjsonparselimit)  
+      [throwIfQueryPageSizeIsNotSet](../../client-api/configuration/conventions#throwifquerypagesizeisnotset)  
+      [transformClassCollectionNameToDocumentIdPrefix](../../client-api/configuration/conventions#transformclasscollectionnametodocumentidprefix)  
+      [useCompression](../../client-api/configuration/conventions#usecompression)  
+      [useJsonlStreaming](../../client-api/configuration/conventions#usejsonlstreaming)  
+      [useOptimisticConcurrency](../../client-api/configuration/conventions#useoptimisticconcurrency)  
+      [waitForIndexesAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforindexesaftersavechangestimeout)  
+      [waitForNonStaleResultsTimeout](../../client-api/configuration/conventions#waitfornonstaleresultstimeout)  
+      [waitForReplicationAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforreplicationaftersavechangestimeout)  
+
+{NOTE/}
+
+---
+
+{PANEL: How to set conventions}
+
+* Access the conventions via the `conventions` property of the `DocumentStore` object.
+
+* The conventions set on a Document Store will apply to ALL [sessions](../../client-api/session/what-is-a-session-and-how-does-it-work) and [operations](../../client-api/operations/what-are-operations) associated with that store.
+ 
+* Customizing the conventions can only be set __before__ calling `documentStore.initialize()`.  
+  Trying to do so after calling _initialize()_ will throw an exception.
+
+{CODE:nodejs conventions_1@client-api\configuration\conventions.js /}
+
+{PANEL/}
+
+{PANEL: Conventions:}
+
+{NOTE: }
+
+#### customFetch
+
+---
+
+* Use the `customFetch` convention to override the default _fetch_ method.  
+  This method is useful to enable RavenDB Node.js client on CloudFlare Workers.
+
+* DEFAULT: undefined
+
+{CODE:nodejs customFetchSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### disableAtomicDocumentWritesInClusterWideTransaction
+
+---
+
+* EXPERT ONLY:   
+  Use the `disableAtomicDocumentWritesInClusterWideTransaction` convention to disable automatic  
+  atomic writes with cluster write transactions.
+
+* When set to `true`, will only consider explicitly added compare exchange values to validate cluster wide transactions.
+
+* DEFAULT: `false`
+
+{CODE:nodejs disableAtomicDocumentWritesInClusterWideTransactionSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### disableTopologyUpdates
+
+---
+
+* When setting the `disableTopologyUpdates` convention to `true`,  
+  no database topology updates will be sent from the server to the client (e.g. adding or removing a node).
+ 
+* DEFAULT: `false`
+
+{CODE:nodejs disableTopologyUpdatesSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### findCollectionName
+
+---
+
+* Use the `findCollectionName` convention to define a function that will customize the collection name  
+  from given type.
+
+* DEFAULT: The collection name will be the plural form of the type name.
+
+{CODE:nodejs findCollectionNameSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### findJsType
+
+---
+
+* Use the `findJsType` convention to define a function that finds the class of a document (if exists).
+
+* The type is retrieved from the `Raven-Node-Type` property under the `@metdata` key in the document.
+
+* DEFAULT: `null`
+
+{CODE:nodejs findJsTypeSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### findJsTypeName
+
+---
+
+* Use the `findJsTypeName` convention to define a function that returns the class type name from a given type.
+
+* The class name will be stored in the entity metadata.
+
+* DEFAULT: `null`
+
+{CODE:nodejs findJsTypeNameSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### firstBroadcastAttemptTimeout
+
+---
+
+* Use the `firstBroadcastAttemptTimeout` convention to set the timeout for the first broadcast attempt.  
+ 
+* In the first attempt, the request executor will send a single request to the selected node.  
+  Learn about the "selected node" in: [Client logic for choosing a node](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+ 
+* A [second attempt](../../client-api/configuration/conventions#secondbroadcastattempttimeout) will be held upon failure.
+ 
+* DEFAULT: `5 seconds`
+
+{CODE:nodejs firstBroadcastAttemptTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### identityPartsSeparator
+
+---
+
+* Use the `identityPartsSeparator` convention to set the default **ID separator** for automatically-generated document IDs.
+ 
+* DEFAULT: `/` (forward slash)  
+ 
+* The value can be any `char` except `|` (pipe).
+ 
+* Changing the separator affects these ID generation strategies:  
+  * [Server-Side ID](../../server/kb/document-identifier-generation#strategy--2)
+  * [Identity](../../server/kb/document-identifier-generation#strategy--3)
+  * [HiLo Algorithm](../../server/kb/document-identifier-generation#strategy--4)
+
+{CODE:nodejs identityPartsSeparatorSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### loadBalanceBehavior
+#### loadBalancerPerSessionContextSelector
+#### loadBalancerContextSeed
+
+---
+
+* Configure the __load balance behavior__ by setting the following conventions:
+  * `loadBalanceBehavior`
+  * `loadBalancerPerSessionContextSelector`
+  * `loadBalancerContextSeed`
+
+* Learn more in the dedicated [Load balance behavior](../../client-api/configuration/load-balance/load-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### maxHttpCacheSize
+
+---
+
+* Use the `maxHttpCacheSize` convention to set the maximum HTTP cache size.
+ 
+* This setting will affect all the databases accessed by the Document Store.
+ 
+* DEFAULT: `128 MB`
+
+* __Disabling Caching__:  
+
+    * To disable caching globally, set `maxHttpCacheSize` to zero.  
+  
+    * Note: When caching is disabled, ALL data requests are sent to the server.
+
+{CODE:nodejs maxHttpCacheSizeSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### maxNumberOfRequestsPerSession
+
+---
+
+* Use the `maxNumberOfRequestsPerSession` convention to set the maximum number of requests per session.
+ 
+* DEFAULT: `30`
+ 
+{CODE:nodejs maxNumberOfRequestsPerSessionSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### readBalanceBehavior
+
+---
+
+* Configure the __read request behavior__ by setting the `readBalanceBehavior` convention.
+
+* Learn more in the dedicated [Read balance behavior](../../client-api/configuration/load-balance/read-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### requestTimeout
+
+---
+
+* Use the `requestTimeout` convention to define the global request timeout value for all `RequestExecutors` created per database.
+ 
+* DEFAULT: `null` (the default HTTP client timout will be applied - 12h)
+
+{CODE:nodejs requestTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### secondBroadcastAttemptTimeout
+
+---
+
+* Use the `secondBroadcastAttemptTimeout` convention to set the timeout for the second broadcast attempt.
+ 
+* Upon failure of the [first attempt](../../client-api/configuration/conventions#firstbroadcastattempttimeout) the request executor will resend the command to all nodes simultaneously.
+ 
+* DEFAULT: `30 seconds`
+
+{CODE:nodejs secondBroadcastAttemptTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### sendApplicationIdentifier
+
+---
+
+* Use the `sendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
+
+* Setting tp _true_ allows the server to issue performance hint notifications to the client, 
+  e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
+
+* DEFAULT: `true`
+
+{CODE:nodejs sendApplicationIdentifierSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### shouldIgnoreEntityChanges
+
+---
+
+* Set the `shouldIgnoreEntityChanges` convention to disable entity tracking for certain entities.  
+ 
+* Learn more in [Customize tracking in conventions](../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions).
+
+{NOTE/}
+{NOTE: }
+
+#### storeDatesInUtc
+
+---
+
+* When setting the `storeDatesInUtc` convention to `true`,  
+  DateTime values will be stored in the database in UTC format.
+
+* DEFAULT: `false`
+
+{CODE:nodejs storeDatesInUtcSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### storeDatesWithTimezoneInfo
+
+---
+
+* When setting the `storeDatesWithTimezoneInfo` to `true`,  
+  DateTime values will be stored in the database with their time zone information included.
+
+* DEFAULT: `false`
+
+{CODE:nodejs storeDatesWithTimezoneInfoSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### syncJsonParseLimit
+
+---
+
+* Use the `syncJsonParseLimit` convention to define the maximum size for the _sync_ parsing of the JSON data responses received from the server.  
+  For data exceeding this size, the client switches to _async_ parsing.
+
+* DEFAULT: `2 * 1_024 * 1_024`
+
+{CODE:nodejs syncJsonParseLimitSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### throwIfQueryPageSizeIsNotSet
+
+---
+
+* When setting the `throwIfQueryPageSizeIsNotSet` convention to `true`,  
+  an exception will be thrown if a query is performed without explicitly setting a page size.
+
+* This can be useful during development to identify potential performance bottlenecks
+  since there is no limitation on the number of results returned from the server.
+
+* DEFAULT: `false`
+
+{CODE:nodejs throwIfQueryPageSizeIsNotSetSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### transformClassCollectionNameToDocumentIdPrefix
+
+---
+
+* Use the `transformTypeCollectionNameToDocumentIdPrefix` convention to define a function that will  
+  customize the document ID prefix from the the collection name.
+
+* DEFAULT:  
+  By default, the document id prefix is determined as follows:
+
+| Number of uppercase letters in collection name   | Document ID prefix                                          |
+|--------------------------------------------------|-------------------------------------------------------------|
+| `<= 1`                                           | Use the collection name with all lowercase letters          |
+| `> 1`                                            | Use the collection name as is, preserving the original case |
+
+{CODE:nodejs transformClassCollectionNameToDocumentIdPrefixSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### useCompression
+
+---
+
+* Set the `useCompression` convention to true in order to accept the __response__ in compressed format and the automatic decompression of the HTTP response content.
+
+* A gzip compression is always applied when sending content in an HTTP request.
+ 
+* DEFAULT: `true`  
+
+{CODE:nodejs useCompressionSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### useJsonlStreaming
+
+---
+
+* Set the `useJsonlStreaming` convention to `true` when streaming query results as JSON Lines (JSONL) format.
+
+* DEFAULT: `true`
+
+{CODE:nodejs useJsonlStreamingSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### useOptimisticConcurrency
+
+---
+
+* When setting the `useOptimisticConcurrency` convention to `true`,  
+  Optimistic Concurrency checks will be applied for all sessions opened from the Document Store. 
+ 
+* DEFAULT: `false`  
+
+{CODE:nodejs useOptimisticConcurrencySyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### waitForIndexesAfterSaveChangesTimeout
+
+---
+
+* Use the `waitForIndexesAfterSaveChangesTimeout` convention to set the default timeout for the 
+  `documentSession.advanced.waitForIndexesAfterSaveChanges` method.  
+ 
+* DEFAULT: 15 Seconds
+
+{CODE:nodejs waitForIndexesAfterSaveChangesTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### waitForNonStaleResultsTimeout
+
+---
+
+* Use the `waitForNonStaleResultsTimeout` convention to set the default timeout used by the  
+  `waitForNonStaleResults` method when querying.  
+ 
+* DEFAULT: 15 Seconds  
+
+{CODE:nodejs waitForNonStaleResultsTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### waitForReplicationAfterSaveChangesTimeout
+
+---
+
+* Use the `waitForReplicationAfterSaveChangesTimeout` convention to set the default timeout for the  
+  `documentSession.advanced.waitForReplicationAfterSaveChanges`method.  
+ 
+* DEFAULT: 15 Seconds  
+
+{CODE:nodejs waitForReplicationAfterSaveChangesTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Conventions
+
+- [Querying](../../client-api/configuration/querying)
+- [Serialization](../../client-api/configuration/serialization)
+- [Load Balancing Client Requests](../../client-api/configuration/load-balance/overview)
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../client-api/configuration/identifier-generation/type-specific)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
@@ -123,7 +123,7 @@
 
 * Use the `findJsType` convention to define a function that finds the class of a document (if exists).
 
-* The type is retrieved from the `Raven-Node-Type` property under the `@metdata` key in the document.
+* The type is retrieved from the `Raven-Node-Type` property under the `@metadata` key in the document.
 
 * DEFAULT: `null`
 
@@ -205,17 +205,18 @@
 
 ---
 
-* Use the `maxHttpCacheSize` convention to set the maximum HTTP cache size.
- 
-* This setting will affect all the databases accessed by the Document Store.
+* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.  
+  This setting will affect all the databases accessed by the Document Store.
  
 * DEFAULT: `128 MB`
 
-* __Disabling Caching__:  
+* __Disabling Caching__:
 
-    * To disable caching globally, set `maxHttpCacheSize` to zero.  
-  
-    * Note: When caching is disabled, ALL data requests are sent to the server.
+    * To disable caching globally, set `MaxHttpCacheSize` to zero.
+    * To disable caching per session, see: [Disable caching per session](../../client-api/session/configuration/how-to-disable-caching).
+
+* Note: RavenDB also supports Aggressive Caching.  
+  Learn more about that in article [Setup aggressive caching](../../client-api/how-to/setup-aggressive-caching).
 
 {CODE:nodejs maxHttpCacheSizeSyntax@client-api\configuration\conventions.js /}
 
@@ -280,7 +281,7 @@
 
 * Use the `sendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
 
-* Setting tp _true_ allows the server to issue performance hint notifications to the client, 
+* Setting to _true_ allows the server to issue performance hint notifications to the client, 
   e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
 
 * DEFAULT: `true`
@@ -415,7 +416,10 @@
 
 * When setting the `useOptimisticConcurrency` convention to `true`,  
   Optimistic Concurrency checks will be applied for all sessions opened from the Document Store. 
- 
+
+* Learn more about Optimistic Concurrency and the various ways to enable it in article  
+  [how to enable optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency).
+
 * DEFAULT: `false`  
 
 {CODE:nodejs useOptimisticConcurrencySyntax@client-api\configuration\conventions.js /}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Linq.Expressions;
 using System.Net.Http;
 using System.Reflection;
-using System.Threading.Tasks;
 using Amazon.XRay.Recorder.Handlers.System.Net;
 using Newtonsoft.Json.Serialization;
 using Raven.Client;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
@@ -1,11 +1,21 @@
 ﻿using System;
+using System.Linq.Expressions;
 using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
 using Amazon.XRay.Recorder.Handlers.System.Net;
 using Newtonsoft.Json.Serialization;
+using Raven.Client;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
 using Raven.Client.Json.Serialization.NewtonsoftJson;
 using Sparrow;
+using Sparrow.Json;
 
 namespace Raven.Documentation.Samples.ClientApi.Configuration
 {
@@ -18,11 +28,17 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
             {
                 Conventions =
                 {
-                    // customizations go here
+                    // Set conventions HERE, e.g.:
+                    MaxNumberOfRequestsPerSession = 50,
+                    AddIdFieldToDynamicObjects = false
+                    // ...
                 }
             }.Initialize())
             {
-
+                // * Here you can interact with the RavenDB store:
+                //   open sessions, create or query for documents, perform operations, etc.
+                
+                // * Conventions CANNOT be set here after calling Initialize()
             }
             #endregion
         }
@@ -38,35 +54,19 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                 Conventions =
                 {
                     #region MaxHttpCacheSize
-                    MaxHttpCacheSize = new Size(256, SizeUnit.Megabytes)
-                    #endregion
-                    ,
-                    #region MaxNumberOfRequestsPerSession
-                    MaxNumberOfRequestsPerSession = 10
+                    MaxHttpCacheSize = new Size(256, SizeUnit.Megabytes) // Set max cache size
                     #endregion
                     ,
                     #region UseOptimisticConcurrency
                     UseOptimisticConcurrency = true
                     #endregion
                     ,
-                    #region DisableTopologyUpdates
-                    DisableTopologyUpdates = false
-                    #endregion
-                    ,
-                    #region SaveEnumsAsIntegers
-                    SaveEnumsAsIntegers = true
-                    #endregion
-                    ,
                     #region RequestTimeout
                     RequestTimeout = TimeSpan.FromSeconds(90)
                     #endregion
                     ,
-                    #region UseCompression
-                    UseCompression = true
-                    #endregion
-                    ,
                     #region OperationStatusFetchMode
-                    OperationStatusFetchMode = OperationStatusFetchMode.ChangesApi
+                    OperationStatusFetchMode = OperationStatusFetchMode.ChangesApi // ChangesApi | Polling
                     #endregion
                     ,
                     #region TopologyCacheLocation
@@ -76,17 +76,14 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                     #region PropertyCasing
                     Serialization = new NewtonsoftJsonSerializationConventions
                     {
+                        // .Net properties will be serialized as camelCase in the JSON document when storing an entity
+                        // and deserialized back to PascalCase
                         CustomizeJsonSerializer = s => s.ContractResolver = new CamelCasePropertyNamesContractResolver()
                     },
-                    PropertyNameConverter = mi => FirstCharToLower(mi.Name)
-                    #endregion
-                    ,
-                    #region AddIdFieldToDynamicObjects
-                    AddIdFieldToDynamicObjects = false
-                    #endregion
-                    ,
-                    #region IdentityPartsSeparator
-                    IdentityPartsSeparator = '~'
+                    
+                    // In addition, the following convention is required when
+                    // making a query that filters by a field name and when indexing. 
+                    PropertyNameConverter = memberInfo => FirstCharToLower(memberInfo.Name)
                     #endregion
                     ,
                     #region WaitForIndexesAfterSaveChangesTimeout
@@ -104,7 +101,7 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                     #region CreateHttpClient
                     CreateHttpClient = handler =>
                     {
-                        // Your HTTP Client code here, e.g. -
+                        // Your HTTP client code here, e.g.:
                         var httpClient = new MyHttpClient(new HttpClientXRayTracingHandler(new HttpClientHandler()));
                         return httpClient;
                     }
@@ -114,20 +111,282 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                     // The type of HTTP client you are using
                     HttpClientType = typeof(MyHttpClient)
                     #endregion
+                    ,
+                    #region FirstBroadcastAttemptTimeout
+                    FirstBroadcastAttemptTimeout = TimeSpan.FromSeconds(10)
+                    #endregion
+                    ,
+                    #region SecondBroadcastAttemptTimeout
+                    SecondBroadcastAttemptTimeout = TimeSpan.FromSeconds(20)
+                    #endregion
+                    ,
+                    #region FindIdentityProperty
+                    // If there exists a property with name "CustomizedId" then it will be the entity's ID property 
+                    FindIdentityProperty = memberInfo => memberInfo.Name == "CustomizedId"
+                    #endregion
+                    ,
+                    #region FindIdentityPropertyNameFromCollectionName
+                    // Will use property "CustomizedId" as the ID property
+                    FindIdentityPropertyNameFromCollectionName = collectionName => "CustomizedId"
+                    #endregion
+                    ,
+                    #region FindClrType
+                    // The default implementation is:
+                    FindClrType = (_, doc) =>
+                    {
+                        if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                            metadata.TryGet(Constants.Documents.Metadata.RavenClrType, out string clrType))
+                            return clrType;
+
+                        return null;
+                    }
+                    #endregion
+                    ,
+                    #region FindCollectionName
+                    // Here the collection name will be the type name separated by dashes
+                    FindCollectionName = type => String.Join("-", type.Name.ToCharArray())
+                    #endregion
+                    ,
+                    #region FindCollectionNameForDynamic
+                    // Here the collection name will be some property of the dynamic entity
+                    FindCollectionNameForDynamic = dynamicEntity => dynamicEntity.SomeProperty
+                    #endregion
+                    ,
+                    #region FindClrTypeNameForDynamic
+                    // The dynamic entity's type is returned by default
+                    FindClrTypeNameForDynamic = dynamicEntity => dynamicEntity.GetType()
+                    #endregion
+                    ,
+                    #region ResolveTypeFromClrTypeName
+                    // The type itself is returned by default
+                    ResolveTypeFromClrTypeName = clrType => clrType.GetType()
+                    #endregion
+                    ,
+                    #region FindPropertyNameForIndex
+                    // The default function:
+                    FindPropertyNameForIndex = (Type indexedType, string indexedName, string path, string prop) => 
+                        (path + prop).Replace("[].", "_").Replace(".", "_")
+                    #endregion
+                    ,
+                    #region FindPropertyNameForDynamicIndex
+                    // The DEFAULT function:
+                    FindPropertyNameForDynamicIndex = (Type indexedType, string indexedName, string path, string prop) =>
+                        path + prop
+                    #endregion
                 }
             };
             
-            var stor2e = new DocumentStore()
+            var store2 = new DocumentStore()
             {
                 Conventions =
                 {
                     #region disable_cache
-                    MaxHttpCacheSize = new Size(0, SizeUnit.Megabytes)
+                    MaxHttpCacheSize = new Size(0, SizeUnit.Megabytes) // Disable caching
                     #endregion
                 }
             };
         }
+        
+        #region AddIdFieldToDynamicObjectsSyntax
+        // Syntax:
+        public bool AddIdFieldToDynamicObjects { get; set; }
+        #endregion
+        
+        #region AggressiveCacheDurationSyntax
+        // Syntax:
+        public TimeSpan Duration { get; set; }
+        #endregion
+        
+        #region AggressiveCacheModeSyntax
+        // Syntax:
+        public AggressiveCacheMode Mode { get; set; }
+        #endregion
+        
+        #region CreateHttpClientSyntax
+        // Syntax:
+        public Func<HttpClientHandler, HttpClient> CreateHttpClient { get; set; }
+        #endregion
+        
+        #region DisableAtomicDocumentWritesInClusterWideTransactionSyntax
+        // Syntax:
+        public bool? DisableAtomicDocumentWritesInClusterWideTransaction { get; set; }
+        #endregion
+        
+        #region DisableTcpCompressionSyntax
+        // Syntax:
+        public bool DisableTcpCompression { get; set; }
+        #endregion
+        
+        #region DisableTopologyCacheSyntax
+        // Syntax:
+        public bool DisableTopologyCache { get; set; }
+        #endregion
+        
+        #region DisableTopologyUpdatesSyntax
+        // Syntax:
+        public bool DisableTopologyUpdates { get; set; }
+        #endregion
+        
+        #region FindClrTypeSyntax
+        // Syntax:
+        public Func<string, BlittableJsonReaderObject, string> FindClrType { get; set; }
+        #endregion
+        
+        #region FindClrTypeNameSyntax
+        // Syntax:
+        public Func<Type, string> FindClrTypeName { get; set; }
+        #endregion
+        
+        #region FindClrTypeNameForDynamicSyntax
+        // Syntax:
+        public Func<dynamic, string> FindClrTypeNameForDynamic { get; set; }
+        #endregion
+        
+        #region FindCollectionNameSyntax
+        // Syntax:
+        public Func<Type, string> FindCollectionName { get; set; }
+        #endregion
+        
+        #region FindCollectionNameForDynamicSyntax
+        // Syntax:
+        public Func<dynamic, string> FindCollectionNameForDynamic { get; set; }
+        #endregion
+        
+        #region FindIdentityPropertySyntax
+        // Syntax:
+        public Func<MemberInfo, bool> FindIdentityProperty { get; set; }
+        #endregion
+                
+        #region FindIdentityPropertyNameFromCollectionNameSyntax
+        // Syntax:
+        public Func<string, string> FindIdentityPropertyNameFromCollectionName { get; set; }
+        #endregion
+
+        #region FindProjectedPropertyNameForIndexSyntax
+        // Syntax:
+        public Func<Type, string, string, string, string> FindProjectedPropertyNameForIndex { get; set; }
+        #endregion
+        
+        #region FindPropertyNameForDynamicIndexSyntax
+        // Syntax:
+        public Func<Type, string, string, string, string> FindPropertyNameForDynamicIndex { get; set; }
+        #endregion
+                
+        #region FindPropertyNameForIndexSyntax
+        // Syntax:
+        public Func<Type, string, string, string, string> FindPropertyNameForIndex { get; set; }
+        #endregion
+        
+        #region FirstBroadcastAttemptTimeoutSyntax
+        // Syntax:
+        public TimeSpan FirstBroadcastAttemptTimeout { get; set; }
+        #endregion
+        
+        #region HttpClientTypeSyntax
+        // Syntax:
+        public Type HttpClientType { get; set; }
+        #endregion
+        
+        #region HttpVersionSyntax
+        // Syntax:
+        public Version HttpVersion { get; set; }
+        #endregion
+        
+        #region IdentityPartsSeparatorSyntax
+        // Syntax:
+        public char IdentityPartsSeparator { get; set; }
+        #endregion
+        
+        #region MaxHttpCacheSizeSyntax
+        // Syntax:
+        public Size MaxHttpCacheSize { get; set; }
+        #endregion
+        
+        #region MaxNumberOfRequestsPerSessionSyntax
+        // Syntax:
+        public int MaxNumberOfRequestsPerSession { get; set; }
+        #endregion
+        
+        #region SerializationSyntax
+        // Syntax:
+        public ISerializationConventions Serialization { get; set; }
+        #endregion
+        
+        #region OperationStatusFetchModeSyntax
+        // Syntax:
+        public OperationStatusFetchMode OperationStatusFetchMode { get; set; }
+        #endregion
+        
+        #region PreserveDocumentPropertiesNotFoundOnModelSyntax
+        // Syntax:
+        public bool PreserveDocumentPropertiesNotFoundOnModel { get; set; }
+        #endregion
+        
+        #region RequestTimeoutSyntax
+        // Syntax:
+        public TimeSpan? RequestTimeout { get; set; } 
+        #endregion
+        
+        #region ResolveTypeFromClrTypeNameSyntax
+        // Syntax:
+        public Func<string, Type> ResolveTypeFromClrTypeName { get; set; }
+        #endregion
+                
+        #region SaveEnumsAsIntegersSyntax
+        // Syntax:
+        public bool SaveEnumsAsIntegers { get; set; } 
+        #endregion
+        
+        #region SecondBroadcastAttemptTimeoutSyntax
+        public TimeSpan SecondBroadcastAttemptTimeout { get; set; } 
+        #endregion
+
+        #region SendApplicationIdentifierSyntax
+        // Syntax:
+        public bool SendApplicationIdentifier { get; set; } 
+        #endregion
+        
+        #region ThrowIfQueryPageSizeIsNotSetSyntax
+        // Syntax:
+        public bool ThrowIfQueryPageSizeIsNotSet { get; set; }
+        #endregion
+        
+        #region TopologyCacheLocationSyntax
+        // Syntax:
+        public string TopologyCacheLocation { get; set; } 
+        #endregion
+            
+        #region TransformTypeCollectionNameToDocumentIdPrefixSyntax
+        // Syntax:
+        public Func<string, string> TransformTypeCollectionNameToDocumentIdPrefix { get; set; }
+        #endregion
+        
+        #region UseCompressionSyntax
+        // Syntax:
+        public bool UseCompression { get; set; }
+        #endregion
+        
+        #region UseOptimisticConcurrencySyntax
+        // Syntax:
+        public bool UseOptimisticConcurrency { get; set; }
+        #endregion
+        
+        #region WaitForIndexesAfterSaveChangesTimeoutSyntax
+        // Syntax:
+        public TimeSpan WaitForIndexesAfterSaveChangesTimeout { get; set; }
+        #endregion
+        
+        #region WaitForNonStaleResultsTimeoutSyntax
+        // Syntax:
+        public TimeSpan WaitForNonStaleResultsTimeout { get; set; }
+        #endregion
+        
+        #region WaitForReplicationAfterSaveChangesTimeoutSyntax
+        // Syntax:
+        public TimeSpan WaitForReplicationAfterSaveChangesTimeout { get; set; }
+        #endregion
     }
+    
     public class MyHttpClient : HttpClient
     {
         public MyHttpClient(HttpMessageHandler handler)

--- a/Documentation/5.4/Samples/nodejs/client-api/configuration/conventions.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/configuration/conventions.js
@@ -1,0 +1,197 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function conventions() {
+    {
+        //region conventions_1
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+
+        // Set conventions HERE, e.g.:
+        documentStore.conventions.maxNumberOfRequestsPerSession = 50;
+        documentStore.conventions.disableTopologyUpdates = true;
+
+        documentStore.initialize();
+
+        // * Here you can interact with the RavenDB store:
+        //   open sessions, create or query for documents, perform operations, etc.
+
+        // * Conventions CANNOT be set here after calling initialize()
+        //endregion
+    }
+   
+    //region syntaxDefinitions 
+
+    //region customFetchSyntax
+    // Returns an object
+    get customFetch();
+    // Set an object bound to worker with type: mtls_certificate
+    set customFetch(customFetch);
+    //endregion
+    
+    //region disableAtomicDocumentWritesInClusterWideTransactionSyntax
+    // Returns a boolean value
+    get disableAtomicDocumentWritesInClusterWideTransaction();
+    // Set a boolean value
+    set disableAtomicDocumentWritesInClusterWideTransaction(
+        disableAtomicDocumentWritesInClusterWideTransaction
+    );
+    //endregion
+
+    //region disableTopologyUpdatesSyntax
+    // Returns a boolean value
+    get disableTopologyUpdates();
+    // Set a boolean value
+    set disableTopologyUpdates(value);
+    //endregion
+
+    //region findCollectionNameSyntax
+    // Returns a method
+    get findCollectionName();
+    // Set a method
+    set findCollectionName(value);
+    //endregion
+
+    //region findJsTypeSyntax
+    // Returns a method
+    get findJsType();
+    // Set a method
+    set findJsType(value);
+    //endregion
+
+    //region findJsTypeNameSyntax
+    // Returns a method
+    get findJsTypeName();
+    // Set a method
+    set findJsTypeName(value);
+    //endregion
+
+    //region firstBroadcastAttemptTimeoutSyntax
+    // Returns a number
+    get firstBroadcastAttemptTimeout();
+    // Set a number
+    set firstBroadcastAttemptTimeout(firstBroadcastAttemptTimeout);
+    //endregion
+
+    //region identityPartsSeparatorSyntax
+    // Returns a string
+    get identityPartsSeparator();
+    // Set a string
+    set identityPartsSeparator(value);
+    //endregion
+
+    //region maxHttpCacheSizeSyntax
+    // Returns a number
+    get maxHttpCacheSize();
+    // Set a number
+    set maxHttpCacheSize(value);
+    //endregion
+
+    //region maxNumberOfRequestsPerSessionSyntax
+    // Returns a number
+    get maxNumberOfRequestsPerSession();
+    // Set a number
+    set maxNumberOfRequestsPerSession(value);
+    //endregion
+
+    //region requestTimeoutSyntax
+    // Returns a number
+    get requestTimeout();
+    // Set a number
+    set requestTimeout(value);
+    //endregion
+
+    //region secondBroadcastAttemptTimeoutSyntax
+    // Returns a number
+    get secondBroadcastAttemptTimeout();
+    // Set a number
+    set secondBroadcastAttemptTimeout(timeout);
+    //endregion
+
+    //region sendApplicationIdentifierSyntax
+    // Returns a boolean
+    get sendApplicationIdentifier();
+    // Set a boolean
+    set sendApplicationIdentifier(sendApplicationIdentifier)
+    //endregion
+    
+    //region storeDatesInUtcSyntax
+    // Returns a boolean
+    get storeDatesInUtc();
+    // Set a boolean
+    set storeDatesInUtc(value);
+    //endregion
+
+    //region storeDatesWithTimezoneInfoSyntax
+    // Returns a boolean
+    get storeDatesWithTimezoneInfo();
+    // Set a boolean
+    set storeDatesWithTimezoneInfo(value);
+    //endregion
+    
+    //region syncJsonParseLimitSyntax
+    // Returns a number
+    get syncJsonParseLimit();
+    // Set a number
+    set syncJsonParseLimit(value);
+    //endregion
+
+    //region throwIfQueryPageSizeIsNotSetSyntax
+    // Returns a boolean
+    get throwIfQueryPageSizeIsNotSet();
+    // Set a boolean
+    set throwIfQueryPageSizeIsNotSet(value);
+    //endregion
+    
+    //region transformClassCollectionNameToDocumentIdPrefixSyntax
+    // Returns a method
+    get transformClassCollectionNameToDocumentIdPrefix();
+    // Set a method
+    set transformClassCollectionNameToDocumentIdPrefix(value);
+    //endregion
+
+    //region useCompressionSyntax
+    // Returns a boolean
+    get useCompression();
+    // Set a boolean
+    set useCompression(value);
+    //endregion
+
+    //region useJsonlStreamingSyntax
+    // Returns a boolean
+    get useJsonlStreaming();
+    // Set a boolean
+    set useJsonlStreaming(value);
+    //endregion
+
+    //region useOptimisticConcurrencySyntax
+    // Returns a boolean
+    get useOptimisticConcurrency();
+    // Set a boolean
+    set useOptimisticConcurrency(value);
+    //endregion
+
+    //region waitForIndexesAfterSaveChangesTimeoutSyntax
+    // Returns a number
+    get waitForIndexesAfterSaveChangesTimeout();
+    // Set a number
+    set waitForIndexesAfterSaveChangesTimeout(value);
+    //endregion
+
+    //region waitForNonStaleResultsTimeoutSyntax
+    // Returns a number
+    get waitForNonStaleResultsTimeout();
+    // Set a number
+    set waitForNonStaleResultsTimeout(value);
+    //endregion
+
+    //region waitForReplicationAfterSaveChangesTimeoutSyntax
+    // Returns a number
+    get waitForReplicationAfterSaveChangesTimeout();
+    // Set a number
+    set waitForReplicationAfterSaveChangesTimeout(value);
+    //endregion
+    
+    //endregion 
+   
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -410,7 +410,9 @@
 * Use the `HttpVersion` convention to set the Http version the client will use when communicating  
   with the server.
 
-* DEFAULT: `System.Net.HttpVersion.Version20` (HTTP 2.0)
+* DEFAULT:
+    * When this convention is explicitly set to `null`, the default HTTP version provided by your .NET framework is used.
+    * Otherwise, the default HTTP version is set to `System.Net.HttpVersion.Version20` (HTTP 2.0).
 
 {CODE HttpVersionSyntax@ClientApi\Configuration\Conventions.cs /}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -220,7 +220,7 @@
 * Use the `FindClrType` convention to define a function that finds the CLR type of a document.
 
 * DEFAULT:  
-  The CLR type is retrieved from the `Raven-Clr-Type` property under the `@metdata` key in the document.
+  The CLR type is retrieved from the `Raven-Clr-Type` property under the `@metadata` key in the document.
 
 {CODE FindClrType@ClientApi\Configuration\Conventions.cs /}
 {CODE FindClrTypeSyntax@ClientApi\Configuration\Conventions.cs /}
@@ -410,7 +410,7 @@
 * Use the `HttpVersion` convention to set the Http version the client will use when communicating  
   with the server.
 
-* DEFAULT: `System.Net.HttpVersion.Version11` (HTTP 1.1)
+* DEFAULT: `System.Net.HttpVersion.Version20` (HTTP 2.0)
 
 {CODE HttpVersionSyntax@ClientApi\Configuration\Conventions.cs /}
 
@@ -457,9 +457,8 @@
 
 ---
 
-* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.
-
-* This setting will affect all the databases accessed by the Document Store.
+* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.  
+  This setting will affect all the databases accessed by the Document Store.
 
 * DEFAULT:
 
@@ -471,12 +470,14 @@
 * __Disabling Caching__:
 
     * To disable caching globally, set `MaxHttpCacheSize` to zero.
+    * To disable caching per session, see: [Disable caching per session](../../client-api/session/configuration/how-to-disable-caching).
 
-    * Note: When caching is disabled, ALL data requests are sent to the server.
+* Note: RavenDB also supports Aggressive Caching.  
+  Learn more about that in article [Setup aggressive caching](../../client-api/how-to/setup-aggressive-caching).
 
-  {CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
-  {CODE disable_cache@ClientApi\Configuration\Conventions.cs /}
-  {CODE MaxHttpCacheSizeSyntax@ClientApi\Configuration\Conventions.cs /}
+{CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
+{CODE disable_cache@ClientApi\Configuration\Conventions.cs /}
+{CODE MaxHttpCacheSizeSyntax@ClientApi\Configuration\Conventions.cs /}
 
 {NOTE/}
 {NOTE: }
@@ -633,7 +634,7 @@
 
 * Use the `SendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
 
-* Setting tp _true_ allows the server to issue performance hint notifications to the client,
+* Setting to _true_ allows the server to issue performance hint notifications to the client,
   e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
 
 * DEFAULT: `true`
@@ -727,6 +728,9 @@
 
 * When setting the `UseOptimisticConcurrency` convention to `true`,  
   Optimistic Concurrency checks will be applied for all sessions opened from the Document Store.
+
+* Learn more about Optimistic Concurrency and the various ways to enable it in article  
+  [how to enable optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency).
 
 * DEFAULT: `false`
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -1,226 +1,773 @@
 # Conventions
 
-* **Conventions** are adjustable RavenDB settings that users 
-  can configure to modify client behaviors by their preferences.  
-* Access conventions through the `DocumentStore` object 
-  `Conventions` property.  
+{NOTE: }
 
-* In this page:  
-   * [Client Conventions](../../client-api/configuration/conventions#client-conventions)  
-   * [MaxHttpCacheSize](../../client-api/configuration/conventions#maxhttpcachesize)  
-   * [MaxNumberOfRequestsPerSession](../../client-api/configuration/conventions#maxnumberofrequestspersession)  
-   * [UseOptimisticConcurrency](../../client-api/configuration/conventions#useoptimisticconcurrency)  
-   * [RequestTimeout](../../client-api/configuration/conventions#requesttimeout)  
-   * [DisableTopologyUpdates](../../client-api/configuration/conventions#disabletopologyupdates)  
-   * [SaveEnumsAsIntegers](../../client-api/configuration/conventions#saveenumsasintegers)  
-   * [UseHttpCompression, UseHttpDecompression](../../client-api/configuration/conventions#usehttpcompression-usehttpdecompression)  
-   * [OperationStatusFetchMode](../../client-api/configuration/conventions#operationstatusfetchmode)  
-   * [Change fields/properties Naming Convention](../../client-api/configuration/conventions#change-fieldsproperties-naming-convention)  
-   * [IdentityPartsSeparator](../../client-api/configuration/conventions#identitypartsseparator)  
-   * [TopologyCacheLocation](../../client-api/configuration/conventions#topologycachelocation)  
-   * [AddIdFieldToDynamicObjects](../../client-api/configuration/conventions#addidfieldtodynamicobjects)  
-   * [ShouldIgnoreEntityChanges](../../client-api/configuration/conventions#shouldignoreentitychanges)  
-   * [WaitForIndexesAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforindexesaftersavechangestimeout)  
-   * [WaitForReplicationAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforreplicationaftersavechangestimeout)  
-   * [WaitForNonStaleResultsTimeout](../../client-api/configuration/conventions#waitfornonstaleresultstimeout)  
-   * [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient)  
-   * [HttpClientType](../../client-api/configuration/conventions#httpclienttype)  
-   * [DisposeCertificate](../../client-api/configuration/conventions#disposecertificate)  
+* __Conventions__ in RavenDB are customizable settings that users can configure to tailor client behaviors according to their preferences.
 
-{PANEL: Client Conventions}
+* In this page:
+    * [How to set conventions](../../client-api/configuration/conventions#how-to-set-conventions)
+    * [Conventions:](../../client-api/configuration/conventions#conventions:)  
+      [AddIdFieldToDynamicObjects](../../client-api/configuration/conventions#addidfieldtodynamicobjects)  
+      [AggressiveCache.Duration](../../client-api/configuration/conventions#aggressivecache.duration)  
+      [AggressiveCache.Mode](../../client-api/configuration/conventions#aggressivecache.mode)  
+      [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient)  
+      [DisableAtomicDocumentWritesInClusterWideTransaction](../../client-api/configuration/conventions#disableatomicdocumentwritesinclusterwidetransaction)  
+      [DisableTcpCompression](../../client-api/configuration/conventions#disabletcpcompression)  
+      [DisableTopologyCache](../../client-api/configuration/conventions#disabletopologycache)  
+      [DisableTopologyUpdates](../../client-api/configuration/conventions#disabletopologyupdates)  
+      [DisposeCertificate](../../client-api/configuration/conventions#disposecertificate)  
+      [FindClrType](../../client-api/configuration/conventions#findclrtype)  
+      [FindClrTypeName](../../client-api/configuration/conventions#findclrtypename)  
+      [FindClrTypeNameForDynamic](../../client-api/configuration/conventions#findclrtypenamefordynamic)  
+      [FindCollectionName](../../client-api/configuration/conventions#findcollectionname)  
+      [FindCollectionNameForDynamic](../../client-api/configuration/conventions#findcollectionnamefordynamic)  
+      [FindIdentityProperty](../../client-api/configuration/conventions#findidentityproperty)  
+      [FindIdentityPropertyNameFromCollectionName](../../client-api/configuration/conventions#findidentitypropertynamefromcollectionname)  
+      [FindProjectedPropertyNameForIndex](../../client-api/configuration/conventions#findprojectedpropertynameforindex)  
+      [FindPropertyNameForDynamicIndex](../../client-api/configuration/conventions#findpropertynamefordynamicindex)  
+      [FindPropertyNameForIndex](../../client-api/configuration/conventions#findpropertynameforindex)  
+      [FirstBroadcastAttemptTimeout](../../client-api/configuration/conventions#firstbroadcastattempttimeout)  
+      [HttpClientType](../../client-api/configuration/conventions#httpclienttype)  
+      [HttpVersion](../../client-api/configuration/conventions#httpversion)  
+      [IdentityPartsSeparator](../../client-api/configuration/conventions#identitypartsseparator)  
+      [LoadBalanceBehavior](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [LoadBalancerContextSeed](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [LoadBalancerPerSessionContextSelector](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [MaxHttpCacheSize](../../client-api/configuration/conventions#maxhttpcachesize)  
+      [MaxNumberOfRequestsPerSession](../../client-api/configuration/conventions#maxnumberofrequestspersession)  
+      [Modify serialization of property name](../../client-api/configuration/conventions#modify-serialization-of-property-name)  
+      [OperationStatusFetchMode](../../client-api/configuration/conventions#operationstatusfetchmode)  
+      [PreserveDocumentPropertiesNotFoundOnModel](../../client-api/configuration/conventions#preservedocumentpropertiesnotfoundonmodel)  
+      [ReadBalanceBehavior](../../client-api/configuration/conventions#readbalancebehavior)  
+      [RequestTimeout](../../client-api/configuration/conventions#requesttimeout)  
+      [ResolveTypeFromClrTypeName](../../client-api/configuration/conventions#resolvetypefromclrtypename)  
+      [SaveEnumsAsIntegers](../../client-api/configuration/conventions#saveenumsasintegers)  
+      [SecondBroadcastAttemptTimeout](../../client-api/configuration/conventions#secondbroadcastattempttimeout)  
+      [SendApplicationIdentifier](../../client-api/configuration/conventions#sendapplicationidentifier)  
+      [ShouldIgnoreEntityChanges](../../client-api/configuration/conventions#shouldignoreentitychanges)  
+      [TopologyCacheLocation](../../client-api/configuration/conventions#topologycachelocation)  
+      [TransformTypeCollectionNameToDocumentIdPrefix](../../client-api/configuration/conventions#transformtypecollectionnametodocumentidprefix)  
+      [UseHttpCompression](../../client-api/configuration/conventions#usehttpcompression)  
+      [UseHttpDecompression](../../client-api/configuration/conventions#usehttpdecompression)  
+      [UseOptimisticConcurrency](../../client-api/configuration/conventions#useoptimisticconcurrency)  
+      [WaitForIndexesAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforindexesaftersavechangestimeout)  
+      [WaitForNonStaleResultsTimeout](../../client-api/configuration/conventions#waitfornonstaleresultstimeout)  
+      [WaitForReplicationAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforreplicationaftersavechangestimeout)
 
-Access conventions via the `Conventions` property of the 
-`DocumentStore` object.  
+{NOTE/}
+
+---
+
+{PANEL: How to set conventions}
+
+* Access the conventions via the `Conventions` property of the `DocumentStore` object.
+
+* The conventions set on a Document Store will apply to ALL [sessions](../../client-api/session/what-is-a-session-and-how-does-it-work) and [operations](../../client-api/operations/what-are-operations) associated with that store.
+
+* Customizing the conventions can only be set __before__ calling `DocumentStore.Initialize()`.  
+  Trying to do so after calling _Initialize()_ will throw an exception.
+
 {CODE conventions_1@ClientApi\Configuration\Conventions.cs /}
 
+{PANEL/}
+
+{PANEL: Conventions:}
+
 {NOTE: }
-Customize conventions **before** `DocumentStore.Initialize()` is called. 
+
+#### AddIdFieldToDynamicObjects
+
+---
+
+* Use the `AddIdFieldToDynamicObjects` convention to determine whether an `Id` field is automatically added  
+  to [dynamic objects](../../https://learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/interop/using-type-dynamic) when [storing new entities](../../client-api/session/storing-entities) via the session.
+
+* DEFAULT: `true`
+
+{CODE AddIdFieldToDynamicObjectsSyntax@ClientApi\Configuration\Conventions.cs /}
+
 {NOTE/}
+{NOTE: }
 
-## MaxHttpCacheSize
+#### AggressiveCache.Duration
 
-Use `MaxHttpCacheSize` as follows to modify the maximum HTTP cache size.  
-{CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
+---
 
-**Default**:
+* Use the `AggressiveCache.Duration` convention to define the [aggressive cache](../../client-api/how-to/setup-aggressive-caching) duration period.
 
-| System | Usable Memory | Default Value |
-| -------| ------------- | ------------- |
-| 64-bit | Lower than or equal to 3GB <br> Greater than 3GB and Lower than or equal to 6GB <br> Greater than 6GB | 64MB <br> 128MB <br> 512MB |
-| 32-bit | | 32MB |
+* DEFAULT: `1 day`
 
-* Caching is set **per database**.  
-* **Disabling Caching**:  
-  To disable caching globally, set `MaxHttpCacheSize` to zero.
+{CODE AggressiveCacheDurationSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### AggressiveCache.Mode
+
+---
+
+* Use the `AggressiveCache.Mode` convention to define the [aggressive cache](../../client-api/how-to/setup-aggressive-caching) mode.  
+  (`AggressiveCacheMode.TrackChanges` or `AggressiveCacheMode.DoNotTrackChanges`)
+
+* DEFAULT: `AggressiveCacheMode.TrackChanges`
+
+{CODE AggressiveCacheModeSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### CreateHttpClient
+
+---
+
+* Use the `CreateHttpClient` convention to modify the HTTP client your client application uses.
+
+* For example, implementing your own HTTP client can be useful when you'd like your clients to provide the server with tracing info.
+
+* If you override the default `CreateHttpClient` convention we advise that you also set the HTTP client type  
+  correctly using the [HttpClientType](../../client-api/configuration/conventions#httpclienttype) convention.
+
+{CODE CreateHttpClient@ClientApi\Configuration\Conventions.cs /}
+{CODE CreateHttpClientSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableAtomicDocumentWritesInClusterWideTransaction
+
+---
+
+* EXPERT ONLY:   
+  Use the `DisableAtomicDocumentWritesInClusterWideTransaction` convention disable automatic  
+  atomic writes with cluster write transactions.
+
+* When set to `true`, will only consider explicitly added compare exchange values to validate cluster wide transactions.
+
+* DEFAULT: `false`
+
+{CODE DisableAtomicDocumentWritesInClusterWideTransactionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableTcpCompression
+
+---
+
+* When setting the `DisableTcpCompression` convention to `true`, TCP data will not be compressed.
+
+* DEFAULT: `false`
+
+{CODE DisableTcpCompressionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableTopologyCache
+
+---
+
+* When setting the `DisableTopologyCache` convention to `true`, the topology cache usage will be disabled.  
+  Even if the client is configured to receive topology updates from the server, no topology files will be saved on disk,
+  thus preventing `*.raven-cluster-topology` files from piling up.
+
+* In addition, when set to _true_, the client will not try to load the topology from the cache upon failing to connect to the server.
+
+* DEFAULT: `false`
+
+{CODE DisableTopologyCacheSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisableTopologyUpdates
+
+---
+
+* When setting the `DisableTopologyUpdates` convention to `true`,  
+  no database topology updates will be sent from the server to the client (e.g. adding or removing a node).
+
+* DEFAULT: `false`
+
+{CODE DisableTopologyUpdatesSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### DisposeCertificate
+
+---
+
+* When setting the `DisposeCertificate` convention to `true`,  
+  the `DocumentStore.Certificate` will be disposed of during DocumentStore disposal. 
+
+* DEFAULT: `true`
+
+{CODE DisposeCertificateSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindClrType
+
+---
+
+* Use the `FindClrType` convention to define a function that finds the CLR type of a document.
+
+* DEFAULT:  
+  The CLR type is retrieved from the `Raven-Clr-Type` property under the `@metdata` key in the document.
+
+{CODE FindClrType@ClientApi\Configuration\Conventions.cs /}
+{CODE FindClrTypeSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindClrTypeName
+
+---
+
+* Use the `FindClrTypeName` convention to define a function that returns the CLR type name from a given type.
+
+* DEFAULT: The entity's full name with the assembly name is returned.
+
+{CODE FindClrTypeNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindClrTypeNameForDynamic
+
+---
+
+* Use the `FindClrTypeNameForDynamic` convention to define a function that returns the CLR type name  
+  from a dynamic entity.
+
+* DEFAULT: The dynamic entity type is returned.
+
+{CODE FindClrTypeNameForDynamic@ClientApi\Configuration\Conventions.cs /}
+{CODE FindClrTypeNameForDynamicSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindCollectionName
+
+---
+
+* Use the `FindCollectionName` convention to define a function that will customize the collection name  
+  from given type.
+
+* DEFAULT: The collection name will be the plural form of the type name.
+
+{CODE FindCollectionName@ClientApi\Configuration\Conventions.cs /}
+{CODE FindCollectionNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindCollectionNameForDynamic
+
+---
+
+* Use the `FindCollectionNameForDynamic` convention to define a function that will customize the  
+  collection name from a dynamic type.
+
+* DEFAULT: The collection name will be the entity's type.
+
+{CODE FindCollectionNameForDynamic@ClientApi\Configuration\Conventions.cs /}
+{CODE FindCollectionNameForDynamicSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindIdentityProperty
+
+---
+
+* Use the `FindIdentityProperty` convention to define a function that finds the specified ID property  
+  in the entity.
+
+* DEFAULT: The entity's `Id` property serves as the ID property.
+
+{CODE FindIdentityProperty@ClientApi\Configuration\Conventions.cs /}
+{CODE FindIdentityPropertySyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindIdentityPropertyNameFromCollectionName
+
+---
+
+* Use the `FindIdentityPropertyNameFromCollectionName` convention to define a function that customizes  
+  the entity's ID property from the collection name.
+
+* DEFAULT: Will use the `Id` property.
+
+{CODE FindIdentityPropertyNameFromCollectionName@ClientApi\Configuration\Conventions.cs /}
+{CODE FindIdentityPropertyNameFromCollectionNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindProjectedPropertyNameForIndex
+
+---
+
+* Use the `FindProjectedPropertyNameForIndex` convention to define a function that customizes the  
+  projected fields names that will be used in the RQL sent to the server when querying an index.
+
+* Given input: The indexed document type, the index name, the current path, and the property path  
+  that is used in a query.
+
+* DEFAULT: `null`
+
+{CODE FindProjectedPropertyNameForIndexSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindPropertyNameForDynamicIndex
+
+---
+
+* Use the `FindPropertyNameForDynamicIndex` convention to define a function that customizes the  
+  property name that will be used in the RQL sent to the server when making a dynamic query.
+
+* Given input: The indexed document type, the index name, the current path, and the property path  
+  that is used in a query predicate.
+
+{CODE FindPropertyNameForDynamicIndex@ClientApi\Configuration\Conventions.cs /}
+{CODE FindPropertyNameForDynamicIndexSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FindPropertyNameForIndex
+
+---
+
+* Use the `FindPropertyNameForIndex` convention to define a function that customizes the name of the  
+  index-field property that will be used in the RQL sent to the server when querying an index.
+
+* Given input: The indexed document type, the index name, the current path, and the property path  
+  that is used in a query predicate.
+
+* DEFAULT: `[].` & `.` are replaced by `_`
+
+{CODE FindPropertyNameForIndex@ClientApi\Configuration\Conventions.cs /}
+{CODE FindPropertyNameForIndexSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### FirstBroadcastAttemptTimeout
+
+---
+
+* Use the `FirstBroadcastAttemptTimeout` convention to set the timeout for the first broadcast attempt.
+
+* In the first attempt, the request executor will send a single request to the selected node.  
+  Learn about the "selected node" in: [Client logic for choosing a node](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+
+* A [second attempt](../../client-api/configuration/conventions#secondbroadcastattempttimeout) will be held upon failure.
+
+* DEFAULT: `5 seconds`
+
+{CODE FirstBroadcastAttemptTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE FirstBroadcastAttemptTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### HttpClientType
+
+---
+
+* Use the `HttpClientType` convention to set the type of HTTP client you're using.
+
+* RavenDB uses the HTTP type internally to manage its cache.
+
+* If you override the [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient) convention to use a non-default HTTP client,  
+  we advise that you also set `HttpClientType` so it returns the client type you are actually using.
+
+{CODE HttpClientType@ClientApi\Configuration\Conventions.cs /}
+{CODE HttpClientTypeSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### HttpVersion
+
+---
+
+* Use the `HttpVersion` convention to set the Http version the client will use when communicating  
+  with the server.
+
+* DEFAULT: `System.Net.HttpVersion.Version11` (HTTP 1.1)
+
+{CODE HttpVersionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### IdentityPartsSeparator
+
+---
+
+* Use the `IdentityPartsSeparator` convention to set the default **ID separator** for automatically-generated document IDs.
+
+* DEFAULT: `/` (forward slash)
+
+* The value can be any `char` except `|` (pipe).
+
+* Changing the separator affects these ID generation strategies:
+    * [Server-Side ID](../../server/kb/document-identifier-generation#strategy--2)
+    * [Identity](../../server/kb/document-identifier-generation#strategy--3)
+    * [HiLo Algorithm](../../server/kb/document-identifier-generation#strategy--4)
+
+{CODE IdentityPartsSeparatorSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### LoadBalanceBehavior
+#### LoadBalancerPerSessionContextSelector
+#### LoadBalancerContextSeed
+
+---
+
+* Configure the __load balance behavior__ by setting the following conventions:
+    * `LoadBalanceBehavior`
+    * `LoadBalancerPerSessionContextSelector`
+    * `LoadBalancerContextSeed`
+
+* Learn more in the dedicated [Load balance behavior](../../client-api/configuration/load-balance/load-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### MaxHttpCacheSize
+
+---
+
+* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.
+
+* This setting will affect all the databases accessed by the Document Store.
+
+* DEFAULT:
+
+  | System   | Usable Memory                                                                                         | Default Value              |
+  |----------|-------------------------------------------------------------------------------------------------------|----------------------------|
+  | 64-bit   | Lower than or equal to 3GB <br> Greater than 3GB and Lower than or equal to 6GB <br> Greater than 6GB | 64MB <br> 128MB <br> 512MB |
+  | 32-bit   |                                                                                                       | 32MB                       |
+
+* __Disabling Caching__:
+
+    * To disable caching globally, set `MaxHttpCacheSize` to zero.
+
+    * Note: When caching is disabled, ALL data requests are sent to the server.
+
+  {CODE MaxHttpCacheSize@ClientApi\Configuration\Conventions.cs /}
   {CODE disable_cache@ClientApi\Configuration\Conventions.cs /}
-  {WARNING: }
-  Please be aware that if cache is disabled **ALL** data requests will be sent to the server.  
-  {WARNING/}
+  {CODE MaxHttpCacheSizeSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## MaxNumberOfRequestsPerSession
-
-Use `MaxNumberOfRequestsPerSession` to get or set the maximum number of GET requests per session.  
-**Default**: `30`  
-{CODE MaxNumberOfRequestsPerSession@ClientApi\Configuration\Conventions.cs /}
-
-## UseOptimisticConcurrency
-
-Use `UseOptimisticConcurrency` to control whether optimistic 
-concurrency is set to true by default for all future sessions.  
-**Default**: `false`  
-{CODE UseOptimisticConcurrency@ClientApi\Configuration\Conventions.cs /}
-
-## RequestTimeout
-
-Use `RequestTimeout` to define the global request timeout 
-value for all `RequestExecutors` created per database.  
-**Default**: `null`
-{CODE RequestTimeout@ClientApi\Configuration\Conventions.cs /}
-
-## DisableTopologyUpdates
-
-Use `DisableTopologyUpdates` to disable database topology updates.  
-**Default**: `false`  
-{CODE DisableTopologyUpdates@ClientApi\Configuration\Conventions.cs /}
-
-## SaveEnumsAsIntegers
-
-`SaveEnumsAsIntegers` determines whether C# `enum` types should be saved as 
-integers or strings and instructs the LINQ provider to query enums as integer values.  
-**Default**: `false`  
-{CODE SaveEnumsAsIntegers@ClientApi\Configuration\Conventions.cs /}
-
-##UseHttpCompression, UseHttpDecompression
-
-It determines if the client will send headers to the server indicating that it allows compression/decompression to be used.  
-Default: `true`.  
-
-{CODE UseHttpCompression@ClientApi\Configuration\Conventions.cs /}
-{CODE UseHttpDecompression@ClientApi\Configuration\Conventions.cs /}
-
-## OperationStatusFetchMode
-
-`OperationStatusFetchMode` changes the way the operation is 
-fetching the operation status when waiting for completion.  
-{NOTE: }
-**By default**, the value is set to `ChangesApi` which uses the WebSocket 
-protocol underneath when a connection is established with the server.  
-On some older systems like Windows 7 the WebSocket protocol might not 
-be available due to the OS and .NET Framework limitations. To bypass 
-this issue, the value can be changed to `Polling`.  
 {NOTE/}
+{NOTE: }
+
+#### MaxNumberOfRequestsPerSession
+
+---
+
+* Use the `MaxNumberOfRequestsPerSession` convention to set the maximum number of requests per session.
+
+* DEFAULT: `30`
+
+{CODE MaxNumberOfRequestsPerSessionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### Modify serialization of property name
+
+---
+
+* Different clients use different casing conventions for entity field names. For example:
+
+  | Language   | Default casing  | Example    |
+  |------------|-----------------|------------|
+  | C#         | PascalCase      | OrderLines |
+  | Java       | camelCase       | orderLines |
+  | JavaScript | camelCase       | orderLines |
+
+* By default, when saving an entity, the naming convention used by the client is reflected in the JSON document properties on the server-side.  
+  This default serialization behavior can be customized to facilitate language interoperability.
+
+* __Example__:
+
+  Set `CustomizeJsonSerializer` and `PropertyNameConverter` to serialize an entity's properties as camelCase from a C# client:
+
+  {CODE PropertyCasing@ClientApi\Configuration\Conventions.cs /}
+  {CODE FirstChar@ClientApi\Configuration\Conventions.cs /}
+  {CODE SerializationSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### OperationStatusFetchMode
+
+---
+
+* Use the `OperationStatusFetchMode` convention to set the way an [operation](../../client-api/operations/what-are-operations) is getting its status when [waiting for completion](../../client-api/operations/what-are-operations#wait-for-completion).
+
+* DEFAULT:  
+  By default, the value is set to `ChangesApi` which uses the WebSocket protocol underneath when a connection is established with the server.
+
+* On some older systems like Windows 7 the WebSocket protocol might not be available due to the OS and .NET Framework limitations.
+  To bypass this issue, the value can be changed to `Polling`.
+
 {CODE OperationStatusFetchMode@ClientApi\Configuration\Conventions.cs /}
+{CODE OperationStatusFetchModeSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## Change fields/properties Naming Convention
-
-Different clients may use different casing conventions for entity field names.  
-E.g., here are the field naming defaults for clients of a few languages.  
-
-| Language | Default convention | Example |
-| ------------- | ----- | --- |
-| C# | PascalCase | OrderLines |
-| Java | camelCase | orderLines |
-| JavaScript | camelCase | orderLines |
-
-Whatever naming convention a client uses, is by default reflected on the server-side.  
-These defauls can be customized, e.g. to allow inter-language operability.  
-
-### Example: Using camelCase by a C# client
-
-Make a C# client use camelCase by setting `CustomizeJsonSerializer` and `PropertyNameConverter `.  
-
-{CODE FirstChar@ClientApi\Configuration\Conventions.cs /}
-{CODE PropertyCasing@ClientApi\Configuration\Conventions.cs /}
-
-## IdentityPartsSeparator
-
-Use the `IdentityPartsSeparator` convention to change the default 
-**ID (Identity) separator** for automatically-generated document IDs.  
-**Default**: `/` (forward slash)  
-{CODE IdentityPartsSeparator@ClientApi\Configuration\Conventions.cs /}
-
-* The value can be any `char` except `|` (pipe).  
-
-{NOTE: }
-Changing the separator affects these ID generation strategies:  
-
-* [Server-Side ID](../../server/kb/document-identifier-generation#strategy--2)
-* [Identity](../../server/kb/document-identifier-generation#strategy--3)
-* [HiLo Algorithm](../../server/kb/document-identifier-generation#strategy--4)
 {NOTE/}
+{NOTE: }
 
-## TopologyCacheLocation
+#### PreserveDocumentPropertiesNotFoundOnModel
 
-Use `TopologyCacheLocation` to change the location of topology cache files.  
-Setting this value will check directory existance and writing permissions.  
-**Default**: The application's base directory (`AppContext.BaseDirectory`)
+---
+
+* When setting the `PreserveDocumentPropertiesNotFoundOnModel` convention to `true`,  
+  the client can report (via [whatChanged](../../lient-api/session/how-to/check-if-there-are-any-changes-on-a-session#get-session-changes) method) the missing properties on the model when loading a document.
+
+* DEFAULT: `true`
+
+{CODE PreserveDocumentPropertiesNotFoundOnModelSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### ReadBalanceBehavior
+
+---
+
+* Configure the __read request behavior__ by setting the `ReadBalanceBehavior` convention.
+
+* Learn more in the dedicated [Read balance behavior](../../client-api/configuration/load-balance/read-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### RequestTimeout
+
+---
+
+* Use the `RequestTimeout` convention to define the global request timeout value for all `RequestExecutors` created per database.
+
+* DEFAULT: `null` (the default HTTP client timout will be applied - 12h)
+
+{CODE RequestTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE RequestTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### ResolveTypeFromClrTypeName
+
+---
+
+* Use the `ResolveTypeFromClrTypeName` convention to define a function that resolves the CLR type  
+  from the CLR type name.
+
+* DEFAULT: The type is returned.
+
+{CODE ResolveTypeFromClrTypeName@ClientApi\Configuration\Conventions.cs /}
+{CODE ResolveTypeFromClrTypeNameSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### SaveEnumsAsIntegers
+
+---
+
+* When setting the `SaveEnumsAsIntegers` convention to `true`,  
+  C# `enum` types will be stored and queried as integers, rather than their string representations.
+
+* DEFAULT: `false` (save as strings)
+
+{CODE SaveEnumsAsIntegersSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### SecondBroadcastAttemptTimeout
+
+---
+
+* Use the `SecondBroadcastAttemptTimeout` convention to set the timeout for the second broadcast attempt.
+
+* Upon failure of the [first attempt](../../client-api/configuration/conventions#firstbroadcastattempttimeout) the request executor will resend the command to all nodes simultaneously.
+
+* DEFAULT: `30 seconds`
+
+{CODE SecondBroadcastAttemptTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE SecondBroadcastAttemptTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### SendApplicationIdentifier
+
+---
+
+* Use the `SendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
+
+* Setting tp _true_ allows the server to issue performance hint notifications to the client,
+  e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
+
+* DEFAULT: `true`
+
+{CODE SendApplicationIdentifierSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### ShouldIgnoreEntityChanges
+
+---
+
+* Set the `ShouldIgnoreEntityChanges` convention to disable entity tracking for certain entities.
+
+* Learn more in [Customize tracking in conventions](../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions).
+
+{NOTE/}
+{NOTE: }
+
+#### TopologyCacheLocation
+
+---
+
+* Use the `TopologyCacheLocation` convention to change the location of the topology cache files   
+  (`*.raven-database-topology` & `*.raven-cluster-topology`).
+
+* Directory existence and writing permissions will be checked when setting this value.
+
+* DEFAULT: `AppContext.BaseDirectory` (The application's base directory)
 
 {CODE TopologyCacheLocation@ClientApi\Configuration\Conventions.cs /}
+{CODE TopologyCacheLocationSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## AddIdFieldToDynamicObjects
+{NOTE/}
+{NOTE: }
 
-Use `AddIdFieldToDynamicObjects` to determine whether an Id field is automatically added to dynamic objects.  
-**Default**: `true`  
-{CODE AddIdFieldToDynamicObjects@ClientApi\Configuration\Conventions.cs /}
+#### TransformTypeCollectionNameToDocumentIdPrefix
 
-## ShouldIgnoreEntityChanges
+---
 
-Configure this function to disable entity tracking for certain entities.  
-Learn more in [Customize tracking in conventions](../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions).
+* Use the `TransformTypeCollectionNameToDocumentIdPrefix` convention to define a function that will  
+  customize the document ID prefix from the the collection name.
 
-## WaitForIndexesAfterSaveChangesTimeout
+* DEFAULT:  
+  By default, the document id prefix is determined as follows:
 
-Use `WaitForIndexesAfterSaveChangesTimeout` to set the default timeout 
-for the DocumentSession.Advanced.WaitForIndexesAfterSaveChanges method.  
-**Default**: 15 Seconds  
+| Number of uppercase letters in collection name   | Document ID prefix                                          |
+|--------------------------------------------------|-------------------------------------------------------------|
+| `<= 1`                                           | Use the collection name with all lowercase letters          |
+| `> 1`                                            | Use the collection name as is, preserving the original case |
+
+{CODE TransformTypeCollectionNameToDocumentIdPrefixSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### UseHttpCompression
+
+---
+
+* When setting the `UseHttpCompression` convention to `true`,  
+  then gzip compression will be used when sending content of HTTP request.
+
+* When the convention is set to `false`, content will not be compressed.
+
+* DEFAULT: `true`
+
+{CODE UseHttpCompressionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### UseHttpDecompression
+
+---
+
+* When setting the `UseHttpDecompression` convention to `true`,  
+  the client can accept compressed HTTP response content and will use zstd/gzip/deflate decompression methods.
+
+* DEFAULT: `true`
+
+{CODE UseHttpDecompressionSyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### UseOptimisticConcurrency
+
+---
+
+* When setting the `UseOptimisticConcurrency` convention to `true`,  
+  Optimistic Concurrency checks will be applied for all sessions opened from the Document Store.
+
+* DEFAULT: `false`
+
+{CODE UseOptimisticConcurrencySyntax@ClientApi\Configuration\Conventions.cs /}
+
+{NOTE/}
+{NOTE: }
+
+#### WaitForIndexesAfterSaveChangesTimeout
+
+---
+
+* Use the `WaitForIndexesAfterSaveChangesTimeout` convention to set the default timeout for the
+  `DocumentSession.Advanced.WaitForIndexesAfterSaveChanges` method.
+
+* DEFAULT: 15 Seconds
+
 {CODE WaitForIndexesAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE WaitForIndexesAfterSaveChangesTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## WaitForReplicationAfterSaveChangesTimeout
+{NOTE/}
+{NOTE: }
 
-Use `WaitForReplicationAfterSaveChangesTimeout` to set the default timeout 
-for the DocumentSession.Advanced.WaitForReplicationAfterSaveChanges method.  
-**Default**: 15 Seconds  
-{CODE WaitForReplicationAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+#### WaitForNonStaleResultsTimeout
 
-## WaitForNonStaleResultsTimeout
+---
 
-Use `WaitForNonStaleResultsTimeout` to set the default timeout WaitForNonStaleResults 
-methods used when querying.  
-**Default**: 15 Seconds  
+* Use the `WaitForNonStaleResultsTimeout` convention to set the default timeout used by the  
+  `WaitForNonStaleResults` method when querying.
+
+* DEFAULT: 15 Seconds
+
 {CODE WaitForNonStaleResultsTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE WaitForNonStaleResultsTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
 
-## CreateHttpClient
-
-Use the `CreateHttpClient` convention to modify the HTTP client your 
-client application uses.  
-Implementing your own  HTTP client can be useful when, for example, 
-you'd like your clients to provide the server with tracing info.  
-{CODE CreateHttpClient@ClientApi\Configuration\Conventions.cs /}
-
-{NOTE: }
-If you override the default `CreateHttpClient` convention we advise 
-that you also set the HTTP client type correctly using the 
-[HttpClientType](../../client-api/configuration/conventions#httpclienttype) convention.  
 {NOTE/}
-
-## HttpClientType
-
-Use `HttpClientType` to get or set the type of HTTP client you're using.  
-{CODE HttpClientType@ClientApi\Configuration\Conventions.cs /}
-
 {NOTE: }
-RavenDB uses the HTTP type internally to manage its cache. If you 
-override the [CreateHttpClient](../../client-api/configuration/conventions#createhttpclient) 
-convention to use a non-default HTTP client, we advise that you also 
-set `HttpClientType` so it returns the client type you are actually using.  
+
+#### WaitForReplicationAfterSaveChangesTimeout
+
+---
+
+* Use the `WaitForReplicationAfterSaveChangesTimeout` convention to set the default timeout for the  
+  `DocumentSession.Advanced.WaitForReplicationAfterSaveChanges`method.
+
+* DEFAULT: 15 Seconds
+
+{CODE WaitForReplicationAfterSaveChangesTimeout@ClientApi\Configuration\Conventions.cs /}
+{CODE WaitForReplicationAfterSaveChangesTimeoutSyntax@ClientApi\Configuration\Conventions.cs /}
+
 {NOTE/}
-
-## DisposeCertificate
-
-Use the `DisposeCertificate` convention to enable or disable the automatic 
-disposal of X509Certificate2 certificates when the store is disposed of.  
-**Default**: `true`  
-{CODE DisposeCertificate@ClientApi\Configuration\Conventions.cs /}
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -138,7 +138,7 @@
 ---
 
 * EXPERT ONLY:   
-  Use the `DisableAtomicDocumentWritesInClusterWideTransaction` convention disable automatic  
+  Use the `DisableAtomicDocumentWritesInClusterWideTransaction` convention to disable automatic  
   atomic writes with cluster write transactions.
 
 * When set to `true`, will only consider explicitly added compare exchange values to validate cluster wide transactions.
@@ -537,8 +537,13 @@
 
 ---
 
-* When setting the `PreserveDocumentPropertiesNotFoundOnModel` convention to `true`,  
-  the client can report (via [whatChanged](../../lient-api/session/how-to/check-if-there-are-any-changes-on-a-session#get-session-changes) method) the missing properties on the model when loading a document.
+* Loading a document using a different model will result in the removal of the missing model properties  
+  from the loaded entity, and no exception is thrown.
+
+* Setting the `PreserveDocumentPropertiesNotFoundOnModel` convention to `true`  
+  allows the client to check (via [whatChanged](../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session#get-session-changes)
+  or via [WhatChangedFor](../../client-api/session/how-to/check-if-entity-has-changed#get-entity-changes) methods)
+  for the missing properties on the entity after loading the document.
 
 * DEFAULT: `true`
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
@@ -167,11 +167,16 @@
 
 ---
 
-* When setting the `DisableTopologyCache` convention to `true`, the topology cache usage will be disabled.  
-  Even if the client is configured to receive topology updates from the server, no topology files will be saved on disk,
-  thus preventing `*.raven-cluster-topology` files from piling up.
+* By default, the client caches the cluster's topology in `*.raven-cluster-topology` files on disk.  
+  When all servers provided in the `DocumentStore.Urls` property are down or unavailable,
+  the client will load the topology from the latest file and try to connect to nodes that are not listed in the URL property.
 
-* In addition, when set to _true_, the client will not try to load the topology from the cache upon failing to connect to the server.
+* This behavior can be disabled when setting the `DisableTopologyCache` convention to `true`.  
+  In such a case:
+
+    * The client will not load the topology from the cache upon failing to connect to a server.
+    * Even if the client is configured to [receive topology updates](../../client-api/configuration/conventions#disabletopologyupdates) from the server, no topology files will be saved on disk,  
+      thus preventing the accumulation of these files.
 
 * DEFAULT: `false`
 

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
@@ -1,0 +1,484 @@
+# Conventions
+
+{NOTE: }
+
+* __Conventions__ in RavenDB are customizable settings that users can configure to tailor client behaviors according to their preferences.
+ 
+* In this page:  
+  * [How to set conventions](../../client-api/configuration/conventions#how-to-set-conventions)  
+  * [Conventions:](../../client-api/configuration/conventions#conventions:)  
+      [customFetch](../../client-api/configuration/conventions#customfetch)  
+      [disableAtomicDocumentWritesInClusterWideTransaction](../../client-api/configuration/conventions#disableatomicdocumentwritesinclusterwidetransaction)  
+      [disableTopologyUpdates](../../client-api/configuration/conventions#disabletopologyupdates)  
+      [findCollectionName](../../client-api/configuration/conventions#findcollectionname)  
+      [findJsType](../../client-api/configuration/conventions#_findjstype)  
+      [findJsTypeName](../../client-api/configuration/conventions#_findjstypeName)  
+      [firstBroadcastAttemptTimeout](../../client-api/configuration/conventions#firstbroadcastattempttimeout)  
+      [identityPartsSeparator](../../client-api/configuration/conventions#identitypartsseparator)  
+      [loadBalanceBehavior](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [loadBalancerContextSeed](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [loadBalancerPerSessionContextSelector](../../client-api/configuration/conventions#loadbalancebehavior)  
+      [maxHttpCacheSize](../../client-api/configuration/conventions#maxhttpcachesize)  
+      [maxNumberOfRequestsPerSession](../../client-api/configuration/conventions#maxnumberofrequestspersession)  
+      [readBalanceBehavior](../../client-api/configuration/conventions#readbalancebehavior)  
+      [requestTimeout](../../client-api/configuration/conventions#requesttimeout)  
+      [secondBroadcastAttemptTimeout](../../client-api/configuration/conventions#secondbroadcastattempttimeout)  
+      [sendApplicationIdentifier](../../client-api/configuration/conventions#sendapplicationidentifier)  
+      [shouldIgnoreEntityChanges](../../client-api/configuration/conventions#shouldignoreentitychanges)  
+      [storeDatesInUtc](../../client-api/configuration/conventions#storedatesinutc)  
+      [storeDatesWithTimezoneInfo](../../client-api/configuration/conventions#storedateswithtimezoneinfo)  
+      [syncJsonParseLimit](../../client-api/configuration/conventions#syncjsonparselimit)  
+      [throwIfQueryPageSizeIsNotSet](../../client-api/configuration/conventions#throwifquerypagesizeisnotset)  
+      [transformClassCollectionNameToDocumentIdPrefix](../../client-api/configuration/conventions#transformclasscollectionnametodocumentidprefix)  
+      [useCompression](../../client-api/configuration/conventions#usecompression)  
+      [useJsonlStreaming](../../client-api/configuration/conventions#usejsonlstreaming)  
+      [useOptimisticConcurrency](../../client-api/configuration/conventions#useoptimisticconcurrency)  
+      [waitForIndexesAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforindexesaftersavechangestimeout)  
+      [waitForNonStaleResultsTimeout](../../client-api/configuration/conventions#waitfornonstaleresultstimeout)  
+      [waitForReplicationAfterSaveChangesTimeout](../../client-api/configuration/conventions#waitforreplicationaftersavechangestimeout)  
+
+{NOTE/}
+
+---
+
+{PANEL: How to set conventions}
+
+* Access the conventions via the `conventions` property of the `DocumentStore` object.
+
+* The conventions set on a Document Store will apply to ALL [sessions](../../client-api/session/what-is-a-session-and-how-does-it-work) and [operations](../../client-api/operations/what-are-operations) associated with that store.
+ 
+* Customizing the conventions can only be set __before__ calling `documentStore.initialize()`.  
+  Trying to do so after calling _initialize()_ will throw an exception.
+
+{CODE:nodejs conventions_1@client-api\configuration\conventions.js /}
+
+{PANEL/}
+
+{PANEL: Conventions:}
+
+{NOTE: }
+
+#### customFetch
+
+---
+
+* Use the `customFetch` convention to override the default _fetch_ method.  
+  This method is useful to enable RavenDB Node.js client on CloudFlare Workers.
+
+* DEFAULT: undefined
+
+{CODE:nodejs customFetchSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### disableAtomicDocumentWritesInClusterWideTransaction
+
+---
+
+* EXPERT ONLY:   
+  Use the `disableAtomicDocumentWritesInClusterWideTransaction` convention to disable automatic  
+  atomic writes with cluster write transactions.
+
+* When set to `true`, will only consider explicitly added compare exchange values to validate cluster wide transactions.
+
+* DEFAULT: `false`
+
+{CODE:nodejs disableAtomicDocumentWritesInClusterWideTransactionSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### disableTopologyUpdates
+
+---
+
+* When setting the `disableTopologyUpdates` convention to `true`,  
+  no database topology updates will be sent from the server to the client (e.g. adding or removing a node).
+ 
+* DEFAULT: `false`
+
+{CODE:nodejs disableTopologyUpdatesSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### findCollectionName
+
+---
+
+* Use the `findCollectionName` convention to define a function that will customize the collection name  
+  from given type.
+
+* DEFAULT: The collection name will be the plural form of the type name.
+
+{CODE:nodejs findCollectionNameSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### findJsType
+
+---
+
+* Use the `findJsType` convention to define a function that finds the class of a document (if exists).
+
+* The type is retrieved from the `Raven-Node-Type` property under the `@metdata` key in the document.
+
+* DEFAULT: `null`
+
+{CODE:nodejs findJsTypeSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### findJsTypeName
+
+---
+
+* Use the `findJsTypeName` convention to define a function that returns the class type name from a given type.
+
+* The class name will be stored in the entity metadata.
+
+* DEFAULT: `null`
+
+{CODE:nodejs findJsTypeNameSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### firstBroadcastAttemptTimeout
+
+---
+
+* Use the `firstBroadcastAttemptTimeout` convention to set the timeout for the first broadcast attempt.  
+ 
+* In the first attempt, the request executor will send a single request to the selected node.  
+  Learn about the "selected node" in: [Client logic for choosing a node](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+ 
+* A [second attempt](../../client-api/configuration/conventions#secondbroadcastattempttimeout) will be held upon failure.
+ 
+* DEFAULT: `5 seconds`
+
+{CODE:nodejs firstBroadcastAttemptTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### identityPartsSeparator
+
+---
+
+* Use the `identityPartsSeparator` convention to set the default **ID separator** for automatically-generated document IDs.
+ 
+* DEFAULT: `/` (forward slash)  
+ 
+* The value can be any `char` except `|` (pipe).
+ 
+* Changing the separator affects these ID generation strategies:  
+  * [Server-Side ID](../../server/kb/document-identifier-generation#strategy--2)
+  * [Identity](../../server/kb/document-identifier-generation#strategy--3)
+  * [HiLo Algorithm](../../server/kb/document-identifier-generation#strategy--4)
+
+{CODE:nodejs identityPartsSeparatorSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### loadBalanceBehavior
+#### loadBalancerPerSessionContextSelector
+#### loadBalancerContextSeed
+
+---
+
+* Configure the __load balance behavior__ by setting the following conventions:
+  * `loadBalanceBehavior`
+  * `loadBalancerPerSessionContextSelector`
+  * `loadBalancerContextSeed`
+
+* Learn more in the dedicated [Load balance behavior](../../client-api/configuration/load-balance/load-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### maxHttpCacheSize
+
+---
+
+* Use the `maxHttpCacheSize` convention to set the maximum HTTP cache size.
+ 
+* This setting will affect all the databases accessed by the Document Store.
+ 
+* DEFAULT: `128 MB`
+
+* __Disabling Caching__:  
+
+    * To disable caching globally, set `maxHttpCacheSize` to zero.  
+  
+    * Note: When caching is disabled, ALL data requests are sent to the server.
+
+{CODE:nodejs maxHttpCacheSizeSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### maxNumberOfRequestsPerSession
+
+---
+
+* Use the `maxNumberOfRequestsPerSession` convention to set the maximum number of requests per session.
+ 
+* DEFAULT: `30`
+ 
+{CODE:nodejs maxNumberOfRequestsPerSessionSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### readBalanceBehavior
+
+---
+
+* Configure the __read request behavior__ by setting the `readBalanceBehavior` convention.
+
+* Learn more in the dedicated [Read balance behavior](../../client-api/configuration/load-balance/read-balance-behavior) article.
+
+{NOTE/}
+{NOTE: }
+
+#### requestTimeout
+
+---
+
+* Use the `requestTimeout` convention to define the global request timeout value for all `RequestExecutors` created per database.
+ 
+* DEFAULT: `null` (the default HTTP client timout will be applied - 12h)
+
+{CODE:nodejs requestTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### secondBroadcastAttemptTimeout
+
+---
+
+* Use the `secondBroadcastAttemptTimeout` convention to set the timeout for the second broadcast attempt.
+ 
+* Upon failure of the [first attempt](../../client-api/configuration/conventions#firstbroadcastattempttimeout) the request executor will resend the command to all nodes simultaneously.
+ 
+* DEFAULT: `30 seconds`
+
+{CODE:nodejs secondBroadcastAttemptTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### sendApplicationIdentifier
+
+---
+
+* Use the `sendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
+
+* Setting tp _true_ allows the server to issue performance hint notifications to the client, 
+  e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
+
+* DEFAULT: `true`
+
+{CODE:nodejs sendApplicationIdentifierSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### shouldIgnoreEntityChanges
+
+---
+
+* Set the `shouldIgnoreEntityChanges` convention to disable entity tracking for certain entities.  
+ 
+* Learn more in [Customize tracking in conventions](../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions).
+
+{NOTE/}
+{NOTE: }
+
+#### storeDatesInUtc
+
+---
+
+* When setting the `storeDatesInUtc` convention to `true`,  
+  DateTime values will be stored in the database in UTC format.
+
+* DEFAULT: `false`
+
+{CODE:nodejs storeDatesInUtcSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### storeDatesWithTimezoneInfo
+
+---
+
+* When setting the `storeDatesWithTimezoneInfo` to `true`,  
+  DateTime values will be stored in the database with their time zone information included.
+
+* DEFAULT: `false`
+
+{CODE:nodejs storeDatesWithTimezoneInfoSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### syncJsonParseLimit
+
+---
+
+* Use the `syncJsonParseLimit` convention to define the maximum size for the _sync_ parsing of the JSON data responses received from the server.  
+  For data exceeding this size, the client switches to _async_ parsing.
+
+* DEFAULT: `2 * 1_024 * 1_024`
+
+{CODE:nodejs syncJsonParseLimitSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### throwIfQueryPageSizeIsNotSet
+
+---
+
+* When setting the `throwIfQueryPageSizeIsNotSet` convention to `true`,  
+  an exception will be thrown if a query is performed without explicitly setting a page size.
+
+* This can be useful during development to identify potential performance bottlenecks
+  since there is no limitation on the number of results returned from the server.
+
+* DEFAULT: `false`
+
+{CODE:nodejs throwIfQueryPageSizeIsNotSetSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### transformClassCollectionNameToDocumentIdPrefix
+
+---
+
+* Use the `transformTypeCollectionNameToDocumentIdPrefix` convention to define a function that will  
+  customize the document ID prefix from the the collection name.
+
+* DEFAULT:  
+  By default, the document id prefix is determined as follows:
+
+| Number of uppercase letters in collection name   | Document ID prefix                                          |
+|--------------------------------------------------|-------------------------------------------------------------|
+| `<= 1`                                           | Use the collection name with all lowercase letters          |
+| `> 1`                                            | Use the collection name as is, preserving the original case |
+
+{CODE:nodejs transformClassCollectionNameToDocumentIdPrefixSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### useCompression
+
+---
+
+* Set the `useCompression` convention to true in order to accept the __response__ in compressed format and the automatic decompression of the HTTP response content.
+
+* A gzip compression is always applied when sending content in an HTTP request.
+ 
+* DEFAULT: `true`  
+
+{CODE:nodejs useCompressionSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### useJsonlStreaming
+
+---
+
+* Set the `useJsonlStreaming` convention to `true` when streaming query results as JSON Lines (JSONL) format.
+
+* DEFAULT: `true`
+
+{CODE:nodejs useJsonlStreamingSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### useOptimisticConcurrency
+
+---
+
+* When setting the `useOptimisticConcurrency` convention to `true`,  
+  Optimistic Concurrency checks will be applied for all sessions opened from the Document Store. 
+ 
+* DEFAULT: `false`  
+
+{CODE:nodejs useOptimisticConcurrencySyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### waitForIndexesAfterSaveChangesTimeout
+
+---
+
+* Use the `waitForIndexesAfterSaveChangesTimeout` convention to set the default timeout for the 
+  `documentSession.advanced.waitForIndexesAfterSaveChanges` method.  
+ 
+* DEFAULT: 15 Seconds
+
+{CODE:nodejs waitForIndexesAfterSaveChangesTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### waitForNonStaleResultsTimeout
+
+---
+
+* Use the `waitForNonStaleResultsTimeout` convention to set the default timeout used by the  
+  `waitForNonStaleResults` method when querying.  
+ 
+* DEFAULT: 15 Seconds  
+
+{CODE:nodejs waitForNonStaleResultsTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{NOTE: }
+
+#### waitForReplicationAfterSaveChangesTimeout
+
+---
+
+* Use the `waitForReplicationAfterSaveChangesTimeout` convention to set the default timeout for the  
+  `documentSession.advanced.waitForReplicationAfterSaveChanges`method.  
+ 
+* DEFAULT: 15 Seconds  
+
+{CODE:nodejs waitForReplicationAfterSaveChangesTimeoutSyntax@client-api\configuration\conventions.js /}
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Conventions
+
+- [Querying](../../client-api/configuration/querying)
+- [Serialization](../../client-api/configuration/serialization)
+- [Load Balancing Client Requests](../../client-api/configuration/load-balance/overview)
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../client-api/configuration/identifier-generation/type-specific)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
@@ -123,7 +123,7 @@
 
 * Use the `findJsType` convention to define a function that finds the class of a document (if exists).
 
-* The type is retrieved from the `Raven-Node-Type` property under the `@metdata` key in the document.
+* The type is retrieved from the `Raven-Node-Type` property under the `@metadata` key in the document.
 
 * DEFAULT: `null`
 
@@ -205,17 +205,18 @@
 
 ---
 
-* Use the `maxHttpCacheSize` convention to set the maximum HTTP cache size.
- 
-* This setting will affect all the databases accessed by the Document Store.
+* Use the `MaxHttpCacheSize` convention to set the maximum HTTP cache size.  
+  This setting will affect all the databases accessed by the Document Store.
  
 * DEFAULT: `128 MB`
 
-* __Disabling Caching__:  
+* __Disabling Caching__:
 
-    * To disable caching globally, set `maxHttpCacheSize` to zero.  
-  
-    * Note: When caching is disabled, ALL data requests are sent to the server.
+    * To disable caching globally, set `MaxHttpCacheSize` to zero.
+    * To disable caching per session, see: [Disable caching per session](../../client-api/session/configuration/how-to-disable-caching).
+
+* Note: RavenDB also supports Aggressive Caching.  
+  Learn more about that in article [Setup aggressive caching](../../client-api/how-to/setup-aggressive-caching).
 
 {CODE:nodejs maxHttpCacheSizeSyntax@client-api\configuration\conventions.js /}
 
@@ -280,7 +281,7 @@
 
 * Use the `sendApplicationIdentifier` convention to `true` to enable sending a unique application identifier to the RavenDB Server.
 
-* Setting tp _true_ allows the server to issue performance hint notifications to the client, 
+* Setting to _true_ allows the server to issue performance hint notifications to the client, 
   e.g. during robust topology update requests which could indicate a Client API misuse impacting the overall performance.
 
 * DEFAULT: `true`
@@ -415,7 +416,10 @@
 
 * When setting the `useOptimisticConcurrency` convention to `true`,  
   Optimistic Concurrency checks will be applied for all sessions opened from the Document Store. 
- 
+
+* Learn more about Optimistic Concurrency and the various ways to enable it in article  
+  [how to enable optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency).
+
 * DEFAULT: `false`  
 
 {CODE:nodejs useOptimisticConcurrencySyntax@client-api\configuration\conventions.js /}

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
@@ -1,28 +1,39 @@
 ﻿using System;
 using System.Net.Http;
+using System.Reflection;
 using Amazon.XRay.Recorder.Handlers.System.Net;
 using Newtonsoft.Json.Serialization;
+using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
 using Raven.Client.Json.Serialization.NewtonsoftJson;
 using Sparrow;
+using Sparrow.Json;
 
 namespace Raven.Documentation.Samples.ClientApi.Configuration
 {
-    public class Conventions
+    public class ConventionsExamples
     {
-        public Conventions()
+        public ConventionsExamples()
         {
             #region conventions_1
             using (var store = new DocumentStore()
             {
                 Conventions =
                 {
-                    // customizations go here
+                    // Set conventions HERE, e.g.:
+                    MaxNumberOfRequestsPerSession = 50,
+                    AddIdFieldToDynamicObjects = false
+                    // ...
                 }
             }.Initialize())
             {
-
+                // * Here you can interact with the RavenDB store:
+                //   open sessions, create or query for documents, perform operations, etc.
+                
+                // * Conventions CANNOT be set here after calling Initialize()
             }
             #endregion
         }
@@ -37,40 +48,20 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
             {
                 Conventions =
                 {
-	                #region MaxHttpCacheSize
-	                MaxHttpCacheSize = new Size(256, SizeUnit.Megabytes)
-	                #endregion
-	                ,
-	                #region MaxNumberOfRequestsPerSession
-	                MaxNumberOfRequestsPerSession = 10
-	                #endregion
-	                ,
-	                #region UseOptimisticConcurrency
-	                UseOptimisticConcurrency = true
-	                #endregion
-	                ,
-	                #region DisableTopologyUpdates
-                    DisableTopologyUpdates = false
-	                #endregion
+                    #region MaxHttpCacheSize
+                    MaxHttpCacheSize = new Size(256, SizeUnit.Megabytes) // Set max cache size
+                    #endregion
                     ,
-	                #region SaveEnumsAsIntegers
-                    SaveEnumsAsIntegers = true
-	                #endregion
+                    #region UseOptimisticConcurrency
+                    UseOptimisticConcurrency = true
+                    #endregion
                     ,
                     #region RequestTimeout
                     RequestTimeout = TimeSpan.FromSeconds(90)
                     #endregion
                     ,
-                    #region UseHttpCompression
-                    UseHttpCompression = true
-                    #endregion
-                    ,
-                    #region UseHttpDecompression
-                    UseHttpDecompression = true
-                    #endregion
-                    ,
                     #region OperationStatusFetchMode
-                    OperationStatusFetchMode = OperationStatusFetchMode.ChangesApi
+                    OperationStatusFetchMode = OperationStatusFetchMode.ChangesApi // ChangesApi | Polling
                     #endregion
                     ,
                     #region TopologyCacheLocation
@@ -80,17 +71,14 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                     #region PropertyCasing
                     Serialization = new NewtonsoftJsonSerializationConventions
                     {
+                        // .Net properties will be serialized as camelCase in the JSON document when storing an entity
+                        // and deserialized back to PascalCase
                         CustomizeJsonSerializer = s => s.ContractResolver = new CamelCasePropertyNamesContractResolver()
                     },
-                    PropertyNameConverter = mi => FirstCharToLower(mi.Name)
-                    #endregion
-                    ,
-                    #region AddIdFieldToDynamicObjects
-                    AddIdFieldToDynamicObjects = false
-                    #endregion
-                    ,
-                    #region IdentityPartsSeparator
-                    IdentityPartsSeparator = '~'
+                    
+                    // In addition, the following convention is required when
+                    // making a query that filters by a field name and when indexing. 
+                    PropertyNameConverter = memberInfo => FirstCharToLower(memberInfo.Name)
                     #endregion
                     ,
                     #region WaitForIndexesAfterSaveChangesTimeout
@@ -108,7 +96,7 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                     #region CreateHttpClient
                     CreateHttpClient = handler =>
                     {
-                        // Your HTTP Client code here, e.g. -
+                        // Your HTTP client code here, e.g.:
                         var httpClient = new MyHttpClient(new HttpClientXRayTracingHandler(new HttpClientHandler()));
                         return httpClient;
                     }
@@ -119,27 +107,283 @@ namespace Raven.Documentation.Samples.ClientApi.Configuration
                     HttpClientType = typeof(MyHttpClient)
                     #endregion
                     ,
-                    #region DisposeCertificate
-                    // Disable the automatic disposal of certificates when the store is disposed of
-                    DisposeCertificate = false
+                    #region FirstBroadcastAttemptTimeout
+                    FirstBroadcastAttemptTimeout = TimeSpan.FromSeconds(10)
+                    #endregion
+                    ,
+                    #region SecondBroadcastAttemptTimeout
+                    SecondBroadcastAttemptTimeout = TimeSpan.FromSeconds(20)
+                    #endregion
+                    ,
+                    #region FindIdentityProperty
+                    // If there exists a property with name "CustomizedId" then it will be the entity's ID property 
+                    FindIdentityProperty = memberInfo => memberInfo.Name == "CustomizedId"
+                    #endregion
+                    ,
+                    #region FindIdentityPropertyNameFromCollectionName
+                    // Will use property "CustomizedId" as the ID property
+                    FindIdentityPropertyNameFromCollectionName = collectionName => "CustomizedId"
+                    #endregion
+                    ,
+                    #region FindClrType
+                    // The default implementation is:
+                    FindClrType = (_, doc) =>
+                    {
+                        if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                            metadata.TryGet(Constants.Documents.Metadata.RavenClrType, out string clrType))
+                            return clrType;
+
+                        return null;
+                    }
+                    #endregion
+                    ,
+                    #region FindCollectionName
+                    // Here the collection name will be the type name separated by dashes
+                    FindCollectionName = type => String.Join("-", type.Name.ToCharArray())
+                    #endregion
+                    ,
+                    #region FindCollectionNameForDynamic
+                    // Here the collection name will be some property of the dynamic entity
+                    FindCollectionNameForDynamic = dynamicEntity => dynamicEntity.SomeProperty
+                    #endregion
+                    ,
+                    #region FindClrTypeNameForDynamic
+                    // The dynamic entity's type is returned by default
+                    FindClrTypeNameForDynamic = dynamicEntity => dynamicEntity.GetType()
+                    #endregion
+                    ,
+                    #region ResolveTypeFromClrTypeName
+                    // The type itself is returned by default
+                    ResolveTypeFromClrTypeName = clrType => clrType.GetType()
+                    #endregion
+                    ,
+                    #region FindPropertyNameForIndex
+                    // The default function:
+                    FindPropertyNameForIndex = (Type indexedType, string indexedName, string path, string prop) => 
+                        (path + prop).Replace("[].", "_").Replace(".", "_")
+                    #endregion
+                    ,
+                    #region FindPropertyNameForDynamicIndex
+                    // The DEFAULT function:
+                    FindPropertyNameForDynamicIndex = (Type indexedType, string indexedName, string path, string prop) =>
+                        path + prop
                     #endregion
                 }
             };
             
-            var stor2e = new DocumentStore()
+            var store2 = new DocumentStore()
             {
                 Conventions =
                 {
                     #region disable_cache
-                    MaxHttpCacheSize = new Size(0, SizeUnit.Megabytes)
+                    MaxHttpCacheSize = new Size(0, SizeUnit.Megabytes) // Disable caching
                     #endregion
                 }
             };
         }
-    }
-    public class MyHttpClient : HttpClient
-    {
-        public MyHttpClient(HttpMessageHandler handler)
-        { }
+        
+        #region AddIdFieldToDynamicObjectsSyntax
+        // Syntax:
+        public bool AddIdFieldToDynamicObjects { get; set; }
+        #endregion
+        
+        #region AggressiveCacheDurationSyntax
+        // Syntax:
+        public TimeSpan Duration { get; set; }
+        #endregion
+        
+        #region AggressiveCacheModeSyntax
+        // Syntax:
+        public AggressiveCacheMode Mode { get; set; }
+        #endregion
+        
+        #region CreateHttpClientSyntax
+        // Syntax:
+        public Func<HttpClientHandler, HttpClient> CreateHttpClient { get; set; }
+        #endregion
+        
+        #region DisableAtomicDocumentWritesInClusterWideTransactionSyntax
+        // Syntax:
+        public bool? DisableAtomicDocumentWritesInClusterWideTransaction { get; set; }
+        #endregion
+        
+        #region DisableTcpCompressionSyntax
+        // Syntax:
+        public bool DisableTcpCompression { get; set; }
+        #endregion
+        
+        #region DisableTopologyCacheSyntax
+        // Syntax:
+        public bool DisableTopologyCache { get; set; }
+        #endregion
+        
+        #region DisableTopologyUpdatesSyntax
+        // Syntax:
+        public bool DisableTopologyUpdates { get; set; }
+        #endregion
+        
+        #region DisposeCertificateSyntax
+        // Syntax:
+        public bool DisposeCertificate { get; set; }
+        #endregion
+        
+        #region FindClrTypeSyntax
+        // Syntax:
+        public Func<string, BlittableJsonReaderObject, string> FindClrType { get; set; }
+        #endregion
+        
+        #region FindClrTypeNameSyntax
+        // Syntax:
+        public Func<Type, string> FindClrTypeName { get; set; }
+        #endregion
+        
+        #region FindClrTypeNameForDynamicSyntax
+        // Syntax:
+        public Func<dynamic, string> FindClrTypeNameForDynamic { get; set; }
+        #endregion
+        
+        #region FindCollectionNameSyntax
+        // Syntax:
+        public Func<Type, string> FindCollectionName { get; set; }
+        #endregion
+        
+        #region FindCollectionNameForDynamicSyntax
+        // Syntax:
+        public Func<dynamic, string> FindCollectionNameForDynamic { get; set; }
+        #endregion
+        
+        #region FindIdentityPropertySyntax
+        // Syntax:
+        public Func<MemberInfo, bool> FindIdentityProperty { get; set; }
+        #endregion
+                
+        #region FindIdentityPropertyNameFromCollectionNameSyntax
+        // Syntax:
+        public Func<string, string> FindIdentityPropertyNameFromCollectionName { get; set; }
+        #endregion
+
+        #region FindProjectedPropertyNameForIndexSyntax
+        // Syntax:
+        public Func<Type, string, string, string, string> FindProjectedPropertyNameForIndex { get; set; }
+        #endregion
+        
+        #region FindPropertyNameForDynamicIndexSyntax
+        // Syntax:
+        public Func<Type, string, string, string, string> FindPropertyNameForDynamicIndex { get; set; }
+        #endregion
+                
+        #region FindPropertyNameForIndexSyntax
+        // Syntax:
+        public Func<Type, string, string, string, string> FindPropertyNameForIndex { get; set; }
+        #endregion
+        
+        #region FirstBroadcastAttemptTimeoutSyntax
+        // Syntax:
+        public TimeSpan FirstBroadcastAttemptTimeout { get; set; }
+        #endregion
+        
+        #region HttpClientTypeSyntax
+        // Syntax:
+        public Type HttpClientType { get; set; }
+        #endregion
+        
+        #region HttpVersionSyntax
+        // Syntax:
+        public Version HttpVersion { get; set; }
+        #endregion
+        
+        #region IdentityPartsSeparatorSyntax
+        // Syntax:
+        public char IdentityPartsSeparator { get; set; }
+        #endregion
+        
+        #region MaxHttpCacheSizeSyntax
+        // Syntax:
+        public Size MaxHttpCacheSize { get; set; }
+        #endregion
+        
+        #region MaxNumberOfRequestsPerSessionSyntax
+        // Syntax:
+        public int MaxNumberOfRequestsPerSession { get; set; }
+        #endregion
+        
+        #region SerializationSyntax
+        // Syntax:
+        public ISerializationConventions Serialization { get; set; }
+        #endregion
+        
+        #region OperationStatusFetchModeSyntax
+        // Syntax:
+        public OperationStatusFetchMode OperationStatusFetchMode { get; set; }
+        #endregion
+        
+        #region PreserveDocumentPropertiesNotFoundOnModelSyntax
+        // Syntax:
+        public bool PreserveDocumentPropertiesNotFoundOnModel { get; set; }
+        #endregion
+        
+        #region RequestTimeoutSyntax
+        // Syntax:
+        public TimeSpan? RequestTimeout { get; set; } 
+        #endregion
+        
+        #region ResolveTypeFromClrTypeNameSyntax
+        // Syntax:
+        public Func<string, Type> ResolveTypeFromClrTypeName { get; set; }
+        #endregion
+                
+        #region SaveEnumsAsIntegersSyntax
+        // Syntax:
+        public bool SaveEnumsAsIntegers { get; set; } 
+        #endregion
+        
+        #region SecondBroadcastAttemptTimeoutSyntax
+        public TimeSpan SecondBroadcastAttemptTimeout { get; set; } 
+        #endregion
+
+        #region SendApplicationIdentifierSyntax
+        // Syntax:
+        public bool SendApplicationIdentifier { get; set; } 
+        #endregion
+        
+        #region TopologyCacheLocationSyntax
+        // Syntax:
+        public string TopologyCacheLocation { get; set; } 
+        #endregion
+            
+        #region TransformTypeCollectionNameToDocumentIdPrefixSyntax
+        // Syntax:
+        public Func<string, string> TransformTypeCollectionNameToDocumentIdPrefix { get; set; }
+        #endregion
+        
+        #region UseHttpCompressionSyntax
+        // Syntax:
+        public bool UseHttpCompression { get; set; }
+        #endregion
+        
+        #region UseHttpDecompressionSyntax
+        // Syntax:
+        public bool UseHttpDecompression { get; set; }
+        #endregion
+        
+        #region UseOptimisticConcurrencySyntax
+        // Syntax:
+        public bool UseOptimisticConcurrency { get; set; }
+        #endregion
+        
+        #region WaitForIndexesAfterSaveChangesTimeoutSyntax
+        // Syntax:
+        public TimeSpan WaitForIndexesAfterSaveChangesTimeout { get; set; }
+        #endregion
+        
+        #region WaitForNonStaleResultsTimeoutSyntax
+        // Syntax:
+        public TimeSpan WaitForNonStaleResultsTimeout { get; set; }
+        #endregion
+        
+        #region WaitForReplicationAfterSaveChangesTimeoutSyntax
+        // Syntax:
+        public TimeSpan WaitForReplicationAfterSaveChangesTimeout { get; set; }
+        #endregion
     }
 }

--- a/Documentation/6.0/Samples/nodejs/client-api/configuration/conventions.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/configuration/conventions.js
@@ -1,0 +1,197 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function conventions() {
+    {
+        //region conventions_1
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+
+        // Set conventions HERE, e.g.:
+        documentStore.conventions.maxNumberOfRequestsPerSession = 50;
+        documentStore.conventions.disableTopologyUpdates = true;
+
+        documentStore.initialize();
+
+        // * Here you can interact with the RavenDB store:
+        //   open sessions, create or query for documents, perform operations, etc.
+
+        // * Conventions CANNOT be set here after calling initialize()
+        //endregion
+    }
+   
+    //region syntaxDefinitions 
+
+    //region customFetchSyntax
+    // Returns an object
+    get customFetch();
+    // Set an object bound to worker with type: mtls_certificate
+    set customFetch(customFetch);
+    //endregion
+    
+    //region disableAtomicDocumentWritesInClusterWideTransactionSyntax
+    // Returns a boolean value
+    get disableAtomicDocumentWritesInClusterWideTransaction();
+    // Set a boolean value
+    set disableAtomicDocumentWritesInClusterWideTransaction(
+        disableAtomicDocumentWritesInClusterWideTransaction
+    );
+    //endregion
+
+    //region disableTopologyUpdatesSyntax
+    // Returns a boolean value
+    get disableTopologyUpdates();
+    // Set a boolean value
+    set disableTopologyUpdates(value);
+    //endregion
+
+    //region findCollectionNameSyntax
+    // Returns a method
+    get findCollectionName();
+    // Set a method
+    set findCollectionName(value);
+    //endregion
+
+    //region findJsTypeSyntax
+    // Returns a method
+    get findJsType();
+    // Set a method
+    set findJsType(value);
+    //endregion
+
+    //region findJsTypeNameSyntax
+    // Returns a method
+    get findJsTypeName();
+    // Set a method
+    set findJsTypeName(value);
+    //endregion
+
+    //region firstBroadcastAttemptTimeoutSyntax
+    // Returns a number
+    get firstBroadcastAttemptTimeout();
+    // Set a number
+    set firstBroadcastAttemptTimeout(firstBroadcastAttemptTimeout);
+    //endregion
+
+    //region identityPartsSeparatorSyntax
+    // Returns a string
+    get identityPartsSeparator();
+    // Set a string
+    set identityPartsSeparator(value);
+    //endregion
+
+    //region maxHttpCacheSizeSyntax
+    // Returns a number
+    get maxHttpCacheSize();
+    // Set a number
+    set maxHttpCacheSize(value);
+    //endregion
+
+    //region maxNumberOfRequestsPerSessionSyntax
+    // Returns a number
+    get maxNumberOfRequestsPerSession();
+    // Set a number
+    set maxNumberOfRequestsPerSession(value);
+    //endregion
+
+    //region requestTimeoutSyntax
+    // Returns a number
+    get requestTimeout();
+    // Set a number
+    set requestTimeout(value);
+    //endregion
+
+    //region secondBroadcastAttemptTimeoutSyntax
+    // Returns a number
+    get secondBroadcastAttemptTimeout();
+    // Set a number
+    set secondBroadcastAttemptTimeout(timeout);
+    //endregion
+
+    //region sendApplicationIdentifierSyntax
+    // Returns a boolean
+    get sendApplicationIdentifier();
+    // Set a boolean
+    set sendApplicationIdentifier(sendApplicationIdentifier)
+    //endregion
+    
+    //region storeDatesInUtcSyntax
+    // Returns a boolean
+    get storeDatesInUtc();
+    // Set a boolean
+    set storeDatesInUtc(value);
+    //endregion
+
+    //region storeDatesWithTimezoneInfoSyntax
+    // Returns a boolean
+    get storeDatesWithTimezoneInfo();
+    // Set a boolean
+    set storeDatesWithTimezoneInfo(value);
+    //endregion
+    
+    //region syncJsonParseLimitSyntax
+    // Returns a number
+    get syncJsonParseLimit();
+    // Set a number
+    set syncJsonParseLimit(value);
+    //endregion
+
+    //region throwIfQueryPageSizeIsNotSetSyntax
+    // Returns a boolean
+    get throwIfQueryPageSizeIsNotSet();
+    // Set a boolean
+    set throwIfQueryPageSizeIsNotSet(value);
+    //endregion
+    
+    //region transformClassCollectionNameToDocumentIdPrefixSyntax
+    // Returns a method
+    get transformClassCollectionNameToDocumentIdPrefix();
+    // Set a method
+    set transformClassCollectionNameToDocumentIdPrefix(value);
+    //endregion
+
+    //region useCompressionSyntax
+    // Returns a boolean
+    get useCompression();
+    // Set a boolean
+    set useCompression(value);
+    //endregion
+
+    //region useJsonlStreamingSyntax
+    // Returns a boolean
+    get useJsonlStreaming();
+    // Set a boolean
+    set useJsonlStreaming(value);
+    //endregion
+
+    //region useOptimisticConcurrencySyntax
+    // Returns a boolean
+    get useOptimisticConcurrency();
+    // Set a boolean
+    set useOptimisticConcurrency(value);
+    //endregion
+
+    //region waitForIndexesAfterSaveChangesTimeoutSyntax
+    // Returns a number
+    get waitForIndexesAfterSaveChangesTimeout();
+    // Set a number
+    set waitForIndexesAfterSaveChangesTimeout(value);
+    //endregion
+
+    //region waitForNonStaleResultsTimeoutSyntax
+    // Returns a number
+    get waitForNonStaleResultsTimeout();
+    // Set a number
+    set waitForNonStaleResultsTimeout(value);
+    //endregion
+
+    //region waitForReplicationAfterSaveChangesTimeoutSyntax
+    // Returns a number
+    get waitForReplicationAfterSaveChangesTimeout();
+    // Set a number
+    set waitForReplicationAfterSaveChangesTimeout(value);
+    //endregion
+    
+    //endregion 
+   
+}


### PR DESCRIPTION
**Related issues:**

https://issues.hibernatingrhinos.com/issue/RDoc-2595/5.4-Add-all-missing-conventions-in-Configuration-Conventions
https://issues.hibernatingrhinos.com/issue/RDoc-2567/Node.js-Client-API-Configuration-Conventions
https://issues.hibernatingrhinos.com/issue/RDoc-1646/Migration-Client-API-Conventions-add-PreserveDocumentPropertiesNotFoundOnModel
https://issues.hibernatingrhinos.com/issue/RDoc-2578/Document-allowing-to-turn-off-writing-raven-cluster-topology-files
https://issues.hibernatingrhinos.com/issue/RDoc-2615/Document-the-HttpVersion-convention


---

**Node.js** - @ml054 - pls review files:
```
Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.js.markdown
Documentation/5.4/Samples/nodejs/client-api/configuration/conventions.js
```
Note: 
* 6.0 files are exactly the same, were just copied over
* I have opened a separate issue for all conventions I need help with (those were Not added in this PR):
  https://issues.hibernatingrhinos.com/issue/RDoc-2613/Node.js-Add-missing-conventions

---

**C#** files to review: @arekpalinski who should review ? you or someone else ?
```
Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
Documentation/6.0/Raven.Documentation.Pages/client-api/configuration/conventions.dotnet.markdown
Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/Conventions.cs
```