### PR TITLE
RDoc-2697 [Node.js] Document extensions > Attachments > Indexing [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.dotnet.markdown
@@ -3,6 +3,8 @@
 
 {NOTE: }
 
+* Indexing attachments allows you to query for documents based on their attachments' details and content.
+
 * __Static indexes__:   
   Both attachments' details and content can be indexed within a static-index definition.
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.dotnet.markdown
@@ -4,7 +4,7 @@
 {NOTE: }
 
 * __Static indexes__:   
-  Both attachments' details and content can be within inside a static-index definition.
+  Both attachments' details and content can be indexed within a static-index definition.
 
 * __Auto-indexes__:  
   Auto-indexing attachments via dynamic queries is not available at this time.

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.dotnet.markdown
@@ -1,0 +1,116 @@
+# Index Attachments
+---
+
+{NOTE: }
+
+* __Static indexes__:   
+  Both attachments' details and content can be within inside a static-index definition.
+
+* __Auto-indexes__:  
+  Auto-indexing attachments via dynamic queries is not available at this time.
+
+
+* In this page:  
+  * [Syntax](../../document-extensions/attachments/indexing#syntax)  
+  * [Examples](../../document-extensions/attachments/indexing#examples)  
+  * [Leveraging indexed attachments](../../document-extensions/attachments/indexing#leveraging-indexed-attachments)  
+
+{NOTE/}
+
+---
+
+{PANEL: Syntax}
+
+### Using AttachmentsFor()
+
+The `AttachmentsFor` method returns information about each attachment that extends 
+a specified document, including their names, sizes, and content type.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Method syntax@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TAB:csharp:Result result@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TABS/}
+
+The `AttachmentsFor` method is available in `AbstractIndexCreationTask`.
+
+### Using LoadAttachment()/LoadAttachments()
+
+`LoadAttachment()` loads an attachment to the index by document and attachment name.  
+`LoadAttachments()` loads all the attachments of a given document.  
+
+{CODE:csharp syntax_2@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **doc** | A server-side document, an entity | The document whose attachments you want to load |
+| **name** | `string` | The name of the attachment you want to load |
+
+#### GetContentAs Methods
+
+To access the attachment content itself, use `GetContentAsStream()`. To 
+convert the content into a `string`, use `GetContentAsString()` with 
+the desired character encoding.  
+
+{CODE-BLOCK: csharp}
+public Stream GetContentAsStream();
+
+public string GetContentAsString(Encoding encoding);
+
+public string GetContentAsString(); // Default: UTF-8
+{CODE-BLOCK/}
+
+{PANEL/}
+
+{PANEL: Examples}
+
+#### Indexes with `AttachmentsFor()`
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ-syntax AttFor_index_LINQ@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TAB:csharp:JavaScript-syntax AttFor_index_JS@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TABS/}
+
+#### Indexes with `LoadAttachment()`
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ-syntax LoadAtt_index_LINQ@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TAB:csharp:JavaScript-syntax LoadAtt_index_JS@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TABS/}
+
+#### Indexes with `LoadAttachments()`
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ-syntax LoadAtts_index_LINQ@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TAB:csharp:JavaScript-syntax LoadAtts_index_JS@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TABS/}
+
+#### Querying the Index
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync query1@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TAB:csharp:Async query2@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TAB:csharp:DocumentQuery query3@DocumentExtensions\Attachments\IndexingAttachments.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Leveraging indexed attachments}
+
+* Access to the indexed attachment content opens the door to many different applications,  
+  including many that can be integrated directly into RavenDB.
+
+* In this [blog post](https://ayende.com/blog/192001-B/using-machine-learning-with-ravendb),
+  Oren Eini demonstrates how image recognition can be applied to indexed attachments using the [additional sources](../../indexes/extending-indexes) feature.
+  The resulting index allows filtering and querying based on image content.
+
+{PANEL/}
+
+## Related Articles
+
+### Document Extensions
+
+- [What are Attachments](../../document-extensions/attachments/what-are-attachments)  
+
+### Indexes
+
+- [What are Indexes](../../indexes/what-are-indexes)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.java.markdown
@@ -3,6 +3,8 @@
 
 {NOTE: }
 
+* Indexing attachments allows you to query for documents based on their attachments' details and content.
+
 * __Static indexes__:   
   Both attachments' details and content can be indexed within a static-index definition.
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.java.markdown
@@ -1,0 +1,110 @@
+# Index Attachments
+---
+
+{NOTE: }
+
+* __Static indexes__:   
+  Both attachments' details and content can be indexed within a static-index definition.
+
+* __Auto-indexes__:  
+  Auto-indexing attachments via dynamic queries is not available at this time.
+
+* In this page:  
+  * [Syntax](../../document-extensions/attachments/indexing#syntax)  
+  * [Examples](../../document-extensions/attachments/indexing#examples)  
+  * [Leveraging indexed attachments](../../document-extensions/attachments/indexing#leveraging-indexed-attachments)  
+
+{NOTE/}
+
+---
+
+{PANEL: Syntax}
+
+### Using AttachmentsFor()
+
+The `AttachmentsFor` method returns information about each attachment that extends 
+a specified document, including their names, sizes, and content type. write index definition as string.
+
+{CODE-TABS}
+{CODE-TAB:java:Method syntax@DocumentExtensions\Attachments\IndexingAttachments.java /}
+{CODE-TAB:java:AttachmentName result@DocumentExtensions\Attachments\IndexingAttachments.java /}
+{CODE-TABS/}
+
+The `AttachmentsFor` method is available in `AbstractIndexCreationTask`.
+
+### Using LoadAttachment()/LoadAttachments()
+
+`LoadAttachment()` loads an attachment to the index by document and attachment name.  
+`LoadAttachments()` loads all the attachments of a given document.  
+
+{CODE:java syntax_2@DocumentExtensions\Attachments\IndexingAttachments.java /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **doc** | A server-side document, an entity | The document whose attachments you want to load |
+| **name** | `String` | The name of the attachment you want to load |
+
+#### GetContentAs Methods
+
+To access the attachment content itself, use `GetContentAsStream()`. To 
+convert the content into a `string`, use `GetContentAsString()` with 
+the desired character encoding.  
+
+{CODE-BLOCK: csharp}
+public Stream GetContentAsStream();
+
+public string GetContentAsString(Encoding encoding);
+
+public string GetContentAsString(); // Default: UTF-8
+{CODE-BLOCK/}
+
+{PANEL/}
+
+{PANEL: Examples}
+
+#### Indexes with `AttachmentsFor()`
+
+{CODE-TABS}
+{CODE-TAB:java:JavaScript-syntax AttFor_index_JS@DocumentExtensions\Attachments\IndexingAttachments.java /}
+{CODE-TABS/}
+
+#### Indexes with `LoadAttachment()`
+
+{CODE-TABS}
+{CODE-TAB:java:JavaScript-syntax LoadAtt_index_JS@DocumentExtensions\Attachments\IndexingAttachments.java /}
+{CODE-TABS/}
+
+#### Indexes with `LoadAttachments()`
+
+{CODE-TABS}
+{CODE-TAB:java:JavaScript-syntax LoadAtts_index_JS@DocumentExtensions\Attachments\IndexingAttachments.java /}
+{CODE-TABS/}
+
+#### Querying the Index
+
+
+{CODE:java query1@DocumentExtensions\Attachments\IndexingAttachments.java /}
+
+{PANEL/}
+
+{PANEL: Leveraging indexed attachments}
+
+* Access to the indexed attachment content opens the door to many different applications,  
+  including many that can be integrated directly into RavenDB.
+
+* In this [blog post](https://ayende.com/blog/192001-B/using-machine-learning-with-ravendb),
+  Oren Eini demonstrates how image recognition can be applied to indexed attachments using the [additional sources](../../indexes/extending-indexes) feature.
+  The resulting index allows filtering and querying based on image content.
+
+{PANEL/}
+
+
+## Related Articles
+
+### Document Extensions
+
+- [What are Attachments](../../document-extensions/attachments/what-are-attachments)  
+
+### Indexes
+
+- [What are Indexes](../../indexes/what-are-indexes)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.js.markdown
@@ -3,7 +3,9 @@
 
 {NOTE: }
 
-* __Static indexes__:   
+* Indexing attachments allows you to query for documents based on their attachments' details and content.
+
+* __Static indexes__:  
   Both attachments' details and content can be indexed within a static-index definition.
 
 * __Auto-indexes__:  
@@ -29,8 +31,9 @@ __The index__:
 ---
 
 * To index attachments' details, call `attachmentsFor()` within the index definition.  
-  `attachmentsFor()` provides access to the __name__, __size__, __hash__, and __content-type__ of each attachment a document has.
-   These details can then be used when defining the index-fields.
+
+* `attachmentsFor()` provides access to the __name__, __size__, __hash__, and __content-type__ of each attachment a document has.
+  These details can then be used when defining the index-fields.
 
 * To index attachments' content, see the examples below. 
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.js.markdown
@@ -1,0 +1,191 @@
+# Index Attachments
+---
+
+{NOTE: }
+
+* __Static indexes__:   
+  Both attachments' details and content can be indexed within a static-index definition.
+
+* __Auto-indexes__:  
+  Auto-indexing attachments via dynamic queries is not available at this time.  
+
+* In this page:  
+  * [Index attachments details](../../document-extensions/attachments/indexing#index-attachments-details)
+  * [Index details & content - by attachment name](../../document-extensions/attachments/indexing#index-details-&-content---by-attachment-name)
+  * [Index details & content - all attachments](../../document-extensions/attachments/indexing#index-details-&-content---all-attachments)
+  * [Leveraging indexed attachments](../../document-extensions/attachments/indexing#leveraging-indexed-attachments)
+  * [Syntax](../../document-extensions/attachments/indexing#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Index attachments details}
+
+{NOTE: }
+
+__The index__:
+
+---
+
+* To index attachments' details, call `attachmentsFor()` within the index definition.  
+  `attachmentsFor()` provides access to the __name__, __size__, __hash__, and __content-type__ of each attachment a document has.
+   These details can then be used when defining the index-fields.
+
+* To index attachments' content, see the examples below. 
+
+{CODE:nodejs index_1@documentExtensions\attachments\indexAttachments.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Query the Index__:
+
+---
+
+You can now query for Employee documents based on their attachments details.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_1@documentExtensions\attachments\indexAttachments.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Employees/ByAttachmentDetails"
+where attachmentNames == "photo.jpg" and attachmentSizes > 20000
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Index details & content - by attachment name}
+
+{NOTE: }
+
+__Sample data__:
+
+---
+
+* Each Employee document in the Northwind sample data already includes a _photo.jpg_ attachment.
+
+* For all following examples, let's store a textual attachment (file _notes.txt_) on 3 documents  
+  in the 'Employees' collection.
+
+{CODE:nodejs store_attachments@documentExtensions\attachments\indexAttachments.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__The index__:
+
+---
+
+* To index the __details & content__ for a specific attachment, call `loadAttachment()` within the index definition.  
+ 
+* In addition to accessing the attachment details, `loadAttachment()` provides access to the attachment's content, 
+  which can be used when defining the index-fields.
+
+{CODE:nodejs index_2@documentExtensions\attachments\indexAttachments.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Query the Index__:
+
+---
+
+You can now query for Employee documents based on their attachment details and/or its content.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_2@documentExtensions\attachments\indexAttachments.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Employees/ByAttachment"
+where search(attachmentContent, "Colorado Dallas")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Index details & content - all attachments}
+
+{NOTE: }
+
+__The index__:
+
+---
+
+* Use `loadAttachments()` to be able to index the __details & content__ of ALL attachments.
+
+* Note how the index example below is employing the [Fanout index](../../indexes/indexing-nested-data#fanout-index---multiple-index-entries-per-document) pattern.
+
+{CODE:nodejs index_3@documentExtensions\attachments\indexAttachments.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Query the Index__:
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_3@documentExtensions\attachments\indexAttachments.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Employees/ByAllAttachments"
+where attachmentSize > 20000 or search(attachmentContent, "Colorado Dallas")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Leveraging indexed attachments}
+
+* Access to the indexed attachment content opens the door to many different applications,  
+  including many that can be integrated directly into RavenDB.
+
+* This [blog post](https://ayende.com/blog/192001-B/using-machine-learning-with-ravendb) demonstrates 
+  how image recognition can be applied to indexed attachments using the [additional sources](../../indexes/extending-indexes) feature. 
+  The resulting index allows filtering and querying based on image content.
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@documentExtensions\attachments\indexAttachments.js /}
+
+| Parameter    | Type     | Description                                             |
+|--------------|----------|---------------------------------------------------------|
+| __document__ | `object` | The document whose attachments details you want to load |
+
+{CODE:nodejs syntax_2@documentExtensions\attachments\indexAttachments.js /}
+
+---
+
+{CODE:nodejs syntax_3@documentExtensions\attachments\indexAttachments.js /}
+
+| Parameter           | Type      | Description                                    |
+|---------------------|-----------|------------------------------------------------|
+| __document__        | `object`  | The document whose attachment you want to load |
+| __attachmentName__  | `string`  | The name of the attachment to load             |
+
+{CODE:nodejs syntax_4@documentExtensions\attachments\indexAttachments.js /}
+
+---
+
+{CODE:nodejs syntax_5@documentExtensions\attachments\indexAttachments.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Document Extensions
+
+- [What are Attachments](../../document-extensions/attachments/what-are-attachments)  
+
+### Indexes
+
+- [What are Indexes](../../indexes/what-are-indexes)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Attachments/IndexingAttachments.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/Attachments/IndexingAttachments.cs
@@ -1,0 +1,206 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.Indexes
+{
+    public class IndexingAttachments
+    {
+        private interface IFoo
+        {
+            #region syntax
+            IEnumerable<AttachmentName> AttachmentsFor(object doc);
+            #endregion
+
+            #region syntax_2
+            public IAttachmentObject LoadAttachment(object doc, string name);
+            public IEnumerable<IAttachmentObject> LoadAttachments(object doc);
+            #endregion
+
+        }
+
+        private class Foo
+        {
+            #region result
+            public string Name;
+            public string Hash;
+            public string ContentType;
+            public long Size;
+            #endregion
+        }
+
+        #region AttFor_index_LINQ
+        public class Employees_ByAttachmentNames : AbstractIndexCreationTask<Employee>
+        {
+            public class Result
+            {
+                public string[] AttachmentNames { get; set; }
+            }
+
+            public Employees_ByAttachmentNames()
+            {
+                Map = employees => from e in employees
+                                   let attachments = AttachmentsFor(e)
+                                   select new Result
+                                   {
+                                       AttachmentNames = attachments.Select(x => x.Name).ToArray()
+                                   };
+            }
+        }
+        #endregion
+
+        #region AttFor_index_JS
+        public class Employees_ByAttachmentNames_JS : AbstractJavaScriptIndexCreationTask
+        {
+            public class Result
+            {
+                public string[] AttachmentNames { get; set; }
+            }
+
+            public Employees_ByAttachmentNames_JS()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Employees', function (e) {
+                        var attachments = attachmentsFor(e);
+                        return {
+                            AttachmentNames: attachments.map(
+                                function(attachment) {
+                                    return attachment.Name;
+                                }
+                        };
+                    })"
+                };
+            }
+        }
+        #endregion
+
+        #region LoadAtt_index_LINQ
+        private class Companies_With_Attachments : AbstractIndexCreationTask<Company>
+        {
+
+            public Companies_With_Attachments()
+            {
+                Map = companies => from company in companies
+                                   let attachment = LoadAttachment(company, company.ExternalId)
+                                   select new
+                                   {
+                                       CompanyName = company.Name,
+                                       AttachmentName = attachment.Name,
+                                       AttachmentContentType = attachment.ContentType,
+                                       AttachmentHash = attachment.Hash,
+                                       AttachmentSize = attachment.Size,
+                                       AttachmentContent = attachment.GetContentAsString(Encoding.UTF8),
+                                   };
+            }
+        }
+        #endregion
+
+        #region LoadAtt_index_JS
+        private class Companies_With_Attachments_JavaScript : AbstractJavaScriptIndexCreationTask
+        {
+            public Companies_With_Attachments_JavaScript()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Companies', function (company) {
+                        var attachment = loadAttachment(company, company.ExternalId);
+                        return {
+                            CompanyName: company.Name,
+                            AttachmentName: attachment.Name,
+                            AttachmentContentType: attachment.ContentType,
+                            AttachmentHash: attachment.Hash,
+                            AttachmentSize: attachment.Size,
+                            AttachmentContent: attachment.getContentAsString('utf8')
+                        };
+                    })"
+                };
+            }
+        }
+        #endregion
+
+        #region LoadAtts_index_LINQ
+        private class Companies_With_All_Attachments : AbstractIndexCreationTask<Company>
+        {
+            public Companies_With_All_Attachments()
+            {
+                Map = companies => from company in companies
+                                   let attachments = LoadAttachments(company)
+                                   from attachment in attachments
+                                   select new
+                                   {
+                                       AttachmentName = attachment.Name,
+                                       AttachmentContent = attachment.GetContentAsString(Encoding.UTF8)
+                                   };
+            }
+        }
+        #endregion
+
+        #region LoadAtts_index_JS
+        private class Companies_With_All_Attachments_JS : AbstractJavaScriptIndexCreationTask
+        {
+            public Companies_With_All_Attachments_JS()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Companies', function (company) {
+                        var attachments = loadAttachments(company);
+                        return attachments.map(attachment => ({
+                            AttachmentName: attachment.Name,
+                            AttachmentContent: attachment.getContentAsString('utf8')
+                        }));
+                    })"
+                };
+            }
+        }
+        #endregion
+
+        public async Task Sample()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region query1
+                    //return all employees that have an attachment called "cv.pdf"
+                    List<Employee> employees = session
+                        .Query<Employees_ByAttachmentNames.Result, Employees_ByAttachmentNames>()
+                        .Where(x => x.AttachmentNames.Contains("cv.pdf"))
+                        .OfType<Employee>()
+                        .ToList();
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region query2
+                    //return all employees that have an attachment called "cv.pdf"
+                    List<Employee> employees = await asyncSession
+                        .Query<Employees_ByAttachmentNames.Result, Employees_ByAttachmentNames>()
+                        .Where(x => x.AttachmentNames.Contains("cv.pdf"))
+                        .OfType<Employee>()
+                        .ToListAsync();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region query3
+                    //return all employees that have an attachment called "cv.pdf"
+                    List<Employee> employees = session
+                        .Advanced
+                        .DocumentQuery<Employee, Employees_ByAttachmentNames>()
+                        .ContainsAny("AttachmentNames", new[] { "cv.pdf" })
+                        .ToList();
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/DocumentExtensions/Attachments/IndexingAttachments.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/DocumentExtensions/Attachments/IndexingAttachments.java
@@ -1,0 +1,148 @@
+package net.ravendb.DocumentExtensions.Attachments;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.AbstractJavaScriptIndexCreationTask;
+import net.ravendb.client.documents.operations.attachments.AttachmentName;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class IndexingAttachments {
+
+    private interface IFoo {
+        /*
+        //region syntax
+        IEnumerable<AttachmentName> AttachmentsFor(object doc);
+        //endregion
+        */
+
+        /*
+        //region syntax_2
+        public IAttachmentObject LoadAttachment(object doc, string name);
+        public IEnumerable<IAttachmentObject> LoadAttachments(object doc);
+        //endregion
+         */
+    }
+
+    public static class Foo {
+        //region result
+        private String name;
+        private String hash;
+        private String contentType;
+        private long size;
+        //endregion
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getHash() {
+            return hash;
+        }
+
+        public void setHash(String hash) {
+            this.hash = hash;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void setContentType(String contentType) {
+            this.contentType = contentType;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        public void setSize(long size) {
+            this.size = size;
+        }
+    }
+
+
+    //region AttFor_index_JS
+    public static class Employees_ByAttachmentNames extends AbstractIndexCreationTask {
+        public Employees_ByAttachmentNames() {
+            map = "from e in docs.Employees\n" +
+                "let attachments = AttachmentsFor(e)\n" +
+                "select new {\n" +
+                "   attachmentNames = attachments.Select(x => x.Name).ToArray()\n" +
+                "}";
+        }
+    }
+    //endregion
+
+    //region LoadAtt_index_JS
+    private class Companies_With_Attachments_JavaScript extends AbstractJavaScriptIndexCreationTask {
+        public Companies_With_Attachments_JavaScript() {
+            setMaps(Collections.singleton(
+                "map('Companies', function (company) {\n" +
+                    "   var attachment = LoadAttachment(company, company.ExternalId);\n" +
+                    "   return {\n" +
+                    "       CompanyName: company.Name,\n" +
+                    "       AttachmentName: attachment.Name,\n" +
+                    "       AttachmentContentType: attachment.ContentType,\n" +
+                    "       AttachmentHash: attachment.Hash,\n" +
+                    "       AttachmentSize: attachment.Size,\n" +
+                    "       AttachmentContent: attachment.getContentAsString('utf8')\n" +
+                    "   }\n"+
+                    "});"
+                )
+            );
+        }
+    }
+    //endregion
+
+    //region LoadAtts_index_JS
+    private class Companies_With_All_Attachments_JS extends AbstractJavaScriptIndexCreationTask {
+        public Companies_With_All_Attachments_JS() {
+            setMaps(Collections.singleton(
+                "map('Companies', function (company) {\n" +
+                "    var attachments = LoadAttachments(company);\n" +
+                "    return attachments.map(attachment => ({\n" +
+                "        AttachmentName: attachment.Name,\n" +
+                "        AttachmentContent: attachment.getContentAsString('utf8')\n" +
+                "     }));\n" +
+                "})"
+                )
+            );
+        }
+    }
+    //endregion
+
+
+    public void sample() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region query1
+                //return all employees that have an attachment called "cv.pdf"
+                List<Employee> employees = session.query(Employees_ByAttachmentNames.class)
+                    .containsAny("attachmentNames", Arrays.asList("employees_cv.pdf"))
+                    .selectFields(Company.class, "cv.pdf").ofType(Employee.class)
+                    .toList();
+                //endregion
+            }
+        }
+    }
+
+    class Employee {
+
+    }
+    class Company {
+
+    }
+
+}

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/attachments/indexAttachments.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/attachments/indexAttachments.js
@@ -1,0 +1,212 @@
+import { DocumentStore, AbstractJavaScriptIndexCreationTask } from "ravendb";
+const fs = require('fs');
+
+const documentStore = new DocumentStore();
+const session = store.openSession();
+
+
+//region index_1
+class Employees_ByAttachmentDetails extends AbstractJavaScriptIndexCreationTask {
+    constructor () {
+        super();
+
+        const { attachmentsFor } = this.mapUtils();
+
+        this.map("employees", employee => {
+            // Call 'attachmentsFor' to get attachments details
+            const attachments = attachmentsFor(employee);
+
+            return {
+                // Can index info from document properties:
+                employeeName: employee.FirstName + " " + employee.LastName,
+
+                // Index DETAILS of attachments:
+                attachmentNames: attachments.map(x => x.Name),
+                attachmentContentTypes: attachments.map(x => x.ContentType),
+                attachmentSizes: attachments.map(x => x.Size)
+            }
+        });
+    }
+}
+//endregion
+
+//region index_2
+class Employees_ByAttachment extends AbstractJavaScriptIndexCreationTask {
+    constructor () {
+        super();
+
+        const { loadAttachment } = this.mapUtils();
+
+        this.map("employees", employee => {
+            // Call 'loadAttachment' to get attachment's details and content
+            // pass the attachment name, e.g. "notes.txt"
+            const attachment = loadAttachment(employee, "notes.txt");
+
+            return {
+                // Index DETAILS of attachment:
+                attachmentName: attachment.Name,
+                attachmentContentType: attachment.ContentType,
+                attachmentSize: attachment.Size,
+
+                // Index CONTENT of attachment:
+                // Call 'getContentAsString' to access content
+                attachmentContent: attachment.getContentAsString()
+            }
+        });
+
+        // It can be useful configure Full-Text search on the attachment content index-field
+        this.index("attachmentContent", "Search");
+
+        // Documents with an attachment named 'notes.txt' will be indexed,
+        // allowing you to query them by either the attachment's details or its content.
+    }
+}
+//endregion
+
+//region index_3
+class Employees_ByAllAttachments extends AbstractJavaScriptIndexCreationTask {
+    constructor () {
+        super();
+
+        const { loadAttachments } = this.mapUtils();
+
+        this.map("employees", employee => {
+            // Call 'loadAttachments' to get details and content for ALL attachments
+            const allAttachments = loadAttachments(employee);
+
+            // This will be a Fanout index -
+            // the index will generate an index-entry for each attachment per document
+
+            return allAttachments.map(attachment => ({
+
+                // Index DETAILS of attachment:
+                attachmentName: attachment.Name,
+                attachmentContentType: attachment.ContentType,
+                attachmentSize: attachment.Size,
+
+                // Index CONTENT of attachment:
+                // Call 'getContentAsString' to access content
+                attachmentContent: attachment.getContentAsString()
+            }));
+        });
+
+        // It can be useful configure Full-Text search on the attachment content index-field
+        this.index("attachmentContent", "Search");
+    }
+}
+//endregion
+
+async function indexAttachments() {
+    {
+        //region store_attachments
+        const session = documentStore.openSession();
+
+        for (let i = 1; i <= 3; i++) {
+            // Load an employee document:
+            const employee = await session.load(`employees/${i}-A`);
+            
+            // Store the employee's notes as an attachment on the document:
+            const stream = Buffer.from(employee.Notes[0]);
+            session.advanced.attachments.store(`employees/${i}-A`, "notes.txt", stream, "text/plain");
+        }
+        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region query_1
+        const employees = await session
+             // Query the index for matching employees
+            .query({ indexName: "Employees/ByAttachmentDetails" })
+             // Filter employee results by their attachments details
+            .whereEquals("attachmentNames", "photo.jpg")
+            .whereGreaterThan("attachmentSizes", 20_000)
+            .all();
+
+        // Results:
+        // ========
+        // Running this query on the Northwind sample data,
+        // results will include 'employees/4-A' and 'employees/5-A'.
+        // These 2 documents contain an attachment by name 'photo.jpg' with a matching size.
+        //endregion
+    }
+    {
+        //region query_2
+        const employees = await session
+            // Query the index for matching employees
+            .query({indexName: "Employees/ByAttachment"})
+            // Can make a full-text search
+            // Looking for employees with an attachment content that contains 'Colorado' OR 'Dallas'
+            .search("attachmentContent", "Colorado Dallas")
+            .all();
+
+        // Results:
+        // ========
+        // Results will include 'employees/1-A' and 'employees/2-A'.
+        // Only these 2 documents have an attachment by name 'notes.txt'
+        // that conains either 'Colorado' or 'Dallas'.
+        //endregion
+    }
+    {
+        //region query_3
+        const employees = await session
+            // Query the index for matching employees
+            .query({indexName: "Employees/ByAllAttachments"})
+            // Filter employee results by their attachments details and content
+            .whereGreaterThan("attachmentSize", 20_000)
+            .orElse()
+            .search("attachmentContent", "Colorado Dallas")
+            .all();
+
+        // Results:
+        // ========
+        // Results will include:
+        // 'employees/1-A' and 'employees/2-A' that match the content criteria 
+        // 'employees/4-A' and 'employees/5-A' that match the size criteria
+        //endregion
+    }
+}
+
+//region syntax_1
+attachmentsFor(document);
+//endregion
+
+//region syntax_2
+// Returns a list containing the following attachment details object:
+{    
+    name;         // string
+    hash;         // string
+    contentType;  // string
+    size;         // number
+}
+//endregion
+
+//region syntax_3
+loadAttachment(document, attachmentName);
+//endregion    
+    
+//region syntax_4
+// Returns the following attachment object:
+{
+    // Properties accessing DETAILS:
+    // =============================
+    name;         // string
+    hash;         // string
+    contentType;  // string
+    size;         // number
+    
+    // Methods accessing CONTENT:
+    // ==========================
+    getContentAsStream();
+    getContentAsString(encoding);
+    getContentAsString(); // Default encoding is "utf8"
+}
+//endregion
+
+//region syntax_5
+loadAttachments(document);
+
+// Returns a list containing the above attachment object per attachment.
+//endregion
+
+//endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2697/Node.js-Document-extensions-Attachments-Indexing-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied + 
   the Node.js article's text & flow WAS improved from the original C# article .

* Fixes to the C# article and other languages will be done in a separate dedicated issue:
   https://issues.hibernatingrhinos.com/issue/RDoc-2698/Document-extensions-Attachments-Indexing-Fix-article

---

**Node.js**: @ml054 

* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/attachments/indexing.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/attachments/indexAttachments.js
```

**C# + Java**: 

* Files were only copied over to v5.4