### PR TITLE
RDoc-2632 [Python] Client API > Session > Deleting entities [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.dotnet.markdown
@@ -1,0 +1,71 @@
+# Session: Deleting Entities
+
+Entities can be marked for deletion by using the `Delete` method, but will not be removed from the server until `SaveChanges` is called.  
+
+## Syntax
+
+{CODE deleting_1@ClientApi\Session\DeletingEntities.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | `T` | instance of the entity to delete |
+| **id** | `string` | ID of the entity to delete |
+| **expectedChangeVector** | `string` | a change vector to use for concurrency checks |
+
+## Example I
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync deleting_2@ClientApi\Session\DeletingEntities.cs /}
+{CODE-TAB:csharp:Async deleting_2_async@ClientApi\Session\DeletingEntities.cs /}
+{CODE-TABS/}
+
+{NOTE: Concurrency on Delete}
+If UseOptimisticConcurrency is set to 'true' (default 'false'), the Delete() method will use loaded 'employees/1' change vector for concurrency check and might throw ConcurrencyException.  
+{NOTE/}
+
+## Example II
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync deleting_3@ClientApi\Session\DeletingEntities.cs /}
+{CODE-TAB:csharp:Async deleting_3_async@ClientApi\Session\DeletingEntities.cs /}
+{CODE-TABS/}
+
+{NOTE: Concurrency on Delete}
+In this overload, the Delete() method will not do any change vector based concurrency checks because the change vector for 'employees/1' is unknown.  
+{NOTE/}
+
+{INFO:Information}
+
+If entity is **not** tracked by session, then executing:  
+
+{CODE deleting_4@ClientApi\Session\DeletingEntities.cs /}
+
+is equal to doing:  
+
+{CODE deleting_5@ClientApi\Session\DeletingEntities.cs /}
+
+{NOTE: Change Vector in DeleteCommandData}
+In this sample the change vector is null - this means that there will be no concurrency checks. A non-null and valid change vector value will trigger a concurrency check.  
+{NOTE/}
+
+You can read more about defer operations [here](../../client-api/session/how-to/defer-operations).  
+
+{INFO/}
+
+## Related Articles  
+
+### Session  
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work)  
+- [Opening a Session](../../client-api/session/opening-a-session)  
+- [Loading Entities](../../client-api/session/loading-entities)  
+- [Saving Changes](../../client-api/session/saving-changes)  
+- [How To: Enable Optimistic Concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency)  
+
+### Querying  
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store  
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.java.markdown
@@ -1,0 +1,65 @@
+# Session: Deleting Entities
+
+Entities can be marked for deletion by using the `delete` method, but will not be removed from the server until `saveChanges` is called.
+
+## Syntax
+
+{CODE:java deleting_1@ClientApi\Session\DeletingEntities.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | `T` | instance of the entity to delete |
+| **id** | `String` | ID of the entity to delete |
+| **expectedChangeVector** | `String` | a change vector to use for concurrency checks |
+
+## Example I
+
+{CODE:java deleting_2@ClientApi\Session\DeletingEntities.java /}
+
+{NOTE: Concurrency on Delete}
+If useOptimisticConcurrency is set to 'true' (default 'false'), the delete() method will use loaded 'employees/1' change vector for concurrency check and might throw ConcurrencyException.
+{NOTE/}
+
+## Example II
+
+{CODE:java deleting_3@ClientApi\Session\DeletingEntities.java /}
+
+{NOTE: Concurrency on Delete}
+In this overload, the delete() method will not do any change vector based concurrency checks because the change vector for 'employees/1' is unknown.
+{NOTE/}
+
+{INFO:Information}
+
+If entity is **not** tracked by session, then executing
+
+{CODE:java deleting_4@ClientApi\Session\DeletingEntities.java /}
+
+is equal to doing
+
+{CODE:java deleting_5@ClientApi\Session\DeletingEntities.java /}
+
+{NOTE: Change Vector in DeleteCommandData}
+In this sample the change vector is null - this means that there will be no concurrency checks. A non-null and valid change vector value will trigger a concurrency check. 
+{NOTE/}
+
+You can read more about defer operations [here](./how-to/defer-operations).
+
+{INFO/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Loading Entities](../../client-api/session/loading-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+- [How To: Enable Optimistic Concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency)  
+
+### Querying
+
+- [Basics](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.js.markdown
@@ -1,0 +1,64 @@
+# Session: Deleting Entities
+
+Entities can be marked for deletion by using the `delete()` method, but will *not* be removed from the server until `saveChanges()` is called.
+
+## Syntax
+
+{CODE:nodejs deleting_1@client-api\session\deletingEntities.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | `object` | Instance of the entity to delete |
+|  **id** | `string` | The entity ID |
+| **changeVector** | `string` | a change vector to use for concurrency checks |
+
+## Example I
+
+{CODE:nodejs deleting_2@client-api\session\deletingEntities.js /}
+
+{NOTE: Concurrency on Delete}
+If `useOptimisticConcurrency` is set to *true* (default *false*), the `delete()` method will use loaded *employees/1* change vector for concurrency check and might throw `ConcurrencyException`.
+{NOTE/}
+
+## Example II
+
+{CODE:nodejs deleting_3@client-api\session\deletingEntities.js /}
+
+{NOTE: Concurrency on Delete}
+In this example, the `delete()` method will not do any change vector based concurrency checks because the change vector for *employees/1* is unknown.
+{NOTE/}
+
+{INFO:Information}
+
+If entity is **not** tracked by session, then executing
+
+{CODE:nodejs deleting_4@client-api\session\deletingEntities.js /}
+
+is equal to doing
+
+{CODE:nodejs deleting_5@client-api\session\deletingEntities.js /}
+
+{NOTE: Change Vector in DeleteCommandData}
+In this sample the change vector is null - this means that there will be no concurrency checks. A non-null and valid change vector value will trigger a concurrency check. 
+{NOTE/}
+
+You can read more about defer operations [here](./how-to/defer-operations).
+
+{INFO/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Loading Entities](../../client-api/session/loading-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.python.markdown
@@ -8,16 +8,15 @@ Entities can be marked for deletion by using the `delete()` method, but will not
 
 | Parameters | | |
 | ------------- | ------------- | ----- |
-| **entity** | `T` | instance of the entity to delete |
-| **id** | `string` | ID of the entity to delete |
-| **expectedChangeVector** | `string` | a change vector to use for concurrency checks |
+| **key_or_entity** | `str` or `object` | instance of the entity to delete |
+| **expected_change_vector** | `str` | a change vector to use for concurrency checks |
 
 ## Example I
 
 {CODE:python deleting_2@ClientApi\Session\DeletingEntities.py /}
 
 {NOTE: Concurrency on Delete}
-If UseOptimisticConcurrency is set to 'true' (default 'false'), the delete() method will use loaded 'employees/1' change vector for concurrency check and might throw ConcurrencyException.  
+If use_optimistic_concurrency is set to 'True' (default 'False'), the delete() method will use loaded 'employees/1' change vector for concurrency check and might throw ConcurrencyException.  
 {NOTE/}
 
 ## Example II
@@ -25,7 +24,7 @@ If UseOptimisticConcurrency is set to 'true' (default 'false'), the delete() met
 {CODE:python deleting_3@ClientApi\Session\DeletingEntities.py /}
 
 {NOTE: Concurrency on Delete}
-In this overload, the delete() method will not do any change vector based concurrency checks because the change vector for 'employees/1' is unknown.  
+The delete() method will not do any change vector based concurrency checks because the change vector for 'employees/1' is unknown.  
 {NOTE/}
 
 {INFO:Information}
@@ -39,7 +38,7 @@ is equal to doing:
 {CODE:python deleting_5@ClientApi\Session\DeletingEntities.py /}
 
 {NOTE: Change Vector in DeleteCommandData}
-In this sample the change vector is null - this means that there will be no concurrency checks. A non-null and valid change vector value will trigger a concurrency check.  
+In this sample the change vector is None - this means that there will be no concurrency checks. A not-None and valid change vector value will trigger a concurrency check.  
 {NOTE/}
 
 You can read more about defer operations [here](../../client-api/session/how-to/defer-operations).  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.python.markdown
@@ -1,0 +1,65 @@
+# Session: Deleting Entities
+
+Entities can be marked for deletion by using the `delete()` method, but will not be removed from the server until `save_changes()` is called.  
+
+## Syntax
+
+{CODE:python deleting_1@ClientApi\Session\DeletingEntities.py /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | `T` | instance of the entity to delete |
+| **id** | `string` | ID of the entity to delete |
+| **expectedChangeVector** | `string` | a change vector to use for concurrency checks |
+
+## Example I
+
+{CODE:python deleting_2@ClientApi\Session\DeletingEntities.py /}
+
+{NOTE: Concurrency on Delete}
+If UseOptimisticConcurrency is set to 'true' (default 'false'), the delete() method will use loaded 'employees/1' change vector for concurrency check and might throw ConcurrencyException.  
+{NOTE/}
+
+## Example II
+
+{CODE:python deleting_3@ClientApi\Session\DeletingEntities.py /}
+
+{NOTE: Concurrency on Delete}
+In this overload, the delete() method will not do any change vector based concurrency checks because the change vector for 'employees/1' is unknown.  
+{NOTE/}
+
+{INFO:Information}
+
+If entity is **not** tracked by session, then executing:  
+
+{CODE:python deleting_4@ClientApi\Session\DeletingEntities.py /}
+
+is equal to doing:  
+
+{CODE:python deleting_5@ClientApi\Session\DeletingEntities.py /}
+
+{NOTE: Change Vector in DeleteCommandData}
+In this sample the change vector is null - this means that there will be no concurrency checks. A non-null and valid change vector value will trigger a concurrency check.  
+{NOTE/}
+
+You can read more about defer operations [here](../../client-api/session/how-to/defer-operations).  
+
+{INFO/}
+
+## Related Articles  
+
+### Session  
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work)  
+- [Opening a Session](../../client-api/session/opening-a-session)  
+- [Loading Entities](../../client-api/session/loading-entities)  
+- [Saving Changes](../../client-api/session/saving-changes)  
+- [How To: Enable Optimistic Concurrency](../../client-api/session/configuration/how-to-enable-optimistic-concurrency)  
+
+### Querying  
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store  
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/deleting-entities.python.markdown
@@ -8,7 +8,7 @@ Entities can be marked for deletion by using the `delete()` method, but will not
 
 | Parameters | | |
 | ------------- | ------------- | ----- |
-| **key_or_entity** | `str` or `object` | instance of the entity to delete |
+| **key_or_entity** | `str` or `object` | ID of the document or instance of the entity to delete |
 | **expected_change_vector** | `str` | a change vector to use for concurrency checks |
 
 ## Example I

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/DeletingEntities.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/DeletingEntities.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Documentation.Samples.Orders;
+
+
+namespace Raven.Documentation.Samples.ClientApi.Session
+{
+    public class DeletingEntities
+    {
+        private interface IFoo
+        {
+            #region deleting_1
+
+            void Delete<T>(T entity);
+
+            void Delete(string id);
+
+            void Delete(string id, string expectedChangeVector);
+
+            #endregion
+        }
+
+        public async Task DeletingEntitiesAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+
+                using (var session = store.OpenSession())
+                {
+                    #region deleting_2
+
+                    Employee employee = session.Load<Employee>("employees/1");
+
+                    session.Delete(employee);
+                    session.SaveChanges();
+
+                    #endregion
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region deleting_2_async
+
+                    Employee employee = await session.LoadAsync<Employee>("employees/1");
+
+                    session.Delete(employee);
+                    await session.SaveChangesAsync();
+
+                    #endregion
+                }
+
+
+                using (var session = store.OpenSession())
+                {
+                    #region deleting_3
+
+                    session.Delete("employees/1");
+                    session.SaveChanges();
+
+                    #endregion
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    #region deleting_3_async
+
+                    session.Delete("employees/1");
+                    await session.SaveChangesAsync();
+
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region deleting_4
+
+                    session.Delete("employees/1");
+
+                    #endregion
+
+                    #region deleting_5
+
+                    session.Advanced.Defer(new DeleteCommandData("employees/1", changeVector: null));
+
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/DeletingEntities.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/DeletingEntities.java
@@ -1,0 +1,52 @@
+package net.ravendb.ClientApi.Session;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.batches.DeleteCommandData;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class DeletingEntities {
+
+    private interface IFoo {
+        //region deleting_1
+        <T> void delete(T entity);
+
+        void delete(String id);
+
+        void delete(String id, String expectedChangeVector);
+        //endregion
+    }
+
+    private static class Employee {
+    }
+
+    public void deletingEntities() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region deleting_2
+                Employee employee = session.load(Employee.class, "employees/1");
+
+                session.delete(employee);
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region deleting_3
+                session.delete("employees/1");
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region deleting_4
+                session.delete("employees/1");
+                //endregion
+
+                //region deleting_5
+                session.advanced().defer(new DeleteCommandData("employees/1", null));
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/deletingEntities.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/deletingEntities.js
@@ -1,0 +1,38 @@
+import {DeleteCommandData, DocumentStore} from "ravendb";
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+let entity, id, changeVector;
+
+//region deleting_1
+await session.delete(entity);
+
+await session.delete(id);
+
+await session.delete(id, [changeVector]);
+//endregion
+
+class Employee {}
+
+async function examples() { 
+    //region deleting_2
+    const employee = await session.load("employees/1");
+
+    await session.delete(employee);
+    await session.saveChanges();
+    //endregion
+
+    //region deleting_3
+    await session.delete("employees/1");
+    await session.saveChanges();
+    //endregion
+
+    //region deleting_4
+    await session.delete("employees/1");
+    //endregion
+
+    //region deleting_5
+    await session.advanced.defer(new DeleteCommandData("employees/1", null));
+    //endregion
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/DeletingEntities.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/DeletingEntities.py
@@ -1,0 +1,56 @@
+from typing import Optional, Union
+
+from ravendb.documents.commands.batches import DeleteCommandData
+from ravendb.infrastructure.orders import Employee
+
+from examples_base import ExamplesBase
+
+
+class DeletingEntities(ExamplesBase):
+    def setUp(self):
+        super().setUp()
+        with self.embedded_server.get_document_store("DeletingEntities") as store:
+            with store.open_session() as session:
+                session.store(Employee(), "employees/1")
+                session.save_changes()
+
+    class Foo:
+        # region deleting_1
+        def delete(self, key_or_entity: Union[str, object], expected_change_vector: Optional[str] = None) -> None:
+            ...
+
+        # endregion
+
+    def test_deleting_entities(self):
+        with self.embedded_server.get_document_store("DeletingEntities") as store:
+            with store.open_session() as session:
+                # region deleting_2
+
+                employee = session.load("employees/1")
+
+                session.delete(employee)
+                session.save_changes()
+
+                # endregion
+
+            with store.open_session() as session:
+                # region deleting_3
+
+                session.delete("employees/1")
+                session.save_changes()
+
+                # endregion
+
+            with store.open_session() as session:
+                # region deleting_4
+
+                session.delete("employees/1")
+
+                # endregion
+
+            with store.open_session() as session:
+                # region deleting_5
+
+                session.advanced.defer(DeleteCommandData("employees/1", change_vector=None))
+
+                # endregion


### PR DESCRIPTION
Related issue:
[RDoc-2632](https://issues.hibernatingrhinos.com/issue/RDoc-2632/Python-Client-API-Session-Deleting-entities-Replace-C-samples)