### PR TITLE
RDoc-2640 [Python] Client API > Session > Cluster transaction > Compare Exchange [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.dotnet.markdown
@@ -1,0 +1,149 @@
+# Compare Exchange in Cluster-Wide Session
+
+---
+
+{NOTE: }
+
+* Compare-Exchange items can be created and managed on the advanced session (`Session.Advanced`)  
+  Other options are listed in this [compare-exchange overview](../../../client-api/operations/compare-exchange/overview#how-to-create-and-manage-compare-exchange-items).
+
+* When working with compare-exchange items from the session,  
+  the session __must be opened as a [cluster-wide session](../../../client-api/session/cluster-transaction/overview#open-a-cluster-transaction)__.
+
+* In this page:
+    * [Create compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#create-compare-exchange)
+    * [Get compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange)
+    * [Delete compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#delete-compare-exchange)
+{NOTE/}
+
+---
+
+{PANEL: Create compare-exchange}
+
+{NOTE: }
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync new_compare_exchange_sync@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TAB:csharp:Async new_compare_exchange_async@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TABS/}
+
+* `SaveChanges()` throws a `ConcurrencyException` if the key already exists.
+* An `InvalidOperationException` exception is thrown if the session was Not opened as __cluster-wide__.
+
+{NOTE/}
+
+{NOTE: }
+__Syntax__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync methods_3_sync@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TAB:csharp:Async methods_async_3@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TABS/}
+
+| Parameters   | Type     | Description                                                        |
+|--------------|----------|--------------------------------------------------------------------|
+| **key**      | `string` | The compare-exchange item key. This string can be up to 512 bytes. |
+| **value**    | `T`      | The associated value to store for the key                          |
+
+| Return Value              | Description                               |
+|---------------------------|-------------------------------------------|
+| `CompareExchangeValue<T>` | The new compare-exchange item is returned |
+{NOTE/}
+
+{NOTE: }
+__The CompareExchangeValue__
+
+| Parameters   | Type     | Description                                                        |
+|--------------|----------|--------------------------------------------------------------------|
+| **key**      | `string` | The compare-exchange item key. This string can be up to 512 bytes. |
+| **value**    | `T`      | The value associated with the key                                  |
+| **index**    | `long`   | Index for concurrency control                                      |
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get compare-exchange}
+
+{NOTE: }
+__Get single value__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync methods_1_sync@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TAB:csharp:Async methods_async_1@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TABS/}
+
+| Parameters   | Type     | Description         |
+|--------------|----------|---------------------|
+| **key**      | `string` | The key to retrieve |
+
+| Return Value | Description |
+| ------------- | ----- |
+| `CompareExchangeValue<T>`| If the key doesn't exist it will return `null` |
+
+{NOTE/}
+
+{NOTE: }
+__Get multiple values__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync methods_2_sync@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TAB:csharp:Async methods_async_2@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TABS/}
+
+| Parameters   | Type       | Description               |
+|--------------|------------|---------------------------|
+| **keys**     | `string[]` | Array of keys to retrieve |
+
+| Return Value | Description |
+| ------------- | ----- |
+| `Dictionary<string, CompareExchangeValue<T>>` | If a key doesn't exists the associate value will be `null` |
+{NOTE/}
+
+{NOTE: }
+__Get compare-exchange lazily__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync methods_sync_lazy_1@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TAB:csharp:Async methods_async_lazy_1@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TABS/}
+
+| Parameters  | Type       | Description               |
+|-------------|------------|---------------------------|
+| **key**     | `string`   | The key to retrieve       |
+| **keys**    | `string[]` | Array of keys to retrieve |
+
+| Return Value | Description |
+| ------------- | ----- |
+| `Lazy<CompareExchangeValue<T>>`| If the key doesn't exist it will return `null` |
+| `Lazy<Dictionary<string, CompareExchangeValue<T>>>` | If a key doesn't exists the associate value will be `null` |
+{NOTE/}
+{PANEL/}
+
+{PANEL: Delete compare-exchange}
+
+{NOTE: }
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync methods_4_sync@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TAB:csharp:Async methods_async_4@ClientApi\Session\ClusterTransaction\CompareExchange.cs /}
+{CODE-TABS/}
+
+| Parameters | Type                      | Description                                    |
+|------------|---------------------------|------------------------------------------------|
+| **key**    | `string`                  | The key of the compare-exchange item to delete |
+| **index**  | `long`                    | The index of this compare-exchange item        |
+| **item**   | `CompareExchangeValue<T>` | The compare-exchange item to delete            |
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Compare-Exchange Operations
+
+- [Compare Exchange: Overview](../../../client-api/operations/compare-exchange/overview)
+- [Get a Compare-Exchange Value](../../../client-api/operations/compare-exchange/get-compare-exchange-value)
+- [Get Compare-Exchange Values](../../../client-api/operations/compare-exchange/get-compare-exchange-values)
+- [Put a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)
+- [Delete a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.js.markdown
@@ -1,0 +1,134 @@
+# Compare Exchange in Cluster-Wide Session
+
+---
+
+{NOTE: }
+
+* Compare-Exchange items can be created and managed on the advanced session (`session.advanced`)  
+  Other options are listed in this [compare-exchange overview](../../../client-api/operations/compare-exchange/overview#how-to-create-and-manage-compare-exchange-items).
+
+* When working with compare-exchange items from the session,  
+  the session __must be opened as a [cluster-wide session](../../../client-api/session/cluster-transaction/overview#open-a-cluster-transaction)__.
+
+* In this page:
+    * [Create compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#create-compare-exchange)
+    * [Get compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange)
+    * [Delete compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#delete-compare-exchange)
+      {NOTE/}
+
+---
+
+{PANEL: Create compare-exchange}
+
+{NOTE: }
+__Example__
+
+{CODE:nodejs create_compare_exchange_example@client-api\session\ClusterTransaction\CompareExchange.js /}
+
+* An `InvalidOperationException` exception is thrown when:
+  * The session was Not opened as __cluster-wide__.
+  * The key already exists in the database.
+
+{NOTE/}
+
+{NOTE: }
+__Syntax__
+
+{CODE:nodejs create_compare_exchange@client-api\session\ClusterTransaction\CompareExchange.js /}
+
+| Parameters   | Type      | Description                                                        |
+|--------------|-----------|--------------------------------------------------------------------|
+| **key**      | `string`  | The compare-exchange item key. This string can be up to 512 bytes. |
+| **value**    | `object`  | The associated value to store for the key                          |
+
+| Return value | Description                               |
+|---------------|-------------------------------------------|
+| `object`      | The new compare-exchange item is returned |
+{NOTE/}
+
+{NOTE: }
+__The compare exchange object returned__
+
+| Parameters   | Type     | Description                                                        |
+|--------------|----------|--------------------------------------------------------------------|
+| **key**      | `string` | The compare-exchange item key. This string can be up to 512 bytes. |
+| **value**    | `object` | The value associated with the key                                  |
+| **index**    | `number` | Index for concurrency control                                      |
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get compare-exchange}
+
+{NOTE: }
+__Get single value__
+
+{CODE:nodejs get_compare_exchange_1@client-api\session\ClusterTransaction\CompareExchange.js /}
+
+| Parameters   | Type     | Description                    |
+|--------------|----------|--------------------------------|
+| **key**      | `string` | The key to retrieve            |
+
+| Return value | Description                                                                     |
+|---------------|---------------------------------------------------------------------------------|
+| `object`      | The compare-exchange item is returned.<br> Returns `null` if key doesn't exist. |
+
+[key: string]: CompareExchangeValue<T>;
+
+{NOTE/}
+
+{NOTE: }
+__Get multiple values__
+
+{CODE:nodejs get_compare_exchange_2@client-api\session\ClusterTransaction\CompareExchange.js /}
+
+| Parameters  | Type        | Description               |
+|-------------|-------------|---------------------------|
+| **keys**    | `string[]`  | Array of keys to retrieve |
+
+| Return value            | Description                                                |
+|--------------------------|------------------------------------------------------------|
+| `Record<string, object>` | If a key doesn't exists the associate value will be `null` |
+{NOTE/}
+
+{NOTE: }
+__Get compare-exchange lazily__
+
+{CODE:nodejs get_compare_exchange_3@client-api\session\ClusterTransaction\CompareExchange.js /}
+
+| Parameters   | Type       | Description               |
+|--------------|------------|---------------------------|
+| **key**      | `string`   | The key to retrieve       |
+| **keys**     | `string[]` | Array of keys to retrieve |
+
+| Return value - after calling `getValue` | Description                                                                        |
+|-----------------------------------------|------------------------------------------------------------------------------------|
+| `object`                                | For single item:<br>If the key doesn't exist it will return `null`                 |
+| `Record<string, object>`                | For multiple items:<br>If a key doesn't exists the associate value will be `null`  |
+{NOTE/}
+{PANEL/}
+
+{PANEL: Delete compare-exchange}
+
+{NOTE: }
+
+{CODE:nodejs delete_compare_exchange@client-api\session\ClusterTransaction\CompareExchange.js /}
+
+| Parameters | Type     | Description                                    |
+|------------|----------|------------------------------------------------|
+| **key**    | `string` | The key of the compare-exchange item to delete |
+| **index**  | `number` | The index of this compare-exchange item        |
+| **item**   | `object` | The compare-exchange item to delete            |
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Compare-Exchange Operations
+
+- [Compare Exchange: Overview](../../../client-api/operations/compare-exchange/overview)
+- [Get a Compare-Exchange Value](../../../client-api/operations/compare-exchange/get-compare-exchange-value)
+- [Get Compare-Exchange Values](../../../client-api/operations/compare-exchange/get-compare-exchange-values)
+- [Put a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)
+- [Delete a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.python.markdown
@@ -1,0 +1,131 @@
+# Compare Exchange in Cluster-Wide Session
+
+---
+
+{NOTE: }
+
+* Compare-Exchange items can be created and managed on the advanced session (`session.advanced`)  
+  Other options are listed in this [compare-exchange overview](../../../client-api/operations/compare-exchange/overview#how-to-create-and-manage-compare-exchange-items).
+
+* When working with compare-exchange items from the session,  
+  the session __must be opened as a [cluster-wide session](../../../client-api/session/cluster-transaction/overview#open-a-cluster-transaction)__.
+
+* In this page:
+    * [Create compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#create-compare-exchange)
+    * [Get compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange)
+    * [Delete compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#delete-compare-exchange)
+{NOTE/}
+
+---
+
+{PANEL: Create compare-exchange}
+
+{NOTE: }
+__Example__
+
+{CODE:python new_compare_exchange_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
+
+* `save_changes()` throws a `ConcurrencyException` if the key already exists.
+* An `InvalidOperationException` exception is thrown if the session was Not opened as __cluster-wide__.
+
+{NOTE/}
+
+{NOTE: }
+__Syntax__
+
+{CODE:python methods_3_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
+
+| Parameters   | Type     | Description                                                        |
+|--------------|----------|--------------------------------------------------------------------|
+| **key**      | `string` | The compare-exchange item key. This string can be up to 512 bytes. |
+| **value**    | `T`      | The associated value to store for the key                          |
+
+| Return Value              | Description                               |
+|---------------------------|-------------------------------------------|
+| `CompareExchangeValue<T>` | The new compare-exchange item is returned |
+{NOTE/}
+
+{NOTE: }
+__The CompareExchangeValue__
+
+| Parameters   | Type     | Description                                                        |
+|--------------|----------|--------------------------------------------------------------------|
+| **key**      | `string` | The compare-exchange item key. This string can be up to 512 bytes. |
+| **value**    | `T`      | The value associated with the key                                  |
+| **index**    | `long`   | Index for concurrency control                                      |
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get compare-exchange}
+
+{NOTE: }
+__Get single value__
+
+{CODE:python methods_1_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
+
+| Parameters   | Type     | Description         |
+|--------------|----------|---------------------|
+| **key**      | `string` | The key to retrieve |
+
+| Return Value | Description |
+| ------------- | ----- |
+| `CompareExchangeValue<T>`| If the key doesn't exist it will return `null` |
+
+{NOTE/}
+
+{NOTE: }
+__Get multiple values__
+
+{CODE:python methods_2_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
+
+| Parameters   | Type       | Description               |
+|--------------|------------|---------------------------|
+| **keys**     | `string[]` | Array of keys to retrieve |
+
+| Return Value | Description |
+| ------------- | ----- |
+| `Dictionary<string, CompareExchangeValue<T>>` | If a key doesn't exists the associate value will be `null` |
+{NOTE/}
+
+{NOTE: }
+__Get compare-exchange lazily__
+
+{CODE:python methods_sync_lazy_1@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
+
+| Parameters  | Type       | Description               |
+|-------------|------------|---------------------------|
+| **key**     | `string`   | The key to retrieve       |
+| **keys**    | `string[]` | Array of keys to retrieve |
+
+| Return Value | Description |
+| ------------- | ----- |
+| `Lazy<CompareExchangeValue<T>>`| If the key doesn't exist it will return `null` |
+| `Lazy<Dictionary<string, CompareExchangeValue<T>>>` | If a key doesn't exists the associate value will be `null` |
+{NOTE/}
+{PANEL/}
+
+{PANEL: Delete compare-exchange}
+
+{NOTE: }
+
+{CODE:python methods_4_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
+
+| Parameters | Type                      | Description                                    |
+|------------|---------------------------|------------------------------------------------|
+| **key**    | `string`                  | The key of the compare-exchange item to delete |
+| **index**  | `long`                    | The index of this compare-exchange item        |
+| **item**   | `CompareExchangeValue<T>` | The compare-exchange item to delete            |
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Compare-Exchange Operations
+
+- [Compare Exchange: Overview](../../../client-api/operations/compare-exchange/overview)
+- [Get a Compare-Exchange Value](../../../client-api/operations/compare-exchange/get-compare-exchange-value)
+- [Get Compare-Exchange Values](../../../client-api/operations/compare-exchange/get-compare-exchange-values)
+- [Put a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)
+- [Delete a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.python.markdown
@@ -8,7 +8,7 @@
   Other options are listed in this [compare-exchange overview](../../../client-api/operations/compare-exchange/overview#how-to-create-and-manage-compare-exchange-items).
 
 * When working with compare-exchange items from the session,  
-  the session __must be opened as a [cluster-wide session](../../../client-api/session/cluster-transaction/overview#open-a-cluster-transaction)__.
+  the session **must** be opened as a [cluster-wide session](../../../client-api/session/cluster-transaction/overview#open-a-cluster-transaction).
 
 * In this page:
     * [Create compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#create-compare-exchange)
@@ -26,7 +26,7 @@ __Example__
 {CODE:python new_compare_exchange_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
 
 * `save_changes()` throws a `ConcurrencyException` if the key already exists.
-* An `InvalidOperationException` exception is thrown if the session was Not opened as __cluster-wide__.
+* A `RuntimeError` exception is thrown if the session was Not opened as __cluster-wide__.
 
 {NOTE/}
 
@@ -35,24 +35,24 @@ __Syntax__
 
 {CODE:python methods_3_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
 
-| Parameters   | Type     | Description                                                       |
-|--------------|----------|-------------------------------------------------------------------|
-| **key**      | `str`    | The compare-exchange item key. This string can be up to 512 bytes |
-| **value**    | `T`      | The associated value to store for the key                         |
+| Parameters   | Type     | Description                                                |
+|--------------|----------|------------------------------------------------------------|
+| **key**      | `str`    | The key for the compare-exchange item to be created<br>This string can be up to 512 bytes |
+| **value**    | `T`      | The value to associate with this key                       |
 
 | Return Value              | Description                               |
 |---------------------------|-------------------------------------------|
-| `CompareExchangeValue<T>` | The new compare-exchange item is returned |
+| `CompareExchangeValue[T]` | The new compare-exchange item is returned |
 {NOTE/}
 
 {NOTE: }
 __The CompareExchangeValue__
 
-| Parameters   | Type     | Description                                                        |
-|--------------|----------|--------------------------------------------------------------------|
-| **key**      | `str`    | The compare-exchange item key. This string can be up to 512 bytes. |
-| **value**    | `T`      | The value associated with the key                                  |
-| **index**    | `long`   | Index for concurrency control                                      |
+| Parameters   | Type     | Description                                                         |
+|--------------|----------|---------------------------------------------------------------------|
+| **key**      | `str`    | The compare-exchange item key<br>This string can be up to 512 bytes |
+| **value**    | `T`      | The value associated with the key                                   |
+| **index**    | `int`    | Index for concurrency control                                       |
 
 {NOTE/}
 {PANEL/}
@@ -66,11 +66,11 @@ __Get single value__
 
 | Parameters   | Type     | Description         |
 |--------------|----------|---------------------|
-| **key**      | `str`    | The key to retrieve |
+| **key**      | `str`    | The key for a compare-exchange item whose value is requested |
 
 | Return Value | Description |
 | ------------- | ----- |
-| `CompareExchangeValue<T>`| If the key doesn't exist it will return `None` |
+| `CompareExchangeValue[T]`| The requested value<br>If the key doesn't exist the value associated with it will be `None` |
 
 {NOTE/}
 
@@ -79,13 +79,13 @@ __Get multiple values__
 
 {CODE:python methods_2_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
 
-| Parameters   | Type       | Description               |
-|--------------|------------|---------------------------|
-| **keys**     | `str[]`    | Array of keys to retrieve |
+| Parameters   | Type        | Description               |
+|--------------|-------------|---------------------------|
+| **keys**     | `List[str]` | An array of compare-exchange keys whose values are requested |
 
 | Return Value | Description |
 | ------------- | ----- |
-| `Dict<str, CompareExchangeValue<T>>` | If a key doesn't exist the associated value will be `None` |
+| `Dict[str, CompareExchangeValue[T]]` | A dictionary of requested values<br>If a key doesn't exist the value associated with it will be `None` |
 {NOTE/}
 
 {NOTE: }
@@ -93,29 +93,31 @@ __Get compare-exchange lazily__
 
 {CODE:python methods_sync_lazy_1@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
 
-| Parameters  | Type       | Description               |
-|-------------|------------|---------------------------|
-| **key**     | `str`      | The key to retrieve       |
-| **keys**    | `str[]`    | Array of keys to retrieve |
+| Parameters  | Type        | Description               |
+|-------------|-------------|---------------------------|
+| **key**     | `str`       | The key for a compare-exchange item whose value is requested |
+| **keys**    | `List[str]` | An array of compare-exchange keys whose values are requested |
 
 | Return Value | Description |
 | ------------- | ----- |
-| `Lazy<CompareExchangeValue<T>>`| If the key doesn't exist it will return `None` |
-| `Lazy<Dict<str, CompareExchangeValue<T>>>` | If a key doesn't exist the associated value will be `None` |
+| `Lazy[CompareExchangeValue[T]]`| The requested value<br>If the key doesn't exist the value associated with it will be `None` |
+| `Lazy[Dict[str, CompareExchangeValue[T]]]` | A dictionary of requested values<br>If a key doesn't exist the value associated with it will be `None` |
 {NOTE/}
 {PANEL/}
 
 {PANEL: Delete compare-exchange}
 
+To delete a compare exchange item, use either of the following methods.  
+
 {NOTE: }
 
 {CODE:python methods_4_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
 
-| Parameters | Type                      | Description                                    |
-|------------|---------------------------|------------------------------------------------|
-| **key**    | `str`                     | The key of the compare-exchange item to delete |
-| **index**  | `long`                    | The index of this compare-exchange item        |
-| **item**   | `CompareExchangeValue<T>` | The compare-exchange item to delete            |
+| Parameters | Type                      | Description                                     |
+|------------|---------------------------|-------------------------------------------------|
+| **key**    | `str`                     | The key for the compare-exchange item to delete |
+| **index**  | `int`                     | The index for the compare-exchange item to delete   |
+| **item**   | `CompareExchangeValue[T]` | The compare-exchange item to delete             |
 
 {NOTE/}
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/cluster-transaction/compare-exchange.python.markdown
@@ -35,10 +35,10 @@ __Syntax__
 
 {CODE:python methods_3_sync@ClientApi\Session\ClusterTransaction\CompareExchange.py /}
 
-| Parameters   | Type     | Description                                                        |
-|--------------|----------|--------------------------------------------------------------------|
-| **key**      | `string` | The compare-exchange item key. This string can be up to 512 bytes. |
-| **value**    | `T`      | The associated value to store for the key                          |
+| Parameters   | Type     | Description                                                       |
+|--------------|----------|-------------------------------------------------------------------|
+| **key**      | `str`    | The compare-exchange item key. This string can be up to 512 bytes |
+| **value**    | `T`      | The associated value to store for the key                         |
 
 | Return Value              | Description                               |
 |---------------------------|-------------------------------------------|
@@ -50,7 +50,7 @@ __The CompareExchangeValue__
 
 | Parameters   | Type     | Description                                                        |
 |--------------|----------|--------------------------------------------------------------------|
-| **key**      | `string` | The compare-exchange item key. This string can be up to 512 bytes. |
+| **key**      | `str`    | The compare-exchange item key. This string can be up to 512 bytes. |
 | **value**    | `T`      | The value associated with the key                                  |
 | **index**    | `long`   | Index for concurrency control                                      |
 
@@ -66,11 +66,11 @@ __Get single value__
 
 | Parameters   | Type     | Description         |
 |--------------|----------|---------------------|
-| **key**      | `string` | The key to retrieve |
+| **key**      | `str`    | The key to retrieve |
 
 | Return Value | Description |
 | ------------- | ----- |
-| `CompareExchangeValue<T>`| If the key doesn't exist it will return `null` |
+| `CompareExchangeValue<T>`| If the key doesn't exist it will return `None` |
 
 {NOTE/}
 
@@ -81,11 +81,11 @@ __Get multiple values__
 
 | Parameters   | Type       | Description               |
 |--------------|------------|---------------------------|
-| **keys**     | `string[]` | Array of keys to retrieve |
+| **keys**     | `str[]`    | Array of keys to retrieve |
 
 | Return Value | Description |
 | ------------- | ----- |
-| `Dictionary<string, CompareExchangeValue<T>>` | If a key doesn't exists the associate value will be `null` |
+| `Dict<str, CompareExchangeValue<T>>` | If a key doesn't exist the associated value will be `None` |
 {NOTE/}
 
 {NOTE: }
@@ -95,13 +95,13 @@ __Get compare-exchange lazily__
 
 | Parameters  | Type       | Description               |
 |-------------|------------|---------------------------|
-| **key**     | `string`   | The key to retrieve       |
-| **keys**    | `string[]` | Array of keys to retrieve |
+| **key**     | `str`      | The key to retrieve       |
+| **keys**    | `str[]`    | Array of keys to retrieve |
 
 | Return Value | Description |
 | ------------- | ----- |
-| `Lazy<CompareExchangeValue<T>>`| If the key doesn't exist it will return `null` |
-| `Lazy<Dictionary<string, CompareExchangeValue<T>>>` | If a key doesn't exists the associate value will be `null` |
+| `Lazy<CompareExchangeValue<T>>`| If the key doesn't exist it will return `None` |
+| `Lazy<Dict<str, CompareExchangeValue<T>>>` | If a key doesn't exist the associated value will be `None` |
 {NOTE/}
 {PANEL/}
 
@@ -113,7 +113,7 @@ __Get compare-exchange lazily__
 
 | Parameters | Type                      | Description                                    |
 |------------|---------------------------|------------------------------------------------|
-| **key**    | `string`                  | The key of the compare-exchange item to delete |
+| **key**    | `str`                     | The key of the compare-exchange item to delete |
 | **index**  | `long`                    | The index of this compare-exchange item        |
 | **item**   | `CompareExchangeValue<T>` | The compare-exchange item to delete            |
 

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/ClusterTransaction/CompareExchange.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/ClusterTransaction/CompareExchange.cs
@@ -1,0 +1,157 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.CompareExchange
+{
+    class CompareExchange<T>
+    {
+        public class DNS
+        {
+            public string IpAddress;
+        }
+
+        public async Task Async()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region open_cluster_session_async
+                using (var session = store.OpenAsyncSession())
+                #endregion
+                {
+                    #region new_compare_exchange_async
+                    // The session must be first opened with cluster-wide mode
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(
+                        key: "Best NoSQL Transactional Database",
+                        value: "RavenDB"
+                    );
+                    
+                    await session.SaveChangesAsync();
+                    #endregion
+
+                    //#region update_compare_exchange_async
+                    //// load the existing dns record of ravendb.net
+                    //CompareExchangeValue<DNS> result = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<DNS>(key: "ravendb.net");
+
+                    //// change the ip
+                    //result.Value.IpAddress = "52.32.173.150";
+                    //session.Advanced.ClusterTransaction.UpdateCompareExchangeValue(result);
+                    
+                    //// save the changes
+                    //await session.SaveChangesAsync();
+                    //#endregion
+
+                    var key = "key";
+                    var keys = new[] {"key"};
+                    var index = 0L;
+                    var value = default(T);
+                    var item = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<T>(key);
+
+                    #region methods_async_1
+                    await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<T>(key);
+                    #endregion
+
+                    #region methods_async_2
+                    await session.Advanced.ClusterTransaction.GetCompareExchangeValuesAsync<T>(keys);
+                    #endregion
+
+                    #region methods_async_3
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue<T>(key, value);
+                    #endregion
+
+                    #region methods_async_4
+                    // Delete by key & index
+                    session.Advanced.ClusterTransaction.DeleteCompareExchangeValue(key, index);
+                    
+                    // Delete by compare-exchange item
+                    session.Advanced.ClusterTransaction.DeleteCompareExchangeValue<T>(item);
+                    #endregion
+
+                    //#region methods_async_5
+                    //session.Advanced.ClusterTransaction.UpdateCompareExchangeValue(new CompareExchangeValue<T>(key, index, value));
+                    //#endregion
+
+                    #region methods_async_lazy_1
+                    // Single value
+                    session.Advanced.ClusterTransaction.Lazily.GetCompareExchangeValueAsync<T>(key);
+
+                    // Multiple values
+                    session.Advanced.ClusterTransaction.Lazily.GetCompareExchangeValuesAsync<T>(keys);
+                    #endregion
+                }
+            }
+        }
+
+        public void Sync()
+        {
+            using (var store = new DocumentStore())
+            {
+
+                #region open_cluster_session_sync
+                using (var session = store.OpenSession())
+                #endregion
+                {
+                    #region new_compare_exchange_sync
+                    // The session must be first opened with cluster-wide mode
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(
+                        key: "Best NoSQL Transactional Database",
+                        value: "RavenDB"
+                    );
+                    
+                    session.SaveChanges();
+                    #endregion
+
+                    //#region update_compare_exchange_sync
+                    //// load the existing dns record of ravendb.net
+                    //CompareExchangeValue<DNS> result = session.Advanced.ClusterTransaction.GetCompareExchangeValue<DNS>(key: "ravendb.net");
+
+                    //// change the ip
+                    //result.Value.IpAddress = "52.32.173.150";
+                    //session.Advanced.ClusterTransaction.UpdateCompareExchangeValue(result);
+
+                    //// save the changes
+                    //session.SaveChanges();
+                    //#endregion
+
+
+                    var key = "key";
+                    var keys = new[] { "key" };
+                    var index = 0L;
+                    var value = default(T);
+                    var item = session.Advanced.ClusterTransaction.GetCompareExchangeValue<T>(key);
+                    
+                    #region methods_1_sync
+                    session.Advanced.ClusterTransaction.GetCompareExchangeValue<T>(key);
+                    #endregion
+
+                    #region methods_2_sync
+                    session.Advanced.ClusterTransaction.GetCompareExchangeValues<T>(keys);
+                    #endregion
+
+                    #region methods_3_sync
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue<T>(key, value);
+                    #endregion
+
+                    #region methods_4_sync
+                    // Delete by key & index
+                    session.Advanced.ClusterTransaction.DeleteCompareExchangeValue(key, index);
+                    
+                    // Delete by compare-exchange item
+                    session.Advanced.ClusterTransaction.DeleteCompareExchangeValue<T>(item);
+                    #endregion
+
+                    //#region methods_5_sync
+                    //session.Advanced.ClusterTransaction.UpdateCompareExchangeValue(new CompareExchangeValue<T>(key, index, value));
+                    //#endregion
+
+                    #region methods_sync_lazy_1
+                    // Single value
+                    session.Advanced.ClusterTransaction.Lazily.GetCompareExchangeValue<T>(key);
+                    
+                    // Multiple values
+                    session.Advanced.ClusterTransaction.Lazily.GetCompareExchangeValues<T>(keys);
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/ClusterTransaction/compareExchange.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/ClusterTransaction/compareExchange.js
@@ -1,0 +1,53 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+class Syntax {
+    //region create_compare_exchange
+    session.advanced.clusterTransaction.createCompareExchangeValue(key, item);
+    //endregion
+
+    //region get_compare_exchange_1
+    await session.advanced.clusterTransaction.getCompareExchangeValue(key);
+    //endregion
+
+    //region get_compare_exchange_2
+    await session.advanced.clusterTransaction.getCompareExchangeValues(keys);
+    //endregion
+
+    //region get_compare_exchange_3
+    // Single item
+    const lazyItem = session.advanced.clusterTransaction.lazily.getCompareExchangeValue(key);
+    const item = await lazyItem.getValue();
+
+    // Multiple items
+    const lazyItems = session.advanced.clusterTransaction.lazily.getCompareExchangeValues(keys);
+    const items = await lazyItems.getValue();
+    //endregion
+
+    //region delete_compare_exchange
+    // Delete by key & index
+    session.advanced.clusterTransaction.deleteCompareExchangeValue(key, index);
+    
+    // Delete by compare-exchange item
+    session.advanced.clusterTransaction.deleteCompareExchangeValue(item);
+    //endregion
+}
+
+
+async function examples() {
+    {
+        //region create_compare_exchange_example
+        // The session must be first opened with cluster-wide mode
+        const session = documentStore.openSession({
+            transactionMode: "ClusterWide"
+        });
+        
+        session.advanced.clusterTransaction.createCompareExchangeValue(
+            "Best NoSQL Transactional Database", "RavenDB"  // key, value
+        );
+        
+        await session.saveChanges();
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/ClusterTransaction/CompareExchange.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/ClusterTransaction/CompareExchange.py
@@ -1,0 +1,62 @@
+from ravendb import SessionOptions, TransactionMode
+from examples_base import ExamplesBase
+
+
+class HowToQuery(ExamplesBase):
+    class DNS:
+        def __init__(self, ip_address: str = None):
+            ip_address = ip_address
+
+    def setUp(self):
+        super().setUp()
+
+    def test_sync(self):
+        with self.embedded_server.get_document_store("ClusterTransactionCompareExchangeSync") as store:
+            # region_cluster_session_sync
+            with store.open_session(
+                session_options=SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
+            ) as session:
+                # endregion
+                # region new_compare_exchange_sync
+                # The session must be first opened with cluster-wide mode
+                session.advanced.cluster_transaction.create_compare_exchange_value(
+                    key="Best NoSQL Transactional Database",
+                    item="RavenDB",
+                )
+
+                session.save_changes()
+                # endregion
+                key = "key"
+                key1 = "Best NoSQL Transactional Database"
+                keys = ["key"]
+                index = 0
+                value = ""
+                item = session.advanced.cluster_transaction.get_compare_exchange_value(key1)
+
+                # region methods_1_sync
+                session.advanced.cluster_transaction.get_compare_exchange_value(key)
+                # endregion
+
+                # region methods_2_sync
+                session.advanced.cluster_transaction.get_compare_exchange_values(keys, str)
+                # endregion
+
+                # region methods_3_sync
+                session.advanced.cluster_transaction.create_compare_exchange_value(key, value)
+                # endregion
+
+                # region methods_4_sync
+                # Delete by key & index
+                session.advanced.cluster_transaction.delete_compare_exchange_value(key, index)
+
+                # Delete by compare-exchange item
+                session.advanced.cluster_transaction.delete_compare_exchange_value(item)
+                # endregion
+
+                # region methods_sync_lazy_1
+                # Single value
+                session.advanced.cluster_transaction.lazily.get_compare_exchange_value(key)
+
+                # Multiple values
+                session.advanced.cluster_transaction.lazily.get_compare_exchange_values(keys)
+                # endregion


### PR DESCRIPTION
Related issue:
[RDoc-2640](https://issues.hibernatingrhinos.com/issue/RDoc-2640/Python-Client-API-Session-Cluster-transaction-Compare-Exchange-Replace-C-samples)