### PR TITLE
RDoc-2619 [Python] Client API > Session > Loading entities [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -1,0 +1,287 @@
+# Session: Loading Entities
+---
+
+{NOTE: }
+
+* There are several methods that allow users to load documents from the database and convert them to entities.
+
+* This article covers the following methods:
+
+  - [Load](../../client-api/session/loading-entities#load)
+  - [Load with Includes](../../client-api/session/loading-entities#load-with-includes)
+  - [Load - multiple entities](../../client-api/session/loading-entities#load---multiple-entities)
+  - [LoadStartingWith](../../client-api/session/loading-entities#loadstartingwith)
+  - [ConditionalLoad](../../client-api/session/loading-entities#conditionalload)
+  - [Stream](../../client-api/session/loading-entities#stream)
+  - [IsLoaded](../../client-api/session/loading-entities#isloaded)
+
+* For loading entities lazily see [perform requests lazily](../../client-api/session/how-to/perform-operations-lazily).
+
+{NOTE/}
+
+---
+
+{PANEL:Load}
+
+The most basic way to load a single entity is to use one of the `Load` methods.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_1_0@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_1_0_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **id** | `string` | Identifier of a document that will be loaded. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `TResult` | Instance of `TResult` or `null` if a document with a given ID does not exist. |
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_1_1@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_1_1_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+{NOTE From RavenDB version 4.x onwards, only string identifiers are supported. If you are upgrading from 3.x, this is a major change, because in 3.x non-string identifiers are supported. /}
+
+{PANEL/}
+
+{PANEL:Load with Includes}
+
+When there is a 'relationship' between documents, those documents can be loaded in a 
+single request call using the `Include + Load` methods. Learn more in 
+[How To Handle Document Relationships](../../client-api/how-to/handle-document-relationships).  
+
+{NOTE: }
+Also see:  
+
+* [Including Counters](../../document-extensions/counters/counters-and-other-features#including-counters)  
+* [Including Time Series](../../document-extensions/timeseries/client-api/session/include/overview)  
+* [Including Compare Exchange Values](../../client-api/operations/compare-exchange/include-compare-exchange)  
+* [Including Document Revisions](../../document-extensions/revisions/client-api/session/including)  
+{NOTE/}
+
+{CODE loading_entities_2_0@ClientApi\Session\LoadingEntities.cs /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **path** | `string` or Expression | Path in documents in which the server should look for 'referenced' documents. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `ILoaderWithInclude` | The `Include` method by itself does not materialize any requests but returns loader containing methods such as `Load`. |
+
+### Example I
+
+We can use this code to also load an employee which made the order.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_2_1@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_2_1_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+### Example II
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_2_2@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_2_2_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+{PANEL/}
+
+{PANEL:Load - multiple entities}
+
+To load multiple entities at once, use one of the following `Load` overloads.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_3_0@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_3_0_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **ids** | `IEnumerable<string>` | Multiple document identifiers to load |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `Dictionary<string, TResult>` | Instance of Dictionary which maps document identifiers to `TResult` or `null` if a document with given ID doesn't exist. |
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_3_1@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_3_1_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+{PANEL/}
+
+{PANEL:LoadStartingWith}
+
+To load multiple entities that contain a common prefix, use the `LoadStartingWith` method from the `Advanced` session operations.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_4_0@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_4_0_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **idPrefix** | `string` |  prefix for which the documents should be returned  |
+| **matches** | `string` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped  |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+| **exclude** | `string` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should **not** be matched ('?' any single character, '*' any characters) |
+| **skipAfter** | `string` | skip document fetching until given ID is found and return documents after that ID (default: `null`) |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `TResult[]` | Array of entities matching given parameters. |
+| `Stream` | Output entities matching given parameters as a stream. |
+
+### Example I
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_4_1@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_4_1_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/}
+
+### Example II
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_4_2@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_4_2_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: ConditionalLoad}
+
+This method can be used to check whether a document has been modified 
+since the last time its change vector was recorded, so that the cost of loading it 
+can be saved if it has not been modified.  
+
+The `ConditionalLoad` method takes a document's [change vector](../../server/clustering/replication/change-vector). 
+If the entity is tracked by the session, this method returns the entity. If the entity 
+is not tracked, it checks if the provided change vector matches the document's 
+current change vector on the server side. If they match, the entity is not loaded. 
+If the change vectors _do not_ match, the document is loaded.  
+
+The method is accessible from the `session.Advanced` operations.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_7_0@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_7_0_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **id** | `string` | The identifier of a document to be loaded. |
+| **changeVector** | `string` | The change vector you want to compare with the server-side change vector. If the change vectors match, the document is not loaded. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| ValueTuple `(T Entity, string ChangeVector)` | If the given change vector and the server side change vector do not match, the method returns the requested entity and its current change vector.<br/>If the change vectors match, the method returns `default` as the entity, and the current change vector.<br/>If the specified document, the method returns only `default` without a change vector. |
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_7_1@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_7_1_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/} 
+
+{PANEL/}
+
+{PANEL:Stream}
+
+Entities can be streamed from the server using one of the following `Stream` methods from the `Advanced` session operations.
+
+Streaming query results does not support the [`include` feature](../../client-api/how-to/handle-document-relationships#includes). 
+Learn more in [How to Stream Query Results](../../client-api/session/querying/how-to-stream-query-results).  
+
+{INFO Entities loaded using `Stream` will be transient (not attached to session). /}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_5_0@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_5_0_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **startsWith** | `string` | prefix for which documents should be streamed |
+| **matches** | `string` | pipe ('&#124;') separated values for which document IDs should be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped  |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+| **skipAfter** | `string` | skip document fetching until a given ID is found and returns documents after that ID (default: `null`) |
+| **StreamQueryStats** | `streamQueryStats` (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `IEnumerator<`[StreamResult](../../glossary/stream-result)`>` | Enumerator with entities. |
+| `streamQueryStats` (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
+
+
+### Example I
+
+Stream documents for a ID prefix:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_5_1@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_5_1_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/}
+
+## Example 2
+
+Fetch documents for a ID prefix directly into a stream:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_5_2@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_5_2_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL:IsLoaded}
+
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the **Advanced** session operations.  
+  
+`IsLoaded` checks if you've already tried to load a document during the current session.  
+If you try to load a document that no longer exists with the `Load` method (perhaps it has been deleted),  
+`IsLoaded` will then return `true` because `IsLoaded` shows that you've already tried to load the non-existent document.  
+
+{CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **id** | `string` | Entity ID for which the check should be performed. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `bool` | Indicates if an entity with a given ID is loaded. |
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync loading_entities_6_1@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TAB:csharp:Async loading_entities_6_1_async@ClientApi\Session\LoadingEntities.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.dotnet.markdown
@@ -243,11 +243,19 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `IsLoaded` method from the **Advanced** session operations.  
-  
-`IsLoaded` checks if you've already tried to load a document during the current session.  
-If you try to load a document that no longer exists with the `Load` method (perhaps it has been deleted),  
-`IsLoaded` will then return `true` because `IsLoaded` shows that you've already tried to load the non-existent document.  
+Use the `IsLoaded` method from the `Advanced` session operations
+To check if an entity is attached to a session (e.g. because it's been 
+previously loaded).  
+
+{NOTE: }
+`IsLoaded` checks if an attempt to load a document has been already made 
+during the current session, and returns `true` even if such an attemp was 
+made and failed.  
+If, for example, the `Load` method was used to load `employees/3` during 
+this session and failed because the document has been previously deleted, 
+`IsLoaded` will still return `true` for `employees/3` for the remainder 
+of the session just because of the attempt to load it.  
+{NOTE/}
 
 {CODE loading_entities_6_0@ClientApi\Session\LoadingEntities.cs /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -1,0 +1,227 @@
+# Session: Loading Entities
+---
+
+{NOTE: }
+
+There are several methods with many overloads that allow users to download documents 
+from the database and convert them to entities. This article will cover the following 
+methods:  
+
+- [Load](../../client-api/session/loading-entities#load)
+- [Load with Includes](../../client-api/session/loading-entities#load-with-includes)
+- [Load - multiple entities](../../client-api/session/loading-entities#load---multiple-entities)
+- [LoadStartingWith](../../client-api/session/loading-entities#loadstartingwith)
+- [ConditionalLoad](../../client-api/session/loading-entities#conditionalload)
+- [Stream](../../client-api/session/loading-entities#stream)
+- [IsLoaded](../../client-api/session/loading-entities#isloaded)
+
+{NOTE/}
+
+---
+
+{PANEL:Load}
+
+The most basic way to load a single entity is to use one of the `load` methods.
+
+{CODE:java loading_entities_1_0@ClientApi\Session\LoadingEntities.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **id** | `String` | Identifier of a document that will be loaded. |
+
+| Return Value | |
+| ------------- | ----- |
+| T | Instance of `T` or `null` if a document with a given ID does not exist. |
+
+### Example
+
+{CODE:java loading_entities_1_1@ClientApi\Session\LoadingEntities.java /}
+
+{NOTE From RavenDB version 4.x onwards, only string identifiers are supported. If you are upgrading from 3.x, this is a major change, because in 3.x non-string identifiers are supported. /}
+
+{PANEL/}
+
+{PANEL:Load with Includes}
+
+When there is a 'relationship' between documents, those documents can be loaded in a 
+single request call using the `include + load` methods. Learn more in 
+[How To Handle Document Relationships](../../client-api/how-to/handle-document-relationships).  
+See also [including counters](../../document-extensions/counters/counters-and-other-features#including-counters) 
+and [including time series](../../document-extensions/timeseries/client-api/session/include/overview).
+
+{CODE:java loading_entities_2_0@ClientApi\Session\LoadingEntities.java /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **path** | `String` | Path in documents in which the server should look for 'referenced' documents. |
+| **ids** | `String` | Ids to load. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `ILoaderWithInclude` | The `include` method by itself does not materialize any requests but returns loader containing methods such as `load`. |
+
+### Example I
+
+We can use this code to also load an employee which made the order.
+
+{CODE:java loading_entities_2_1@ClientApi\Session\LoadingEntities.java /}
+
+{PANEL/}
+
+{PANEL:Load - multiple entities}
+
+To load multiple entities at once, use one of the following `load` overloads.
+
+{CODE:java loading_entities_3_0@ClientApi\Session\LoadingEntities.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **ids** | Collection<String> or String... | Multiple document identifiers to load |
+
+| Return Value | |
+| ------------- | ----- |
+| Map<String, T> | Instance of Map which maps document identifiers to `T` or `null` if a document with given ID doesn't exist. |
+
+{CODE:java loading_entities_3_1@ClientApi\Session\LoadingEntities.java /}
+
+{PANEL/}
+
+{PANEL:LoadStartingWith}
+
+To load multiple entities that contain a common prefix, use the `loadStartingWith` method from the `advanced` session operations.
+
+{CODE:java loading_entities_4_0@ClientApi\Session\LoadingEntities.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **idPrefix** | String |  prefix for which the documents should be returned  |
+| **matches** | String | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should be matched ('?' any single character, '*' any characters) |
+| **start** | int | number of documents that should be skipped  |
+| **pageSize** | int | maximum number of documents that will be retrieved |
+| **exclude** | String | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should **not** be matched ('?' any single character, '*' any characters) |
+| **skipAfter** | String | skip document fetching until given ID is found and return documents after that ID (default: `null`) |
+
+| Return Value | |
+| ------------- | ----- |
+| T[] | Array of entities matching given parameters. |
+
+### Example I
+
+{CODE:java loading_entities_4_1@ClientApi\Session\LoadingEntities.java /}
+
+### Example II
+
+{CODE:java loading_entities_4_2@ClientApi\Session\LoadingEntities.java /}
+
+{PANEL/}
+
+{PANEL: ConditionalLoad}
+
+The `conditionalLoad` method takes a document's [change vector](../../server/clustering/replication/change-vector). 
+If the entity is tracked by the session, this method returns the entity. If the entity 
+is not tracked, it checks if the provided change vector matches the document's 
+current change vector on the server side. If they match, the entity is not loaded. 
+If the change vectors _do not_ match, the document is loaded.  
+
+In other words, this method can be used to check whether a document has been modified 
+since the last time its change vector was recorded, so that the cost of loading it 
+can be saved if it has not been modified.  
+
+The method is accessible from the `session.advanced()` operations.  
+
+{CODE:java loading_entities_7_0@ClientApi\Session\LoadingEntities.java /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **clazz** | `Class<T>` | The class of a document to be loaded. |
+| **id** | `String` | The identifier of a document to be loaded. |
+| **changeVector** | `String` | The change vector you want to compare with the server-side change vector. If the change vectors match, the document is not loaded. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| ConditionalLoadResult<T>`(Class<T>, String ChangeVector)` | If the given change vector and the server side change vector do not match, the method returns the requested entity and its current change vector.<br/>If the change vectors match, the method returns `default` as the entity, and the current change vector.<br/>If the specified document, the method returns only `default` without a change vector. |
+
+### Example
+
+{CODE:java loading_entities_7_1@ClientApi\Session\LoadingEntities.java /}
+
+{PANEL/}
+
+{PANEL:Stream}
+
+Entities can be streamed from the server using one of the following `stream` methods from the `advanced` session operations.
+
+{CODE:java loading_entities_5_0@ClientApi\Session\LoadingEntities.java /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **startsWith** | `String` | prefix for which documents should be streamed |
+| **matches** | `String` | pipe ('&#124;') separated values for which document IDs should be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped  |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+| **skipAfter** | `String` | skip document fetching until a given ID is found and returns documents after that ID (default: `null`) |
+| **streamQueryStats** | `Reference streamQueryStats (out parameter)` | Information about the streaming query (amount of results, which index was queried, etc.) |
+
+| Return Value | |
+| ------------- | ----- |
+| CloseableIterator<StreamResult<T>> | Iterator with entities. |
+| streamQueryStats (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
+
+
+### Example I
+
+Stream documents for a ID prefix:
+
+{CODE:java loading_entities_5_1@ClientApi\Session\LoadingEntities.java /}
+
+## Example 2
+
+Fetch documents for a ID prefix directly into a stream:
+
+{CODE:java loading_entities_5_2@ClientApi\Session\LoadingEntities.java /}
+
+### Remarks
+
+{INFO Entities loaded using `stream` will be transient (not attached to session). /}
+
+{PANEL/}
+
+{PANEL:IsLoaded}
+
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
+  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
+
+{CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **id** | `String` | Entity ID for which the check should be performed. |
+
+| Return Value | |
+| ------------- | ----- |
+| boolean | Indicates if an entity with a given ID is loaded. |
+
+### Example
+
+{CODE:java loading_entities_6_1@ClientApi\Session\LoadingEntities.java /}
+
+{PANEL/}
+
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Basics](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.java.markdown
@@ -188,9 +188,19 @@ Fetch documents for a ID prefix directly into a stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
+Use the `isLoaded` method from the `advanced` session operations
+To check if an entity is attached to a session (e.g. because it's been 
+previously loaded).  
   
-If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
+{NOTE: }
+`isLoaded` checks if an attempt to load a document has been already made 
+during the current session, and returns `true` even if such an attemp was 
+made and failed.  
+If, for example, the `load` method was used to load `employees/3` during 
+this session and failed because the document has been previously deleted, 
+`isLoaded` will still return `true` for `employees/3` for the remainder 
+of the session just because of the attempt to load it.  
+{NOTE/}
 
 {CODE:java loading_entities_6_0@ClientApi\Session\LoadingEntities.java /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
@@ -1,0 +1,244 @@
+# Session: Loading Entities
+---
+
+{NOTE: }
+
+* There are several methods that allow users to load documents from the database and convert them to entities.
+
+* This article covers the following methods:
+
+  - [Load](../../client-api/session/loading-entities#load)
+  - [Load with Includes](../../client-api/session/loading-entities#load-with-includes)
+  - [Load - multiple entities](../../client-api/session/loading-entities#load---multiple-entities)
+  - [LoadStartingWith](../../client-api/session/loading-entities#loadstartingwith)
+  - [ConditionalLoad](../../client-api/session/loading-entities#conditionalload)
+  - [IsLoaded](../../client-api/session/loading-entities#isloaded)
+  - [Stream](../../client-api/session/loading-entities#stream)
+
+* For loading entities lazily see [perform requests lazily](../../client-api/session/how-to/perform-operations-lazily).
+
+{NOTE/}
+
+---
+
+{PANEL:Load}
+
+The most basic way to load a single entity is to use session's `load()` method.
+
+{CODE:nodejs loading_entities_1_0@client-api\Session\loadingEntities.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **id** | string | Identifier of a document that will be loaded. |
+| **documentType** | function | A class constructor used for reviving the results' entities |
+
+| Return Value | |
+| ------------- | ----- |
+| `Promise<object>` | A `Promise` returning `object` or `null` if a document with a given ID does not exist. |
+
+### Example
+
+{CODE:nodejs loading_entities_1_1@client-api\Session\loadingEntities.js /}
+
+{NOTE In 4.x RavenDB, only string identifiers are supported. If you are upgrading from 3.x, this is a major change, because in 3.x non-string identifiers are supported. /}
+
+{PANEL/}
+
+{PANEL:Load with Includes}
+
+When there is a *relationship* between documents, those documents can be loaded in a single request call using the `include()` and `load()` methods.
+
+{CODE:nodejs loading_entities_2_0@client-api\Session\loadingEntities.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **path** | string | Field path in documents in which the server should look for 'referenced' documents. |
+
+| Return Value | |
+| ------------- | ----- |
+| `object{load()}` | The `include()` method by itself does not materialize any requests but returns loader containing methods such as `load()`. |
+
+### Example I
+
+We can use this code to also load an employee which made the order.
+
+{CODE:nodejs loading_entities_2_1@client-api\Session\loadingEntities.js /}
+
+{PANEL/}
+
+{PANEL:Load - multiple entities}
+
+To load multiple entities at once, use one of the following ways to call `load()`.
+
+{CODE:nodejs loading_entities_3_0@client-api\Session\loadingEntities.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **idsArray** | string[] | Multiple document identifiers to load |
+| **documentType** | function | A class constructor used for reviving the results' entities |
+| **options** | string | Options with the following properties |
+| **documentType** | function | A class construcor used for reviving the results' entities |
+| **includes** | string[] | Field paths in documents in which the server should look for 'referenced' documents. |
+
+| Return Value | |
+| ------------- | ----- |
+| `Promise<{ [id]: object }>` | A `Promise` resolving to an object mapping document identifiers to `object` or `null` if a document with given ID doesn't exist |
+
+{CODE:nodejs loading_entities_3_1@client-api\Session\loadingEntities.js /}
+
+{PANEL/}
+
+{PANEL:LoadStartingWith}
+
+To load multiple entities that contain a common prefix, use the `loadStartingWith()` method from the `advanced` session operations.
+
+{CODE:nodejs loading_entities_4_0@client-api\Session\loadingEntities.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **idPrefix** | string | prefix for which the documents should be returned  |
+| **options** | string | Options with the following properties |
+| **matches** | string | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should be matched ('?' any single character, '*' any characters) |
+| **start** | number | number of documents that should be skipped  |
+| **pageSize** | number | maximum number of documents that will be retrieved |
+| **exclude** | string | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should **not** be matched ('?' any single character, '*' any characters) |
+| **skipAfter** | string | skip document fetching until given ID is found and return documents after that ID (default: `null`) |
+| **documentType** | function | A class constructor used for reviving the results' entities |
+
+| Return Value | |
+| ------------- | ----- |
+| `Promise<object[]>` | A `Promise` resolving to an array of entities matching given parameters |
+
+### Example I
+
+{CODE:nodejs loading_entities_4_1@client-api\Session\loadingEntities.js /}
+
+### Example II
+
+{CODE:nodejs loading_entities_4_2@client-api\Session\loadingEntities.js /}
+
+{PANEL/}
+
+{PANEL: ConditionalLoad}
+
+This method can be used to check whether a document has been modified 
+since the last time its change vector was recorded, so that the cost of loading it 
+can be saved if it has not been modified.  
+
+The `conditionalLoad` method takes a document's [change vector](../../server/clustering/replication/change-vector). 
+If the entity is tracked by the session, this method returns the entity. If the entity 
+is not tracked, it checks if the provided change vector matches the document's 
+current change vector on the server side. If they match, the entity is not loaded. 
+If the change vectors _do not_ match, the document is loaded.  
+
+The method is accessible from the `session.Advanced` operations.  
+{CODE:nodejs loading_entities_7_0@client-api\Session\loadingEntities.js /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **id** | `string` | The identifier of a document to be loaded. |
+| **changeVector** | `string` | The change vector you want to compare with the server-side change vector. If the change vectors match, the document is not loaded. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| ValueTuple `(object, changeVector)` | If the given change vector and the server side change vector do not match, the method returns the requested entity and its current change vector.<br/>If the change vectors match, the method returns `default` as the entity, and the current change vector.<br/>If the specified document, the method returns only `default` without a change vector. |
+
+### Example
+
+{CODE:nodejs loading_entities_7_1@client-api\Session\loadingEntities.js /}
+
+{PANEL/}
+
+{PANEL:Stream}
+
+Entities can be streamed from the server using the `stream()` method from the `advanced` session operations.
+
+{CODE:nodejs loading_entities_5_0@client-api\Session\loadingEntities.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **idPrefix** | string | prefix for which the documents should be returned  |
+| **query** | query object | a query obtained from a call to `session.query()` or `session.advanced.rawQuery()` |
+| **options** | string | Options with the following properties |
+| **startsWith** | string | prefix for which documents should be streamed |
+| **matches** | string | pipe ('&#124;') separated values for which document IDs should be matched ('?' any single character, '*' any characters) |
+| **start** | number | number of documents that should be skipped  |
+| **pageSize** | number | maximum number of documents that will be retrieved |
+| **skipAfter** | string | skip document fetching until a given ID is found and returns documents after that ID (default: `null`) |
+| **documentType** | function | A class constructor used for reviving the results' entities |
+| **statsCallback** | function | callback returning information about the streaming query (amount of results, which index was queried, etc.) |
+
+
+| Return Value | |
+| ------------- | ----- |
+| `Promise<Readable>` | A `Promise` resolving to readable stream with query results |
+
+
+### Example I
+
+Stream documents for a ID prefix:
+
+{CODE:nodejs loading_entities_5_1@client-api\Session\loadingEntities.js /}
+
+### Example 2
+
+Fetch documents for a ID prefix directly into a writable stream:
+
+{CODE:nodejs loading_entities_5_2@client-api\Session\loadingEntities.js /}
+
+{INFO Entities loaded using `stream()` will be transient (not attached to session). /}
+
+{PANEL/}
+
+{PANEL:IsLoaded}
+
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
+  
+If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
+
+{CODE:nodejs loading_entities_6_0@client-api\Session\loadingEntities.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **id** | string | Entity ID for which the check should be performed. |
+
+| Return Value | |
+| ------------- | ----- |
+| boolean | Indicates if an entity with a given ID is loaded. |
+
+### Example
+
+{CODE:nodejs loading_entities_6_1@client-api\Session\loadingEntities.js /}
+
+{PANEL/}
+
+### On entities loading, JS classes and the **documentType** parameter
+
+Type information about the entity and its contents is by default stored in the document metadata. Based on that its types are revived when loaded from the server.
+
+{INFO: Entity type registration }
+In order to avoid passing **documentType** argument every time, you can register the type in the document conventions using the `registerEntityType()` method before calling DocumentStore's `initialize()` like so:
+
+{CODE:nodejs loading_entities_8@client-api\Session\loadingEntities.js /}
+
+{INFO/}
+
+If you fail to do so, entities (and all subobjects) loaded from the server are going to be plain object literals and not instances of the original type they were stored with.
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.js.markdown
@@ -192,9 +192,19 @@ Fetch documents for a ID prefix directly into a writable stream:
 
 {PANEL:IsLoaded}
 
-To check if an entity is attached to a session, e.g. it has been loaded previously, use the `isLoaded` method from the `advanced` session operations.  
+Use the `isLoaded` method from the `advanced` session operations
+To check if an entity is attached to a session (e.g. because it's been 
+previously loaded).  
   
-If you try to load a document that does not exist with the `load` method, `isLoaded` will return `true` because that document load has already been attempted.  
+{NOTE: }
+`isLoaded` checks if an attempt to load a document has been already made 
+during the current session, and returns `true` even if such an attemp was 
+made and failed.  
+If, for example, the `load` method was used to load `employees/3` during 
+this session and failed because the document has been previously deleted, 
+`isLoaded` will still return `true` for `employees/3` for the remainder 
+of the session just because of the attempt to load it.  
+{NOTE/}
 
 {CODE:nodejs loading_entities_6_0@client-api\Session\loadingEntities.js /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.python.markdown
@@ -1,0 +1,242 @@
+# Session: Loading Entities
+---
+
+{NOTE: }
+
+* There are several methods that allow users to load documents from the database and convert them to entities.
+
+* This article covers the following methods:
+
+  - [load](../../client-api/session/loading-entities#load)
+  - [load with includes](../../client-api/session/loading-entities#load-with-includes)
+  - [load - multiple entities](../../client-api/session/loading-entities#load---multiple-entities)
+  - [load_starting_with](../../client-api/session/loading-entities#load_starting_with)
+  - [conditional_load](../../client-api/session/loading-entities#conditional_load)
+  - [stream](../../client-api/session/loading-entities#stream)
+  - [is_loaded](../../client-api/session/loading-entities#is_loaded)
+
+* For loading entities lazily see [perform requests lazily](../../client-api/session/how-to/perform-operations-lazily).
+
+{NOTE/}
+
+---
+
+{PANEL:load}
+
+The most basic way to load a single entity is to use one of the `load` methods.
+
+{CODE:python loading_entities_1_0@ClientApi\Session\LoadingEntities.py /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **id** | `string` | Identifier of a document that will be loaded. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `TResult` | Instance of `TResult` or `null` if a document with a given ID does not exist. |
+
+### Example
+
+{CODE:python loading_entities_1_1@ClientApi\Session\LoadingEntities.py /}
+
+{NOTE From RavenDB version 4.x onwards, only string identifiers are supported. If you are upgrading from 3.x, this is a major change, because in 3.x non-string identifiers are supported. /}
+
+{PANEL/}
+
+{PANEL:load with includes}
+
+When there is a 'relationship' between documents, those documents can be loaded in a 
+single request call using the `include + load` methods. Learn more in 
+[How To Handle Document Relationships](../../client-api/how-to/handle-document-relationships).  
+
+{NOTE: }
+Also see:  
+
+* [Including Counters](../../document-extensions/counters/counters-and-other-features#including-counters)  
+* [Including Time Series](../../document-extensions/timeseries/client-api/session/include/overview)  
+* [Including Compare Exchange Values](../../client-api/operations/compare-exchange/include-compare-exchange)  
+* [Including Document Revisions](../../document-extensions/revisions/client-api/session/including)  
+{NOTE/}
+
+{CODE:python loading_entities_2_0@ClientApi\Session\LoadingEntities.py /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **path** | `string` or Expression | Path in documents in which the server should look for 'referenced' documents. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `ILoaderWithInclude` | The ` include` method by itself does not materialize any requests but returns loader containing methods such as `load`. |
+
+### Example I
+
+We can use this code to also load an employee which made the order.
+
+{CODE:python loading_entities_2_1@ClientApi\Session\LoadingEntities.py /}
+
+### Example II
+
+{CODE:python loading_entities_2_2@ClientApi\Session\LoadingEntities.py /}
+
+{PANEL/}
+
+{PANEL:load - multiple entities}
+
+To load multiple entities at once, use one of the following `load` overloads.
+
+{CODE:python loading_entities_3_0@ClientApi\Session\LoadingEntities.py /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **ids** | `IEnumerable<string>` | Multiple document identifiers to load |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `Dictionary<string, TResult>` | Instance of Dictionary which maps document identifiers to `TResult` or `null` if a document with given ID doesn't exist. |
+
+{CODE:python loading_entities_3_1@ClientApi\Session\LoadingEntities.py /}
+
+{PANEL/}
+
+{PANEL:load_starting_with}
+
+To load multiple entities that contain a common prefix, use the `load_starting_with` method from the `advanced` session operations.
+
+{CODE:python loading_entities_4_0@ClientApi\Session\LoadingEntities.py /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **idPrefix** | `string` |  prefix for which the documents should be returned  |
+| **matches** | `string` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped  |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+| **exclude** | `string` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should **not** be matched ('?' any single character, '*' any characters) |
+| **skipAfter** | `string` | skip document fetching until given ID is found and return documents after that ID (default: `null`) |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `TResult[]` | Array of entities matching given parameters. |
+| `Stream` | Output entities matching given parameters as a stream. |
+
+### Example I
+
+{CODE:python loading_entities_4_1@ClientApi\Session\LoadingEntities.py /}
+
+### Example II
+
+{CODE:python loading_entities_4_2@ClientApi\Session\LoadingEntities.py /}
+
+{PANEL/}
+
+{PANEL: conditional_load}
+
+This method can be used to check whether a document has been modified 
+since the last time its change vector was recorded, so that the cost of loading it 
+can be saved if it has not been modified.  
+
+The `conditional_load` method takes a document's [change vector](../../server/clustering/replication/change-vector). 
+If the entity is tracked by the session, this method returns the entity. If the entity 
+is not tracked, it checks if the provided change vector matches the document's 
+current change vector on the server side. If they match, the entity is not loaded. 
+If the change vectors _do not_ match, the document is loaded.  
+
+The method is accessible from the `session.advanced` operations.  
+
+{CODE:python loading_entities_7_0@ClientApi\Session\LoadingEntities.py /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **id** | `string` | The identifier of a document to be loaded. |
+| **changeVector** | `string` | The change vector you want to compare with the server-side change vector. If the change vectors match, the document is not loaded. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| ValueTuple `(T Entity, string ChangeVector)` | If the given change vector and the server side change vector do not match, the method returns the requested entity and its current change vector.<br/>If the change vectors match, the method returns `default` as the entity, and the current change vector.<br/>If the specified document, the method returns only `default` without a change vector. |
+
+### Example
+
+{CODE:python loading_entities_7_1@ClientApi\Session\LoadingEntities.py /}
+
+{PANEL/}
+
+{PANEL:stream}
+
+Entities can be streamed from the server using one of the following `stream` methods from the `advanced` session operations.
+
+Streaming query results does not support the [`include` feature](../../client-api/how-to/handle-document-relationships#includes). 
+Learn more in [How to Stream Query Results](../../client-api/session/querying/how-to-stream-query-results).  
+
+{INFO Entities loaded using `stream` will be transient (not attached to session). /}
+
+{CODE:python loading_entities_5_0@ClientApi\Session\LoadingEntities.py /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **startsWith** | `string` | prefix for which documents should be streamed |
+| **matches** | `string` | pipe ('&#124;') separated values for which document IDs should be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped  |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+| **skipAfter** | `string` | skip document fetching until a given ID is found and returns documents after that ID (default: `null`) |
+| **StreamQueryStats** | `streamQueryStats` (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `IEnumerator<`[StreamResult](../../glossary/stream-result)`>` | Enumerator with entities. |
+| `streamQueryStats` (out parameter) | Information about the streaming query (amount of results, which index was queried, etc.) |
+
+
+### Example I
+
+Stream documents for a ID prefix:
+
+{CODE:python loading_entities_5_1@ClientApi\Session\LoadingEntities.py /}
+
+## Example 2
+
+Fetch documents for a ID prefix directly into a stream:
+
+{CODE:python loading_entities_5_2@ClientApi\Session\LoadingEntities.py /}
+
+{PANEL/}
+
+{PANEL:is_loaded}
+
+To check if an entity is attached to a session, e.g. it has been loaded previously, use the `is_loaded` method from the **advanced** session operations.  
+  
+`is_loaded` checks if you've already tried to load a document during the current session.  
+If you try to load a document that no longer exists with the `load` method (perhaps it has been deleted),  
+`is_loaded` will then return `true` because `is_loaded` shows that you've already tried to load the non-existent document.  
+
+{CODE:python loading_entities_6_0@ClientApi\Session\LoadingEntities.py /}
+
+| Parameter | Type | Description |
+| ------------- | ------------- | ----- |
+| **id** | `string` | Entity ID for which the check should be performed. |
+
+| Return Type | Description |
+| ------------- | ----- |
+| `bool` | Indicates if an entity with a given ID is loaded. |
+
+### Example
+
+{CODE:python loading_entities_6_1@ClientApi\Session\LoadingEntities.py /}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Saving Changes](../../client-api/session/saving-changes)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+- [Querying an Index](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/loading-entities.python.markdown
@@ -34,11 +34,12 @@ Use the `load` method to load **an entity** or **multiple entities**.
 | ------------- | ------------- | ----- |
 | **key_or_keys** | `str` or `List[str]` | Identifier or a list of identifiers of entities to load |
 | **object_type**<br>(optional) | `[Type[_T]` | Entity type to load (optional) |
+| **includes**<br>(optional) | `Callable[[IncludeBuilder], None]` | A **consumer function** that takes an [include builder](../../client-api/how-to/handle-document-relationships#includes) argument.<br>The user should use the builder inside this function to _include_ all the data needed within a load. |
 
 | Return Type | Description |
 | ------------- | ----- |
 | `_T` | If a single document was requested, return an instance of the document or `None` if no document was found |
-| `Dict[str, _T]` | If multiple documents were requested, return a dictionary of document instances or `None` if no documnts were found |
+| `Dict[str, _T]` | If multiple documents were requested, return a dictionary of document instances or `None` if no documents were found |
 
 
 ### Examples
@@ -99,10 +100,10 @@ To load multiple entities with a common prefix, use the following `advanced` ses
 | ------------- | ------------- | ----- |
 | **id_prefix** | `str` |  Prefix to return the documents to |
 | **object_type**<br>(optional) | `Type[_T]` | Object type |
-| **matches**<br>(optional) | `str` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should be matched ('?' any single character, '*' any characters) |
+| **matches**<br>(optional) | `str` | pipe ('&#124;') separated values for which document IDs (after 'id_prefix') should be matched ('?' any single character, '*' any characters) |
 | **start**<br>(optional) | `int` | number of documents that should be skipped  |
 | **page_size**<br>(optional) | `int` | maximum number of documents that will be retrieved |
-| **exclude**<br>(optional) | `str` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should **not** be matched ('?' any single character, '*' any characters) |
+| **exclude**<br>(optional) | `str` | pipe ('&#124;') separated values for which document IDs (after 'id_prefix') should **not** be matched ('?' any single character, '*' any characters) |
 | **start_after**<br>(optional) | `str` | skip document fetching until given ID is found and return documents after that ID (default: `None`) |
 
 | Return Type | Description |
@@ -117,10 +118,10 @@ To load multiple entities with a common prefix, use the following `advanced` ses
     | ------------- | ------------- | ----- |
     | **id_prefix** | `str` |  Prefix to return the documents to |
     | **output** | `bytes` | Stream |
-    | **matches** | `str` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should be matched ('?' any single character, '*' any characters) |
+    | **matches** | `str` | pipe ('&#124;') separated values for which document IDs (after 'id_prefix') should be matched ('?' any single character, '*' any characters) |
     | **start** | `int` | number of documents that should be skipped  |
     | **page_size** | `int` | maximum number of documents that will be retrieved |
-    | **exclude** | `str` | pipe ('&#124;') separated values for which document IDs (after 'idPrefix') should **not** be matched ('?' any single character, '*' any characters) |
+    | **exclude** | `str` | pipe ('&#124;') separated values for which document IDs (after 'id_prefix') should **not** be matched ('?' any single character, '*' any characters) |
     | **start_after** | `str` | skip document fetching until given ID is found and return documents after that ID (default: `None`) |
 -->
 
@@ -154,7 +155,7 @@ The method is accessible from the `session.advanced` operations.
 | ------------- | ------------- | ----- |
 | **key** | `str` | The identifier of a document to be loaded |
 | **change_vector** | `str` | The change vector you want to compare with the server-side change vector. If the change vectors match, the document is not loaded. |
-| **object_type** | `Type[_T]` | Object type |
+| **object_type**<br>(optional) | `Type[_T]` | Object type |
 
 | Return Type | Description |
 | ------------- | ----- |

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/LoadingEntities.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/LoadingEntities.cs
@@ -1,0 +1,441 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.Loaders;
+using Raven.Client.Util;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session
+{
+    using System.Linq;
+
+    public class LoadingEntities
+    {
+        private interface IFoo
+        {
+            #region loading_entities_1_0
+            TResult Load<TResult>(string id);
+            #endregion
+
+            #region loading_entities_1_0_async
+            Task<TResult> LoadAsync<TResult>(string id);
+            #endregion
+
+            #region loading_entities_2_0
+            ILoaderWithInclude<object> Include(string path);
+
+            ILoaderWithInclude<T> Include<T>(Expression<Func<T, string>> path);
+
+            ILoaderWithInclude<T> Include<T>(Expression<Func<T, IEnumerable<string>>> path);
+
+            ILoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, string>> path);
+
+            ILoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, IEnumerable<string>>> path);
+            #endregion
+
+            #region loading_entities_3_0
+            Dictionary<string, TResult> Load<TResult>(IEnumerable<string> ids);
+            #endregion
+
+            #region loading_entities_3_0_async
+            Task<Dictionary<string, TResult>> LoadAsync<TResult>(IEnumerable<string> ids);
+            #endregion
+
+            #region loading_entities_4_0
+            T[] LoadStartingWith<T>(
+                string idPrefix,
+                string matches = null,
+                int start = 0,
+                int pageSize = 25,
+                string exclude = null,
+                string startAfter = null);
+
+            void LoadStartingWithIntoStream(
+                string idPrefix,
+                Stream output,
+                string matches = null,
+                int start = 0,
+                int pageSize = 25,
+                string exclude = null,
+                string startAfter = null);
+            #endregion
+
+            #region loading_entities_4_0_async
+            Task<T[]> LoadStartingWithAsync<T>(
+                string idPrefix,
+                string matches = null,
+                int start = 0,
+                int pageSize = 25,
+                string exclude = null,
+                string startAfter = null);
+
+            Task LoadStartingWithIntoStreamAsync(
+                string idPrefix,
+                Stream output,
+                string matches = null,
+                int start = 0,
+                int pageSize = 25,
+                string exclude = null,
+                string startAfter = null);
+            #endregion
+
+            #region loading_entities_5_0
+            IEnumerator<StreamResult<T>> Stream<T>(IQueryable<T> query);
+
+            IEnumerator<StreamResult<T>> Stream<T>(IQueryable<T> query, out StreamQueryStatistics streamQueryStats);
+
+            IEnumerator<StreamResult<T>> Stream<T>(IDocumentQuery<T> query);
+
+            IEnumerator<StreamResult<T>> Stream<T>(IRawDocumentQuery<T> query);
+
+            IEnumerator<StreamResult<T>> Stream<T>(IRawDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats);
+
+            IEnumerator<StreamResult<T>> Stream<T>(IDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats);
+
+            IEnumerator<StreamResult<T>> Stream<T>(string startsWith, string matches = null, int start = 0, int pageSize = int.MaxValue, string startAfter = null);
+            #endregion
+
+            #region loading_entities_5_0_async
+            Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query);
+
+            Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query, out StreamQueryStatistics streamQueryStats);
+
+            Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IDocumentQuery<T> query);
+
+            Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IRawDocumentQuery<T> query);
+
+            Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IRawDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats);
+
+            Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats);
+
+            Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(string startsWith, string matches = null, int start = 0, int pageSize = int.MaxValue, string startAfter = null);
+            #endregion
+
+            #region loading_entities_6_0
+            bool IsLoaded(string id);
+            #endregion
+
+            #region loading_entities_7_0
+            (T Entity, string ChangeVector) ConditionalLoad<T>(string id, string changeVector);
+            #endregion
+
+            #region loading_entities_7_0_async
+            Task<(T Entity, string ChangeVector)> ConditionalLoadAsync<T>(string id, string changeVector);
+            #endregion
+        }
+
+        public async Task LoadingEntitiesXY()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_1_1
+
+                    Employee employee = session.Load<Employee>("employees/1");
+
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_1_1_async
+
+                    Employee employee = await asyncSession.LoadAsync<Employee>("employees/1");
+
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_2_1
+
+                    // loading 'products/1'
+                    // including document found in 'Supplier' property
+                    Product product = session
+                        .Include("Supplier")
+                        .Load<Product>("products/1");
+
+                    Supplier supplier = session.Load<Supplier>(product.Supplier); // this will not make server call
+
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_2_1_async
+
+                    // loading 'products/1'
+                    // including document found in 'Supplier' property
+                    Product product = await asyncSession
+                        .Include("Supplier")
+                        .LoadAsync<Product>("products/1");
+
+                    Supplier supplier = await asyncSession.LoadAsync<Supplier>(product.Supplier); // this will not make server call
+
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_2_2
+
+                    // loading 'products/1'
+                    // including document found in 'Supplier' property
+                    Product product = session
+                        .Include<Product>(x => x.Supplier)
+                        .Load<Product>("products/1");
+
+                    Supplier supplier = session.Load<Supplier>(product.Supplier); // this will not make server call
+
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_2_2_async
+
+                    // loading 'products/1'
+                    // including document found in 'Supplier' property
+                    Product product = await asyncSession
+                        .Include<Product>(x => x.Supplier)
+                        .LoadAsync<Product>("products/1");
+
+                    Supplier supplier = await asyncSession.LoadAsync<Supplier>(product.Supplier); // this will not make server call
+
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_3_1
+
+                    Dictionary<string, Employee> employees = session.Load<Employee>(new[]
+                    {
+                        "employees/1",
+                        "employees/2",
+                        "employees/3"
+                    });
+
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_3_1_async
+
+                    Dictionary<string, Employee> employees = await asyncSession.LoadAsync<Employee>(new[]
+                    {
+                        "employees/1",
+                        "employees/2",
+                    });
+
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_4_1
+                    // return up to 128 entities with Id that starts with 'employees'
+                    Employee[] result = session
+                        .Advanced
+                        .LoadStartingWith<Employee>("employees", null, 0, 128);
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_4_1_async
+                    // return up to 128 entities with Id that starts with 'employees'
+                    Employee[] result = (await asyncSession
+                        .Advanced
+                        .LoadStartingWithAsync<Employee>("employees", null, 0, 128))
+                        .ToArray();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_4_2
+                    // return up to 128 entities with Id that starts with 'employees/' 
+                    // and rest of the key begins with "1" or "2" e.g. employees/10, employees/25
+                    Employee[] result = session
+                        .Advanced
+                        .LoadStartingWith<Employee>("employees/", "1*|2*", 0, 128);
+                    #endregion
+                }
+
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_4_2_async
+                    // return up to 128 entities with Id that starts with 'employees/' 
+                    // and rest of the key begins with "1" or "2" e.g. employees/10, employees/25
+                    Employee[] result = (await asyncSession
+                        .Advanced
+                        .LoadStartingWithAsync<Employee>("employees/", "1*|2*", 0, 128))
+                        .ToArray();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_5_1
+
+                    IEnumerator<StreamResult<Employee>> enumerator = session
+                        .Advanced
+                        .Stream<Employee>("employees/");
+
+                    while (enumerator.MoveNext())
+                    {
+                        StreamResult<Employee> employee = enumerator.Current;
+                    }
+
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_5_1_async
+
+                    IAsyncEnumerator<StreamResult<Employee>> enumerator = await asyncSession
+                        .Advanced
+                        .StreamAsync<Employee>("employees/");
+
+                    while (await enumerator.MoveNextAsync())
+                    {
+                        StreamResult<Employee> employee = enumerator.Current;
+                    }
+
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_5_2
+
+                    using (var outputStream = new MemoryStream())
+                    {
+                        session
+                            .Advanced
+                            .LoadStartingWithIntoStream("employees/", outputStream);
+                    }
+
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_5_2_async
+
+                    using (var outputStream = new MemoryStream())
+                    {
+                        await asyncSession
+                            .Advanced
+                            .LoadStartingWithIntoStreamAsync("employees/", outputStream);
+                    }
+
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region loading_entities_6_1
+                    bool isLoaded = session.Advanced.IsLoaded("employees/1"); // false
+                    Employee employee = session.Load<Employee>("employees/1");
+                    isLoaded = session.Advanced.IsLoaded("employees/1"); // true
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region loading_entities_6_1_async
+                    bool isLoaded = asyncSession.Advanced.IsLoaded("employees/1"); // false
+                    Employee employee = await asyncSession.LoadAsync<Employee>("employees/1");
+                    isLoaded = asyncSession.Advanced.IsLoaded("employees/1"); // true
+                    #endregion
+                }
+
+                #region loading_entities_7_1
+                string changeVector;
+                User user = new User { Name = "Bob" };
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(user, "users/1");
+                    session.SaveChanges();
+
+                    changeVector = session.Advanced.GetChangeVectorFor(user);
+                }
+
+                // New session which does not track our User entity
+                using (var session = store.OpenSession())
+                {
+                    // The given change vector matches 
+                    // the server-side change vector
+                    // Does not load the document
+                    var result1 = session.Advanced
+                                   .ConditionalLoad<User>("users/1", changeVector);
+
+                    // Modify the document
+                    user.Name = "Bob Smith";
+                    session.Store(user);
+                    session.SaveChanges();
+
+                    // Change vectors do not match
+                    // Loads the document
+                    var result2 = session.Advanced
+                                   .ConditionalLoad<User>("users/1", changeVector);
+                }
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region loading_entities_7_1_async
+                string changeVector;
+                User user = new User { Name = "Bob" };
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user, "users/1");
+                    await session.SaveChangesAsync();
+
+                    changeVector = session.Advanced.GetChangeVectorFor(user);
+                }
+
+                // New session which does not track our User entity
+                using (var session = store.OpenAsyncSession())
+                {
+                    // The given change vector matches 
+                    // the server-side change vector
+                    // Does not load the document
+                    var result1 = await session.Advanced
+                                   .ConditionalLoadAsync<User>("users/1", changeVector);
+
+                    // Modify the document
+                    user.Name = "Bob Smith";
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+
+                    // Change vectors do not match
+                    // Loads the document
+                    var result2 = await session.Advanced
+                                   .ConditionalLoadAsync<User>("users/1", changeVector);
+                }
+                #endregion
+            }
+        }
+    }
+
+    internal class User
+    {
+        public string Name { get; internal set; }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/LoadingEntities.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/LoadingEntities.java
@@ -1,0 +1,242 @@
+package net.ravendb.ClientApi.Session;
+
+import net.ravendb.client.documents.CloseableIterator;
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.StreamResult;
+import net.ravendb.client.documents.session.*;
+import net.ravendb.client.documents.session.loaders.ILoaderWithInclude;
+import net.ravendb.client.primitives.Reference;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collection;
+import java.util.Map;
+
+public class LoadingEntities {
+
+    private interface IFoo {
+        //region loading_entities_1_0
+        <T> T load(Class<T> clazz, String id);
+        //endregion
+    }
+
+    private interface IFoo2 {
+        //region loading_entities_2_0
+        ILoaderWithInclude include(String path);
+
+        <TResult> Map<String, TResult> load(Class<TResult> clazz, String... ids);
+
+        <TResult> Map<String, TResult> load(Class<TResult> clazz, Collection<String> ids);
+
+        <TResult> TResult load(Class<TResult> clazz, String id);
+        //endregion
+    }
+
+    private interface IFoo3 {
+        //region loading_entities_3_0
+        <TResult> Map<String, TResult> load(Class<TResult> clazz, String... ids);
+
+        <TResult> Map<String, TResult> load(Class<TResult> clazz, Collection<String> ids);
+        //endregion
+
+        //region loading_entities_4_0
+        <T> T[] loadStartingWith(Class<T> clazz, String idPrefix);
+
+        <T> T[] loadStartingWith(Class<T> clazz, String idPrefix, String matches);
+
+        <T> T[] loadStartingWith(Class<T> clazz, String idPrefix, String matches, int start);
+
+        <T> T[] loadStartingWith(Class<T> clazz, String idPrefix, String matches, int start, int pageSize);
+
+        <T> T[] loadStartingWith(Class<T> clazz, String idPrefix, String matches, int start, int pageSize, String exclude);
+
+        <T> T[] loadStartingWith(Class<T> clazz, String idPrefix, String matches, int start, int pageSize, String exclude, String startAfter);
+        //endregion
+
+        //region loading_entities_5_0
+        <T> CloseableIterator<StreamResult<T>> stream(IDocumentQuery<T> query);
+
+        <T> CloseableIterator<StreamResult<T>> stream(IDocumentQuery<T> query, Reference<StreamQueryStatistics> streamQueryStats);
+
+        <T> CloseableIterator<StreamResult<T>> stream(IRawDocumentQuery<T> query);
+
+        <T> CloseableIterator<StreamResult<T>> stream(IRawDocumentQuery<T> query, Reference<StreamQueryStatistics> streamQueryStats);
+
+        <T> CloseableIterator<StreamResult<T>> stream(Class<T> clazz, String startsWith);
+
+        <T> CloseableIterator<StreamResult<T>> stream(Class<T> clazz, String startsWith, String matches);
+
+        <T> CloseableIterator<StreamResult<T>> stream(Class<T> clazz, String startsWith, String matches, int start);
+
+        <T> CloseableIterator<StreamResult<T>> stream(Class<T> clazz, String startsWith, String matches, int start, int pageSize);
+
+        <T> CloseableIterator<StreamResult<T>> stream(Class<T> clazz, String startsWith, String matches, int start, int pageSize, String startAfter);
+        //endregion
+
+        //region loading_entities_6_0
+        boolean isLoaded(String id);
+        //endregion
+
+        //region loading_entities_7_0
+        <T> ConditionalLoadResult<T> conditionalLoad(Class<T> clazz, String id, String changeVector);
+        //endregion
+    }
+
+    private static class User {
+        String name;
+
+        public User(String name) {
+            this.name = name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    private static class Employee {
+
+    }
+
+    private static class Supplier {
+
+    }
+
+    private static class Product {
+        private String supplier;
+
+        public String getSupplier() {
+            return supplier;
+        }
+
+        public void setSupplier(String supplier) {
+            this.supplier = supplier;
+        }
+    }
+
+    public LoadingEntities() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_1_1
+                Employee employee = session.load(Employee.class, "employees/1");
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_2_1
+                // loading 'products/1'
+                // including document found in 'supplier' property
+                Product product = session
+                    .include("Supplier")
+                    .load(Product.class, "products/1");
+
+                Supplier supplier = session.load(Supplier.class, product.getSupplier()); // this will not make server call
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_2_2
+                // loading 'products/1'
+                // including document found in 'supplier' property
+                Product product = session
+                    .include("Supplier")
+                    .load(Product.class, "products/1");
+
+                Supplier supplier = session.load(Supplier.class, product.getSupplier()); // this will not make server call
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_3_1
+                Map<String, Employee> employees
+                    = session.load(Employee.class,
+                    "employees/1", "employees/2", "employees/3");
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_4_1
+                // return up to 128 entities with Id that starts with 'employees'
+                Employee[] result = session
+                    .advanced()
+                    .loadStartingWith(Employee.class, "employees/", null, 0, 128);
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_4_2
+                // return up to 128 entities with Id that starts with 'employees/'
+                // and rest of the key begins with "1" or "2" e.g. employees/10, employees/25
+                Employee[] result = session
+                    .advanced()
+                    .loadStartingWith(Employee.class, "employees/", "1*|2*", 0, 128);
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_5_1
+                try (CloseableIterator<StreamResult<Employee>> iterator =
+                         session.advanced().stream(Employee.class, "employees/")) {
+                    while (iterator.hasNext()) {
+                        StreamResult<Employee> employee = iterator.next();
+                    }
+                }
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_5_2
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                session
+                    .advanced()
+                    .loadStartingWithIntoStream("employees/", baos);
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region loading_entities_6_1
+                boolean isLoaded = session.advanced().isLoaded("employees/1");//false
+                Employee employee = session.load(Employee.class, "employees/1");
+                isLoaded = session.advanced().isLoaded("employees/1"); // true
+                //endregion
+            }
+
+
+            //region loading_entities_7_1
+            try (IDocumentSession session = store.openSession()) {
+
+                String changeVector;
+                User user = new User("Bob");
+
+                session.store(User.class, "users/1");
+                session.saveChanges();
+
+                changeVector = session.advanced().getChangeVectorFor(user);
+            }
+
+            User user = new User("Bob");
+            String changeVector = "a";
+
+            try (IDocumentSession session = store.openSession()) {
+                // New session which does not track our User entity
+
+                // The given change vector matches
+                // the server-side change vector
+                // Does not load the document
+                ConditionalLoadResult<User> result1 = session.advanced()
+                    .conditionalLoad(User.class, "users/1", changeVector);
+
+                // Modify the document
+                user.setName("Bob Smith");
+                session.store(user);
+                session.saveChanges();
+
+                // Change vectors do not match
+                // Loads the document
+                ConditionalLoadResult<User> result2 = session.advanced()
+                    .conditionalLoad(User.class, "users/1", changeVector);
+            }
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/loadingEntities.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/loadingEntities.js
@@ -1,0 +1,224 @@
+import * as fs from "fs";
+import {DocumentStore} from "ravendb";
+
+let query,
+    id,
+    callback,
+    statsCallback,
+    documentType,
+    idsArray,
+    includes,
+    path,
+    idPrefix,
+    matches,
+    start,
+    pageSize,
+    exclude,
+    startAfter,
+    options;
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+//region loading_entities_1_0
+await session.load(id, [documentType]);
+//endregion
+
+//region loading_entities_2_0
+session.include(path);
+//endregion
+
+//region loading_entities_3_0
+await session.load(idsArray, [documentType]);
+await session.load(idsArray, [options]);
+//endregion
+
+//region loading_entities_4_0
+await session.advanced.loadStartingWith(idPrefix, [options]);
+
+await session.advanced.loadStartingWithIntoStream(idPrefix, output, [options]);
+//endregion
+
+//region loading_entities_5_0
+// stream query results
+await session.stream(query, [statsCallback]);
+
+// stream documents with ID starting with
+await session.stream(idPrefix, [options]);
+//endregion
+
+//region loading_entities_6_0
+session.advanced.isLoaded(id);
+
+//endregion
+
+class Employee {
+
+}
+
+class Supplier {
+
+}
+
+class Product {
+    constructor(supplier) {
+        this.supplier = supplier;
+    }
+}
+
+async function examples() {
+
+    //region loading_entities_1_1
+    const employee = await session.load("employees/1");
+    //endregion
+
+    //region loading_entities_2_1
+    // loading 'products/1'
+    // including document found in 'supplier' property
+    const product = await session
+        .include("supplier")
+        .load("products/1");
+
+    const supplier = await session.load(product.supplier); // this will *not* make a server call
+    //endregion
+
+    {
+        //region loading_entities_2_2
+        // loading 'products/1'
+        // including document found in 'supplier' property
+        const product = await session
+            .include("supplier")
+            .load("products/1");
+
+        const supplier = await session.load(product.supplier); // this will *not* make a server call
+        //endregion
+    }
+
+    //region loading_entities_3_1
+    const employees = await session.load(
+        ["employees/1", "employees/2", "employees/3"]);
+    // {
+    //     "employees/1": { ... },
+    //     "employees/2": { ... }
+    //     "employees/3": { ... }
+    // }
+    //endregion
+
+    //region loading_entities_4_1
+    // return up to 128 entities with Id that starts with 'employees'
+    const result = await session
+        .advanced
+        .loadStartingWith("employees/", {
+            start: 0,
+            pageSize: 128
+        });
+    //endregion
+
+    {
+        //region loading_entities_4_2
+        // return up to 128 entities with Id that starts with 'employees/'
+        // and rest of the key begins with "1" or "2" e.g. employees/10, employees/25
+        const result = await session
+            .advanced
+            .loadStartingWith("employees/", {
+                matches: "1*|2*",
+                start: 0,
+                pageSize: 128
+            });
+        //endregion
+    }
+
+    //region loading_entities_5_1
+    // stream() returns a Node.js Readable
+    const stream = await session.advanced.stream("employees/");
+
+    stream.on("data", data => {
+        // Employee { name: 'Anna', id: 'employees/1-A' }
+    });
+
+    stream.on("error", err => {
+        // handle errors
+    });
+
+    stream.on("end", () => {
+        // stream ended
+    });
+    //endregion
+
+    //region loading_entities_5_2
+    const employeesFile = fs.createWriteStream("employees.json");
+    await session.advanced.loadStartingWithIntoStream("employees/", employeesFile);
+    //endregion
+
+    {
+        //region loading_entities_6_1
+        session.advanced.isLoaded("employees/1"); // false
+        const employee = await session.load("employees/1");
+        session.advanced.isLoaded("employees/1"); // true
+        //endregion
+    }
+}
+
+{
+    let id, object, changeVector, user, clazz;
+
+    class User {
+    }
+
+    //region loading_entities_7_0
+    await session.advanced.conditionalLoad(id, changeVector, clazz);
+    //endregion
+}
+{
+    //region loading_entities_7_1
+    const session = store.openSession();
+    const user = new User("Bob");
+    await session.store(user, "users/1");
+    await session.saveChanges();
+
+    const changeVector = session.advanced.getChangeVectorFor(user);
+    
+    {
+        // New session which does not track our User entity
+        // The given change vector matches
+        // the server-side change vector
+        // Does not load the document
+        const session = store.openSession();
+        const result1 = await session.advanced
+            .conditionalLoad("users/1", changeVector, User);
+
+        // Modify the document
+        user.name = "Bob Smith";
+        await session.store(user);
+        await session.saveChanges();
+
+        // Change vectors do not match
+        // Loads the document
+        const result2 = await session.advanced
+            .conditionalLoad("users/1", changeVector, User);
+        //endregion
+    }
+}
+
+{
+    //region loading_entities_8
+    class Pet {
+        constructor(name) {
+            this.name = name;
+        }
+    }
+
+    class Person {
+        constructor(name, pet) {
+            this.name = name;
+            this.pet = pet;
+        }
+    }
+
+    documentStore.conventions.registerEntityType(Person);
+    documentStore.conventions.registerEntityType(Pet);
+    // ...
+
+    documentStore.initialize();
+    //endregion
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/LoadingEntities.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/LoadingEntities.py
@@ -1,0 +1,181 @@
+from typing import Optional, Union, Dict, Callable, Type, List, TypeVar
+
+from ravendb import IncludeBuilder, LoaderWithInclude, ConditionalLoadResult
+from ravendb.infrastructure.entities import User
+from ravendb.infrastructure.orders import Employee, Product, Supplier
+
+from examples_base import ExamplesBase
+
+_T = TypeVar("_T")
+
+
+class LoadingEntities(ExamplesBase):
+    def setUp(self):
+        super().setUp()
+        with self.embedded_server.get_document_store("LoadingEntitiesXY").open_session() as session:
+            session.store(Product(supplier="suppliers/1"), "products/1")
+            session.save_changes()
+
+    class Foo:
+        # region loading_entities_1_0
+        def load(
+            self,
+            key_or_keys: Union[List[str], str],
+            object_type: Optional[Type[_T]] = None,
+            includes: Callable[[IncludeBuilder], None] = None,
+        ) -> Union[Dict[str, _T], _T]:
+            ...
+
+        # endregion
+        # region loading_entities_2_0
+        def include(self, path: str) -> LoaderWithInclude:
+            ...
+
+        # endregion
+
+        # region loading_entities_3_0
+        def load(
+            self,
+            key_or_keys: Union[List[str], str],  # <- List of ids
+            object_type: Optional[Type[_T]] = None,
+            includes: Callable[[IncludeBuilder], None] = None,
+        ) -> Union[Dict[str, _T], _T]:
+            ...
+
+        # endregion
+        # region loading_entities_4_0
+        def load_starting_with(
+            self,
+            id_prefix: str,
+            object_type: Optional[Type[_T]] = None,
+            matches: Optional[str] = None,
+            start: Optional[int] = None,
+            page_size: Optional[int] = None,
+            exclude: Optional[str] = None,
+            start_after: Optional[str] = None,
+        ) -> List[_T]:
+            ...
+
+        def load_starting_with_into_stream(
+            self,
+            id_prefix: str,
+            output: bytes,
+            matches: str = None,
+            start: int = 0,
+            page_size: int = 25,
+            exclude: str = None,
+            start_after: str = None,
+        ):
+            ...
+
+    # endregion
+    # region loading_entities_5_0
+    # unsupported, will be supported from 5.4 client release (https://pypi.org/project/ravendb/)
+    # endregion
+    # region loading_entities_6_0
+    def is_loaded(self, key: str) -> bool:
+        ...
+
+    # endregion
+
+    # region loading_entities_7_0
+    def conditional_load(self, key: str, change_vector: str, object_type: Type[_T] = None) -> ConditionalLoadResult[_T]:
+        ...
+
+    # endregion
+
+    def test_loading_entities_xy(self):
+        with self.embedded_server.get_document_store("LoadingEntitiesXY") as store:
+            with store.open_session() as session:
+                # region loading_entities_1_1
+
+                employee = session.load("employees/1", Employee)
+
+                # endregion
+
+            with store.open_session() as session:
+                # region loading_entities_2_1
+
+                # loading 'products/1'
+                # including document found in 'supplier' property
+                products_by_key = session.include("supplier").load(Product, "products/1")
+                product = products_by_key["products/1"]
+
+                supplier = session.load(product.supplier)  # this will not make server call
+
+                # endregion
+
+            with store.open_session() as session:
+                # region loading_entities_2_2
+
+                # loading 'products/1'
+                # including document found in 'Supplier' property
+                products_by_key = session.include("Supplier").load(Product, "products/1")
+                product = products_by_key["products/1"]
+
+                supplier = session.load(product.supplier, Supplier)
+                # endregion
+
+            with store.open_session() as session:
+                # region loading_entities_3_1
+                employees = session.load(["employees/1", "employees/2", "employees/3"], Employee)
+                # endregion
+
+            with store.open_session() as session:
+                # region loading_entities_4_1
+                # return up to 128 entities with Id that starts with 'employees'
+                result = session.advanced.load_starting_with("employees/", Employee, None, 0, 128)
+                # endregion
+
+            with store.open_session() as session:
+                # region loading_entities_4_2
+                # return up to 128 entities with Id that starts with 'employees'
+                # and rest of the key begins with "1" or "2" e.g. employees/10, employees/25
+                result = session.advanced.load_starting_with("employees/", Employee, "1*|2*", 0, 128)
+                # endregion
+
+            with store.open_session() as session:
+                # region loading_entities_5_1
+                # unsupported, will be supported from 5.4 client release (https://pypi.org/project/ravendb/)
+                # endregion
+                ...
+            with store.open_session() as session:
+                session.advanced.load_starting_with_into_stream = lambda x, y: None
+                # region loading_entities_5_2
+                stream_bytes = bytes(b"My loaded documents will go here -> ")
+                session.advanced.load_starting_with_into_stream("employees/", stream_bytes)
+                # endregion
+
+            with store.open_session() as session:
+                # region loading_entities_6_1
+                is_loaded = session.advanced.is_loaded("employees/1")  # False
+                employee = session.load("employees/1")
+                is_loaded = session.advanced.is_loaded("employees/1")  # True
+                # endregion
+
+            # region loading_entities_7_1
+            change_vector: Optional[str] = None
+            user = User(name="Bob")
+
+            with store.open_session() as session:
+                session.store(user, "users/1")
+                session.save_changes()
+
+                change_vector = session.advanced.get_change_vector_for(user)
+
+            # Now session which does not track our User entity
+            with store.open_session() as session:
+                # The given change vector matches
+                # the server-side change vector
+                # Does not load the document
+                result1 = session.advanced.conditional_load("users/1", change_vector)
+
+                # Modify the document
+                user.name = "Bob Smith"
+                session.store(user)
+                session.save_changes()
+
+                # Change vectors do not natch
+                # Loads the document
+                result2 = session.advanced.conditional_load("user/1", change_vector)
+            # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/LoadingEntities.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/LoadingEntities.py
@@ -33,17 +33,7 @@ class LoadingEntities(ExamplesBase):
 
         # endregion
 
-        # region loading_entities_3_0
-        def load(
-            self,
-            key_or_keys: Union[List[str], str],  # <- List of ids
-            object_type: Optional[Type[_T]] = None,
-            includes: Callable[[IncludeBuilder], None] = None,
-        ) -> Union[Dict[str, _T], _T]:
-            ...
-
-        # endregion
-        # region loading_entities_4_0
+        # region loading_entities_4_0_1
         def load_starting_with(
             self,
             id_prefix: str,
@@ -55,7 +45,9 @@ class LoadingEntities(ExamplesBase):
             start_after: Optional[str] = None,
         ) -> List[_T]:
             ...
+        # endregion
 
+        # region loading_entities_4_0_2
         def load_starting_with_into_stream(
             self,
             id_prefix: str,
@@ -67,8 +59,8 @@ class LoadingEntities(ExamplesBase):
             start_after: str = None,
         ):
             ...
+        # endregion
 
-    # endregion
     # region loading_entities_5_0
     # unsupported, will be supported from 5.4 client release (https://pypi.org/project/ravendb/)
     # endregion
@@ -101,7 +93,7 @@ class LoadingEntities(ExamplesBase):
                 products_by_key = session.include("supplier").load(Product, "products/1")
                 product = products_by_key["products/1"]
 
-                supplier = session.load(product.supplier)  # this will not make server call
+                supplier = session.load(product.supplier)  # this will not initiate an additional server call
 
                 # endregion
 


### PR DESCRIPTION
Related issue:
[RDoc-2619](https://issues.hibernatingrhinos.com/issue/RDoc-2619/Python-Client-API-Session-Loading-entities-Replace-C-samples)