### PR TITLE
RDoc-2638 [Python] Client API > Session > Saving changes [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.dotnet.markdown
@@ -1,0 +1,121 @@
+# Session: Saving changes
+
+Pending session operations e.g. `Store`, `Delete` and many others will not be send to the server until `SaveChanges` is called.
+
+{INFO: }
+
+Whenever you execute `SaveChanges()` to send a batch of operations like put, update, or delete in a request,  
+the server will wrap these operations in a [transaction](../../client-api/faq/transaction-support) upon execution in the database.  
+
+Either all operations will be saved as a single, atomic transaction or none of them will be.  
+Once `SaveChanges()` returns successfully, it is guaranteed that all changes are persisted in the database.  
+
+{INFO/}
+
+##Syntax
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync saving_changes_1@ClientApi\Session\SavingChanges.cs /}
+{CODE-TAB:csharp:Async saving_changes_1_async@ClientApi\Session\SavingChanges.cs /}
+{CODE-TABS/} 
+
+###Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync saving_changes_2@ClientApi\Session\SavingChanges.cs /}
+{CODE-TAB:csharp:Async saving_changes_2_async@ClientApi\Session\SavingChanges.cs /}
+{CODE-TABS/} 
+
+
+{PANEL:Waiting for Indexes}
+
+You can ask the server to wait until the indexes are caught up with changes made within the current session before the `SaveChanges` returns.
+
+* You can set a timeout (default: 15 seconds).
+* You can specify whether you want to throw on timeout (default: `false`).
+* You can specify indexes that you want to wait for. If you don't specify anything here, RavenDB will automatically select just the indexes that are impacted 
+by this write.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync saving_changes_3@ClientApi\Session\SavingChanges.cs /}
+{CODE-TAB:csharp:Async saving_changes_3_async@ClientApi\Session\SavingChanges.cs /}
+{CODE-TABS/} 
+
+{PANEL/}
+
+{PANEL:Waiting for Replication - Write Assurance}
+
+Sometimes you might need to ensure that changes made in the session will be replicated to more than one node of the cluster before the `SaveChanges` returns.
+It can be useful if you have some writes that are really important so you want to be sure the stored values will reside on multiple machines. Also it might be necessary to use
+when you customize [the read balance behavior](../../client-api/configuration/load-balance/read-balance-behavior) and need to ensure the next request from the user 
+will be able to read what he or she just wrote (the next open session might access a different node).
+
+You can ask the server to wait until the replication is caught up with those particular changes.
+
+* You can set a timeout (default: 15 seconds).
+* You can specify whether you want to throw on timeout, which may happen in case of network issues (default: `true`).
+* You can specify to how many replicas (nodes) the currently saved write must be replicated, before the `SaveChanges` returns (default: 1).
+* You can specify whether the `SaveChanges` will return only when the current write was replicated to majority of the nodes (default: `false`).
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync saving_changes_4@ClientApi\Session\SavingChanges.cs /}
+{CODE-TAB:csharp:Async saving_changes_4_async@ClientApi\Session\SavingChanges.cs /}
+{CODE-TABS/} 
+
+{WARNING:Important}
+The `WaitForReplicationAfterSaveChanges` waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
+{WARNING/}
+
+{WARNING:Important}
+
+Even if RavenDB was not able to write your changes to the number of replicas you specified, the data has been already written to some nodes. You will get an error but data is already there.
+
+This is a powerful feature, but you need to be aware of the possible pitfalls of using it.
+
+{WARNING/}
+
+{PANEL/}
+
+{PANEL:Transaction Mode - Cluster Wide}
+
+Setting `TransactionMode` to `TransactionMode.ClusterWide` will enable the [Cluster Transactions](../../server/clustering/cluster-transactions) feature.
+
+With this feature enabled the [Session](../../client-api/session/what-is-a-session-and-how-does-it-work) will support the following _write_ commands:
+
+- `Store`/`StoreAsync`
+- `Delete`
+- `CreateCompareExchangeValue`
+- `UpdateCompareExchangeValue`
+- `DeleteCompareExchangeValue`
+
+
+Here is an example of creating a unique user with cluster wide.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync cluster_store_with_compare_exchange@ClientApi\Session\SavingChanges.cs /}
+{CODE-TAB:csharp:Async cluster_store_with_compare_exchange_async@ClientApi\Session\SavingChanges.cs /}
+{CODE-TABS/} 
+
+{PANEL/}
+
+## Related Articles
+
+### Transactions
+
+- [Transaction Support](../../client-api/faq/transaction-support)
+- [Cluster Transactions](../../server/clustering/cluster-transactions)
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Loading Entities](../../client-api/session/loading-entities)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.java.markdown
@@ -50,7 +50,7 @@ You can ask the server to wait until the replication is caught up with those par
 {CODE:java saving_changes_4@ClientApi\Session\SavingChanges.java /}
 
 {WARNING:Important}
-The `waitForReplicationAfterSaveChanges` waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
+The `waitForReplicationAfterSaveChanges` method waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
 {WARNING/}
 
 {WARNING:Important}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.java.markdown
@@ -1,0 +1,106 @@
+# Session: Saving changes
+
+Pending session operations e.g. `store`, `delete` and many others will not be send to the server until `saveChanges` is called.
+
+{INFO: }
+
+Whenever you execute `saveChanges()` to send a batch of operations like put, update, or delete in a request,  
+the server will wrap these operations in a [transaction](../../client-api/faq/transaction-support) upon execution in the database.
+
+Either all operations will be saved as a single, atomic transaction or none of them will be.  
+Once `saveChanges()` returns successfully, it is guaranteed that all changes are persisted in the database.
+
+{INFO/}
+
+##Syntax
+
+{CODE:java saving_changes_1@ClientApi\Session\SavingChanges.java /}
+
+###Example
+
+{CODE:java saving_changes_2@ClientApi\Session\SavingChanges.java /}
+
+{PANEL:Waiting for Indexes}
+
+You can ask the server to wait until the indexes are caught up with changes made within the current session before the `saveChanges` returns.
+
+* You can set a timeout (default: 15 seconds).
+* You can specify whether you want to throw on timeout (default: `false`).
+* You can specify indexes that you want to wait for. If you don't specify anything here, RavenDB will automatically select just the indexes that are impacted 
+by this write.
+
+{CODE:java saving_changes_3@ClientApi\Session\SavingChanges.java /}
+
+{PANEL/}
+
+{PANEL:Waiting for Replication - Write Assurance}
+
+Sometimes you might need to ensure that changes made in the session will be replicated to more than one node of the cluster before the `saveChanges` returns.
+It can be useful if you have some writes that are really important so you want to be sure the stored values will reside on multiple machines. Also it might be necessary to use
+when you customize [the read balance behavior](../../client-api/configuration/load-balance/overview) and need to ensure the next request from the user 
+will be able to read what he or she just wrote (the next open session might access a different node).
+
+You can ask the server to wait until the replication is caught up with those particular changes.
+
+* You can set a timeout (default: 15 seconds).
+* You can specify whether you want to throw on timeout, which may happen in case of network issues (default: `true`).
+* You can specify to how many replicas (nodes) the currently saved write must be replicated, before the `saveChanges` returns (default: 1).
+* You can specify whether the `saveChanges` will return only when the current write was replicated to majority of the nodes (default: `false`).
+
+{CODE:java saving_changes_4@ClientApi\Session\SavingChanges.java /}
+
+{WARNING:Important}
+The `waitForReplicationAfterSaveChanges` waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
+{WARNING/}
+
+{WARNING:Important}
+
+The usage of `waitForReplicationAfterSaveChanges` doesn't involve a distributed transaction (those are not supported since RavenDB 4.0). Even if RavenDB was not able
+to write your changes to the number of replicas you specified, the data has been already written to some nodes. You will get an error but data is already there.
+
+This is a powerful feature, but you need to be aware of the possible pitfalls of using it.
+
+{WARNING/}
+
+{PANEL/} 
+
+{PANEL:Transaction Mode - Cluster Wide}
+
+Setting `transactionMode` to `TransactionMode.CLUSTER_WIDE` will enable the [Cluster Transactions](../../server/clustering/cluster-transactions) feature.
+
+With this feature enabled the [Session](../../client-api/session/what-is-a-session-and-how-does-it-work) will support the following _write_ commands:
+
+- `store`
+- `delete`
+- `createCompareExchangeValue`
+- `updateCompareExchangeValue`
+- `deleteCompareExchangeValue`
+
+
+Here is an example of creating a unique user with cluster wide.
+
+{CODE:java cluster_store_with_compare_exchange@ClientApi\Session\SavingChanges.java /}
+
+{PANEL/}
+
+## Related Articles
+
+### Transactions
+
+- [Transaction Support](../../client-api/faq/transaction-support)
+- [Cluster Transactions](../../server/clustering/cluster-transactions)
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Loading Entities](../../client-api/session/loading-entities)
+
+### Querying
+
+- [Basics](../../indexes/querying/query-index)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.js.markdown
@@ -1,0 +1,90 @@
+# Session: Saving changes
+
+Pending session operations e.g. `store()`, `delete()` and many others will not be send to the server until `saveChanges()` is called.
+
+{INFO: }
+
+Whenever you execute `saveChanges()` to send a batch of operations like put, update, or delete in a request,  
+the server will wrap these operations in a [transaction](../../client-api/faq/transaction-support) upon execution in the database.
+
+Either all operations will be saved as a single, atomic transaction or none of them will be.  
+Once `saveChanges()` returns successfully, it is guaranteed that all changes are persisted in the database.
+
+{INFO/}
+
+##Syntax
+
+{CODE:nodejs saving_changes_1@client-api\session\savingChanges.js /}
+
+| Return Value | |
+| ------------- | ----- |
+| `Promise` | A `Promise` resolved once session changes are persisted to the server |
+
+###Example
+
+{CODE:nodejs saving_changes_2@client-api\session\savingChanges.js /}
+
+{PANEL:Waiting for Indexes}
+
+You can ask the server to wait until the indexes are caught up with changes made within the current session before the `saveChanges()` returns.
+
+* You can set a timeout (default: 15 seconds).
+* You can specify whether you want to throw on timeout (default: `false`).
+* You can specify indexes that you want to wait for. If you don't specify anything here, RavenDB will automatically select just the indexes that are impacted 
+by this write.
+
+{CODE:nodejs saving_changes_3@client-api\session\savingChanges.js /}
+
+{PANEL/}
+
+{PANEL:Waiting for Replication - Write Assurance}
+
+Sometimes you might need to ensure that changes made in the session will be replicated to more than one node of the cluster before the `saveChanges()` returns.
+It can be useful if you have some writes that are really important so you want to be sure the stored values will reside on multiple machines. Also it might be necessary to use
+when you customize [the read balance behavior](../../client-api/configuration/load-balance/read-balance-behavior) and need to ensure the next request from the user 
+will be able to read what he or she just wrote (the next open session might access a different node).
+
+You can ask the server to wait until the replication is caught up with those particular changes.
+
+* You can set a timeout (default: 15 seconds).
+* You can specify whether you want to throw on timeout, which may happen in case of network issues (default: `true`).
+* You can specify to how many replicas (nodes) the currently saved write must be replicated, before the `saveChanges` returns (default: 1).
+* You can specify whether the `saveChanges()` will return only when the current write was replicated to majority of the nodes (default: `false`).
+
+{CODE:nodejs saving_changes_4@client-api\session\savingChanges.js /}
+
+{WARNING:Important}
+The `waitForReplicationAfterSaveChanges` waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
+{WARNING/}
+
+{WARNING:Important}
+
+The usage of `waitForReplicationAfterSaveChanges` doesn't involve a distributed transaction (those are not supported since RavenDB 4.0). Even if RavenDB was not able
+to write your changes to the number of replicas you specified, the data has been already written to some nodes. You will get an error but data is already there.
+
+This is a powerful feature, but you need to be aware of the possible pitfalls of using it.
+
+{WARNING/}
+
+{PANEL/} 
+
+## Related Articles
+
+### Transactions
+
+- [Transaction Support](../../client-api/faq/transaction-support)
+
+### Session
+
+- [What is a Session and How Does it Work](../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../client-api/session/opening-a-session)
+- [Deleting Entities](../../client-api/session/deleting-entities)
+- [Loading Entities](../../client-api/session/loading-entities)
+
+### Querying
+
+- [Query Overview](../../client-api/session/querying/how-to-query)
+
+### Document Store
+
+- [What is a Document Store](../../client-api/what-is-a-document-store)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.js.markdown
@@ -54,7 +54,7 @@ You can ask the server to wait until the replication is caught up with those par
 {CODE:nodejs saving_changes_4@client-api\session\savingChanges.js /}
 
 {WARNING:Important}
-The `waitForReplicationAfterSaveChanges` waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
+The `waitForReplicationAfterSaveChanges` method waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
 {WARNING/}
 
 {WARNING:Important}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.python.markdown
@@ -51,7 +51,7 @@ You can ask the server to wait until the replication is caught up with those par
 {CODE:python saving_changes_4@ClientApi\Session\savingChanges.py /}
 
 {WARNING:Important}
-The `wait_for_replication_after_save_changes` waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
+The `wait_for_replication_after_save_changes` method waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
 {WARNING/}
 
 {WARNING:Important}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.python.markdown
@@ -1,51 +1,42 @@
 # Session: Saving changes
 
-Pending session operations e.g. `Store`, `Delete` and many others will not be send to the server until `SaveChanges` is called.
+Pending session operations e.g. `store`, `delete` and many others will not be send to the server until `save_changes` is called.
 
 {INFO: }
 
-Whenever you execute `SaveChanges()` to send a batch of operations like put, update, or delete in a request,  
+Whenever you execute `save_changes()` to send a batch of operations like put, update, or delete in a request,  
 the server will wrap these operations in a [transaction](../../client-api/faq/transaction-support) upon execution in the database.  
 
 Either all operations will be saved as a single, atomic transaction or none of them will be.  
-Once `SaveChanges()` returns successfully, it is guaranteed that all changes are persisted in the database.  
+Once `save_changes()` returns successfully, it is guaranteed that all changes are persisted in the database.  
 
 {INFO/}
 
 ##Syntax
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync saving_changes_1@ClientApi\Session\SavingChanges.cs /}
-{CODE-TAB:csharp:Async saving_changes_1_async@ClientApi\Session\SavingChanges.cs /}
-{CODE-TABS/} 
+{CODE:python saving_changes_1@ClientApi\Session\savingChanges.py /}
 
 ###Example
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync saving_changes_2@ClientApi\Session\SavingChanges.cs /}
-{CODE-TAB:csharp:Async saving_changes_2_async@ClientApi\Session\SavingChanges.cs /}
-{CODE-TABS/} 
+{CODE:python saving_changes_2@ClientApi\Session\savingChanges.py /}
 
 
 {PANEL:Waiting for Indexes}
 
-You can ask the server to wait until the indexes are caught up with changes made within the current session before the `SaveChanges` returns.
+You can ask the server to wait until the indexes are caught up with changes made within the current session before the `save_changes` returns.
 
 * You can set a timeout (default: 15 seconds).
 * You can specify whether you want to throw on timeout (default: `false`).
 * You can specify indexes that you want to wait for. If you don't specify anything here, RavenDB will automatically select just the indexes that are impacted 
 by this write.
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync saving_changes_3@ClientApi\Session\SavingChanges.cs /}
-{CODE-TAB:csharp:Async saving_changes_3_async@ClientApi\Session\SavingChanges.cs /}
-{CODE-TABS/} 
+{CODE:python saving_changes_3@ClientApi\Session\savingChanges.py /}
 
 {PANEL/}
 
 {PANEL:Waiting for Replication - Write Assurance}
 
-Sometimes you might need to ensure that changes made in the session will be replicated to more than one node of the cluster before the `SaveChanges` returns.
+Sometimes you might need to ensure that changes made in the session will be replicated to more than one node of the cluster before the `save_changes` returns.
 It can be useful if you have some writes that are really important so you want to be sure the stored values will reside on multiple machines. Also it might be necessary to use
 when you customize [the read balance behavior](../../client-api/configuration/load-balance/read-balance-behavior) and need to ensure the next request from the user 
 will be able to read what he or she just wrote (the next open session might access a different node).
@@ -54,16 +45,13 @@ You can ask the server to wait until the replication is caught up with those par
 
 * You can set a timeout (default: 15 seconds).
 * You can specify whether you want to throw on timeout, which may happen in case of network issues (default: `true`).
-* You can specify to how many replicas (nodes) the currently saved write must be replicated, before the `SaveChanges` returns (default: 1).
-* You can specify whether the `SaveChanges` will return only when the current write was replicated to majority of the nodes (default: `false`).
+* You can specify to how many replicas (nodes) the currently saved write must be replicated, before the `save_changes` returns (default: 1).
+* You can specify whether the `save_changes` will return only when the current write was replicated to majority of the nodes (default: `false`).
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync saving_changes_4@ClientApi\Session\SavingChanges.cs /}
-{CODE-TAB:csharp:Async saving_changes_4_async@ClientApi\Session\SavingChanges.cs /}
-{CODE-TABS/} 
+{CODE:python saving_changes_4@ClientApi\Session\savingChanges.py /}
 
 {WARNING:Important}
-The `WaitForReplicationAfterSaveChanges` method waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
+The `wait_for_replication_after_save_changes` waits only for replicas which are part of the cluster. It means that external replication destinations are not counted towards the number specified in `replicas` parameter, since they are not part of the cluster.
 {WARNING/}
 
 {WARNING:Important}
@@ -80,21 +68,18 @@ This is a powerful feature, but you need to be aware of the possible pitfalls of
 
 Setting `TransactionMode` to `TransactionMode.ClusterWide` will enable the [Cluster Transactions](../../server/clustering/cluster-transactions) feature.
 
-With this feature enabled the [Session](../../client-api/session/what-is-a-session-and-how-does-it-work) will support the following _write_ commands:
+With this feature enabled the [session](../../client-api/session/what-is-a-session-and-how-does-it-work) will support the following _write_ commands:
 
-- `Store`/`StoreAsync`
-- `Delete`
-- `CreateCompareExchangeValue`
-- `UpdateCompareExchangeValue`
-- `DeleteCompareExchangeValue`
+- `store`
+- `delete`
+- `create_compare_exchange_value`
+- `update_compare_exchange_value`
+- `delete_compare_exchange_value`
 
 
 Here is an example of creating a unique user with cluster wide.
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync cluster_store_with_compare_exchange@ClientApi\Session\SavingChanges.cs /}
-{CODE-TAB:csharp:Async cluster_store_with_compare_exchange_async@ClientApi\Session\SavingChanges.cs /}
-{CODE-TABS/} 
+{CODE:python cluster_store_with_compare_exchange@ClientApi\Session\savingChanges.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/saving-changes.python.markdown
@@ -26,7 +26,7 @@ Once `save_changes()` returns successfully, it is guaranteed that all changes ar
 You can ask the server to wait until the indexes are caught up with changes made within the current session before the `save_changes` returns.
 
 * You can set a timeout (default: 15 seconds).
-* You can specify whether you want to throw on timeout (default: `false`).
+* You can specify whether you want to throw on timeout (default: `False`).
 * You can specify indexes that you want to wait for. If you don't specify anything here, RavenDB will automatically select just the indexes that are impacted 
 by this write.
 
@@ -44,9 +44,9 @@ will be able to read what he or she just wrote (the next open session might acce
 You can ask the server to wait until the replication is caught up with those particular changes.
 
 * You can set a timeout (default: 15 seconds).
-* You can specify whether you want to throw on timeout, which may happen in case of network issues (default: `true`).
+* You can specify whether you want to throw on timeout, which may happen in case of network issues (default: `True`).
 * You can specify to how many replicas (nodes) the currently saved write must be replicated, before the `save_changes` returns (default: 1).
-* You can specify whether the `save_changes` will return only when the current write was replicated to majority of the nodes (default: `false`).
+* You can specify whether the `save_changes` will return only when the current write was replicated to majority of the nodes (default: `False`).
 
 {CODE:python saving_changes_4@ClientApi\Session\savingChanges.py /}
 
@@ -66,7 +66,7 @@ This is a powerful feature, but you need to be aware of the possible pitfalls of
 
 {PANEL:Transaction Mode - Cluster Wide}
 
-Setting `TransactionMode` to `TransactionMode.ClusterWide` will enable the [Cluster Transactions](../../server/clustering/cluster-transactions) feature.
+Setting `TransactionMode` to `TransactionMode.CLUSTER_WIDE` will enable the [Cluster Transactions](../../server/clustering/cluster-transactions) feature.
 
 With this feature enabled the [session](../../client-api/session/what-is-a-session-and-how-does-it-work) will support the following _write_ commands:
 

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/SavingChanges.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/SavingChanges.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+using Xunit.Sdk;
+
+namespace Raven.Documentation.Samples.ClientApi.Session
+{
+    public class SavingChanges
+    {
+        private interface IInterface
+        {
+            #region saving_changes_1
+            void SaveChanges();
+            #endregion
+
+            #region saving_changes_1_async
+            Task SaveChangesAsync();
+            #endregion
+        }
+
+        public async Task SavingChangesXY()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region saving_changes_2
+                    // storing new entity
+                    session.Store(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    session.SaveChanges();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region saving_changes_2_async
+                    // storing new entity
+                    await asyncSession.StoreAsync(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+            }
+
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    // storing new entity
+                    #region saving_changes_3
+                    session.Advanced.WaitForIndexesAfterSaveChanges(
+                        timeout: TimeSpan.FromSeconds(30),
+                        throwOnTimeout: true,
+                        indexes: new[] { "index/1", "index/2" });
+
+                    session.Store(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    session.SaveChanges();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    // storing new entity
+                    #region saving_changes_3_async
+                    asyncSession.Advanced.WaitForIndexesAfterSaveChanges(
+                        timeout: TimeSpan.FromSeconds(30),
+                        throwOnTimeout: true,
+                        indexes: new[] { "index/1", "index/2" });
+
+                    await asyncSession.StoreAsync(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    // storing new entity
+                    #region saving_changes_4
+
+                    session.Advanced.WaitForReplicationAfterSaveChanges(
+                        timeout: TimeSpan.FromSeconds(30),
+                        throwOnTimeout: false, //default true
+                        replicas: 2, //minimum replicas to replicate
+                        majority: false);
+
+                    session.Store(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    session.SaveChanges();
+                    #endregion
+                }
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    // storing new entity
+                    #region saving_changes_4_async
+
+                    asyncSession.Advanced.WaitForReplicationAfterSaveChanges(
+                        timeout: TimeSpan.FromSeconds(30),
+                        throwOnTimeout: false, //default true
+                        replicas: 2, //minimum replicas to replicate
+                        majority: false);
+
+                    await asyncSession.StoreAsync(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+            }
+
+            #region cluster_store_with_compare_exchange
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession(new SessionOptions
+                {
+                    //default is:     TransactionMode.SingleNode
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var user = new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    };
+                    session.Store(user);
+
+                    // this transaction is now conditional on this being 
+                    // successfully created (so, no other users with this name)
+                    // it also creates an association to the new user's id
+                    session.Advanced.ClusterTransaction
+                        .CreateCompareExchangeValue("usernames/John", user.Id);
+
+                    session.SaveChanges();
+                }
+                #endregion
+
+                #region cluster_store_with_compare_exchange_async
+                using (var session = store.OpenAsyncSession(new SessionOptions
+                {
+                    //default is:     TransactionMode.SingleNode
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    var user = new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    };
+                    await session.StoreAsync(user);
+
+                    // this transaction is now conditional on this being 
+                    // successfully created (so, no other users with this name)
+                    // it also creates an association to the new user's id
+                    session.Advanced.ClusterTransaction
+                        .CreateCompareExchangeValue("usernames/John", user.Id);
+
+                    await session.SaveChangesAsync();
+                }
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/SavingChanges.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/SavingChanges.java
@@ -1,0 +1,123 @@
+package net.ravendb.ClientApi.Session;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.client.documents.session.SessionOptions;
+import net.ravendb.client.documents.session.TransactionMode;
+
+import java.time.Duration;
+
+public class SavingChanges {
+
+    private interface IFoo {
+        //region saving_changes_1
+        void saveChanges();
+        //endregion
+    }
+
+    private class Employee {
+        private String id;
+        private String firstName;
+        private String lastName;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+
+    public SavingChanges() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region saving_changes_2
+                Employee employee = new Employee();
+                employee.setFirstName("John");
+                employee.setLastName("Doe");
+
+                session.store(employee);
+                session.saveChanges();;
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region saving_changes_3
+                session.advanced().waitForIndexesAfterSaveChanges(builder -> {
+                    builder.withTimeout(Duration.ofSeconds(30))
+                        .throwOnTimeout(true)
+                        .waitForIndexes("index/1", "index/2");
+
+                    Employee employee = new Employee();
+                    employee.setFirstName("John");
+                    employee.setLastName("Doe");
+                    session.store(employee);
+
+                    session.saveChanges();
+                });
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region saving_changes_4
+                session
+                    .advanced()
+                    .waitForReplicationAfterSaveChanges(builder -> {
+                        builder.withTimeout(Duration.ofSeconds(30))
+                            .throwOnTimeout(false) //default true
+                            .numberOfReplicas(2)//minimum replicas to replicate
+                            .majority(false);
+                    });
+
+                Employee employee = new Employee();
+                employee.setFirstName("John");
+                employee.setLastName("Doe");
+
+                session.store(employee);
+                session.saveChanges();
+                //endregion
+            }
+        }
+
+        //region cluster_store_with_compare_exchange
+        try (IDocumentStore store = new DocumentStore()) {
+            SessionOptions sessionOptions = new SessionOptions();
+            // default is: TransactionMode.SINGLE_NODE
+            sessionOptions.setTransactionMode(TransactionMode.CLUSTER_WIDE);
+            try (IDocumentSession session = store.openSession(sessionOptions)) {
+                Employee user = new Employee();
+                user.setFirstName("John");
+                user.setLastName("Doe");
+
+                session.store(user);
+
+                // this transaction is now conditional on this being
+                // successfully created (so, no other users with this name)
+                // it also creates an association to the new user's id
+                session.advanced().clusterTransaction()
+                    .createCompareExchangeValue("usernames/John", user.getId());
+
+                session.saveChanges();
+            }
+        }
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/savingChanges.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/savingChanges.js
@@ -1,0 +1,56 @@
+import { DocumentStore } from "ravendb";
+
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+//region saving_changes_1
+session.saveChanges();
+//endregion
+
+class Employee {
+    constructor(firstName, lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+}
+
+async function examples() {
+    {
+        //region saving_changes_2
+        const employee = new Employee("John", "Doe");
+        await session.store(employee);
+        await session.saveChanges();
+        //endregion
+    }
+
+    {
+        //region saving_changes_3
+        session.advanced.waitForIndexesAfterSaveChanges({
+            indexes: ["index/1", "index/2"],
+            throwOnTimeout: true,
+            timeout: 30 * 1000 // 30 seconds in ms
+        });
+
+        const employee = new Employee("John", "Doe");
+        await session.store(employee);
+        await session.saveChanges();
+        //endregion
+    }
+
+    {
+        //region saving_changes_4
+        session.advanced
+            .waitForReplicationAfterSaveChanges({
+                throwOnTimeout: false, // default true
+                timeout: 30000,
+                replicas: 2, // minimum replicas to replicate
+                majority: false
+            });
+
+        const employee = new Employee("John", "Doe");
+        await session.store(employee);
+        await session.saveChanges();
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/savingChanges.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/savingChanges.py
@@ -1,0 +1,84 @@
+from datetime import timedelta
+from typing import Optional
+
+from ravendb import InMemoryDocumentSessionOperations, SessionOptions, TransactionMode
+from ravendb.infrastructure.orders import Employee
+
+from ClientAPI.Session.opening_session import DocumentStoreFake
+from examples_base import ExamplesBase
+
+
+class StoringEntities(ExamplesBase):
+    def setUp(self):
+        super().setUp()
+
+    class Interface:
+        # region saving_changes_1
+        def save_changes(self) -> None:
+            ...
+
+        # endregion
+
+    def test_saving_changes_xy(self):
+        with self.embedded_server.get_document_store("SavingChangesXY") as store:
+            with store.open_session() as session:
+                # region saving_changes_2
+                session.store(Employee(first_name="John", last_name="Doe"))
+
+                session.save_changes()
+                # endregion
+
+            with store.open_session() as session:
+                # storing new entity
+                # region saving_changes_3
+                def _build_wait(idx_wait_opt_builder: InMemoryDocumentSessionOperations.IndexesWaitOptsBuilder) -> None:
+                    idx_wait_opt_builder.with_timeout(timedelta(seconds=30))
+                    idx_wait_opt_builder.throw_on_timeout(True)
+                    idx_wait_opt_builder.wait_for_indexes("index/1", "index/2")
+
+                # this function can be also passed as a lambda
+                session.advanced.wait_for_indexes_after_save_changes(_build_wait)
+
+                session.store(Employee(first_name="John", last_name="Doe"))
+
+                session.save_changes()
+                # endregion
+
+            with store.open_session() as session:
+                # storing new entity
+                # region saving_changes_4
+
+                def _build_wait(
+                    repl_wait_builder: InMemoryDocumentSessionOperations.ReplicationWaitOptsBuilder,
+                ) -> None:
+                    repl_wait_builder.with_timeout(timedelta(seconds=30))
+                    repl_wait_builder.throw_on_timeout(False)  # default True
+                    repl_wait_builder.number_of_replicas(2)  # minimum replicas to replicate
+                    repl_wait_builder.majority(False)
+
+                # this function can be also passed as a lambda
+                session.advanced.wait_for_replication_after_save_changes(_build_wait)
+
+                session.store(Employee(first_name="John", last_name="Doe"))
+                session.save_changes()
+                # endregion
+
+            # region cluster_store_with_compare_exchange
+            DocumentStore = DocumentStoreFake
+            with DocumentStore() as store:
+                with store.open_session(
+                    session_options=SessionOptions(
+                        # default is:    TransactionMode.SINGLE_NODE
+                        transaction_mode=TransactionMode.CLUSTER_WIDE
+                    )
+                ) as session:
+                    user = Employee(first_name="John", last_name="Doe")
+                    session.store(user)
+
+                    # this transaction is now conditional on this being
+                    # successfully created (so, no other users with this name)
+                    # it also creates an association to the new user's id
+                    session.advanced.cluster_transaction.create_compare_exchange_value("usernames/John", user.Id)
+
+                    session.save_changes()
+            # endregion


### PR DESCRIPTION
Related issue:
[RDoc-2638](https://issues.hibernatingrhinos.com/issue/RDoc-2638/Python-Client-API-Session-Saving-changes-Replace-C-samples)