### PR TITLE
RDoc-2596 Clarifications about transactions in RavenDB and the session API

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/faq/transaction-support.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/faq/transaction-support.markdown
@@ -1,36 +1,259 @@
 # FAQ: Transaction Support in RavenDB
 
-{PANEL:ACID storage}
+---
 
-All storage operations performed in RavenDB are fully ACID (Atomicity, Consistency, Isolation, Durability), this is because internally RavenDB used a custom made storage engine called *Voron*, which guarantees all the properties of the ACID, no matter if those are executed on document, index or cluster storage data.
+{NOTE: }  
+
+* In this page:
+  * [ACID storage](../../client-api/faq/transaction-support#acid-storage)  
+  * [What is and what isn't a transaction](../../client-api/faq/transaction-support#what-is-and-what-isn)  
+  * [Working with transactions in RavenDB ](../../client-api/faq/transaction-support#working-with-transactions-in-ravendb)
+     * [Single-node model](../../client-api/faq/transaction-support#single-node-model)
+     * [Multi-master model](../../client-api/faq/transaction-support#multi-master-model)
+     * [Cluster-wide transactions](../../client-api/faq/transaction-support#cluster-wide-transactions)
+  * [ACID for document operations](../../client-api/faq/transaction-support#acid-for-document-operations)
+  * [BASE for query operations](../../client-api/faq/transaction-support#base-for-query-operations)
+  * [Consistency and isolation with the usage of Client API Session](../../client-api/faq/transaction-support#consistency-and-isolation-with-the-usage-of-client-api-session)
+
+{NOTE/}  
+
+---
+
+{PANEL: ACID storage}
+
+All storage operations performed in RavenDB are fully ACID-compliant (Atomicity, Consistency, Isolation, Durability),  
+this is because internally RavenDB uses a storage engine called [Voron](../../server/storage/storage-engine), built specifically for RavenDB's usage,
+which guarantees all ACID properties, whether executed on document, index or local cluster data.
 
 {PANEL/}
 
-{PANEL:ACID for document operations}
+{PANEL: What is and what isn't a transaction}
 
-In RavenDB all actions performed on documents are fully ACID. An each document operation or a batch of operations applied to a set of documents sent in a single HTTP request will execute in a single transaction. The ACID properties of RavenDB are:
+* A transaction represents a set of operations executed against a database as a single, atomic, and isolated unit.
 
-* _Atomicity_  - All operations are atomic. Either they succeed or fail, not midway operation. In particular, operations on multiple documents will all happen atomically, all the way or none at all.
+* In RavenDB, a transaction (read or write) is limited to the scope of a __single__ HTTP request.
 
-* _Consistency and Isolation / Consistency of Scans_ - In a single transaction, all operations operate under snapshot isolation. Even if you access multiple documents, you'll get all of their state as it was in the beginning of the request.
+* The terms "ACID transaction" or "transaction" refer to the storage engine transactions. 
+  Whenever a database receives an operation or batch of operations in a request, it will wrap it in a "storage transaction",  
+  execute the operations and commit the transaction.
 
-* _Visibility_ - All transactions are immediately made available on commit. Thus, if a transaction is commit after updating two docs, you'll always see the updates to those two docs at the same time. (That is, you either see the updates to both, or you don't see the update to either one).
+* RavenDB ensures that for a single HTTP request, all the operations in that request are transactional.  
+  It employs _Serializable_ isolation for write operations and _Snapshot_ isolation for read operations.
 
-* _Durability_ - If an operation has completed successfully, it was fsync'ed to disk. Reads will never return any data that hasn't been flushed to disk.
+* RavenDB doesn't support a transaction spanning __multiple__ HTTP requests. Interactive transactions are not implemented by RavenDB 
+  (see [below](../../client-api/faq/transaction-support#no-support-for-interactive-transactions) for the reasoning behind this decision). 
+  RavenDB offers [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency) feature to achieve similar behavior.  
 
-All of these constraints are ensured when you use [a session](../session/what-is-a-session-and-how-does-it-work) and call [`SaveChanges`](../session/saving-changes).
+* The [Client API Session](../../client-api/session/what-is-a-session-and-how-does-it-work) is a pure Client API object and does not represent a transaction, 
+  thus it is not meant to provide interactive transaction semantics. 
+  It is entirely managed on the client side without maintaining a corresponding session state on the server. 
+  The server does not reference or keep track of the session context.
 
 {PANEL/}
 
-{PANEL:BASE for query operations}
+{PANEL: Working with transactions in RavenDB}
 
-The transaction model is different when indexes are involved, because indexes are BASE (Basically Available, Soft state, Eventual consistency), not ACID. Then the following constraints are applied to query operations:
+### Single-node model
 
-* _Basically Available_ - Index query results will be always available but they might be stale.
+Transactional behavior with RavenDB is divided into two modes:
 
-* _Soft state_ - The state of the system could change over the time because some amount of time is needed to perform the indexing. This is an incremental operation the less documents remains to index, the more accurate index results we have.
+* __Single requests__:  
+In this mode, a user can perform all requested operations (read and/or write) in a single request.  
+   
+  * _Multiple writes_:  
+  A batch of multiple write operations will be executed atomically in a single transaction via calling `SaveChanges()` which generates a single HTTP request to the database.
+   
+  * _Multiple reads & writes_:  
+  Performing interleaving reads and writes or conditional execution can be achieved by [running a patching script](../../client-api/operations/patching/single-document).  
+  In the script you can read documents, make decisions based on their content and update or put document(s) within the scope of a single transaction.  
+  If you only need to modify a document in a transaction, [JSON Patch syntax](../../client-api/operations/patching/json-patch-syntax) allows you to do that.
 
-* _Eventual consistency_ - The database will eventually become consistent once it stops receiving new documents and the indexing operation finishes.
+* __Multiple requests__:  
+  RavenDB does not support a single transaction that spans all requested operations within multiple requests.  
+  Instead, users are expected to utilize [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency) to achieve similar behavior.  
+  Your changes will get committed only if no one else has changed the data you are modifying in the meantime. 
+
+#### No support for interactive transactions
+
+RavenDB client uses HTTP to communicate with the RavenDB server. 
+It means that RavenDB doesn't allow you to open a transaction on the server side, make multiple operations over a network connection, and then commit or roll it back.  
+This model, known as the interactive transactions model, is incredibly costly. Both in terms of engine complexity and the impact on the overall performance of the system.
+
+{INFO: }
+
+In [one study](http://nms.csail.mit.edu/~stavros/pubs/OLTP_sigmod08.pdf) the cost of managing the transaction state across multiple network operations was measured at over 40% of the total system performance. 
+This is because the server needs to maintain locks and state across potentially very large time frames.
+
+{INFO/}
+
+RavenDB's approach differs from the classical SQL model, which relies on interactive transactions. Instead, RavenDB uses the batch transaction model. It allows us to provide the same capabilities as interactive transactions in 
+conjunction with [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency), with much better performance.
+
+Key to that design decision is our ability to provide similar guarantees about the state of your data without experiencing the overhead of interactive transactions.  
+
+#### Batch transaction model
+
+RavenDB uses the batch transaction model, where a RavenDB client submits all the operations to be run in a single transaction in one network call. 
+This allows the storage engine inside RavenDB to avoid holding locks for an extended period of time and gives plenty of room to optimize the performance.
+
+This decision is based on the typical interaction pattern by which RavenDB is used.  
+RavenDB serves as a transactional system of record for business applications, where the common workflow involves presenting data to users, 
+allowing them to make modifications, and subsequently save these changes.  
+A single request loads the data which is then presented to the user. 
+After a period of contemplation or "think time," the user submits a set of updates, which are then saved to the database.  
+This model fits the batch transaction model a lot more closely than the interactive one, as there's no necessity to keep a transaction open during the user's "think time."
+
+All changes that are sent via _SaveChanges_ are persisted in a single unit.  
+If you modify documents concurrently and you want to assure they won't by affected by the lost update problem,  
+then you must enable [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency) (turned off by default) across all sessions that modify those documents.
+
+<hr/>
+
+### Multi-master model
+
+RavenDB employs the multi-master model, allowing writes to be made to any node in the cluster.  
+These writes are then propagated asynchronously to the other nodes via [replication](../../server/clustering/replication/replication). 
+
+The interaction of transactions and distributed work is anything but trivial. Let's start from the obvious problem:
+
+* RavenDB allows you to perform concurrent write operations on multiple nodes.  
+* RavenDB explicitly allows you to write to a node that was partitioned from the rest of the network.
+
+Taken together, this violates the [CAP theorem](https://en.wikipedia.org/wiki/CAP_theorem) 
+which states that a system can only provide 2 out of 3 guarantees around consistency, availability, and partition tolerance.
+
+RavenDB's answer to distributed transactional work is nuanced and was designed to give you as the user the choice  
+so you can utilize RavenDB for each of your scenarios:  
+
+* Single-node operations are available and partition tolerant (AP) but cannot meet the consistency guarantee.
+* If you need to guarantee uniqueness or replicate the data for redundancy across more than one node,  
+  you can choose to have higher consistency at the cost of availability (CP).
+
+When running in a multi-node setup, RavenDB still uses transactions. However, they are single-node transactions.  
+That means that the set of changes that you write in a transaction is committed only to the node you are writing to.  
+It will then asynchronously replicate to the other nodes.  
+To achieve consistency across the entire cluster please refer to the [Cluster-wide transactions](../../client-api/faq/transaction-support#cluster-wide-transactions) section below.  
+
+#### Replication conflicts
+
+This is an important observation because you can get into situations where two clients wrote (even with [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency) turned on)
+to the same document and both of them committed successfully (each one to a separate node). 
+RavenDB attempts to minimize this situation by designating a [preferred node](../../client-api/configuration/load-balance/overview#the-preferred-node) for writes for each database,  
+but since writing to the preferred node isn't guaranteed, this might not alleviate the issue.
+
+In such a case, the data will replicate across the cluster, and RavenDB will detect that there were [conflicting](../../server/clustering/replication/replication-conflicts) modifications to the document. 
+It will then apply the [conflict resolution](../../studio/database/settings/conflict-resolution) strategy that you choose.  
+That can include selecting a manual resolution, running a [resolution script](../../server/clustering/replication/replication-conflicts#conflict-resolution-script) to reconcile the conflicting versions,  
+or simply selecting the latest version. You are in control of this behavior. 
+
+This behavior was influenced by the [Dynamo paper](https://dl.acm.org/doi/10.1145/1323293.1294281) which emphasizes the importance of writes.  
+The assumption is that if you are writing data to the database, you expect it to be persisted.
+
+RavenDB will do its utmost to provide that to you, allowing you to write to the database even in the case of partitions or partial failure states. 
+However, handling replication conflicts is a consideration you have to take into account when using single-node transactions in RavenDB (see below for running a [cluster-wide transaction](../../client-api/faq/transaction-support#cluster-wide-transactions)).
+
+{WARNING: Lost updates}
+
+If no conflict resolution script is defined for a collection, then by default RavenDB resolves the conflict using the latest version based on the `@last-modified` property of conflicted versions of the document.  
+That might result in the lost update anomaly.
+
+If you care about avoiding lost updates, you need to ensure you have the conflict resolution script defined accordingly or use a [cluster-wide transaction](../../client-api/faq/transaction-support#cluster-wide-transactions).
+
+{WARNING/}
+
+#### Replication & transaction boundary
+
+The following is an important aspect to RavenDB's transactional behavior with regards to asynchronous replication.  
+
+When replicating modifications to another server, RavenDB will ensure that the [transaction boundaries](../../server/clustering/replication/replication#replication-&-transaction-boundary) are maintained.  
+If there are several document modifications in the same transaction they will be sent in the same replication batch, keeping the transaction boundary on the destination as well.  
+
+However, a special attention is needed when a document is modified in two separate transactions but the replication of the first transaction has not occurred yet. 
+Read more about that in [How revisions replication help data consistency](../../server/clustering/replication/replication#how-revisions-replication-help-data-consistency).
+
+<hr/>
+
+### Cluster-wide transactions
+
+RavenDB also supports [cluster-wide transactions](../../client-api/session/cluster-transaction/overview).  
+This feature modifies the way RavenDB commits a transaction, and it is meant to address scenarios where you prefer to get a failure if the transaction cannot be persisted to a majority of the nodes in the cluster.  
+In other words, this feature is for scenarios where you want to favor consistency over availability.
+
+For cluster-wide transactions, RavenDB uses the [Raft](../../server/clustering/rachis/what-is-rachis#what-is-raft-?) protocol. 
+This protocol ensures that the transaction is acknowledged by a majority of the nodes in the cluster and once committed, the changes will be visible on any node that you'll use henceforth.  
+
+Similar to single-node transactions, RavenDB requires that you submit the cluster-wide transaction as a single request of all the changes you want to commit to the database. 
+
+Cluster-wide transactions have the notion of [atomic guards](../../client-api/session/cluster-transaction/atomic-guards) to prevent an overwrite of a document modified in a cluster transaction by a change made in another cluster transaction.
+
+{INFO: }
+
+The usage of atomic guards makes cluster-wide transactions conflict-free.  
+There is no way to make a conflict between two versions of the same document.  
+If a document got updated meanwhile by someone else then a `ConcurrencyException` will be thrown.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: ACID for document operations}
+
+In RavenDB all actions performed on documents are fully ACID. 
+Each document operation or a batch of operations applied to a set of documents sent in a single HTTP request will execute in a single transaction.  
+The ACID properties of RavenDB are:  
+
+* __Atomicity__  
+  All operations are atomic. Either they fully succeed or fail without any partial execution. 
+  In particular, operations on multiple documents will be carried out atomically, meaning they are either completed entirely or not executed at all.
+
+* __Consistency and Isolation / Consistency of Scans__  
+  Within a single _read_ transaction, all operations are performed under _Snapshot_ isolation. 
+  This ensures that even if you access multiple documents, you'll get all of their state exactly as it was at the beginning of the request.
+
+* __Visibility__  
+  All changes to the database are immediately made available upon commit.  
+  Therefore, if a transaction updates two documents and is committed, you will always see the updates to both documents at the same time.
+  That is, you either see the updates to both, or you don't see the update to either one.
+
+* __Durability__   
+  If an operation has been completed successfully, it is fsync'ed to disk.  
+  Reads will never return any data that has not been flushed to disk.
+
+All of these constraints are guaranteed for each individual request made to the database when using a [Session](../../client-api/session/what-is-a-session-and-how-does-it-work).  
+In particular, every `Load` call is a separate transaction, and the [`SaveChanges`](../../client-api/session/saving-changes) 
+call will encapsulate all documents created, deleted, or modified within the session into a single transaction.
+
+{PANEL/}
+
+{PANEL: BASE for query operations}
+
+The transaction model is different when indexes are involved, because indexes are BASE (Basically Available, Soft state, Eventual consistency), not ACID. 
+The indexing in RavenDB will always happen in the background. When you write a new document or update an existing one, RavenDB doesn't wait to update all the indexes before it completes the write operation.
+Instead, it writes the document data and completes the write operation as soon as the transaction is written to disk, scheduling any index updates to occur in an async manner.
+
+There are several reasons for this behavior:
+
+* Writes are faster because they aren't going to be held up by the indexes.
+* Indexes running in an async manner allow to handle updates in batches instead of having to update all the indexes on every write.
+* Indexes are operating independently, so a single slow or expensive index isn't going to impact any other indexes or the overall write performance in the system.
+* Indexes can be added dynamically and on the fly to busy production systems.
+* Indexes can be updated in a [side-by-side manner](../../indexes/creating-and-deploying).
+
+The BASE model means that the following constraints are applied to query operations:
+
+* __Basically Available__  
+  Index query results will be always available but they might be stale.
+
+* __Soft state__  
+  The state of the system could change over time because some amount of time is needed to perform the indexing. 
+  This is an incremental operation; the fewer documents remain to index, the more accurate index results we have.
+
+* __Eventual consistency__  
+  The database will eventually become consistent once it stops receiving new documents and the indexing operation finishes.
+
+The async nature of RavenDB indexes means that you need to be aware that, by default, writes will complete without waiting for indexes.
+Although there are ways to wait for the indexes to complete as part of the write or even during the read (although that is not recommended). 
+Please read a dedicated article about the [stale indexes](../../indexes/stale-indexes).
 
 {PANEL/}
 
@@ -39,3 +262,5 @@ The transaction model is different when indexes are involved, because indexes ar
 ### Server
 
 - [Storage Engine](../../server/storage/storage-engine)
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency)

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.dotnet.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.dotnet.markdown
@@ -1,51 +1,111 @@
-# Session: How to Enable Optimistic Concurrency
+# How to Enable Optimistic Concurrency
+---
 
-By default, optimistic concurrency checks are turned **off**. Changes made outside our session object will be overwritten. Concurrent changes to the same document will use
-the Last Write Wins strategy. 
+{NOTE: }
 
-You can enable the optimistic concurrency strategy either globally, at the document store level or a per session basis. 
-In either case, with optimistic concurrency enabled, RavenDB will generate a concurrency exception (and abort all 
-modifications in the current transaction) when the document has been modified on the server side after the client received and modified it.
-You can see the sample code below on the specific on
+* By default, optimistic concurrency checks are turned **off**. Changes made outside the session object will be overwritten. 
+  Concurrent changes to the same document will use the _Last Write Wins_ strategy so a lost update anomaly is possible 
+  with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
 
-Note that `UseOptimisticConcurrency` only applies to documents that has been _modified_ by the session. Loading documents `users/1-A` and `users/2-A` in a session, modifying
-`users/1-A` and then calling `SaveChanges` will succeed, regardless of the optimistic concurrency setting, even if `users/2-A` has changed in the meantime. 
-If the session were to try to save to `users/2-A` as well with optimistic concurrency turned on, then an exception will be raised and the updates to both `users/1-A` and `users/2-A`
-will be cancelled. 
+* You can enable the optimistic concurrency for either:
+  * All sessions - enable globally, at the document store level  
+  * A specific session - enable on a per-session basis  
+  * A specific document  
 
-Another option is to control optimistic concurrency per specific document.   
-To enable it, you can [supply a Change Vector to Store](../../../client-api/session/storing-entities). If you don't supply a 'Change Vector' or if the 'Change Vector' is null, 
-then optimistic concurrency will be disabled. Setting the 'Change Vector' to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already 
-exists.
+* With optimistic concurrency __enabled__, RavenDB will generate a concurrency exception 
+  (and abort all modifications in the current transaction) when trying to save a document that has been modified on the server side after the client loaded and modified it.
 
-Setting optimistic concurrency per specific document overrides the use of the `UseOptimisticConcurrency` property from the `Advanced` session operations.
+* The `ConcurrencyException` that might be thrown upon the `SaveChanges` call needs to be handled by the caller. 
+  The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error in a way that is suitable in a given scenario.
 
-## Enabling for a specific Session
+* In this page:
+  * [Enable for specific session](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-session)
+  * [Enable globally](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-globally)
+  * [Disable for specific document (when enabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#disable-for-specific-document-(when-enabled-on-session))
+  * [Enable for specific document (when disabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-document-(when-disabled-on-session)) 
+
+{WARNING: }
+
+* Note that the `UseOptimisticConcurrency` setting only applies to documents that have been modified by the current session. 
+  For example, if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `SaveChanges`, 
+  the operation will succeed regardless of the optimistic concurrency setting, even if `users/2-A` has been changed by another process in the meantime.
+
+* However, if you modify both documents and attempt to save changes with optimistic concurrency turned on, an exception will be raised if `users/2-A` has been modified externally.  
+  In this case, the updates to both `users/1-A` and `users/2-A` will be cancelled.
+
+{WARNING/}
+
+{INFO: }
+
+For a detailed description of transactions and concurrency control in RavenDB please refer to the  
+[Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
+
+{INFO/}
+
+{NOTE/}
+
+---
+
+{PANEL: Enable for specific session}
 
 {CODE optimistic_concurrency_1@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
 
-## Enabling Globally
+{WARNING: }
 
-The first example shows how to enable optimistic concurrency for a particular session. 
-This can be also turned on globally, for all opened sessions by using the convention `store.Conventions.UseOptimisticConcurrency`.
+* Enabling optimistic concurrency in a session will ensure that changes made to a document will only be persisted 
+  if the version of the document sent in the `SaveChanges()` call matches its version from the time it was initially read (loaded from the server).
+ 
+* Note that it's necessary to enable optimistic concurrency for ALL sessions that modify the documents for which you want to guarantee that no writes will be silently discarded.
+  If optimistic concurrency is enabled in some sessions but not in others, and they modify the same documents, the risk of the lost update anomaly still exists.
+
+{WARNING/}
+
+{PANEL/}
+
+{PANEL: Enable globally}
+
+* Optimistic concurrency can also be turned on for all sessions that are opened under a document store.
+
+* Use the [store.Conventions.UseOptimisticConcurrency](../../../client-api/configuration/conventions#useoptimisticconcurrency) convention to enable globally.
 
 {CODE optimistic_concurrency_2@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
 
-## Turning Off Optimistic Concurrency for a Single Document when it is Enabled on Session
+{PANEL/}
 
-Optimistic concurrency can be turned off for a single document by passing `null` as a change vector value to `Store` method even when it is turned on for an entire session (or globally).
+{PANEL: Disable for specific document (when enabled on session)}
+
+* Optimistic concurrency can be turned OFF when __storing__ a specific document,  
+  even when it is turned ON for an entire session (or globally).
+
+* This is done by passing `null` as a change vector value to the [Store](../../../client-api/session/storing-entities) method.
 
 {CODE optimistic_concurrency_3@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
 
-## Turning On Optimistic Concurrency for a New Document when it is Disabled on Session
+{PANEL/}
 
-Optimistic concurrency can be turned on for a new document by passing `string.Empty` as a change vector value to `Store` method even when it is turned off for an entire session (or globally).
-It will cause to throw `ConcurrencyException` if the document already exists.
+{PANEL: Enable for specific document (when disabled on session)}
+
+* Optimistic concurrency can be turned ON when __storing__ a specific document,  
+  even when it is turned OFF for an entire session (or globally).
+
+* This is done by passing `string.Empty` as the change vector value to the [Store](../../../client-api/session/storing-entities) method.  
+  Setting the change vector to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exist.
+  A `ConcurrencyException` will be thrown if the document already exists. 
+
+* If you don't supply a 'Change Vector' or if the 'Change Vector' is `null`, then optimistic concurrency will be disabled.  
+
+* Setting optimistic concurrency for a specific document overrides the `UseOptimisticConcurrency` property from the `Advanced` session operations.
 
 {CODE optimistic_concurrency_4@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+
+{PANEL/}
 
 ## Related articles
 
 ### Configuration
 
 - [Conventions](../../../client-api/configuration/conventions)
+
+### FAQ
+
+- [Transaction Support in RavenDB](../../../client-api/faq/transaction-support)

--- a/Documentation/4.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.java.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.java.markdown
@@ -1,28 +1,46 @@
 # Session: How to Enable Optimistic Concurrency
 
 By default, optimistic concurrency checks are turned **off**. Changes made outside our session object will be overwritten. Concurrent changes to the same document will use
-the Last Write Wins strategy. 
+the Last Write Wins strategy so a lost update anomaly is possible with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
 
-You can enable the optimistic concurrency strategy either globally, at the document store level or a per session basis. 
-In either case, with optimistic concurrency enabled, RavenDB will generate a concurrency exception (and abort all 
-modifications in the current transaction) when the document has been modified on the server side after the client received and modified it.
-You can see the sample code below on the specific on
+You can enable the optimistic concurrency strategy either globally, at the document store level or a per session basis.  
+In either case, with optimistic concurrency enabled, RavenDB will generate a concurrency exception (and abort all
+modifications in the current transaction) when trying to save a document that has been modified on the server side after the client loaded and modified it.
 
+The `ConcurrencyException` that might be thrown upon the `saveChanges` call, needs to be handled by the caller.  
+The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error in a way that is suitable in a given scenario.
+
+{WARNING: }
 Note that `useOptimisticConcurrency` only applies to documents that has been _modified_ by the session. Loading documents `users/1-A` and `users/2-A` in a session, modifying
 `users/1-A` and then calling `saveChanges` will succeed, regardless of the optimistic concurrency setting, even if `users/2-A` has changed in the meantime. 
 If the session were to try to save to `users/2-A` as well with optimistic concurrency turned on, then an exception will be raised and the updates to both `users/1-A` and `users/2-A`
-will be cancelled. 
+will be cancelled.
+{WARNING/}
 
-Another option is to control optimistic concurrency per specific document.   
-To enable it, you can [supply a Change Vector to Store](../../../client-api/session/storing-entities). If you don't supply a 'Change Vector' or if the 'Change Vector' is null, 
-then optimistic concurrency will be disabled. Setting the 'Change Vector' to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already 
-exists.
+You can also control optimistic concurrency per specific document. To enable it, [supply a Change Vector to Store](../../../client-api/session/storing-entities).  
+If you don't supply a 'Change Vector' or if the 'Change Vector' is null, then optimistic concurrency will be disabled.  
+Setting the 'Change Vector' to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exists.
 
 Setting optimistic concurrency per specific document overrides the use of the `useOptimisticConcurrency` field from the `advanced` session operations.
+
+{INFO: }
+For a detailed description of transactions and concurrency control in RavenDB please refer to the  
+[Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
+{INFO/}
 
 ## Enabling for a specific Session
 
 {CODE:java optimistic_concurrency_1@ClientApi\Session\Configuration\OptimisticConcurrency.java /}
+
+{WARNING: }
+
+* Enabling optimistic concurrency in a session will ensure that changes made to a document will only be persisted
+  if the version of the document sent in the `saveChanges()` call matches its version from the time it was initially read (loaded from the server).
+
+* Note that it's necessary to enable optimistic concurrency for ALL sessions that modify the documents for which you want to guarantee that no writes will be silently discarded.
+  If optimistic concurrency is enabled in some sessions but not in others, and they modify the same documents, the risk of the lost update anomaly still exists.
+
+{WARNING/}
 
 ## Enabling Globally
 
@@ -49,3 +67,7 @@ It will cause to throw `ConcurrencyException` if the document already exists.
 ### Configuration
 
 - [Conventions](../../../client-api/configuration/conventions)
+
+### FAQ
+
+- [Transaction Support in RavenDB](../../../client-api/faq/transaction-support)

--- a/Documentation/4.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/OptimisticConcurrency.cs
+++ b/Documentation/4.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/OptimisticConcurrency.cs
@@ -13,27 +13,30 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
                 #region optimistic_concurrency_1
                 using (IDocumentSession session = store.OpenSession())
                 {
+                    // Enable optimistic concurrency for this session
                     session.Advanced.UseOptimisticConcurrency = true;
 
+                    // Save a document in this session
                     Product product = new Product { Name = "Some Name" };
-
                     session.Store(product, "products/999");
                     session.SaveChanges();
 
+                    // Modify the document 'externally' by another session 
                     using (IDocumentSession otherSession = store.OpenSession())
                     {
                         Product otherProduct = otherSession.Load<Product>("products/999");
                         otherProduct.Name = "Other Name";
-
                         otherSession.SaveChanges();
                     }
 
+                    // Trying to modify the document without reloading it first will throw
                     product.Name = "Better Name";
-                    session.SaveChanges(); // will throw ConcurrencyException
+                    session.SaveChanges(); // This will throw a ConcurrencyException
                 }
                 #endregion
 
                 #region optimistic_concurrency_2
+                // Enable for all sessions that will be opened within this document store
                 store.Conventions.UseOptimisticConcurrency = true;
 
                 using (IDocumentSession session = store.OpenSession())
@@ -45,32 +48,44 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
                 #region optimistic_concurrency_3
                 using (IDocumentSession session = store.OpenSession())
                 {
+                    // Store document 'products/999'
                     session.Store(new Product { Name = "Some Name" }, id: "products/999");
                     session.SaveChanges();
                 }
 
                 using (IDocumentSession session = store.OpenSession())
                 {
+                    // Enable optimistic concurrency for the session
                     session.Advanced.UseOptimisticConcurrency = true;
 
+                    // Store the same document
+                    // Pass 'null' as the changeVector to turn OFF optimistic concurrency for this document
                     session.Store(new Product { Name = "Some Other Name" }, changeVector: null, id: "products/999");
-                    session.SaveChanges(); // will NOT throw Concurrency exception
+                    
+                    // This will NOT throw a ConcurrencyException, and the document will be saved
+                    session.SaveChanges();
                 }
                 #endregion
 
                 #region optimistic_concurrency_4
                 using (IDocumentSession session = store.OpenSession())
                 {
+                    // Store document 'products/999'
                     session.Store(new Product { Name = "Some Name" }, id: "products/999");
                     session.SaveChanges();
                 }
 
                 using (IDocumentSession session = store.OpenSession())
                 {
-                    session.Advanced.UseOptimisticConcurrency = false; // default value
+                    // Disable optimistic concurrency for the session 
+                    session.Advanced.UseOptimisticConcurrency = false; // This is also the default value
 
+                    // Store the same document
+                    // Pass 'string.Empty' as the changeVector to turn ON optimistic concurrency for this document
                     session.Store(new Product { Name = "Some Other Name" }, changeVector: string.Empty, id: "products/999");
-                    session.SaveChanges(); // will throw Concurrency exception
+                    
+                    // This will throw a ConcurrencyException, and the document will NOT be saved
+                    session.SaveChanges();
                 }
                 #endregion
             }

--- a/Documentation/4.1/Raven.Documentation.Pages/client-api/operations/patching/set-based.dotnet.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/client-api/operations/patching/set-based.dotnet.markdown
@@ -93,6 +93,13 @@ The patching of documents matching a specified query is run in batches of size 1
 
 {WARNING/}
 
+{WARNING: Patching and Transaction} 
+
+The patching of documents matching a specified query is run in batches of size 1024.  
+Each batch is handled in a separate write transaction.
+
+{WARNING/}
+
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/4.1/Raven.Documentation.Pages/client-api/operations/patching/set-based.java.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/client-api/operations/patching/set-based.java.markdown
@@ -87,6 +87,13 @@ The patching of documents matching a specified query is run in batches of size 1
 
 {WARNING/}
 
+{WARNING: Patching and Transaction}
+
+The patching of documents matching a specified query is run in batches of size 1024.  
+Each batch is handled in a separate write transaction.
+
+{WARNING/}
+
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/4.1/Raven.Documentation.Pages/server/clustering/cluster-transactions.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/server/clustering/cluster-transactions.markdown
@@ -99,7 +99,7 @@ have changed since the transaction was initiated, the entire session transaction
 
 Optimistic concurrency at the document level is _not_ supported for cluster-wide transactions. 
 Compare-exchange operations should be used to ensure consistency in that regard. Concurrent cluster-wide transactions are guaranteed 
-to appear as if they are run one at a time (`serializable` isolation level). 
+to appear as if they are run one at a time. 
 
 Cluster-wide transactions may only contain `PUT` / `DELETE` commands. This is required to ensure that we can apply the transaction 
 to each of the database nodes without regard to the current node state.

--- a/Documentation/5.1/Raven.Documentation.Pages/client-api/operations/patching/single-document.dotnet.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/client-api/operations/patching/single-document.dotnet.markdown
@@ -7,6 +7,9 @@
   The whole operation is executed on the server-side and is useful as a performance enhancement or for 
   updating denormalized data in entities.
 
+* Since the operation is executed in a single request to the database,  
+  the patch command is performed in a single write [transaction](../../../client-api/faq/transaction-support).  
+
 * The current page covers patch operations on single documents.
 
 * Patching has three possible interfaces: [Typed Session API](../../../client-api/operations/patching/single-document#typed-session-api), 

--- a/Documentation/5.1/Raven.Documentation.Pages/server/clustering/cluster-transactions.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/server/clustering/cluster-transactions.markdown
@@ -99,7 +99,7 @@ have changed since the transaction was initiated, the entire session transaction
 
 Optimistic concurrency at the document level is _not_ supported for cluster-wide transactions. 
 Compare-exchange operations should be used to ensure consistency in that regard. Concurrent cluster-wide transactions are guaranteed 
-to appear as if they are run one at a time (`serializable` isolation level). 
+to appear as if they are run one at a time. 
 
 Cluster-wide transactions may only contain `PUT` / `DELETE` commands. This is required to ensure that we can apply the transaction 
 to each of the database nodes without regard to the current node state.

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/cluster-transaction/overview.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/cluster-transaction/overview.dotnet.markdown
@@ -4,8 +4,9 @@
 
 {NOTE: }
 
-* A session represents a single business transaction.  
-  When opening a session, the session's mode can be set to either:  
+* A session represents a single [business transaction](https://martinfowler.com/eaaCatalog/unitOfWork.html) (not to be confused with an [ACID transaction](../../../client-api/faq/transaction-support)).  
+ 
+* When opening a session, the session's mode can be set to either:  
     * __Single-Node__ - transaction is executed on a specific node and then replicated
     * __Cluster-Wide__ - transaction is registered for execution on all nodes in an atomic fashion
 
@@ -113,6 +114,13 @@
     * And - when resolving occasional conflicts is acceptable
 
 {NOTE/}
+
+{INFO:Transactions in RavenDB}
+
+For a detailed description of transactions in RavenDB please refer to the [Transaction support in RavenDB](../../client-api/faq/transaction-support) article.
+
+{INFO/}
+
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/cluster-transaction/overview.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/cluster-transaction/overview.js.markdown
@@ -4,10 +4,11 @@
 
 {NOTE: }
 
-* A session represents a single business transaction.  
-  When opening a session, the session's mode can be set to either:
-    * __Single-Node__ - transaction is executed on a specific node and then replicated
-    * __Cluster-Wide__ - transaction is registered for execution on all nodes in an atomic fashion
+* A session represents a single [business transaction](https://martinfowler.com/eaaCatalog/unitOfWork.html) (not to be confused with an [ACID transaction](../../../client-api/faq/transaction-support)).
+
+* When opening a session, the session's mode can be set to either:  
+    * __Single-Node__ - transaction is executed on a specific node and then replicated  
+    * __Cluster-Wide__ - transaction is registered for execution on all nodes in an atomic fashion  
 
 * In this page:
     * [Open a cluster transaction](../../../client-api/session/cluster-transaction/overview#open-a-cluster-transaction)
@@ -112,6 +113,13 @@
     * And - when resolving occasional conflicts is acceptable
 
 {NOTE/}
+
+{INFO:Transactions in RavenDB}
+
+For a detailed description of transactions in RavenDB please refer to the [Transaction support in RavenDB](../../client-api/faq/transaction-support) article.
+
+{INFO/}
+
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/saving-changes.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/saving-changes.dotnet.markdown
@@ -1,6 +1,16 @@
 # Session: Saving changes
 
-Pending session operations e.g. `Store`, `Delete` and many others will not be send to server till `SaveChanges` is called.
+Pending session operations e.g. `Store`, `Delete` and many others will not be send to the server until `SaveChanges` is called.
+
+{INFO: }
+
+Whenever you execute `SaveChanges()` to send a batch of operations like put, update, or delete in a request,  
+the server will wrap these operations in a [transaction](../../client-api/faq/transaction-support) upon execution in the database.  
+
+Either all operations will be saved as a single, atomic transaction or none of them will be.  
+Once `SaveChanges()` returns successfully, it is guaranteed that all changes are persisted in the database.  
+
+{INFO/}
 
 ##Syntax
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/saving-changes.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/saving-changes.java.markdown
@@ -1,6 +1,16 @@
 # Session: Saving changes
 
-Pending session operations e.g. `store`, `delete` and many others will not be send to server till `saveChanges` is called.
+Pending session operations e.g. `store`, `delete` and many others will not be send to the server until `saveChanges` is called.
+
+{INFO: }
+
+Whenever you execute `saveChanges()` to send a batch of operations like put, update, or delete in a request,  
+the server will wrap these operations in a [transaction](../../client-api/faq/transaction-support) upon execution in the database.
+
+Either all operations will be saved as a single, atomic transaction or none of them will be.  
+Once `saveChanges()` returns successfully, it is guaranteed that all changes are persisted in the database.
+
+{INFO/}
 
 ##Syntax
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/saving-changes.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/saving-changes.js.markdown
@@ -1,6 +1,16 @@
 # Session: Saving changes
 
-Pending session operations e.g. `store()`, `delete()` and many others will not be send to server until `saveChanges()` is called.
+Pending session operations e.g. `store()`, `delete()` and many others will not be send to the server until `saveChanges()` is called.
+
+{INFO: }
+
+Whenever you execute `saveChanges()` to send a batch of operations like put, update, or delete in a request,  
+the server will wrap these operations in a [transaction](../../client-api/faq/transaction-support) upon execution in the database.
+
+Either all operations will be saved as a single, atomic transaction or none of them will be.  
+Once `saveChanges()` returns successfully, it is guaranteed that all changes are persisted in the database.
+
+{INFO/}
 
 ##Syntax
 

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.dotnet.markdown
@@ -4,25 +4,18 @@
 
 {NOTE: }  
 
-* The **Session**, which is obtained from the [Document Store](../../client-api/what-is-a-document-store),  
-  is a [Unit of Work](https://martinfowler.com/eaaCatalog/unitOfWork.html) that represents a single business transaction on a particular database.  
-
-* Basic **document CRUD** actions and **document Queries** are available through the `Session`.  
-  More advanced options are available using `Advanced` Session operations.  
-
-* The Session **tracks all changes** made to all entities that it has either loaded, stored, or queried for,  
-  and persists to the server only what is needed when `SaveChanges()` is called.  
-
-* The number of server requests allowed per session is configurable (default is 30).  
-  See: [Change maximum number of requests per session](../../client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session).  
+* The __Session__, which is obtained from the [Document Store](../../client-api/what-is-a-document-store),  
+  is the primary interface your application will interact with.
 
 * In this page:
+  * [Session overview](../../client-api/session/what-is-a-session-and-how-does-it-work#session-overview)  
   * [Unit of work pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern)  
       * [Tracking changes](../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes)
       * [Create document example](../../client-api/session/what-is-a-session-and-how-does-it-work#create-document-example)
       * [Modify document example](../../client-api/session/what-is-a-session-and-how-does-it-work#modify-document-example)
   * [Identity map pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#identity-map-pattern)
-  * [Batching & Transactions](../../client-api/session/what-is-a-session-and-how-does-it-work#batching-&-transactions)<br><br>
+  * [Batching & Transactions](../../client-api/session/what-is-a-session-and-how-does-it-work#batching-&-transactions)
+  * [Concurrency control](../../client-api/session/what-is-a-session-and-how-does-it-work#concurrency-control)<br><br>
   * [Reducing server calls (best practices) for:](../../client-api/session/what-is-a-session-and-how-does-it-work#reducing-server-calls-(best-practices)-for:)  
       * [The N+1 problem](../../client-api/session/what-is-a-session-and-how-does-it-work#the-select-n1-problem)    
       * [Large query results](../../client-api/session/what-is-a-session-and-how-does-it-work#large-query-results)    
@@ -31,6 +24,44 @@
 {NOTE/}  
 
 ---
+
+{PANEL: Session overview}
+
+* __What is the session__:  
+    
+  * The session (`ISession`/`IAsyncDocumentSession`) serves as a [Unit of Work](https://en.wikipedia.org/wiki/Unit_of_work) representing a single  
+    __[Business Transaction](https://martinfowler.com/eaaCatalog/unitOfWork.html)__ on a specific database (not to be confused with an [ACID transaction](../../client-api/faq/transaction-support)).  
+   
+  * It is a container that allows you to query for documents and load, create, or update entities  
+    while keeping track of changes.
+   
+  * Basic document CRUD actions and document Queries are available through the `Session`.  
+    More advanced options are available using the `Advanced` Session operations.
+
+* __Batching modifications__:  
+  A business transaction usually involves multiple requests such as loading of documents or execution of queries.  
+  Calling [SaveChanges()](../../client-api/session/saving-changes) indicates the completion of the client-side business logic . 
+  At this point, all modifications made within the session are batched and sent together in a __single HTTP request__ to the server to be persisted as a single ACID transaction.
+
+* __Tracking changes__:  
+  Based on the [Unit of Work](https://martinfowler.com/eaaCatalog/unitOfWork.html) and the [Identity Map](https://martinfowler.com/eaaCatalog/identityMap.html) patterns, 
+  the session tracks all changes made to all entities that it has either loaded, stored, or queried for.  
+  Only the modifications are sent to the server when _SaveChanges()_ is called.
+
+* __Client side object__:  
+  The session is a pure client side object. Opening the session does Not establish any connection to a database,  
+  and the session's state isn't reflected on the server side during its duration.
+
+* __Configurability__:  
+  Various aspects of the session are configurable.  
+  For example, the number of server requests allowed per session is [configurable](../../client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session) (default is 30). 
+
+* __The session and ORM Comparison__:  
+  The RavenDB Client API is a native way to interact with a RavenDB database.  
+  It is _not_ an Object–relational mapping (ORM) tool. Although if you're familiar with NHibernate of Entity Framework ORMs you'll recognize that
+  the session is equivalent of NHibernate's session and Entity Framework's DataContext which implement UoW pattern as well.
+
+{PANEL/}  
 
 {PANEL: Unit of work pattern}  
 
@@ -70,7 +101,7 @@
 
 {PANEL/}  
 
-{PANEL:Identity map pattern}  
+{PANEL: Identity map pattern}  
 
 * The session implements the [Identity Map Pattern](https://martinfowler.com/eaaCatalog/identityMap.html).
 * The first `Load()` call goes to the server and fetches the document from the database.  
@@ -91,27 +122,113 @@
 
 {PANEL: Batching & Transactions}
 
+{NOTE: }
+
 #### Batching
 
 * Remote calls to a server over the network are among the most expensive operations an application makes.  
   The session optimizes this by batching all __write operations__ it has tracked into the `SaveChanges()` call.  
-* When calling SaveChanges, the session checks its state for all changes made that need to be saved in the database,  
-  and combines them into a single batch that is sent to the server as a __single remote call__.
+* When calling _SaveChanges_, the session evaluates its state to identify all pending changes requiring persistence in the database. 
+  These changes are then combined into a single batch that is sent to the server as a __single remote call__ and a single ACID transaction.
+
+{NOTE/}
+{NOTE: }
 
 #### Transactions
 
-* The batched operations that are sent in the `SaveChanges()` will complete transactionally.  
+* The client API does not provide transactional semantics over the entire session.  
+  The session **does not** represent a [transaction](../../client-api/faq/transaction-support) (nor a transaction scope) in terms of ACID transactions.
+* RavenDB provides transactions over individual requests, so each call made within the session's usage will be processed in a separate transaction on the server side.
+  This applies to both reads and writes. 
+
+##### Read transactions
+
+* Each call retrieving data from the database will generate a separate request. Multiple requests mean separate transactions.
+* The following options allow you to read _multiple_ documents in a single request:
+    * Using overloads of the [Load()](../../client-api/session/loading-entities#load---multiple-entities) method that specify a collection of IDs or a prefix of ID.
+    * Using [Include](../../client-api/session/loading-entities#load-with-includes) to retrieve additional documents in a single request.
+    * A query that can return multiple documents is executed in a single request,  
+      hence it is processed in a single read transaction.
+
+##### Write transactions
+
+* The batched operations that are sent in the `SaveChanges()` complete transactionally, as this call generates a single request to the database. 
   In other words, either all changes are saved as a **Single Atomic Transaction** or none of them are.  
-  So once SaveChanges returns successfully, it is guaranteed that all changes are persisted to the database.  
-* The SaveChanges is the only time when a RavenDB client sends updates to the server from the Session,  
-  so you will experience a reduced number of network calls.
+  So once _SaveChanges_ returns successfully, it is guaranteed that all changes are persisted to the database.  
+* _SaveChanges_ is the only time when the RavenDB Client API sends updates to the server from the Session,  
+  resulting in a reduced number of network calls.
+* To execute an operation that both loads and updates a document within the same write transaction, use the patching feature. 
+  This can be done either with the usage of a [JavaScript patch](../../client-api/operations/patching/single-document) syntax or [JSON Patch](../../client-api/operations/patching/json-patch-syntax) syntax.
+
+{NOTE/}
+{NOTE: }
 
 #### Transaction mode
 
-* The session's transaction mode can be set to either:
-  * __Single-Node__ - transaction is executed on a specific node and then replicated
+* The session's transaction mode can be set to either:  
+  * __Single-Node__ - transaction is executed on a specific node and then replicated  
   * __Cluster-Wide__ - transaction is registered for execution on all nodes in an atomic fashion
-* Learn more about these modes in [Cluster-wide vs. Single-node](../../client-api/session/cluster-transaction/overview#cluster-wide-transaction-vs.-single-node-transaction) transactions. 
+  * {WARNING: }
+      The phrase "session's transaction mode" refers to the type of transaction that will be executed on the server-side when `SaveChanges()` is called.
+      As mentioned earlier, the session itself does not represent an ACID transaction.
+    {WARNING/}
+  * Learn more about these modes in [Cluster-wide vs. Single-node](../../client-api/session/cluster-transaction/overview#cluster-wide-transaction-vs.-single-node-transaction) transactions. 
+
+{NOTE/}
+
+{INFO: Transactions in RavenDB}
+For a detailed description of transactions in RavenDB please refer to the [Transaction support in RavenDB](../../../client-api/faq/transaction-support) article. 
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Concurrency control}
+
+The typical usage model of the session is:
+
+  * Load documents
+  * Modify the documents
+  * Save changes
+
+For example, a real case scenario would be:  
+
+  * Load an entity from a database.
+  * Display an Edit form on the screen.
+  * Update the entity after the user completes editing.
+
+When using the session, the interaction with the database is divided into two parts - the load part and save changes part. 
+Each of these parts is executed separately, via its own HTTP request.  
+Consequently, data that was loaded and edited could potentially be changed by another user in the meantime.  
+To address this, the session API offers the concurrency control feature.
+
+#### Default strategy on single node
+
+* By default, concurrency checks are turned off. 
+  This means that with the default configuration of the session, concurrent changes to the same document will use the Last Write Wins strategy.   
+ 
+* The second write of an updated document will override the previous version, causing potential data loss. 
+  This behavior should be considered when using the session with single node transaction mode.
+
+#### Optimistic concurrency on single node
+
+* The modification or editing stage can extend over a considerable time period or may occur offline.  
+  To prevent conflicting writes, where a document is modified while it is being edited by another user or client,  
+  the session can be configured to employ [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency).
+
+* Once optimistic concurrency is enabled, the session performs version tracking to ensure that any document modified within the session has not been altered in the database since it was loaded into the session.  
+  The version is tracked using a [change vector](../../server/clustering/replication/change-vector).
+
+* When `SaveChanges()` is called, the session additionally transmits the version of the modified documents to the database, allowing it to verify if any changes have occurred in the meantime.  
+  If modifications are detected, the transaction will be aborted with a `ConcurrencyException`,  
+  providing the caller with an opportunity to retry or handle the error as needed.
+
+#### Concurrency control in cluster-wide transactions
+
+* In a cluster-wide transaction scenario, RavenDB server tracks a cluster-wide version for each modified document, updating it through the Raft protocol. 
+  This means that when using a session with the cluster-wide transaction mode, a `ConcurrencyException` will be triggered upon calling `SaveChanges()` 
+  if another user has modified a document and saved it in a separate cluster-wide transaction in the meantime.
+
+* More information about cluster transactions can be found in [Cluster Transaction - Overview](../../client-api/session/cluster-transaction/overview).
 
 {PANEL/}
 
@@ -123,14 +240,14 @@
   It results in an excessive number of remote calls to the server, which makes a query very expensive.  
 * Make use of RavenDB's `include()` method to include related documents and avoid this issue.  
   See: [Document relationships](../../client-api/how-to/handle-document-relationships)  
-<br>
+
 #### Large query results
 * When query results are large and you don't want the overhead of keeping all results in memory,  
   then you can [Stream query results](../../client-api/session/querying/how-to-stream-query-results).  
   A single server call is executed and the client can handle the results one by one.  
 * [Paging](../../indexes/querying/paging) also avoids getting all query results at one time,  
   however, multiple server calls are generated - one per page retrieved.  
-<br>
+
 #### Retrieving results on demand (Lazy)
 * Query calls to the server can be delayed and executed on-demand as needed using `Lazily()`
 * See [Perform queries lazily](../../client-api/session/querying/how-to-perform-queries-lazily)
@@ -148,3 +265,5 @@
 - [Query Overview](../../client-api/session/querying/how-to-query)
 - [Querying an Index](../../indexes/querying/query-index)
 - [What is a Document Store](../../client-api/what-is-a-document-store)
+- [Optimistic Concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency)
+- [Transaction Support](../../client-api/faq/transaction-support)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.java.markdown
@@ -1,61 +1,260 @@
 # What is a Session and How Does it Work
 
-After creating a RavenDB document store, we are ready to use the database server instance it is pointing at. For any operation we want to perform on RavenDB, we start by obtaining a new Session object from the document store. The Session object will contain everything we need to perform any operation necessary.
+---
+
+{NOTE: }
+
+* The __Session__, which is obtained from the [Document Store](../../client-api/what-is-a-document-store),  
+  is the primary interface your application will interact with.
+
+* In this page:
+    * [Session overview](../../client-api/session/what-is-a-session-and-how-does-it-work#session-overview)
+    * [Unit of work pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern)
+        * [Tracking changes](../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes)
+        * [Create document example](../../client-api/session/what-is-a-session-and-how-does-it-work#create-document-example)
+        * [Modify document example](../../client-api/session/what-is-a-session-and-how-does-it-work#modify-document-example)
+    * [Identity map pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#identity-map-pattern)
+    * [Batching & Transactions](../../client-api/session/what-is-a-session-and-how-does-it-work#batching-&-transactions)
+    * [Concurrency control](../../client-api/session/what-is-a-session-and-how-does-it-work#concurrency-control)<br><br>
+    * [Reducing server calls (best practices) for:](../../client-api/session/what-is-a-session-and-how-does-it-work#reducing-server-calls-(best-practices)-for:)
+        * [The N+1 problem](../../client-api/session/what-is-a-session-and-how-does-it-work#the-select-n1-problem)
+        * [Large query results](../../client-api/session/what-is-a-session-and-how-does-it-work#large-query-results)
+        * [Retrieving results on demand (Lazy)](../../client-api/session/what-is-a-session-and-how-does-it-work#retrieving-results-on-demand-lazy)
+
+{NOTE/}
+
+---
+
+{PANEL: Session overview}
+
+* __What is the session__:  
+
+    * The session (`IDocumentSession`/`IAsyncDocumentSession`) serves as a [Unit of Work](https://en.wikipedia.org/wiki/Unit_of_work) representing a single  
+      __[Business Transaction](https://martinfowler.com/eaaCatalog/unitOfWork.html)__ on a specific database (not to be confused with an [ACID transaction](../../client-api/faq/transaction-support)).
+
+    * It is a container that allows you to query for documents and load, create, or update entities  
+      while keeping track of changes.
+
+    * Basic document CRUD actions and document Queries are available through the `session`.  
+      More advanced options are available using the `advanced` Session operations.
+
+* __Batching modifications__:  
+  A business transaction usually involves multiple requests such as loading of documents or execution of queries.  
+  Calling [saveChanges()](../../client-api/session/saving-changes) indicates the completion of the client-side business logic .
+  At this point, all modifications made within the session are batched and sent together in a __single HTTP request__ to the server to be persisted as a single ACID transaction.
+
+* __Tracking changes__:  
+  Based on the [Unit of Work](https://martinfowler.com/eaaCatalog/unitOfWork.html) and the [Identity Map](https://martinfowler.com/eaaCatalog/identityMap.html) patterns,
+  the session tracks all changes made to all entities that it has either loaded, stored, or queried for.  
+  Only the modifications are sent to the server when _saveChanges()_ is called.
+
+* __Client side object__:  
+  The session is a pure client side object. Opening the session does Not establish any connection to a database,  
+  and the session's state isn't reflected on the server side during its duration.
+
+* __Configurability__:  
+  Various aspects of the session are configurable.  
+  For example, the number of server requests allowed per session is [configurable](../../client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session) (default is 30).
+
+* __The session and ORM Comparison__:  
+  The RavenDB Client API is a native way to interact with a RavenDB database.  
+  It is _not_ an Object–relational mapping (ORM) tool. Although if you're familiar with NHibernate of Entity Framework ORMs you'll recognize that
+  the session is equivalent of NHibernate's session and Entity Framework's DataContext which implement UoW pattern as well.
+
+{PANEL/}
+
+{PANEL: Unit of work pattern}
+
+#### Tracking changes
+
+* Using the Session, perform needed operations on your documents.  
+  e.g. create a new document, modify an existing document, query for documents, etc.
+* Any such operation '*loads*' the document as an entity to the Session,  
+  and the entity is added to the __Session's entities map__.
+* The Session **tracks all changes** made to all entities stored in its internal map.  
+  You don't need to manually track the changes and decide what needs to be saved and what doesn't, the Session will do it for you.  
+  Prior to saving, you can review the changes made if necessary. See: [Check for session changes](../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session).
+* All the tracked changes are combined & persisted in the database only when calling `saveChanges()`.
+* Entity tracking can be disabled if needed. See:
+    * [Disable entity tracking](../../client-api/session/configuration/how-to-disable-tracking)
+    * [Clear session](../../client-api/session/how-to/clear-a-session)
+
+---
+
+#### Create document example
+* The Client API, and the Session in particular, is designed to be as straightforward as possible.  
+  Open the session, do some operations, and apply the changes to the RavenDB server.
+* The following example shows how to create a new document in the database using the Session.
 
 {CODE:java session_usage_1@ClientApi\Session\WhatIsSession.java /}
 
-The Client API, and using the Session object in particular, is very straightforward. Open the session, do some operations, and apply the changes to the RavenDB server. The usage of the second session is similar: open the session, get a document from the server, and do something with it.
-
-{NOTE: Storing Entities} 
-You can read more about storing data with the session [here](./storing-entities).
-{NOTE/}
-
-
-## Unit of Work
-
-The Client API implements the Unit of Work pattern. That has several implications:
-
-* In the context of a single session, a single document (identified by its ID) always resolves to the same instance.
-
-{CODE:java session_usage_3@ClientApi\Session\WhatIsSession.java /}
-
-* The session manages change tracking for all the entities that it has either loaded or stored.
+#### Modify document example
+* The following example modifies the content of an existing document.
 
 {CODE:java session_usage_2@ClientApi\Session\WhatIsSession.java /}
 
-{INFO:How to Disable Entities Tacking}
+{PANEL/}
 
-Entities tracking can be disabled using the `SessionOptions.NoTracking` property when session is being [opened](../../client-api/session/opening-a-session#example-ii---disabling-entities-tracking).
+{PANEL: Identity map pattern}
 
+* The session implements the [Identity Map Pattern](https://martinfowler.com/eaaCatalog/identityMap.html).
+* The first `load()` call goes to the server and fetches the document from the database.  
+  The document is then stored as an entity in the Session's entities map.
+* All subsequent `load()` calls to the same document will simply retrieve the entity from the Session -  
+  no additional calls to the server are made.
+
+{CODE:java session_usage_3@ClientApi\Session\WhatIsSession.java /}
+
+* Note:  
+  To override this behavior and force `load()` to fetch the latest changes from the server see:
+  [Refresh an entity](../../client-api/session/how-to/refresh-entity).
+
+{PANEL/}
+
+{PANEL: Batching & Transactions}
+
+{NOTE: }
+
+#### Batching
+
+* Remote calls to a server over the network are among the most expensive operations an application makes.  
+  The session optimizes this by batching all __write operations__ it has tracked into the `saveChanges()` call.
+* When calling _saveChanges_, the session evaluates its state to identify all pending changes requiring persistence in the database.
+  These changes are then combined into a single batch that is sent to the server as a __single remote call__ and a single ACID transaction.
+
+{NOTE/}
+{NOTE: }
+
+#### Transactions
+
+* The client API does not provide transactional semantics over the entire session.  
+  The session **does not** represent a [transaction](../../client-api/faq/transaction-support) (nor a transaction scope) in terms of ACID transactions.
+* RavenDB provides transactions over individual requests, so each call made within the session's usage will be processed in a separate transaction on the server side.
+  This applies to both reads and writes.
+
+##### Read transactions
+
+* Each call retrieving data from the database will generate a separate request. Multiple requests mean separate transactions.
+* The following options allow you to read _multiple_ documents in a single request:
+    * Using overloads of the [load()](../../client-api/session/loading-entities#load---multiple-entities) method that specify a collection of IDs or a prefix of ID.
+    * Using [include](../../client-api/session/loading-entities#load-with-includes) to retrieve additional documents in a single request.
+    * A query that can return multiple documents is executed in a single request,  
+      hence it is processed in a single read transaction.
+
+##### Write transactions
+
+* The batched operations that are sent in the `saveChanges()` complete transactionally, as this call generates a single request to the database.
+  In other words, either all changes are saved as a **Single Atomic Transaction** or none of them are.  
+  So once _saveChanges_ returns successfully, it is guaranteed that all changes are persisted to the database.
+* _saveChanges_ is the only time when the RavenDB Client API sends updates to the server from the Session,  
+  resulting in a reduced number of network calls.
+* To execute an operation that both loads and updates a document within the same write transaction, use the patching feature.
+  This can be done either with the usage of a [JavaScript patch](../../client-api/operations/patching/single-document) syntax or [JSON Patch](../../client-api/operations/patching/json-patch-syntax) syntax.
+
+{NOTE/}
+{NOTE: }
+
+#### Transaction mode
+
+* The session's transaction mode can be set to either:
+    * __Single-Node__ - transaction is executed on a specific node and then replicated
+    * __Cluster-Wide__ - transaction is registered for execution on all nodes in an atomic fashion
+    * {WARNING: }
+      The phrase "session's transaction mode" refers to the type of transaction that will be executed on the server-side when `saveChanges()` is called.
+      As mentioned earlier, the session itself does not represent an ACID transaction.
+      {WARNING/}
+    * Learn more about these modes in [Cluster-wide vs. Single-node](../../client-api/session/cluster-transaction/overview#cluster-wide-transaction-vs.-single-node-transaction) transactions.
+
+{NOTE/}
+
+{INFO: Transactions in RavenDB}
+For a detailed description of transactions in RavenDB please refer to the [Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
 {INFO/}
 
-## Batching
+{PANEL/}
 
-One of the most expensive operations in an application is making remote calls. The RavenDB Client API optimizes this for you by batching all write calls to the RavenDB server into a single call. This is the default behavior whenever using the Session object, you don't have to do anything to enable it. This also ensures that writes to the database are always executed in a single transaction, no matter how many operations you are actually executing.
+{PANEL: Concurrency control}
 
-## Remarks
+The typical usage model of the session is:
 
-A very common problem with all ORMs and ORM-like APIs is the Select N+1 problem. This is relevant to any database API which is designed to work like an ORM, RavenDB Client API included.
-How RavenDB API attempts to mitigate this is not immediate, and should never be reached if RavenDB is being utilized correctly. Remote calls are expensive and the number of remote calls per "session" should be as close to "1" as possible. If the limit is reached, it is a sure sign of either a Select N+1 problem or other misuse of the RavenDB session.
+  * Load documents
+  * Modify the documents
+  * Save changes
 
-{NOTE: Configuring the maximum requests in a session} 
-By default, the maximum requests count in the session is 30.
-This can be changed by the DocumentConventions::maxNumberOfRequestsPerSession property.
-{NOTE/}
+For example, a real case scenario would be:
+
+  * Load an entity from a database.
+  * Display an Edit form on the screen.
+  * Update the entity after the user completes editing.
+
+When using the session, the interaction with the database is divided into two parts - the load part and save changes part.
+Each of these parts is executed separately, via its own HTTP request.  
+Consequently, data that was loaded and edited could potentially be changed by another user in the meantime.  
+To address this, the session API offers the concurrency control feature.
+
+#### Default strategy on single node
+
+* By default, concurrency checks are turned off.
+  This means that with the default configuration of the session, concurrent changes to the same document will use the Last Write Wins strategy.
+
+* The second write of an updated document will override the previous version, causing potential data loss.
+  This behavior should be considered when using the session with single node transaction mode.
+
+#### Optimistic concurrency on single node
+
+* The modification or editing stage can extend over a considerable time period or may occur offline.  
+  To prevent conflicting writes, where a document is modified while it is being edited by another user or client,  
+  the session can be configured to employ [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency).
+
+* Once optimistic concurrency is enabled, the session performs version tracking to ensure that any document modified within the session has not been altered in the database since it was loaded into the session.  
+  The version is tracked using a [change vector](../../server/clustering/replication/change-vector).
+
+* When `saveChanges()` is called, the session additionally transmits the version of the modified documents to the database, allowing it to verify if any changes have occurred in the meantime.  
+  If modifications are detected, the transaction will be aborted with a `ConcurrencyException`,  
+  providing the caller with an opportunity to retry or handle the error as needed.
+
+#### Concurrency control in cluster-wide transactions
+
+* In a cluster-wide transaction scenario, RavenDB server tracks a cluster-wide version for each modified document, updating it through the Raft protocol.
+  This means that when using a session with the cluster-wide transaction mode, a `ConcurrencyException` will be triggered upon calling `saveChanges()`
+  if another user has modified a document and saved it in a separate cluster-wide transaction in the meantime.
+
+* More information about cluster transactions can be found in [Cluster Transaction - Overview](../../client-api/session/cluster-transaction/overview).
+
+{PANEL/}
+
+{PANEL: Reducing server calls (best practices) for:}
+
+#### The select N+1 problem
+* The Select N+1 problem is common
+  with all ORMs and ORM-like APIs.  
+  It results in an excessive number of remote calls to the server, which makes a query very expensive.
+* Make use of RavenDB's `include()` method to include related documents and avoid this issue.  
+  See: [Document relationships](../../client-api/how-to/handle-document-relationships)
+
+#### Large query results
+* When query results are large and you don't want the overhead of keeping all results in memory,  
+  then you can [Stream query results](../../client-api/session/querying/how-to-stream-query-results).  
+  A single server call is executed and the client can handle the results one by one.
+* [Paging](../../indexes/querying/paging) also avoids getting all query results at one time,  
+  however, multiple server calls are generated - one per page retrieved.
+
+#### Retrieving results on demand (Lazy)
+* Query calls to the server can be delayed and executed on-demand as needed using `Lazily()`
+* See [Perform queries lazily](../../client-api/session/querying/how-to-perform-queries-lazily)
+
+{PANEL/}
 
 ## Related Articles
 
-### Session
+### Client API
 
-- [Opening a Session](../../client-api/session/opening-a-session)
+- [Open a Session](../../client-api/session/opening-a-session)
 - [Storing Entities](../../client-api/session/storing-entities)
 - [Loading Entities](../../client-api/session/loading-entities)
 - [Saving Changes](../../client-api/session/saving-changes)
-
-### Querying
-
-- [Basics](../../indexes/querying/query-index)
-
-### Document Store
-
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
 - [What is a Document Store](../../client-api/what-is-a-document-store)
+- [Optimistic Concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency)
+- [Transaction Support](../../client-api/faq/transaction-support)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.js.markdown
@@ -2,35 +2,66 @@
 
 ---
 
-{NOTE: }  
+{NOTE: }
 
-* The **session**, which is obtained from the [Document Store](../../client-api/what-is-a-document-store),  
-  is a [Unit of Work](https://martinfowler.com/eaaCatalog/unitOfWork.html) that represents a single business transaction on a particular database.  
-
-* Basic **document CRUD** actions and **document Queries** are available through the `session`.  
-  More advanced options are available using `advanced` session operations.  
-
-* The session **tracks all changes** made to all entities that it has either loaded, stored, or queried for,  
-  and persists to the server only what is needed when `saveChanges()` is called.  
-
-* The number of server requests allowed per session is configurable (default is 30).  
-  See: [Change maximum number of requests per session](../../client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session).  
+* The __session__, which is obtained from the [Document Store](../../client-api/what-is-a-document-store),  
+  is the primary interface your application will interact with.
 
 * In this page:
-  * [Unit of work pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern)  
-      * [Tracking changes](../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes)
-      * [Create document example](../../client-api/session/what-is-a-session-and-how-does-it-work#create-document-example)
-      * [Modify document example](../../client-api/session/what-is-a-session-and-how-does-it-work#modify-document-example)
-  * [Identity map pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#identity-map-pattern)
-  * [Batching & Transactions](../../client-api/session/what-is-a-session-and-how-does-it-work#batching-&-transactions)<br><br>
-  * [Reducing server calls (best practices) for:](../../client-api/session/what-is-a-session-and-how-does-it-work#reducing-server-calls-(best-practices)-for:)  
-      * [The N+1 problem](../../client-api/session/what-is-a-session-and-how-does-it-work#the-select-n1-problem)    
-      * [Large query results](../../client-api/session/what-is-a-session-and-how-does-it-work#large-query-results)    
-      * [Retrieving results on demand (Lazy)](../../client-api/session/what-is-a-session-and-how-does-it-work#retrieving-results-on-demand-lazy)
+    * [Session overview](../../client-api/session/what-is-a-session-and-how-does-it-work#session-overview)
+    * [Unit of work pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern)
+        * [Tracking changes](../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes)
+        * [Create document example](../../client-api/session/what-is-a-session-and-how-does-it-work#create-document-example)
+        * [Modify document example](../../client-api/session/what-is-a-session-and-how-does-it-work#modify-document-example)
+    * [Identity map pattern](../../client-api/session/what-is-a-session-and-how-does-it-work#identity-map-pattern)
+    * [Batching & Transactions](../../client-api/session/what-is-a-session-and-how-does-it-work#batching-&-transactions)
+    * [Concurrency control](../../client-api/session/what-is-a-session-and-how-does-it-work#concurrency-control)<br><br>
+    * [Reducing server calls (best practices) for:](../../client-api/session/what-is-a-session-and-how-does-it-work#reducing-server-calls-(best-practices)-for:)
+        * [The N+1 problem](../../client-api/session/what-is-a-session-and-how-does-it-work#the-select-n1-problem)
+        * [Large query results](../../client-api/session/what-is-a-session-and-how-does-it-work#large-query-results)
+        * [Retrieving results on demand (Lazy)](../../client-api/session/what-is-a-session-and-how-does-it-work#retrieving-results-on-demand-lazy)
 
-{NOTE/}  
+{NOTE/}
 
 ---
+
+{PANEL: Session overview}
+
+* __What is the session__:  
+
+    * The session (`IDocumentSession`/`IAsyncDocumentSession`) serves as a [Unit of Work](https://en.wikipedia.org/wiki/Unit_of_work) representing a single  
+      __[Business Transaction](https://martinfowler.com/eaaCatalog/unitOfWork.html)__ on a specific database (not to be confused with an [ACID transaction](../../client-api/faq/transaction-support)).
+
+    * It is a container that allows you to query for documents and load, create, or update entities  
+      while keeping track of changes.
+
+    * Basic document CRUD actions and document Queries are available through the `session`.  
+      More advanced options are available using the `advanced` Session operations.
+
+* __Batching modifications__:  
+  A business transaction usually involves multiple requests such as loading of documents or execution of queries.  
+  Calling [saveChanges()](../../client-api/session/saving-changes) indicates the completion of the client-side business logic .
+  At this point, all modifications made within the session are batched and sent together in a __single HTTP request__ to the server to be persisted as a single ACID transaction.
+
+* __Tracking changes__:  
+  Based on the [Unit of Work](https://martinfowler.com/eaaCatalog/unitOfWork.html) and the [Identity Map](https://martinfowler.com/eaaCatalog/identityMap.html) patterns,
+  the session tracks all changes made to all entities that it has either loaded, stored, or queried for.  
+  Only the modifications are sent to the server when _saveChanges()_ is called.
+
+* __Client side object__:  
+  The session is a pure client side object. Opening the session does Not establish any connection to a database,  
+  and the session's state isn't reflected on the server side during its duration.
+
+* __Configurability__:  
+  Various aspects of the session are configurable.  
+  For example, the number of server requests allowed per session is [configurable](../../client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session) (default is 30).
+
+* __The session and ORM Comparison__:  
+  The RavenDB Client API is a native way to interact with a RavenDB database.  
+  It is _not_ an Object–relational mapping (ORM) tool. Although if you're familiar with NHibernate of Entity Framework ORMs you'll recognize that
+  the session is equivalent of NHibernate's session and Entity Framework's DataContext which implement UoW pattern as well.
+
+{PANEL/}
 
 {PANEL: Unit of work pattern}  
 
@@ -88,27 +119,113 @@
 
 {PANEL: Batching & Transactions}
 
+{NOTE: }
+
 #### Batching
 
 * Remote calls to a server over the network are among the most expensive operations an application makes.  
-  The session optimizes this by batching all __write operations__ it has tracked into the `saveChanges()` call.  
-* When calling saveChanges, the session checks its state for all changes made that need to be saved in the database,  
-  and combines them into a single batch that is sent to the server as a __single remote call__.
+  The session optimizes this by batching all __write operations__ it has tracked into the `saveChanges()` call.
+* When calling _saveChanges_, the session evaluates its state to identify all pending changes requiring persistence in the database.
+  These changes are then combined into a single batch that is sent to the server as a __single remote call__  and a single ACID transaction.
+
+{NOTE/}
+{NOTE: }
 
 #### Transactions
 
-* The batched operations that are sent in the `saveChanges()` will complete transactionally.  
+* The client API does not provide transactional semantics over the entire session.  
+  The session **does not** represent a [transaction](../../client-api/faq/transaction-support) (nor a transaction scope) in terms of ACID transactions.
+* RavenDB provides transactions over individual requests, so each call made within the session's usage will be processed in a separate transaction on the server side.
+  This applies to both reads and writes.
+
+##### Read transactions
+
+* Each call retrieving data from the database will generate a separate request. Multiple requests mean separate transactions.
+* The following options allow you to read _multiple_ documents in a single request:
+    * Using overloads of the [load()](../../client-api/session/loading-entities#load---multiple-entities) method that specify a collection of IDs or a prefix of ID.
+    * Using [include](../../client-api/session/loading-entities#load-with-includes) to retrieve additional documents in a single request.
+    * A query that can return multiple documents is executed in a single request,  
+      hence it is processed in a single read transaction.
+
+##### Write transactions
+
+* The batched operations that are sent in the `saveChanges()` complete transactionally, as this call generates a single request to the database.
   In other words, either all changes are saved as a **Single Atomic Transaction** or none of them are.  
-  So once saveChanges returns successfully, it is guaranteed that all changes are persisted to the database.  
-* The saveChanges is the only time when a RavenDB client sends updates to the server from the session,  
-  so you will experience a reduced number of network calls.
+  So once _saveChanges_ returns successfully, it is guaranteed that all changes are persisted to the database.
+* _saveChanges_ is the only time when the RavenDB Client API sends updates to the server from the Session,  
+  resulting in a reduced number of network calls.
+* To execute an operation that both loads and updates a document within the same write transaction, use the patching feature.
+  This can be done either with the usage of a [JavaScript patch](../../client-api/operations/patching/single-document) syntax or [JSON Patch](../../client-api/operations/patching/json-patch-syntax) syntax.
+
+{NOTE/}
+{NOTE: }
 
 #### Transaction mode
 
 * The session's transaction mode can be set to either:
-  * __Single-Node__ - transaction is executed on a specific node and then replicated
-  * __Cluster-Wide__ - transaction is registered for execution on all nodes in an atomic fashion
-* Learn more about these modes in [Cluster-wide vs. Single-node](../../client-api/session/cluster-transaction/overview#cluster-wide-transaction-vs.-single-node-transaction) transactions. 
+    * __Single-Node__ - transaction is executed on a specific node and then replicated
+    * __Cluster-Wide__ - transaction is registered for execution on all nodes in an atomic fashion
+    * {WARNING: }
+      The phrase "session's transaction mode" refers to the type of transaction that will be executed on the server-side when `saveChanges()` is called.
+      As mentioned earlier, the session itself does not represent an ACID transaction.
+      {WARNING/}
+    * Learn more about these modes in [Cluster-wide vs. Single-node](../../client-api/session/cluster-transaction/overview#cluster-wide-transaction-vs.-single-node-transaction) transactions.
+
+{NOTE/}
+
+{INFO: Transactions in RavenDB}
+For a detailed description of transactions in RavenDB please refer to the [Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Concurrency control}
+
+The typical usage model of the session is:
+
+  * Load documents
+  * Modify the documents
+  * Save changes
+
+For example, a real case scenario would be:
+
+  * Load an entity from a database.
+  * Display an Edit form on the screen.
+  * Update the entity after the user completes editing.
+
+When using the session, the interaction with the database is divided into two parts - the load part and save changes part.
+Each of these parts is executed separately, via its own HTTP request.  
+Consequently, data that was loaded and edited could potentially be changed by another user in the meantime.  
+To address this, the session API offers the concurrency control feature.
+
+#### Default strategy on single node
+
+* By default, concurrency checks are turned off.
+  This means that with the default configuration of the session, concurrent changes to the same document will use the Last Write Wins strategy.
+
+* The second write of an updated document will override the previous version, causing potential data loss.
+  This behavior should be considered when using the session with single node transaction mode.
+
+#### Optimistic concurrency on single node
+
+* The modification or editing stage can extend over a considerable time period or may occur offline.  
+  To prevent conflicting writes, where a document is modified while it is being edited by another user or client,  
+  the session can be configured to employ [optimistic concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency).
+
+* Once optimistic concurrency is enabled, the session performs version tracking to ensure that any document modified within the session has not been altered in the database since it was loaded into the session.  
+  The version is tracked using a [change vector](../../server/clustering/replication/change-vector).
+
+* When `saveChanges()` is called, the session additionally transmits the version of the modified documents to the database, allowing it to verify if any changes have occurred in the meantime.  
+  If modifications are detected, the transaction will be aborted with a `ConcurrencyException`,  
+  providing the caller with an opportunity to retry or handle the error as needed.
+
+#### Concurrency control in cluster-wide transactions
+
+* In a cluster-wide transaction scenario, RavenDB server tracks a cluster-wide version for each modified document, updating it through the Raft protocol.
+  This means that when using a session with the cluster-wide transaction mode, a `ConcurrencyException` will be triggered upon calling `saveChanges()`
+  if another user has modified a document and saved it in a separate cluster-wide transaction in the meantime.
+
+* More information about cluster transactions can be found in [Cluster Transaction - Overview](../../client-api/session/cluster-transaction/overview).
 
 {PANEL/}
 
@@ -120,14 +237,14 @@
   It results in an excessive number of remote calls to the server, which makes a query very expensive.  
 * Make use of RavenDB's `include()` method to include related documents and avoid this issue.  
   See: [Document relationships](../../client-api/how-to/handle-document-relationships)  
-<br>
+
 #### Large query results
 * When query results are large and you don't want the overhead of keeping all results in memory,  
   then you can [Stream query results](../../client-api/session/querying/how-to-stream-query-results).  
   A single server call is executed and the client can handle the results one by one.  
 * [Paging](../../indexes/querying/paging) also avoids getting all query results at one time,  
   however, multiple server calls are generated - one per page retrieved.  
-<br>
+
 #### Retrieving results on demand (Lazy)
 * Query calls to the server can be delayed and executed on-demand as needed using `Lazily()`
 * See [Perform queries lazily](../../client-api/session/querying/how-to-perform-queries-lazily)
@@ -145,3 +262,5 @@
 - [Query Overview](../../client-api/session/querying/how-to-query)
 - [Querying an Index](../../indexes/querying/query-index)
 - [What is a Document Store](../../client-api/what-is-a-document-store)
+- [Optimistic Concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency)
+- [Transaction Support](../../client-api/faq/transaction-support)

--- a/Documentation/5.2/Raven.Documentation.Pages/server/clustering/replication/replication.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/server/clustering/replication/replication.markdown
@@ -166,7 +166,7 @@ __Replication & cluster-wide transactions__
   is either persisted on all database group nodes or rolled back on all upon failure.  
 
 * After a cluster consensus is reached, the Raft command to be executed is propagated to all nodes.  
-  When the command is executed locally on a node, if the items that are persisted are of the [type that replicates](../../../server/clustering/replication/replication#what-is-replicated),  
+  When the command is executed locally on a node, if the items that are persisted are of the [type that replicates](../../../server/clustering/replication/replication#what-is-replicated), 
   then the node will __replicate__ them to the other nodes via the replication process.  
 
 * A node that receives such replication will accept this write,  

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/WhatIsSession.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/WhatIsSession.cs
@@ -92,7 +92,7 @@ namespace Raven.Documentation.Samples.ClientApi.Session
                     // Loading the same document will now retrieve its entity from the Session's map
                     Company entity2 = session.Load<Company>(companyId);
                     
-                    // This command will Not throw an exception.
+                    // This command will Not throw an exception
                     Assert.Same(entity1, entity2);
                     #endregion
                 }
@@ -106,7 +106,7 @@ namespace Raven.Documentation.Samples.ClientApi.Session
                     // Loading the same document will now retrieve its entity from the Session's map
                     Company entity2 = await asyncSession.LoadAsync<Company>(companyId);
                     
-                    // This command will Not throw an exception.
+                    // This command will Not throw an exception
                     Assert.Same(entity1, entity2);
                     #endregion
                 }

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Session/WhatIsSession.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Session/WhatIsSession.java
@@ -31,43 +31,49 @@ public class WhatIsSession {
     public WhatIsSession() {
         try (IDocumentStore store = new DocumentStore()) {
             //region session_usage_1
-            String companyId;
-
-            //store new object
+            // Obtain a Session from your Document Store
             try (IDocumentSession session = store.openSession()) {
+            
+                // Create a new entity
                 Company entity = new Company();
                 entity.setName("Company");
+                
+                // Store the entity in the Session's internal map
                 session.store(entity);
+                // From now on, any changes that will be made to the entity will be tracked by the Session.
+                // However, the changes will be persisted to the server only when 'SaveChanges()' is called.
+                
                 session.saveChanges();
-
-                // after calling saveChanges(), an id field if exists
-                // is filled by the entity's id
-                companyId = entity.getId();
-            }
-
-            try (IDocumentSession session = store.openSession()) {
-                //load by id
-                Company entity = session.load(Company.class, companyId);
-
-                // do something with the loaded entity
+                // At this point the entity is persisted to the database as a new document.
+                // Since no database was specified when opening the Session, the Default Database is used.
             }
             //endregion
 
             //region session_usage_2
+            // Open a session
             try (IDocumentSession session = store.openSession()) {
+                // Load an existing document to the Session using its ID
+                // The loaded entity will be added to the session's internal map
                 Company entity = session.load(Company.class, companyId);
-                entity.setName("Another Company");
+                
+                // Edit the entity, the Session will track this change
+                entity.setName("NewCompanyName");
 
-                // when a document is loaded by Id (or by query),
-                // its changes are tracked (by default).
-                // A call to saveChanges() sends all accumulated changes to the server
                 session.saveChanges();
+                // At this point, the change made is persisted to the existing document in the database
             }
             //endregion
 
             try (IDocumentSession session = store.openSession()) {
                 //region session_usage_3
-                Assert.assertSame(session.load(Company.class, companyId), session.load(Company.class, companyId));
+                // A document is fetched from the server
+                Company entity1 = session.load(Company.class, companyId);
+                
+                // Loading the same document will now retrieve its entity from the Session's map
+                Company entity2 = session.load(Company.class, companyId);
+                
+                // This command will Not throw an exception
+                Assert.assertSame(entity1, entity2);
                 //endregion
             }
         }

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Session/whatIsSession.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Session/whatIsSession.js
@@ -54,7 +54,7 @@ async function whatIsSessionUsingAwait() {
         // Loading the same document will now retrieve its entity from the session's map
         const entity2 = await session.load("companies/1-A");
 
-        // This command will Not throw an exception.
+        // This command will Not throw an exception
         assert.equal(entity1, entity2);
         //endregion
     }

--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/patching/json-patch-syntax.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/patching/json-patch-syntax.markdown
@@ -9,6 +9,8 @@
   the ID of a target (RavenDB) document and a patch operation to be applied 
   to this document.  
 
+* Since the operation is executed in a single request to a database, the JSON Patch command is performed in a single write [transaction](../../../client-api/faq/transaction-support).
+
 * JSON Patch operations include -  
    * **Add** a document property  
    * **Remove** a document property  


### PR DESCRIPTION
In particular:

- what is and what isn't a transaction
- being more explicit that the session doesn't represent a transaction
- underlining that transactions are scoped to a single request
- explaining transactions in multi mode-master model and cluster-wide transactions
- explicitly writing about no support for interactive transactions
- emphasising the role of optimistic concurrency feature