### PR TITLE
RDoc-2690 [Node.js] Document extensions > Attachments > Copy, move, rename [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/copying-moving-renaming.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/copying-moving-renaming.dotnet.markdown
@@ -1,0 +1,65 @@
+# Attachments: Copy, Move, Rename
+
+Attachments can be copied, moved, or renamed using built-in session methods.  
+All of those actions are executed when `SaveChanges` is called and take place on the server-side,  
+removing the need to transfer the entire attachment binary data over the network in order to perform the action.
+
+{PANEL: Copy attachment}
+
+Attachment can be copied using one of the `session.Advanced.Attachments.Copy` methods:
+
+### Syntax
+
+{CODE copy_0@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync copy_1@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+{CODE-TAB:csharp:Async copy_2@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Move attachment}
+
+Attachment can be moved using one of the `session.Advanced.Attachments.Move` methods:
+
+### Syntax
+
+{CODE move_0@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync move_1@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+{CODE-TAB:csharp:Async move_2@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Rename attachment}
+
+Attachment can be renamed using one of the `session.Advanced.Attachments.Rename` methods:
+
+### Syntax
+
+{CODE rename_0@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+
+### Example
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync rename_1@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+{CODE-TAB:csharp:Async rename_2@DocumentExtensions\Attachments\CopyMoveRename.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+## Related Articles
+
+### Attachments
+
+- [What are Attachments](../../document-extensions/attachments/what-are-attachments)
+- [Storing](../../document-extensions/attachments/storing)
+- [Loading](../../document-extensions/attachments/loading)
+- [Deleting](../../document-extensions/attachments/deleting)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/copying-moving-renaming.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/copying-moving-renaming.java.markdown
@@ -1,0 +1,56 @@
+# Attachments: Copy, Move, Rename
+
+Attachments can be copied, moved, or renamed using built-in session methods.  
+All of those actions are executed when `saveChanges` is called and take place on the server-side,  
+removing the need to transfer the entire attachment binary data over the network in order to perform the action.
+
+{PANEL: Copy attachment}
+
+Attachment can be copied using one of the `session.advanced().attachments().copy` methods:
+
+### Syntax
+
+{CODE:java copy_0@DocumentExtensions\Attachments\CopyMoveRename.java /}
+
+### Example
+
+{CODE:java copy_1@DocumentExtensions\Attachments\CopyMoveRename.java /}
+
+{PANEL/}
+
+{PANEL: Move attachment}
+
+Attachment can be moved using one of the `session.advanced().attachments().move` methods:
+
+### Syntax
+
+{CODE:java move_0@DocumentExtensions\Attachments\CopyMoveRename.java /}
+
+### Example
+
+{CODE:java move_1@DocumentExtensions\Attachments\CopyMoveRename.java /}
+
+{PANEL/}
+
+{PANEL: Rename attachment}
+
+Attachment can be renamed using one of the `session.advanced().attachments().rename` methods:
+
+### Syntax
+
+{CODE:java rename_0@DocumentExtensions\Attachments\CopyMoveRename.java /}
+
+### Example
+
+{CODE:java rename_1@DocumentExtensions\Attachments\CopyMoveRename.java /}
+
+{PANEL/}
+
+## Related Articles
+
+### Attachments
+
+- [What are Attachments](../../document-extensions/attachments/what-are-attachments)  
+- [Storing](../../document-extensions/attachments/storing)  
+- [Loading](../../document-extensions/attachments/loading)  
+- [Deleting](../../document-extensions/attachments/deleting)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/copying-moving-renaming.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/copying-moving-renaming.js.markdown
@@ -1,0 +1,88 @@
+# Attachments: Copy, Move, Rename
+---
+
+{NOTE: }
+
+* Attachments can be copied, moved, or renamed using built-in session methods.  
+
+* All of those actions are executed when `saveChanges` is called and take place on the server-side,  
+  removing the need to transfer the entire attachment binary data over the network in order to perform the action.
+
+* In this page:  
+  * [Copy attachment](../../document-extensions/attachments/copying-moving-renaming#copy-attachment)
+  * [Move attachment](../../document-extensions/attachments/copying-moving-renaming#move-attachment)
+  * [Rename attachment](../../document-extensions/attachments/copying-moving-renaming#rename-attachment)
+  * [Syntax](../../document-extensions/attachments/copying-moving-renaming#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Copy attachment}
+
+Use `session.advanced.attachments.copy` to copy an attachment from one document to another.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Copy_with_entity copy_1@documentExtensions\attachments\copyMoveRename.js /}
+{CODE-TAB:nodejs:Copy_with_document_ID copy_2@documentExtensions\attachments\copyMoveRename.js /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Move attachment}
+
+Use `session.advanced.attachments.move` to move an attachment from one document to another.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Move_with_entity move_1@documentExtensions\attachments\copyMoveRename.js /}
+{CODE-TAB:nodejs:Move_with_document_ID move_2@documentExtensions\attachments\copyMoveRename.js /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Rename attachment}
+
+Use `session.advanced.attachments.rename` to rename an attachment.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Rename_with_entity rename_1@documentExtensions\attachments\copyMoveRename.js /}
+{CODE-TAB:nodejs:Rename_with_document_ID rename_2@documentExtensions\attachments\copyMoveRename.js /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_copy@documentExtensions\attachments\copyMoveRename.js /}
+
+{CODE:nodejs syntax_move@documentExtensions\attachments\copyMoveRename.js /}
+
+| Parameter                 | Type     | Description                 |
+|---------------------------|----------|-----------------------------|
+| __sourceEntity__          | `object` | Source entity               |
+| __destinationEntity__     | `object` | Destination entity          |
+| __sourceDocumentId__      | string   | Source document Id          |
+| __destinationDocumentId__ | string   | Destination document Id     |
+| __sourceName__            | string   | Source attachment name      |
+| __destinationName__       | string   | Destination attachment name |
+
+
+{CODE:nodejs syntax_rename@documentExtensions\attachments\copyMoveRename.js /}
+
+| Parameter      | Type     | Description                     |
+|----------------|----------|---------------------------------|
+| __entity__     | `object` | The document entity             |
+| __documentId__ | string   | The document Id                 |
+| __name__       | string   | Current name of attachment      |
+| __newName__    | string   | The new name for the attachment |
+
+{PANEL/}
+
+## Related Articles
+
+### Attachments
+
+- [What are Attachments](../../document-extensions/attachments/what-are-attachments)
+- [Storing](../../document-extensions/attachments/storing)
+- [Loading](../../document-extensions/attachments/loading)
+- [Deleting](../../document-extensions/attachments/deleting)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Attachments/CopyMoveRename.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Attachments/CopyMoveRename.cs
@@ -1,0 +1,114 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Attachments
+{
+    public class CopyMoveRename
+    {
+        private interface IFoo
+        {
+            #region copy_0
+            void Copy(
+                object sourceEntity,
+                string sourceName,
+                object destinationEntity,
+                string destinationName);
+
+            void Copy(
+                string sourceDocumentId,
+                string sourceName,
+                string destinationDocumentId,
+                string destinationName);
+            #endregion
+
+            #region rename_0
+            void Rename(object entity, string name, string newName);
+
+            void Rename(string documentId, string name, string newName);
+            #endregion
+
+            #region move_0
+            void Move(object sourceEntity, string sourceName, object destinationEntity, string destinationName);
+
+            void Move(string sourceDocumentId, string sourceName, string destinationDocumentId, string destinationName);
+            #endregion
+        }
+
+        public async Task Sample()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region copy_1
+                    var employee1 = session.Load<Employee>("employees/1-A");
+                    var employee2 = session.Load<Employee>("employees/2-A");
+
+                    session.Advanced.Attachments.Copy(employee1, "photo.jpg", employee2, "photo-copy.jpg");
+
+                    session.SaveChanges();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region copy_2
+                    var employee1 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+                    var employee2 = await asyncSession.LoadAsync<Employee>("employees/2-A");
+
+                    asyncSession.Advanced.Attachments.Copy(employee1, "photo.jpg", employee2, "photo-copy.jpg");
+
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region rename_1
+                    var employee = session.Load<Employee>("employees/1-A");
+
+                    session.Advanced.Attachments.Rename(employee, "photo.jpg", "photo-new.jpg");
+
+                    session.SaveChanges();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region rename_2
+                    var employee = await asyncSession.LoadAsync<Employee>("employees/1-A");
+
+                    asyncSession.Advanced.Attachments.Rename(employee, "photo.jpg", "photo-new.jpg");
+
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region move_1
+                    var employee1 = session.Load<Employee>("employees/1-A");
+                    var employee2 = session.Load<Employee>("employees/2-A");
+
+                    session.Advanced.Attachments.Move(employee1, "photo.jpg", employee2, "photo.jpg");
+
+                    session.SaveChanges();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region move_2
+                    var employee1 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+                    var employee2 = await asyncSession.LoadAsync<Employee>("employees/2-A");
+
+                    asyncSession.Advanced.Attachments.Move(employee1, "photo.jpg", employee2, "photo.jpg");
+
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/DocumentExtensions/Attachments/CopyMoveRename.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/DocumentExtensions/Attachments/CopyMoveRename.java
@@ -1,0 +1,76 @@
+package net.ravendb.ClientApi.Session.attachments;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.northwind.Employee;
+
+public class CopyMoveRename {
+
+    private interface IFoo {
+        //region copy_0
+        void copy(Object sourceEntity, String sourceName,
+                  Object destinationEntity, String destinationName);
+
+        void copy(String sourceDocumentId, String sourceName,
+                  String destinationDocumentId, String destinationName);
+        //endregion
+
+        //region rename_0
+        void rename(Object entity, String name, String newName);
+
+        void rename(String documentId, String name, String newName);
+        //endregion
+
+        //region move_0
+        void move(Object sourceEntity, String sourceName,
+                  Object destinationEntity, String destinationName);
+
+        void move(String sourceDocumentId, String sourceName,
+                  String destinationDocumentId, String destinationName);
+        //endregion
+    }
+
+    public void sample() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region copy_1
+                Employee employee1 = session.load(Employee.class, "employees/1-A");
+                Employee employee2 = session.load(Employee.class, "employees/2-A");
+
+                session.advanced()
+                    .attachments()
+                    .copy(employee1, "photo.jpg", employee2, "photo-copy.jpg");
+
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region rename_1
+                Employee employee1 = session.load(Employee.class, "employees/1-A");
+
+                session.advanced()
+                    .attachments()
+                    .rename(employee1, "photo.jpg", "photo-new.jpg");
+
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region move_1
+
+                Employee employee1 = session.load(Employee.class, "employees/1-A");
+                Employee employee2 = session.load(Employee.class, "employees/2-A");
+
+                session.advanced()
+                    .attachments()
+                    .copy(employee1, "photo.jpg", employee2, "photo.jpg");
+
+                session.saveChanges();
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/attachments/copyMoveRename.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/attachments/copyMoveRename.js
@@ -1,0 +1,99 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function copyMoveRenameAttachment() {
+    {
+        //region copy_1
+        // Load entities
+        const employee1 = await session.load("employees/1-A");
+        const employee2 = await session.load("employees/2-A");
+
+        // Call method 'copy'
+        // Copy attachment from employee1 to employee2
+        session.advanced.attachments.copy(employee1, "photo.jpg", employee2, "photo-copy.jpg");
+
+        // Attachment will be copied on the server-side only when saveChanges is called
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region copy_2
+        // Call method 'copy'
+        // Copy attachment from "employees/1-A" to "employees/2-A"
+        session.advanced.attachments.copy("employees/1-A", "photo.jpg", "employees/2-A", "photo-copy.jpg");
+
+        // Attachment will be copied on the server-side only when saveChanges is called
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region move_1
+        // Load entities 
+        const employee1 = await session.load("employees/1-A");
+        const employee2 = await session.load("employees/2-A");
+
+        // Call method 'move'
+        // Move attachment from employee1 to employee2
+        session.advanced.attachments.move(employee1, "photo.jpg", employee2, "photo.jpg");
+
+        // Attachment will be moved on the server-side only when saveChanges is called
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region move_2
+        // Call method 'move'
+        // Move attachment from "employees/1-A" to "employees/2-A"
+        session.advanced.attachments.move("employees/1-A", "photo.jpg", "employees/2-A", "photo.jpg");
+
+        // Attachment will be moved on the server-side only when saveChanges is called
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region rename_1
+        // Load entity
+        const employee = await session.load("employees/1-A");
+
+        // Call method 'rename'
+        // Rename "photo.jpg"
+        session.advanced.attachments.rename(employee, "photo.jpg", "photo-new.jpg");
+
+        // Attachment will be renamed on the server-side only when saveChanges is called
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region rename_2
+        // Call method 'rename'
+        // Rename "photo.jpg"
+        session.advanced.attachments.rename("employees/1-A", "photo.jpg", "photo-new.jpg");
+
+        // Attachment will be renamed on the server-side only when saveChanges is called
+        await session.saveChanges();
+        //endregion
+    }
+}
+
+//region syntax_copy
+// Copy - available overloads:
+// ===========================
+copy(sourceEntity, sourceName, destinationEntity, destinationName);
+copy(sourceDocumentId, sourceName, destinationDocumentId, destinationName);
+//endregion
+
+//region syntax_move
+// Move - a vailable overloads:
+// ============================
+move(sourceEntity, sourceName, destinationEntity, destinationName);
+move(sourceDocumentId, sourceName, destinationDocumentId, destinationName);
+//endregion
+
+//region syntax_rename
+// Rename - available overloads:
+// =============================
+rename(entity, name, newName);
+rename(documentId, name, newName);
+//endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2690/Node.js-Document-extensions-Attachments-Copy-move-rename-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied + menu was organized in the Node.js article
  The article's text from the original C# file was Not improved

* Fixes to the C# article will be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2696/Document-extensions-Attachments-Copy-move-rename-Fix-article

---

**Node.js**: @ml054 

* Node.js code to review is in:
   ```Documentation/5.4/Samples/nodejs/documentExtensions/attachments/copyMoveRename.js```

**C# + Java**: 

* Files were only copied over to v5.4