### PR TITLE
RDoc-2624 - enable python in the documentation

### DIFF
--- a/Raven.Documentation.Parser/Data/Language.cs
+++ b/Raven.Documentation.Parser/Data/Language.cs
@@ -1,33 +1,33 @@
 ﻿namespace Raven.Documentation.Parser.Data
 {
-	using System.ComponentModel;
+    using System.ComponentModel;
 
-	using Raven.Documentation.Parser.Attributes;
+    using Raven.Documentation.Parser.Attributes;
 
-	public enum Language
-	{
-		[FileExtension(".dotnet")]
-		[Description("C#")]
-		Csharp,
+    public enum Language
+    {
+        [FileExtension(".dotnet")]
+        [Description("C#")]
+        Csharp,
 
-		[FileExtension(".java")]
-		[Description("Java")]
-		Java,
+        [FileExtension(".java")]
+        [Description("Java")]
+        Java,
 
-		[FileExtension(".http")]
-		[Description("HTTP")]
-		Http,
+        [FileExtension(".http")]
+        [Description("HTTP")]
+        Http,
 
-        //[FileExtension(".python")] // temporary removed for RDoc-2346
-        //[Description("Python")]
-        //Python,
+        [FileExtension(".python")]
+        [Description("Python")]
+        Python,
 
-	    [FileExtension(".js")]
-	    [Description("Node.js")]
-	    NodeJs,
+        [FileExtension(".js")]
+        [Description("Node.js")]
+        NodeJs,
 
         [FileExtension("")]
-		[Description("General")]
-		All
-	}
+        [Description("General")]
+        All
+    }
 }

--- a/Raven.Documentation.Parser/Helpers/DocumentBuilding/CodeBlockHelper.cs
+++ b/Raven.Documentation.Parser/Helpers/DocumentBuilding/CodeBlockHelper.cs
@@ -131,10 +131,9 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                 case Language.NodeJs:
                     content = ExtractSectionFromFile(section, Path.Combine(samplesDirectory, file));
                     break;
-                // temporary removed for RDoc-2346
-                // case Language.Python:
-                //     content = ExtractSectionFromPythonFile(section, Path.Combine(samplesDirectory, file));
-                //     break;
+                case Language.Python:
+                    content = ExtractSectionFromPythonFile(section, Path.Combine(samplesDirectory, file));
+                    break;
                 default:
                     throw new NotSupportedException(language.ToString());
             }
@@ -154,11 +153,6 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                 var parts = languageAndTitle.Split(':');
                 var languageAsString = parts[0];
 
-                if (languageAsString == "python") // temp fix for RDoc-2346
-                {
-                    return "";
-                }
-
                 var title = parts.Length > 1 ? parts[1] : null;
                 var value = match.Groups[2].Value.Trim();
                 tabs.Add(GenerateCodeTabFromFile(languageAsString, title, value, documentationVersion, options));
@@ -170,11 +164,6 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                 var languageAndTitle = match.Groups[1].Value.Trim();
                 var parts = languageAndTitle.Split(':');
                 var languageAsString = parts[0];
-
-                if (languageAsString == "python") // temp fix for RDoc-2346
-                {
-                    return "";
-                }
 
                 var title = parts.Length > 1 ? parts[1] : null;
                 var value = match.Groups[2].Value.Trim();
@@ -235,10 +224,9 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                 case Language.NodeJs:
                     content = ExtractSectionFromFile(section, Path.Combine(samplesDirectory, file));
                     break;
-                // temporary removed for RDoc-2346
-                // case Language.Python:
-                //     content = ExtractSectionFromPythonFile(section, Path.Combine(samplesDirectory, file));
-                //     break;
+                case Language.Python:
+                    content = ExtractSectionFromPythonFile(section, Path.Combine(samplesDirectory, file));
+                    break;
                 default:
                     throw new NotSupportedException(language.ToString());
             }
@@ -353,9 +341,8 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                 case Language.Http:
                 case Language.NodeJs:
                     return "language-javascript";
-                // temporary removed for RDoc-2346
-                // case Language.Python:
-                //     return "language-python";
+                case Language.Python:
+                    return "language-python";
                 default:
                     throw new NotSupportedException(language.ToString());
             }
@@ -414,9 +401,8 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                     return "Node.js";
                 case Language.Http:
                     return "HTTP";
-                // temporary removed for RDoc-2346
-                // case Language.Python:
-                //     return "Python";
+                case Language.Python:
+                    return "Python";
                 default:
                     throw new NotSupportedException(language.ToString());
             }

--- a/Raven.Documentation.Parser/ParserOptions.cs
+++ b/Raven.Documentation.Parser/ParserOptions.cs
@@ -50,9 +50,8 @@ namespace Raven.Documentation.Parser
                     return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "csharp", "Raven.Documentation.Samples");
                 case Language.Java:
                     return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "java", "src", "test", "java", "net", "ravendb");
-                // temporary removed for RDoc-2346
-                // case Language.Python:
-                //     return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "python");
+                case Language.Python:
+                    return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "python");
                 case Language.NodeJs:
                     return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "nodejs");
                 default:

--- a/Raven.Documentation.Web.Core/ViewModels/Models.cs
+++ b/Raven.Documentation.Web.Core/ViewModels/Models.cs
@@ -10,7 +10,7 @@ namespace Raven.Documentation.Web.Core.ViewModels
     {
         public DocsVersion.DocsMode Mode { get; set; }
 
-        private readonly List<Language> langs; 
+        private readonly List<Language> langs;
 
         public TableOfContentsViewModel(TableOfContents fromDb, DocsVersion.DocsMode mode)
         {
@@ -95,11 +95,11 @@ namespace Raven.Documentation.Web.Core.ViewModels
             "5.0",
             "4.2",
             "4.1",
-            "4.0", 
-            "3.5", 
-            "3.0", 
+            "4.0",
+            "3.5",
+            "3.0",
             "2.5",
-            "2.0", 
+            "2.0",
             "1.0"
         };
 
@@ -181,9 +181,8 @@ namespace Raven.Documentation.Web.Core.ViewModels
                     return "java";
                 case Language.Http:
                     return "http";
-                // temporary removed for RDoc-2346
-                // case Language.Python:
-                //     return "python";
+                case Language.Python:
+                    return "python";
                 default:
                     return "general";
             }

--- a/Raven.Documentation.Web/App_Start/RouteConfig.cs
+++ b/Raven.Documentation.Web/App_Start/RouteConfig.cs
@@ -11,8 +11,7 @@ namespace Raven.Documentation.Web
     public class RouteConfig
     {
         private const string RouteAvailableVersions = "1.0|2.0|2.5|3.0|3.5|4.0|4.1|4.2|5.0|5.1|5.2|5.3|5.4|6.0";
-        // private const string RouteAvailableLanguages = "csharp|java|nodejs|http|python";
-        private const string RouteAvailableLanguages = "csharp|java|nodejs|http"; // temporary removed python for RDoc-2346
+        private const string RouteAvailableLanguages = "csharp|java|nodejs|http|python";
 
         public static void RegisterRoutes(RouteCollection routes)
         {

--- a/Raven.Documentation.Web/Indexes/DocumentationPages_ByKey.cs
+++ b/Raven.Documentation.Web/Indexes/DocumentationPages_ByKey.cs
@@ -63,9 +63,6 @@ namespace Raven.Documentation.Web.Indexes
 
             private static Language[] ConvertLanguages(string[] languages)
             {
-
-                languages = languages.Where(lang => lang != "Python").ToArray(); // temp fix for RDoc-2346
-
                 return languages
                     .Select(language => (Language)Enum.Parse(typeof(Language), language, ignoreCase: true))
                     .ToArray();


### PR DESCRIPTION
Related issue: 
[RDoc-2624](https://issues.hibernatingrhinos.com/issue/RDoc-2624/Enable-Python-support-in-documentation)