### PR TITLE
RDoc-2634 [Node.js] Client API > Commands > Documents > Put [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
@@ -1,25 +1,25 @@
 [
-  {
-    "Path": "get.markdown",
-    "Name": "Get",
-    "DiscussionId": "eafb1bd0-dd05-449e-bacc-0d5747d96385",
-    "Mappings": []
-  },
-  {
-    "Path": "put.markdown",
-    "Name": "Put",
-    "DiscussionId": "ed032e64-6fe9-4528-a4c0-893dbf4d2bf8",
-    "Mappings": []
-  },
-  {
-    "Path": "delete.markdown",
-    "Name": "Delete",
-    "DiscussionId": "603df172-c032-48c6-8f8a-ef40e721c3c0",
-    "Mappings": []
-  },
-  {
-    "Path": "/how-to",
-    "Name": "How to...",
-    "Mappings": []
-  }
+    {
+        "Path": "get.markdown",
+        "Name": "Get",
+        "DiscussionId": "eafb1bd0-dd05-449e-bacc-0d5747d96385",
+        "Mappings": []
+    },
+    {
+        "Path": "put.markdown",
+        "Name": "Put",
+        "DiscussionId": "ed032e64-6fe9-4528-a4c0-893dbf4d2bf8",
+        "Mappings": []
+    },
+    {
+        "Path": "delete.markdown",
+        "Name": "Delete",
+        "DiscussionId": "603df172-c032-48c6-8f8a-ef40e721c3c0",
+        "Mappings": []
+    },
+    {
+        "Path": "/how-to",
+        "Name": "How to...",
+        "Mappings": []
+    }
 ]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.dotnet.markdown
@@ -1,0 +1,35 @@
+# Commands: Documents: Put
+---
+
+{NOTE: }
+**Put** is used to insert or update a document in a database.
+
+In this page:
+
+* [Syntax](../../../client-api/commands/documents/put#syntax)
+* [Example](../../../client-api/commands/documents/put#example)
+
+{NOTE/}
+
+## Syntax
+
+{CODE put_interface@ClientApi\Commands\Documents\Put.cs /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **conventions** | DocumentConventions | Document conventions |
+| **id** | string | Unique ID under which document will be stored |
+| **changeVector** | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **document** | BlittableJsonReaderObject | The document to store. You may use `session.Advanced.JsonConverter.ToBlittable(doc, docInfo);` to convert your entity to a `BlittableJsonReaderObject`. |
+
+## Example
+
+{CODE put_sample@ClientApi\Commands\Documents\Put.cs /}
+
+## Related Articles
+
+### Commands
+
+- [Get](../../../client-api/commands/documents/get)
+- [Delete](../../../client-api/commands/documents/delete)
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.java.markdown
@@ -1,0 +1,25 @@
+# Commands: Documents: Put
+
+**Put** is used to insert or update a document in a database.
+
+## Syntax
+
+{CODE:java put_interface@ClientApi\Commands\Documents\Put.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **id** | String | unique ID under which document will be stored |
+| **changeVector** | String | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **document** | ObjectNode | The document to store. You may use `session.advanced().getEntityToJson().convertEntityToJson` to convert your entity to a `ObjectNode` |
+
+## Example
+
+{CODE:java put_sample@ClientApi\Commands\Documents\Put.java /}
+
+## Related Articles
+
+### Commands 
+
+- [Get](../../../client-api/commands/documents/get)  
+- [Delete](../../../client-api/commands/documents/delete)
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.js.markdown
@@ -1,0 +1,43 @@
+# Put Document Command
+---
+
+{NOTE: }
+
+* Use the `PutDocumentCommand` to insert or update a document in the database.
+
+* In this page:
+
+   * [Example](../../../client-api/commands/documents/put#example)
+   * [Syntax](../../../client-api/commands/documents/put#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Example}
+
+{CODE:nodejs put@client-api\commands\documents\put.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\commands\documents\put.js /}
+
+| Parameter        | Type   | Description                                                             |
+|------------------|--------|-------------------------------------------------------------------------|
+| __id__           | string | Unique ID under which document will be stored                           |
+| __changeVector__ | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| __document__     | object | The document to store.                                                  |
+
+{CODE:nodejs syntax_2@client-api\commands\documents\put.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Commands
+
+- [Get document](../../../client-api/commands/documents/get)
+- [Delete document](../../../client-api/commands/documents/delete)
+- [Send multiple commands using a batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Documents/Put.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Documents/Put.cs
@@ -1,0 +1,52 @@
+﻿
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+using Sparrow.Json;
+
+namespace Raven.Documentation.Samples.ClientApi.Commands.Documents
+{
+    public class PutInterfaces
+    {
+        private class PutDocumentCommand
+        {
+            #region put_interface
+            public PutDocumentCommand(string id, string changeVector, BlittableJsonReaderObject document)
+            #endregion
+            {
+            }
+        }
+    }
+
+    public class PutSamples
+    {
+        public void Foo()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region put_sample
+                // Create a new document
+                var doc = new Category
+                {
+                    Name = "My category",
+                    Description = "My category description"
+                };
+                // Create metadata on the document
+                var docInfo = new DocumentInfo
+                {
+                    Collection = "Categories"
+                };
+                // Convert your entity to a BlittableJsonReaderObject
+                var blittableDoc = session.Advanced.JsonConverter.ToBlittable(doc, docInfo);
+
+                // The Put command (parameters are document ID, changeVector check is null, the document to store)
+                var command = new PutDocumentCommand("categories/999", null, blittableDoc);
+                // RequestExecutor sends the command to the server
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Commands/Documents/Put.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Commands/Documents/Put.java
@@ -1,0 +1,62 @@
+package net.ravendb.ClientApi.Commands.Documents;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.PutDocumentCommand;
+import net.ravendb.client.documents.session.DocumentInfo;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class Put {
+
+    private class Foo {
+        private class PutDocumentCommand {
+            //region put_interface
+            public PutDocumentCommand(String id, String changeVector, ObjectNode document)
+            //endregion
+            {}
+        }
+    }
+
+    public class PutSamples {
+        public void foo() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region put_sample
+                    Category doc = new Category();
+                    doc.setName("My category");
+                    doc.setDescription("My category description");
+
+                    DocumentInfo docInfo = new DocumentInfo();
+                    docInfo.setCollection("Categories");
+
+                    ObjectNode jsonDoc = session.advanced().getEntityToJson().convertEntityToJson(doc, docInfo);
+                    PutDocumentCommand command = new PutDocumentCommand("categories/999", null, jsonDoc);
+                    session.advanced().getRequestExecutor().execute(command);
+                    //endregion
+                }
+            }
+        }
+    }
+
+    private static class Category {
+        private String name;
+        private String description;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/commands/documents/put.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/commands/documents/put.js
@@ -1,0 +1,54 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function putDocumentsCommand() {
+    {
+        //region put
+        // Create a new entity
+        const category = new Category();
+        category.name = "My category";
+        category.description = "My category description";
+       
+        // To be able to specify under which collection the document should be stored 
+        // you need to convert the entity to a json document first.
+        
+        // Passing the entity as is instead of the json document
+        // will result in storing the documet under the "@empty" collection.
+        
+        const documentInfo = new DocumentInfo();
+        documentInfo.collection = "categories"; // The target collection
+        const jsonDocument = EntityToJson.convertEntityToJson(category, documentStore.conventions, documentInfo);
+        
+        // Define the Put Command
+        // Pass the document ID, whether to make concurrency checks, and the json document to store
+        const putDocCmd = new PutDocumentCommand("categories/999", null, jsonDocument);
+        
+        // Send the command to the server using the RequestExecutor
+        await documentStore.getRequestExecutor().execute(putDocCmd);
+
+        // Can check the command's result
+        const result = putDocCmd.result;
+        assert.strictEqual(result.id, "categories/999");
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    PutDocumentCommand(id, changeVector, document);
+    //endregion
+    
+    //region syntax_2
+    // Executing the `PutDocumentCommand` returns the following object:
+    {
+        // string, the document id under which the entity was stored
+        id;
+        
+        // string, the change vector assigned to the stored document
+        changeVector;
+    }
+    //endregion
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
@@ -1,25 +1,25 @@
 [
-  {
-    "Path": "get.markdown",
-    "Name": "Get",
-    "DiscussionId": "eafb1bd0-dd05-449e-bacc-0d5747d96385",
-    "Mappings": []
-  },
-  {
-    "Path": "put.markdown",
-    "Name": "Put",
-    "DiscussionId": "ed032e64-6fe9-4528-a4c0-893dbf4d2bf8",
-    "Mappings": []
-  },
-  {
-    "Path": "delete.markdown",
-    "Name": "Delete",
-    "DiscussionId": "603df172-c032-48c6-8f8a-ef40e721c3c0",
-    "Mappings": []
-  },
-  {
-    "Path": "/how-to",
-    "Name": "How to...",
-    "Mappings": []
-  }
+    {
+        "Path": "get.markdown",
+        "Name": "Get",
+        "DiscussionId": "eafb1bd0-dd05-449e-bacc-0d5747d96385",
+        "Mappings": []
+    },
+    {
+        "Path": "put.markdown",
+        "Name": "Put",
+        "DiscussionId": "ed032e64-6fe9-4528-a4c0-893dbf4d2bf8",
+        "Mappings": []
+    },
+    {
+        "Path": "delete.markdown",
+        "Name": "Delete",
+        "DiscussionId": "603df172-c032-48c6-8f8a-ef40e721c3c0",
+        "Mappings": []
+    },
+    {
+        "Path": "/how-to",
+        "Name": "How to...",
+        "Mappings": []
+    }
 ]


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2634/Node.js-Client-API-Commands-Documents-Put-Replace-C-samples

---

**Important notes for this PR:**
In this PR the sample code for `Node.js` was applied.
The article's text from the original C# file was Not refactored/improved.
Refactoring the C# (text & code) will be done in a separate dedicated issue 
https://issues.hibernatingrhinos.com/issue/RDoc-2637/Client-API-Commands-Fix-articles

---

**Node.js**: @ml054 
Node.js code to review is in:
```Documentation/5.4/Samples/nodejs/client-api/commands/documents/put.js```

**C# + Java**: 
Files were only copied over to v5.4, no changes were made. 