### PR TITLE
RDoc-2636 [Python] Client API > Session > Update entities [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/updating-entities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/updating-entities.dotnet.markdown
@@ -1,0 +1,66 @@
+# Update Entities
+---
+
+{NOTE: }
+
+* To modify existing documents:
+
+    * __Retrieve__ documents from the database using [Load](../../client-api/session/loading-entities#load) or by a [Query](../../client-api/session/querying/how-to-query#session.query).  
+      The entities loaded from the documents are added to the internal entities map that the Session manages.
+  
+    * __Edit__ the properties you wish to change.  
+      The session will track all changes made to the loaded entities.
+
+    * __Save__ to apply the changes.  
+      Once `SaveChanges()` returns it is guaranteed that the data is persisted in the database.
+      
+
+
+* In this page:
+    * [Load a document & update](../../client-api/session/updating-entities#load-a-document-&-update)
+    * [Query for documents & update](../../client-api/session/updating-entities#query-for-documents-&-update)
+    
+{NOTE/}
+
+---
+
+{PANEL: Load a document & update}
+
+* In this example we `Load` a company document and update its **PostalCode** property.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync load-company-and-update@ClientApi\Session\UpdateDocuments.cs /}
+{CODE-TAB:csharp:Async load-company-and-update-async@ClientApi\Session\UpdateDocuments.cs /}
+{CODE-TABS/} 
+
+{PANEL/}
+
+{PANEL: Query for documents & update}
+
+* In this example we `Query` for company documents whose **PostalCode** property is _12345_,  
+  and modify this property for the matching documents.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync query-companies-and-update@ClientApi\Session\UpdateDocuments.cs /}
+{CODE-TAB:csharp:Async query-companies-and-update-async@ClientApi\Session\UpdateDocuments.cs /}
+{CODE-TABS/} 
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/updating-entities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/updating-entities.js.markdown
@@ -1,0 +1,62 @@
+# Update Entities
+---
+
+{NOTE: }
+
+* To modify existing documents:
+
+    * __Retrieve__ documents from the database using [load](../../client-api/session/loading-entities#load) or by a [query](../../client-api/session/querying/how-to-query#session.query).  
+      The entities loaded from the documents are added to the internal entities map that the Session manages.
+
+    * __Edit__ the properties you wish to change.  
+      The session will track all changes made to the loaded entities.
+
+    * __Save__ to apply the changes.  
+      Once `saveChanges()` returns it is guaranteed that the data is persisted in the database.
+
+
+
+* In this page:
+    * [Load a document & update](../../client-api/session/updating-entities#load-a-document-&-update)
+    * [Query for documents & update](../../client-api/session/updating-entities#query-for-documents-&-update)
+
+{NOTE/}
+
+---
+
+{PANEL: Load a document & update}
+
+* In this example we `load` a company document and update its **postalCode** property.
+
+{CODE:nodejs sample_document@client-api\session\updateDocuments.js /}
+
+{CODE:nodejs load-company-and-update@client-api\session\updateDocuments.js /}
+
+{PANEL/}
+
+{PANEL: Query for documents & update}
+
+* In this example we `query` for company documents whose **postalCode** property is _12345_,  
+  and modify this property for the matching documents.
+
+{CODE:nodejs query-company-and-update@client-api\session\updateDocuments.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/updating-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/updating-entities.python.markdown
@@ -1,0 +1,60 @@
+# Update Entities
+---
+
+{NOTE: }
+
+* To modify existing documents:
+
+    * __Retrieve__ documents from the database using [load](../../client-api/session/loading-entities#load) or by a [query](../../client-api/session/querying/how-to-query#session.query).  
+      The entities loaded from the documents are added to the internal entities map that the Session manages.
+  
+    * __Edit__ the properties you wish to change.  
+      The session will track all changes made to the loaded entities.
+
+    * __Save__ to apply the changes.  
+      Once `save_changes()` returns it is guaranteed that the data is persisted in the database.
+      
+
+
+* In this page:
+    * [Load a document & update](../../client-api/session/updating-entities#load-a-document-&-update)
+    * [Query for documents & update](../../client-api/session/updating-entities#query-for-documents-&-update)
+    
+{NOTE/}
+
+---
+
+{PANEL: Load a document & update}
+
+* In this example we `load` a company document and update its **PostalCode** property.  
+
+{CODE:python load-company-and-update@ClientApi\Session\UpdateDocuments.py /}
+
+{PANEL/}
+
+{PANEL: Query for documents & update}
+
+* In this example we `query` for company documents whose **PostalCode** property is _12345_,  
+  and modify this property for the matching documents.  
+
+{CODE:python query-companies-and-update@ClientApi\Session\UpdateDocuments.py /}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/UpdateDocuments.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/UpdateDocuments.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using Raven.Client.Documents;
+using System.Linq;
+using Raven.Client.Documents.Linq;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.UpdateDocuments
+{
+    public class UpdateDocuments
+    {
+        public DocumentStore getDocumentStore()
+        {
+            DocumentStore store = new DocumentStore
+            {
+                Urls = new[] { "http://localhost:8080" },
+                Database = "TestDatabase"
+            };
+            store.Initialize();
+
+            var parameters = new DeleteDatabasesOperation.Parameters
+            {
+                DatabaseNames = new[] { "TestDatabase" },
+                HardDelete = true,
+            };
+            store.Maintenance.Server.Send(new DeleteDatabasesOperation(parameters));
+            store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord("TestDatabase")));
+
+            return store;
+        }
+
+        public void UpdateDocumentsSync()
+        {
+            using (var store = getDocumentStore())
+            {
+                var baseline = DateTime.Today;
+
+                // Open a session
+                using (var session = store.OpenSession())
+                {
+                    // Use the session to create a document
+                    session.Store(new Company
+                    {
+                        Name = "KitchenAppliances",
+                        Address = new Address { PostalCode = "12345" }
+                    }, "companies/KitchenAppliances");
+
+                    session.Store(new Company
+                    {
+                        Name = "ShoeAppliances",
+                        Address = new Address { PostalCode = "12345" }
+                    }, "companies/ShoeAppliances");
+
+                    session.Store(new Company
+                    {
+                        Name = "CarAppliances",
+                        Address = new Address { PostalCode = "67890" }
+                    }, "companies/CarAppliances");
+
+                    session.SaveChanges();
+                }
+
+                #region load-company-and-update
+                using (var session = store.OpenSession())
+                {
+                    // Load a company document
+                    // The entity loaded from the document will be added to the Session's entities map
+                    Company company = session.Load<Company>("companies/1-A");
+
+                    // Update the company's PostalCode
+                    company.Address.PostalCode = "TheNewPostalCode";
+
+                    // Apply changes
+                    session.SaveChanges();
+                }
+                #endregion
+
+                #region query-companies-and-update
+                using (var session = store.OpenSession())
+                {
+                    // Query: find companies with the specified PostalCode
+                    // The entities loaded from the matching documents will be added to the Session's entities map
+                    IRavenQueryable<Company> query = session.Query<Company>()
+                        .Where(c => c.Address.PostalCode == "12345");
+
+                    var matchingCompanies = query.ToList();
+
+                    // Update the PostalCode for the resulting company documents
+                    for (var i = 0; i < matchingCompanies.Count; i++)
+                    {
+                        matchingCompanies[i].Address.PostalCode = "TheNewPostalCode";
+                    }
+
+                    // Apply changes
+                    session.SaveChanges();
+                }
+                #endregion
+
+            }
+        }
+
+        async public void UpdateDocumentsAsync()
+        {
+            using (var store = getDocumentStore())
+            {
+                var baseline = DateTime.Today;
+
+                // Open a session
+                using (var session = store.OpenSession())
+                {
+                    // Use the session to create a document
+                    session.Store(new Company
+                    {
+                        Name = "KitchenAppliances",
+                        Address = new Address { PostalCode = "12345" }
+                    }, "companies/KitchenAppliances");
+
+                    session.Store(new Company
+                    {
+                        Name = "ShoeAppliances",
+                        Address = new Address { PostalCode = "12345" }
+                    }, "companies/ShoeAppliances");
+
+                    session.Store(new Company
+                    {
+                        Name = "CarAppliances",
+                        Address = new Address { PostalCode = "67890" }
+                    }, "companies/CarAppliances");
+
+                    session.SaveChanges();
+                }
+
+                #region load-company-and-update-async
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    // Load a document
+                    // The entity loaded from the document will be added to the Session's entities map
+                    Company company = await asyncSession.LoadAsync<Company>("companies/KitchenAppliances");
+
+                    // Update the company's PostalCode
+                    company.Address.PostalCode = "TheNewPostalCode";
+
+                    // Apply changes
+                    await asyncSession.SaveChangesAsync();
+                }
+                #endregion
+
+                #region query-companies-and-update-async
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    // Query: find companies with the specified PostalCode
+                    // The entities loaded from the matching documents will be added to the Session's entities map
+                    IRavenQueryable<Company> query = asyncSession.Query<Company>()
+                        .Where(c => c.Address.PostalCode == "12345");
+
+                    var matchingCompanies = await query.ToListAsync();
+
+                    // Update the PostalCode for the resulting company documents
+                    for (var i = 0; i < matchingCompanies.Count; i++)
+                    {
+                        matchingCompanies[i].Address.PostalCode = "TheNewPostalCode";
+                    }
+
+                    // Apply changes
+                    await asyncSession.SaveChangesAsync();
+                }
+                #endregion
+            }
+        }
+
+        public class Company
+        {
+            public string Name { get; set; }
+            public Address Address { get; set; }
+        }
+
+        public class Address
+        {
+            public string PostalCode { get; set; }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/updateDocuments.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/updateDocuments.js
@@ -1,0 +1,55 @@
+import {DocumentStore} from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function updateDocuments() {
+    {
+        //region sample_document
+        // Sample company document structure
+        class Address {
+            constructor(code) {
+                this.postalCode = code;
+            }
+        }
+
+        class Company {
+            constructor(name, code) {
+                this.name = name;
+                this.address = new Address(code);
+            }
+        }
+        //endregion
+    }
+    {
+        //region load-company-and-update
+        const session = documentStore.openSession();
+
+        // Load a company document
+        // The entity loaded from the document will be added to the Session's entities map
+        const company = await session.load("companies/1-A");
+
+        // Update the company's postalCode
+        company.address.postalCode = "TheNewPostalCode";
+
+        // Apply changes
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region query-company-and-update
+        const session = documentStore.openSession();
+
+        // Query: find companies with the specified postalCode
+        // The entities loaded from the matching documents will be added to the Session's entities map
+        const matchingCompanies = await session.query({collection: "Companies"})
+            .whereEquals("address.postalCode", "12345")
+            .all();
+
+        // Update the postalCode for the resulting company documents
+        matchingCompanies.forEach(c => c.address.postalCode = "TheNewPostalCode");
+
+        // Apply changes
+        await session.saveChanges();
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/UpdateDocuments.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/UpdateDocuments.py
@@ -1,0 +1,69 @@
+from ravendb import DocumentStore
+from ravendb.infrastructure.orders import Company, Address
+from ravendb.serverwide.database_record import DatabaseRecord
+from ravendb.serverwide.operations.common import DeleteDatabaseOperation, CreateDatabaseOperation
+from examples_base import ExamplesBase
+
+
+class StoringEntities(ExamplesBase):
+    def setUp(self):
+        super().setUp()
+
+    def get_document_store(self) -> DocumentStore:
+        store = self.embedded_server.get_document_store("TestDatabase")
+
+        parameters = DeleteDatabaseOperation.Parameters(["TestDatabase"], True)
+        store.maintenance.server.send(DeleteDatabaseOperation(parameters=parameters))
+        store.maintenance.server.send(CreateDatabaseOperation(DatabaseRecord("TestDatabase")))
+        return store
+
+    def test_update_document_sync(self):
+        with self.get_document_store() as store:
+            # Open a session
+            with store.open_session() as session:
+                # Use the session to create a document
+                session.store(
+                    Company(name="KitchenAppliances", address=Address(postal_code="12345")),
+                    "companies/1-A",
+                )
+                session.store(
+                    Company(name="ShoeAppliances", address=Address(postal_code="12345")), "companies/ShoeAppliances"
+                )
+                session.store(
+                    Company(name="CarAppliances", address=Address(postal_code="12345")), "companies/CarAppliances"
+                )
+                session.save_changes()
+
+            # region load-company-and-update
+            with store.open_session() as session:
+                # Load a company document
+                # The entity loaded from the document will be added to the Session's entities map
+                company = session.load("companies/1-A", Company)
+
+                # Update the company's postal_code
+                company.address["postal_code"] = "TheNewPostalCode"
+
+                # In Python client nested objects are loaded as dicts for convenience
+                # You can customize and control your class (from/to) JSON conversion to fit any case
+                # Implement classmethod 'from_json(json_dict) -> YourType' to control how the object its being read
+                # Implement method 'to_json() -> Dict' to manage how it's serialized
+
+                # Apply changes
+                session.save_changes()
+            # endregion
+
+            # region query-companies-and-update
+            with store.open_session() as session:
+                # Query: find companies with the specified postal_code
+                # The entities loaded from the matching documents will be added to the Session's entities map
+                query = session.query(object_type=Company).where_equals("address.postal_code", "12345")
+
+                matching_companies = list(query)
+
+                # Update the postal_code for the resulting company documents
+                for company in matching_companies:
+                    company.address["postal_code"] = "TheNewPostalCode"
+
+                # Apply changes
+                session.save_changes()
+            # endregion


### PR DESCRIPTION
Related issue:
[RDoc-2636](https://issues.hibernatingrhinos.com/issue/RDoc-2636/Python-Client-API-Session-Update-entities-Replace-C-samples)