### PR TITLE
RDoc-2322 [Node.js] Client API > Session > Configuration > Disable caching [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
@@ -42,7 +42,7 @@
     },
     {
         "Path": "how-to-disable-caching.markdown",
-        "Name": "How to Disable Caching",
+        "Name": "Disable Caching",
         "DiscussionId": "a1765e03-347e-44bb-9637-046fb7a08235",
         "Mappings": []
     }

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.dotnet.markdown
@@ -1,0 +1,27 @@
+# Disable Caching per Session
+
+To reduce the overhead of sending the documents over the network, 
+client library is caching the HTTP responses and sends only ETags to Server. 
+
+If the request was previously cached giving the Server an opportunity to send back `304 Not Modified` 
+without any content data or sending the up-to-date results, this will update the cache. 
+
+This behavior can be changed globally by disabling the HTTP Cache size (more [here](../../../client-api/configuration/conventions#maxhttpcachesize)), 
+but can also be changed per session using the `SessionOptions.NoCaching` property.
+
+## Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_caching@ClientApi\Session\Configuration\DisableCaching.cs /}
+{CODE-TAB:csharp:Async disable_caching_async@ClientApi\Session\Configuration\DisableCaching.cs /}
+{CODE-TABS/}
+
+## Related Articles
+
+### Session
+
+- [What is a session and how does it work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a session](../../../client-api/session/opening-a-session)
+- [Storing entities](../../../client-api/session/storing-entities)
+- [Loading entities](../../../client-api/session/loading-entities)
+- [Saving changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.java.markdown
@@ -1,0 +1,24 @@
+# Disable Caching per Session
+
+To reduce the overhead of sending the documents over the network, 
+client library is caching the HTTP responses and sends only ETags to Server. 
+
+If the request was previously cached giving the Server an opportunity to send back `304 Not Modified` 
+without any content data or sending the up-to-date results, this will update the cache.  
+
+This behavior can be changed globally by disabling the HTTP Cache size (more [here](../../../client-api/configuration/conventions#maxhttpcachesize)), 
+but can also be changed per session using the `sessionOptions.noCaching` property.
+
+## Example
+
+{CODE:java disable_caching@ClientApi\Session\Configuration\DisableCaching.java /}
+
+## Related Articles
+
+### Session
+
+- [What is a session and how does it work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a session](../../../client-api/session/opening-a-session)
+- [Storing entities](../../../client-api/session/storing-entities)
+- [Loading entities](../../../client-api/session/loading-entities)
+- [Saving changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.js.markdown
@@ -1,0 +1,24 @@
+# Disable Caching per Session
+
+To reduce the overhead of sending the documents over the network, 
+client library is caching the HTTP responses and sends only ETags to Server. 
+
+If the request was previously cached giving the Server an opportunity to send back `304 Not Modified` 
+without any content data or sending the up-to-date results, this will update the cache. 
+
+This behavior can be changed globally by disabling the HTTP Cache size (more [here](../../../client-api/configuration/conventions#maxhttpcachesize)), 
+but can also be changed per session using the `SessionOptions.noCaching` property.
+
+## Example
+
+{CODE:nodejs disable_caching@client-api\session\configuration\disableCaching.js /}
+
+## Related Articles
+
+### Session
+
+- [What is a session and how does it work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a session](../../../client-api/session/opening-a-session)
+- [Storing entities](../../../client-api/session/storing-entities)
+- [Loading entities](../../../client-api/session/loading-entities)
+- [Saving changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableCaching.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableCaching.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class DisableCaching
+    {
+        public async Task Sample()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region disable_caching
+                using (IDocumentSession Session = store.OpenSession(new SessionOptions
+                {
+                    NoCaching = true
+                }))
+                {
+                    // code here
+                }
+                #endregion
+
+                #region disable_caching_async
+                using (IAsyncDocumentSession Session = store.OpenAsyncSession(new SessionOptions
+                {
+                    NoCaching = true
+                }))
+                {
+                    // async code here
+                }
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/DisableCaching.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/DisableCaching.java
@@ -1,0 +1,28 @@
+package net.ravendb.ClientApi.Session;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.client.documents.session.SessionOptions;
+import net.ravendb.client.documents.session.TransactionMode;
+import net.ravendb.client.http.RequestExecutor;
+import net.ravendb.northwind.Employee;
+import org.junit.Assert;
+
+public class DisableCaching {
+
+    public DisableCaching() {
+        String databaseName = "DB1";
+
+        try (IDocumentStore store = new DocumentStore()) {
+        
+           //region disable_caching
+           SessionOptions sessionOptions = new SessionOptions();
+           sessionOptions.setNoCaching(true);
+           try (IDocumentSession session = store.openSession(sessionOptions)) {
+               // code here
+           }
+           //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/configuration/disableCaching.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/configuration/disableCaching.js
@@ -1,0 +1,23 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+async function disableCaching() {
+    
+    {
+        const documentStore = new DocumentStore();
+
+        //region disable_caching
+        // Define the session's options object
+        const sessionOptions: SessionOptions = {
+            noCaching: true // Disable caching
+        };
+
+        // Open the session, pass the options object 
+        const session = store.openSession(sessionOptions);
+        
+        // The session will not cache any HTTP response data from the server
+        //endregion
+    }
+    
+}
+

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/.docs.json
@@ -42,7 +42,7 @@
     },
     {
         "Path": "how-to-disable-caching.markdown",
-        "Name": "How to Disable Caching",
+        "Name": "Disable Caching",
         "DiscussionId": "a1765e03-347e-44bb-9637-046fb7a08235",
         "Mappings": []
     }


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2322/Node.js-Client-API-Session-Configuration-Disable-caching-Replace-C-samples

---

**Important notes for this PR:**
* In this PR the sample code for `Node.js` was applied.
  The article's text from the original C# file was NOT refactored/improved.
* Refactoring the C# (text & code) will be done in a separate dedicated issue:
   https://issues.hibernatingrhinos.com/issue/RDoc-2668/Client-API-Caching-Fix-articles

---

**Node.js**: @ml054 
Node.js code to review is in:
```Documentation/5.4/Samples/nodejs/client-api/session/configuration/disableCaching.js```

**C# + Java**: 
Files were only copied over to v5.4, no changes were made. 