### PR TITLE
RDoc-2596 Text fix in 'what is a session'

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.dotnet.markdown
@@ -129,7 +129,7 @@
 * Remote calls to a server over the network are among the most expensive operations an application makes.  
   The session optimizes this by batching all __write operations__ it has tracked into the `SaveChanges()` call.  
 * When calling _SaveChanges_, the session evaluates its state to identify all pending changes requiring persistence in the database. 
-  These changes are then combined into a single batch that is sent to the server as a __single remote call__ and a single ACID transaction.
+  These changes are then combined into a single batch that is sent to the server in a __single remote call__ and executed as a single ACID transaction.
 
 {NOTE/}
 {NOTE: }

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.java.markdown
@@ -120,7 +120,7 @@
 * Remote calls to a server over the network are among the most expensive operations an application makes.  
   The session optimizes this by batching all __write operations__ it has tracked into the `saveChanges()` call.
 * When calling _saveChanges_, the session evaluates its state to identify all pending changes requiring persistence in the database.
-  These changes are then combined into a single batch that is sent to the server as a __single remote call__ and a single ACID transaction.
+  These changes are then combined into a single batch that is sent to the server in a __single remote call__ and executed as a single ACID transaction.
 
 {NOTE/}
 {NOTE: }

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/session/what-is-a-session-and-how-does-it-work.js.markdown
@@ -126,7 +126,7 @@
 * Remote calls to a server over the network are among the most expensive operations an application makes.  
   The session optimizes this by batching all __write operations__ it has tracked into the `saveChanges()` call.
 * When calling _saveChanges_, the session evaluates its state to identify all pending changes requiring persistence in the database.
-  These changes are then combined into a single batch that is sent to the server as a __single remote call__  and a single ACID transaction.
+  These changes are then combined into a single batch that is sent to the server in a __single remote call__ and executed as a single ACID transaction.
 
 {NOTE/}
 {NOTE: }


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2596/Clarifications-about-transaction-support-and-session-API