### PR TITLE
RDoc-2635 [Node.js] Client API > Commands > Documents > Delete [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/.docs.json
@@ -1,0 +1,12 @@
+﻿[
+    {
+        "Path": "/documents",
+        "Name": "Documents",
+        "Mappings": []
+    },
+    {
+        "Path": "/batches",
+        "Name": "Batches",
+        "Mappings": []
+    }
+]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
@@ -1,0 +1,25 @@
+[
+  {
+    "Path": "get.markdown",
+    "Name": "Get",
+    "DiscussionId": "eafb1bd0-dd05-449e-bacc-0d5747d96385",
+    "Mappings": []
+  },
+  {
+    "Path": "put.markdown",
+    "Name": "Put",
+    "DiscussionId": "ed032e64-6fe9-4528-a4c0-893dbf4d2bf8",
+    "Mappings": []
+  },
+  {
+    "Path": "delete.markdown",
+    "Name": "Delete",
+    "DiscussionId": "603df172-c032-48c6-8f8a-ef40e721c3c0",
+    "Mappings": []
+  },
+  {
+    "Path": "/how-to",
+    "Name": "How to...",
+    "Mappings": []
+  }
+]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.dotnet.markdown
@@ -1,0 +1,24 @@
+# Commands: Documents: Delete
+
+**Delete** is used to remove a document from a database.
+
+## Syntax
+
+{CODE delete_interface@ClientApi\Commands\Documents\Delete.cs /}
+
+| Parameters       |        |                                                                          |
+|------------------|--------|--------------------------------------------------------------------------|
+| **id**           | string | ID of a document to be deleted                                           |
+| **changeVector** | string | Entity Change Vector, used for concurrency checks (`null` to skip check) |
+
+## Example
+
+{CODE delete_sample@ClientApi\Commands\Documents\Delete.cs /}
+
+## Related Articles
+
+### Commands 
+
+- [Get](../../../client-api/commands/documents/get)  
+- [Put](../../../client-api/commands/documents/put)  
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.java.markdown
@@ -1,0 +1,24 @@
+# Commands: Documents: Delete
+
+**Delete** is used to remove a document from a database.
+
+## Syntax
+
+{CODE:java delete_interface@ClientApi\Commands\Documents\Delete.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **id** | String | ID of a document to be deleted |
+| **changeVector** | String | Entity Change Vector, used for concurrency checks (`null` to skip check) |
+
+## Example
+
+{CODE:java delete_sample@ClientApi\Commands\Documents\Delete.java /}
+
+## Related Articles
+
+### Commands 
+
+- [Get](../../../client-api/commands/documents/get)  
+- [Put](../../../client-api/commands/documents/put)  
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.js.markdown
@@ -1,0 +1,39 @@
+# Delete Document Command
+
+{NOTE: }
+
+* Use the `DeleteDocumentCommand` to remove a document from the database.
+
+* In this page:
+
+    * [Example](../../../client-api/commands/documents/delete#example)
+    * [Syntax](../../../client-api/commands/documents/delete#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Example}
+
+{CODE:nodejs delete@client-api\commands\documents\delete.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\commands\documents\delete.js /}
+
+| Parameter        | Type   | Description                                                             |
+|------------------|--------|-------------------------------------------------------------------------|
+| __id__           | string | ID of a document to be deleted                                          |
+| __changeVector__ | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
+
+{PANEL/}
+
+## Related Articles
+
+### Commands 
+
+- [Get document command](../../../client-api/commands/documents/get)  
+- [Put document command](../../../client-api/commands/documents/put)  
+- [Send multiple commands using a batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Documents/Delete.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Documents/Delete.cs
@@ -1,0 +1,33 @@
+﻿
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+
+namespace Raven.Documentation.Samples.ClientApi.Commands.Documents
+{
+    public class DeleteInterfaces
+    {
+        private class DeleteDocumentCommand
+        {
+            #region delete_interface
+            public DeleteDocumentCommand(string id, string changeVector)
+            #endregion
+            {
+            }
+        }
+    }
+
+    public class DeleteSamples
+	{
+		public void Foo()
+		{
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region delete_sample
+                var command = new DeleteDocumentCommand("employees/1-A", null);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                #endregion
+            }
+		}
+	}
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Commands/Documents/Delete.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Commands/Documents/Delete.java
@@ -1,0 +1,32 @@
+package net.ravendb.ClientApi.Commands.Documents;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.DeleteDocumentCommand;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class Delete {
+
+
+    public static class DeleteInterfaces {
+        private static class DeleteDocumentCommand {
+            //region delete_interface
+            public DeleteDocumentCommand(String id, String changeVector)
+            //endregion
+            {}
+        }
+    }
+
+    public class DeleteSamples {
+        public void foo() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region delete_sample
+                    DeleteDocumentCommand command = new DeleteDocumentCommand("employees/1-A", null);
+                    session.advanced().getRequestExecutor().execute(command);
+                    //endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/commands/documents/delete.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/commands/documents/delete.js
@@ -1,0 +1,22 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function deleteDocumentsCommand() {
+    {
+        //region delete
+        // Define the Delete Command
+        // Pass the document ID & whether to make concurrency checks
+        const deleteDocCmd = new DeleteDocumentCommand("employees/1-A", null);
+
+        // Send the command to the server using the RequestExecutor
+        await documentStore.getRequestExecutor().execute(deleteDocCmd);
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    DeleteDocumentCommand(id, changeVector);
+    //endregion
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/commands/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/commands/.docs.json
@@ -1,0 +1,12 @@
+﻿[
+    {
+        "Path": "/documents",
+        "Name": "Documents",
+        "Mappings": []
+    },
+    {
+        "Path": "/batches",
+        "Name": "Batches",
+        "Mappings": []
+    }
+]

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/commands/documents/.docs.json
@@ -1,0 +1,25 @@
+[
+  {
+    "Path": "get.markdown",
+    "Name": "Get",
+    "DiscussionId": "eafb1bd0-dd05-449e-bacc-0d5747d96385",
+    "Mappings": []
+  },
+  {
+    "Path": "put.markdown",
+    "Name": "Put",
+    "DiscussionId": "ed032e64-6fe9-4528-a4c0-893dbf4d2bf8",
+    "Mappings": []
+  },
+  {
+    "Path": "delete.markdown",
+    "Name": "Delete",
+    "DiscussionId": "603df172-c032-48c6-8f8a-ef40e721c3c0",
+    "Mappings": []
+  },
+  {
+    "Path": "/how-to",
+    "Name": "How to...",
+    "Mappings": []
+  }
+]


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2635/Node.js-Client-API-Commands-Documents-Delete-Replace-C-samples

---

**Important notes for this PR:**
In this PR the sample code for `Node.js` was applied.
The article's text from the original C# file was Not refactored/improved.
Refactoring the C# (text & code) will be done in a separate dedicated issue 
https://issues.hibernatingrhinos.com/issue/RDoc-2637/Client-API-Commands-Fix-articles

---

**Node.js**: @ml054 
Node.js code to review is in:
```Documentation/5.4/Samples/nodejs/client-api/commands/documents/delete.js```

**C# + Java**: 
Files were only copied over to v5.4, no changes were made. 