### PR TITLE
RDoc-1654 [C#] Fix the Javascript splice example

### DIFF
--- a/Documentation/4.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
+++ b/Documentation/4.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
@@ -346,7 +346,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -369,7 +369,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -391,7 +391,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(3,1,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {
@@ -415,7 +415,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {

--- a/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
+++ b/Documentation/4.1/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
@@ -346,7 +346,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -369,7 +369,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -391,7 +391,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(3,1,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {
@@ -415,7 +415,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {

--- a/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
+++ b/Documentation/4.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
@@ -346,7 +346,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -369,7 +369,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -391,7 +391,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(3,1,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {
@@ -415,7 +415,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {

--- a/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
+++ b/Documentation/5.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
@@ -346,7 +346,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -369,7 +369,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -391,7 +391,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(3,1,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {
@@ -415,7 +415,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {

--- a/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
+++ b/Documentation/5.1/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
@@ -359,7 +359,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -382,7 +382,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
                         Values =
                         {
                             {
@@ -404,7 +404,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(3,1,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {
@@ -428,7 +428,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
                     changeVector: null,
                     patch: new PatchRequest
                     {
-                        Script = "this.Comments.splice(1,0,args.Comment)",
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
                         Values =
                         {
                             {


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-1654/C-Fix-JS-patching-docs-splice-should-have-a-proper-value

