### PR TITLE
RDoc-2631 [Python] Client API > Session > Storing entities [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.dotnet.markdown
@@ -1,0 +1,45 @@
+# Session: Storing Entities
+
+To store entities inside the **session** object, use one of the three `Store` methods.
+
+## Syntax
+
+First overload: Stores the entity in a session, then extracts the ID from the entity or generates a new one if it's not available.
+
+{CODE store_entities_1@ClientApi\Session\StoringEntities.cs /}
+
+Second overload: Stores the entity in a session with given ID.
+
+{CODE store_entities_2@ClientApi\Session\StoringEntities.cs /}
+
+Third overload: Stores the entity in a session with given ID, forces concurrency check with given change vector.
+
+{CODE store_entities_3@ClientApi\Session\StoringEntities.cs /}
+
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | object | Entity that will be stored |
+| **changeVector** | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **id** | string | Entity will be stored under this ID, (`null` to generate automatically) |
+
+## Example
+
+{CODE store_entities_5@ClientApi\Session\StoringEntities.cs /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Loading Entities](../../client-api/session/loading-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.java.markdown
@@ -1,0 +1,45 @@
+# Session: Storing Entities
+
+To store entities inside the **session** object, use one of the three `store` methods.
+
+## Syntax
+
+First overload: Stores the entity in a session, then extracts the ID from the entity or generates a new one if it's not available.
+
+{CODE:java store_entities_1@ClientApi\Session\StoringEntities.java /}
+
+Second overload: Stores the entity in a session with given ID.
+
+{CODE:java store_entities_2@ClientApi\Session\StoringEntities.java /}
+
+Third overload: Stores the entity in a session with given ID, forces concurrency check with given change vector.
+
+{CODE:java store_entities_3@ClientApi\Session\StoringEntities.java /}
+
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | Object | Entity that will be stored |
+| **changeVector** | String | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **id** | String | Entity will be stored under this ID, (`null` to generate automatically) |
+
+## Example
+
+{CODE:java store_entities_5@ClientApi\Session\StoringEntities.java /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Loading Entities](../../client-api/session/loading-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Basics](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.js.markdown
@@ -1,0 +1,67 @@
+# Session: Storing Entities
+
+To store entities inside the **session** object, use `store()` method.
+
+## Syntax
+
+You can pass the following arguments to the `store()` method:
+
+- entity only: Stores the entity in the session, then extracts the ID from the entity or generates a new one if it's not available.
+
+{CODE:nodejs store_entities_1@client-api\session\storingEntities.js /}
+
+- entity and an id: Stores the entity in a session with given ID.
+
+{CODE:nodejs store_entities_2@client-api\session\storingEntities.js /}
+
+- entity, an id and store options: Stores the entity in a session with given ID, forces concurrency check with given change vector.
+
+{CODE:nodejs store_entities_3@client-api\session\storingEntities.js /}
+
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | object | Entity that will be stored |
+| **id** | string | Entity will be stored under this ID, (`null` to generate automatically) |
+| **documentType** | class | class used to determine collection of the entity (extracted from entity by default)|
+| **options** | object | Options object with the below properties: |
+| **changeVector** | string | entity *change vector* used for concurrency checks (`null` to skip check) |
+| **documentType** | class | class used to determine collection of the entity (extracted from entity by default)|
+
+| Return value | |
+| ------------- | ----- |
+| Promise | A promise resolved once entity obtained an ID and is stored in Unit of Work |
+
+{WARNING: Asynchronous call }
+`store()` method is asynchronous (since it reaches out to server to get a new ID) and returns a `Promise`, so don't forget to use either `await`, `.then()` *before* saving changes. 
+{WARNING/}
+
+{INFO: On collection name when storing object literals }
+In order to comfortably use object literals as entities set the function getting collection name based on the content of the object - `store.conventions.findCollectionNameForObjectLiteral()`
+
+{CODE:nodejs storing_literals_1@client-api\session\storingEntities.js /}
+
+This needs to be done before an `initialize()` call on `DocumentStore` instance. If you fail to do so, your entites will land up in *@empty* collection having an *UUID* for an ID.
+
+{INFO/}
+
+## Example
+
+{CODE:nodejs store_entities_5@client-api\session\storingEntities.js /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Loading Entities](../../client-api/session/loading-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.python.markdown
@@ -11,8 +11,8 @@ Stores the entity in a session, then extracts the ID from the entity or if not a
 | Parameters | | |
 | ------------- | ------------- | ----- |
 | **entity** | object | Entity that will be stored |
-| **change_vector** | string | Entity change vector, used for concurrency checks (`null` to skip check) |
-| **id** | string | Entity will be stored under this ID, (`null` to generate automatically) |
+| **change_vector** | str | Entity change vector, used for concurrency checks (`None` to skip check) |
+| **key** | str | Entity will be stored under this ID, (`None` to generate automatically) |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/storing-entities.python.markdown
@@ -1,0 +1,36 @@
+# Session: Storing Entities
+
+To store entities inside the **session** object, use the `store` method.
+
+## Syntax
+
+Stores the entity in a session, then extracts the ID from the entity or if not available generates a new one.
+
+{CODE:python store_entities_1@ClientApi\Session\StoringEntities.py /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | object | Entity that will be stored |
+| **change_vector** | string | Entity change vector, used for concurrency checks (`null` to skip check) |
+| **id** | string | Entity will be stored under this ID, (`null` to generate automatically) |
+
+## Example
+
+{CODE:python store_entities_5@ClientApi\Session\StoringEntities.py /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Loading Entities](../../client-api/session/loading-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/StoringEntities.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/StoringEntities.cs
@@ -1,0 +1,45 @@
+﻿using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session
+{
+    public class StoringEntities
+    {
+        private interface IFoo
+        {
+            #region store_entities_1
+            void Store(object entity);
+            #endregion
+
+            #region store_entities_2
+            void Store(object entity, string id);
+            #endregion
+
+            #region store_entities_3
+            void Store(object entity, string changeVector, string id);
+            #endregion
+
+        }
+
+        public StoringEntities()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region store_entities_5
+                    // generate Id automatically
+                    session.Store(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    // send all pending operations to server, in this case only `Put` operation
+                    session.SaveChanges();
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/StoringEntities.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/StoringEntities.java
@@ -1,0 +1,61 @@
+package net.ravendb.ClientApi.Session;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class StoringEntities {
+
+    private interface IFoo {
+        //region store_entities_1
+        void store(Object entity);
+        //endregion
+
+        //region store_entities_2
+        void store(Object entity, String id);
+        //endregion
+
+        //region store_entities_3
+        void store(Object entity, String changeVector, String id);
+        //endregion
+    }
+
+    private static class Employee {
+        private String firstName;
+        private String lastName;
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+
+    public StoringEntities() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region store_entities_5
+                Employee employee = new Employee();
+                employee.setFirstName("John");
+                employee.setLastName("Doe");
+
+                // generate Id automatically
+                session.store(employee);
+
+                // send all pending operations to server, in this case only `Put` operation
+                session.saveChanges();
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/storingEntities.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/storingEntities.js
@@ -1,0 +1,47 @@
+import { DocumentStore } from "ravendb";
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+let id, entity, documentType, options, urls, database;
+
+//region store_entities_1
+session.store(entity, [documentType]);
+//endregion
+
+//region store_entities_2
+session.store(entity, id);
+//endregion
+
+//region store_entities_3
+session.store(entity, id, [options]);
+session.store(entity, id, [documentType]);
+//endregion
+
+class Employee {
+    constructor(firstName, lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+}
+
+async function store_entities_5() {
+    //region store_entities_5
+    const employee = new Employee("John", "Doe");
+
+    // generate Id automatically
+    await session.store(employee);
+
+    // send all pending operations to server, in this case only `Put` operation
+    await session.saveChanges();
+    //endregion
+}
+
+async function storing_literals_1() {
+    //region storing_literals_1
+    const store = new DocumentStore(urls, database);
+    store.conventions.findCollectionNameForObjectLiteral = entity => entity["collection"];
+    // ...
+    store.initialize();
+    //endregion
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/StoringEntities.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/StoringEntities.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from ravendb.infrastructure.orders import Employee
+
+from examples_base import ExamplesBase
+
+
+class StoringEntities(ExamplesBase):
+    def setUp(self):
+        super().setUp()
+
+    class IFoo:
+        # region store_entities_1
+        def store(self, entity: object, key: Optional[str] = None, change_vector: Optional[str] = None) -> None:
+            ...
+
+        # endregion
+
+    def test_storing_entities(self):
+        with self.embedded_server.get_document_store("StoringEntities") as store:
+            with store.open_session() as session:
+                # region store_entities_5
+                session.store(Employee(first_name="John", last_name="Doe"))
+
+                # send all pending operations to server, in this case only 'Put' operation
+                session.save_changes()
+                # endregion


### PR DESCRIPTION
Related issue:
[RDoc-2631](https://issues.hibernatingrhinos.com/issue/RDoc-2631/Python-Client-API-Session-Storing-entities-Replace-C-samples)