### PR TITLE
RDoc-2620 [Node.js] Server > Extensions > Expiration [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/server/extensions/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/extensions/.docs.json
@@ -1,19 +1,19 @@
 [
-  {
-    "Path": "expiration.markdown",
-    "Name": "Expiration",
-    "DiscussionId": "27a7c957-d31a-4098-8c61-57b7b53f3b13",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "server/bundles/expiration"
-      }
-    ]
-  },
-  {
-    "Path": "refresh.markdown",
-    "Name": "Refresh",
-    "DiscussionId": "b976732a-3da7-48e5-a454-4f34b8f716f9",
-    "Mappings": []
-  }
+    {
+        "Path": "expiration.markdown",
+        "Name": "Document Expiration",
+        "DiscussionId": "27a7c957-d31a-4098-8c61-57b7b53f3b13",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "server/bundles/expiration"
+            }
+        ]
+    },
+    {
+        "Path": "refresh.markdown",
+        "Name": "Document Refresh",
+        "DiscussionId": "b976732a-3da7-48e5-a454-4f34b8f716f9",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.4/Raven.Documentation.Pages/server/extensions/expiration.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/extensions/expiration.dotnet.markdown
@@ -1,0 +1,79 @@
+﻿# Document Expiration
+---
+
+{NOTE: }
+
+* The Expiration feature deletes expired documents, documents whose time has passed.  
+  Documents that are set with a future expiration time will be automatically deleted.  
+
+* The Expiration feature can be turned on and off while the database is already live with data.  
+
+* In this page:  
+  * [Expiration feature usages](../../server/extensions/expiration#expiration-feature-usages)  
+  * [Configuring the expiration feature](../../server/extensions/expiration#configuring-the-expiration-feature)  
+  * [Setting the document expiration time](../../server/extensions/expiration#setting-the-document-expiration-time)  
+  * [Eventual consistency considerations](../../server/extensions/expiration#eventual-consistency-considerations)  
+  * [More details](../../server/extensions/expiration#more-details)
+ {NOTE/}
+
+---
+
+{PANEL: Expiration feature usages}
+
+* Use the Expiration feature when data is needed to be kept for only a temporary time.  
+
+* Examples:
+  * Shopping cart data that is kept for only a specific time  
+  * Email links that need to be expired after a few hours  
+  * Storing a web application login session details  
+  * When using RavenDB to hold cache data from a SQL server.  
+{PANEL/}
+
+{PANEL: Configuring the expiration feature}
+
+* By default, the expiration feature is turned off.  
+
+* The delete frequency is configurable, the default value is 60 secs.  
+
+* The Expiration feature can be turned on and off using the **Studio**, see [Setting Document Expiration in Studio](../../studio/database/settings/document-expiration).  
+
+* The Expiration feature can also be configured using the **Client**:
+
+{CODE configuration@Server\Expiration\Expiration.cs /}
+{PANEL/}
+
+{PANEL: Setting the document expiration time}
+
+* To set the document expiration time just add the `@expires` property to the document `@metadata` and set it to contain the appropriate expiration time.  
+
+* Once the Expiration feature is enabled, the document will automatically be deleted at the specified time.  
+
+* **Note**: The date must be in **UTC** format, not local time.  
+
+* The document expiration time can be set using the following code from the client:  
+
+{CODE expiration1@Server\Expiration\Expiration.cs /}
+{PANEL/}
+
+{PANEL: Eventual consistency considerations}
+
+* Once documents are expired, it can take up to the delete frequency interval (60 seconds by default) until these expired documents are actually deleted.  
+
+* Expired documents are _not_ filtered on load/query/indexing time, so be aware that an expired document might still be there after it has expired up to the 'delete frequency interval' timeframe.  
+{PANEL/}
+
+{PANEL: More details}
+
+* Internally, each document that has the `@expires` property in the metadata is tracked by the RavenDB server  
+  even if the expiration feature is turned off.  
+This way, once the expiration feature is turned on we can easily delete all the expired documents.  
+
+* **Note**: Metadata properties starting with `@` are internal for RavenDB usage.  
+You should _not_ use the `@expires` property in the metadata for any other purpose other than the built-in expiration feature.  
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Setting Document Expiration in Studio](../../studio/database/settings/document-expiration)

--- a/Documentation/5.4/Raven.Documentation.Pages/server/extensions/expiration.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/extensions/expiration.js.markdown
@@ -1,0 +1,81 @@
+﻿# Document Expiration
+---
+
+{NOTE: }
+
+* The Expiration feature deletes expired documents, documents whose time has passed.  
+  Documents that are set with a future expiration time will be automatically deleted.  
+
+* The Expiration feature can be turned on and off while the database is already live with data.  
+
+* In this page:  
+  * [Expiration feature usages](../../server/extensions/expiration#expiration-feature-usages)  
+  * [Configuring the expiration feature](../../server/extensions/expiration#configuring-the-expiration-feature)  
+  * [Setting the document expiration time](../../server/extensions/expiration#setting-the-document-expiration-time)  
+  * [Eventual consistency considerations](../../server/extensions/expiration#eventual-consistency-considerations)  
+  * [More details](../../server/extensions/expiration#more-details)
+ {NOTE/}
+
+---
+
+{PANEL: Expiration feature usages}
+
+* Use the Expiration feature when data is needed to be kept for only a temporary time.  
+
+* Examples:
+  * Shopping cart data that is kept for only a specific time  
+  * Email links that need to be expired after a few hours  
+  * Storing a web application login session details  
+  * When using RavenDB to hold cache data from a SQL server.  
+{PANEL/}
+
+{PANEL: Configuring the expiration feature}
+
+* By default, the expiration feature is turned off.  
+
+* The delete frequency is configurable, the default value is 60 secs.  
+
+* The Expiration feature can be turned on and off using the **Studio**, see [Setting Document Expiration in Studio](../../studio/database/settings/document-expiration).  
+
+* The Expiration feature can also be configured using the **Client**:
+
+{CODE:nodejs expiration_1@Server\Expiration\expiration.js /}
+
+{PANEL/}
+
+{PANEL: Setting the document expiration time}
+
+* To set the document expiration time just add the `@expires` property to the document `@metadata` and set it to contain the appropriate expiration time.  
+
+* Once the Expiration feature is enabled, the document will automatically be deleted at the specified time.  
+
+* **Note**: The date must be in **UTC** format, not local time.  
+
+* The document expiration time can be set using the following code from the client:  
+
+{CODE:nodejs expiration_2@Server\Expiration\expiration.js /}
+
+{PANEL/}
+
+{PANEL: Eventual consistency considerations}
+
+* Once documents are expired, it can take up to the delete frequency interval (60 seconds by default) until these expired documents are actually deleted.  
+
+* Expired documents are _not_ filtered on load/query/indexing time, so be aware that an expired document might still be there after it has expired up to the 'delete frequency interval' timeframe.  
+{PANEL/}
+
+{PANEL: More details}
+
+* Internally, each document that has the `@expires` property in the metadata is tracked by the RavenDB server  
+  even if the expiration feature is turned off.  
+This way, once the expiration feature is turned on we can easily delete all the expired documents.  
+
+* **Note**: Metadata properties starting with `@` are internal for RavenDB usage.  
+You should _not_ use the `@expires` property in the metadata for any other purpose other than the built-in expiration feature.  
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Setting Document Expiration in Studio](../../studio/database/settings/document-expiration)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Server/Expiration/Expiration.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Server/Expiration/Expiration.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Session;
+
+namespace Raven.Documentation.Samples.Server
+{
+    public class Expiration
+    {
+        private class User
+        {
+            public string Name { get; set; }
+        }
+
+        public async Task Sample()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region configuration
+                await store.Maintenance.SendAsync(new ConfigureExpirationOperation(new ExpirationConfiguration
+                {
+                    Disabled = false, DeleteFrequencyInSec = 60
+                }));
+                #endregion
+
+                var user = new User();
+
+                #region expiration1
+                DateTime expiry = DateTime.UtcNow.AddMinutes(5);
+                using (IAsyncDocumentSession session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user);
+                    session.Advanced.GetMetadataFor(user)[Constants.Documents.Metadata.Expires] = expiry;
+                    await session.SaveChangesAsync();
+                }
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/server/expiration/expiration.js
+++ b/Documentation/5.4/Samples/nodejs/server/expiration/expiration.js
@@ -1,0 +1,46 @@
+import { DocumentStore, AbstractCsharpIndexCreationTask } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function expiration() {    
+    {
+        const session = store.openSession();
+
+        //region expiration_1
+        // Define the expiration configuration object 
+        const expirationConfiguration: ExpirationConfiguration = {
+            deleteFrequencyInSec: 50,
+            disabled: false
+        };
+        
+        // Define the configure expiration operation,
+        // pass the configuration to set
+        const configureExpirationOp = new ConfigureExpirationOperation(expirationConfiguration);
+
+        // Execute the operation by passing it to maintenance.send
+        await store.maintenance.send(configureExpirationOp);
+        //endregion
+
+        //region expiration_2
+        // Setting a new document to expire after 5 minutes:
+        // =================================================
+
+        // Create a new document
+        const newEmployee = new Employee();
+        newEmployee.lastName = "Smith";
+
+        const session = documentStore.openSession();
+        await session.store(newEmployee);
+
+        // Get the metadata of the document
+        const metadata = session.advanced.getMetadataFor(newEmployee);
+
+        // Set the '@expires' metadata property with the expiration date in UTC format
+        const expiresAt = new Date(new Date().getTime() + (5 * 60_000))
+        metadata[CONSTANTS.Documents.Metadata.EXPIRES] = expiresAt.toISOString();
+
+        // Save the new document to the database
+        await session.saveChanges();
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/server/expiration/expiration.js
+++ b/Documentation/5.4/Samples/nodejs/server/expiration/expiration.js
@@ -7,10 +7,13 @@ async function expiration() {
         const session = store.openSession();
 
         //region expiration_1
+        // Enable document expiration and set the frequency to 50 seconds:
+        // ===============================================================
+        
         // Define the expiration configuration object 
-        const expirationConfiguration: ExpirationConfiguration = {
-            deleteFrequencyInSec: 50,
-            disabled: false
+        const expirationConfiguration = {
+            disabled: false,           // Enable expiration
+            deleteFrequencyInSec: 50   // Set frequency to 50 seconds
         };
         
         // Define the configure expiration operation,

--- a/Documentation/6.0/Raven.Documentation.Pages/server/extensions/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/extensions/.docs.json
@@ -1,25 +1,25 @@
 [
-  {
-    "Path": "expiration.markdown",
-    "Name": "Expiration",
-    "DiscussionId": "27a7c957-d31a-4098-8c61-57b7b53f3b13",
-    "Mappings": [
-      {
-        "Version": 3.5,
-        "Key": "server/bundles/expiration"
-      }
-    ]
-  },
-  {
-    "Path": "refresh.markdown",
-    "Name": "Refresh",
-    "DiscussionId": "b976732a-3da7-48e5-a454-4f34b8f716f9",
-    "Mappings": []
-  },
-  {
-    "Path": "archival.markdown",
-    "Name": "Data Archival",
-    "DiscussionId": "b976732a-3da7-48e5-a454-4f34b8f716f9",
-    "Mappings": []
-  }
+    {
+        "Path": "expiration.markdown",
+        "Name": "Document Expiration",
+        "DiscussionId": "27a7c957-d31a-4098-8c61-57b7b53f3b13",
+        "Mappings": [
+            {
+                "Version": 3.5,
+                "Key": "server/bundles/expiration"
+            }
+        ]
+    },
+    {
+        "Path": "refresh.markdown",
+        "Name": "Document Refresh",
+        "DiscussionId": "b976732a-3da7-48e5-a454-4f34b8f716f9",
+        "Mappings": []
+    },
+    {
+        "Path": "archival.markdown",
+        "Name": "Data Archival",
+        "DiscussionId": "b976732a-3da7-48e5-a454-4f34b8f716f9",
+        "Mappings": []
+    }
 ]


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2620/Node.js-Server-Extensions-Expiration-Replace-C-samples

---

**Important notes for this PR:**
In this PR only the sample code for `Node.js` was applied.
The article's text from the original C# file was Not refactored/improved.
Refactoring the C# (text & code) will be done in a separate dedicated issue 
https://issues.hibernatingrhinos.com/issue/RDoc-2625/Server-Extensions-Document-Expiration-Fix-article

---

**Node.js**: @ml054 
Node.js code to review is in:
```Documentation/5.4/Samples/nodejs/server/expiration/expiration.js```

**C#**: 
Files were only copied over to v5.4, no changes were made. 