### PR TITLE
RDoc-2706 + RDoc-2707 + RDoc-2708 [Node.js ] Client API > Operations > Attachments > Put + Get + Delete [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/.docs.json
@@ -1,0 +1,20 @@
+[
+    {
+        "Path": "put-attachment.markdown",
+        "Name": "Put Attachment",
+        "DiscussionId": "002a2d15-8425-4a9a-a16a-78dd64c09aeb",
+        "Mappings": []
+    },
+    {
+        "Path": "get-attachment.markdown",
+        "Name": "Get Attachment",
+        "DiscussionId": "4d71988a-3bb8-47e8-bbe3-57a93780a1ae",
+        "Mappings": []
+    },
+    {
+        "Path": "delete-attachment.markdown",
+        "Name": "Delete Attachment",
+        "DiscussionId": "8ac4e36a-3e75-4a16-8cf3-e0dd08a225f6",
+        "Mappings": []
+    }
+]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/delete-attachment.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/delete-attachment.dotnet.markdown
@@ -1,0 +1,25 @@
+# Delete Attachment Operation
+
+This operation is used to delete an attachment from a document. 
+
+## Syntax
+
+{CODE delete_attachment_syntax@ClientApi\Operations\Attachments\Attachments.cs /}
+
+| Parameter        |        |                                                                         |
+|------------------|--------|-------------------------------------------------------------------------|
+| **documentId**   | string | ID of a document containing an attachment                               |
+| **name**         | string | Name of an attachment                                                   |
+| **changeVector** | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
+
+## Example
+
+{CODE delete_1@ClientApi\Operations\Attachments\Attachments.cs /}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Put attachment](../../../client-api/operations/attachments/put-attachment) 
+- [Get attachment](../../../client-api/operations/attachments/get-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/delete-attachment.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/delete-attachment.java.markdown
@@ -1,0 +1,25 @@
+# Delete Attachment Operation
+
+This operation is used to delete an attachment from a document. 
+
+## Syntax
+
+{CODE:java delete_attachment_syntax@ClientApi\Operations\Attachments\Attachments.java /}
+
+| Parameter        |        |                                                                         |
+|------------------|--------|-------------------------------------------------------------------------|
+| **documentId**   | String | ID of a document containing an attachment                               |
+| **name**         | String | Name of an attachment                                                   |
+| **changeVector** | String | Entity changeVector, used for concurrency checks (`null` to skip check) |
+
+## Example
+
+{CODE:java delete_1@ClientApi\Operations\Attachments\Attachments.java /}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Put attachment](../../../client-api/operations/attachments/put-attachment) 
+- [Get attachment](../../../client-api/operations/attachments/get-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/delete-attachment.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/delete-attachment.js.markdown
@@ -1,0 +1,41 @@
+# Delete Attachment Operation
+---
+
+{NOTE: }
+
+* Use the `DeleteAttachmentOperation` to delete an attachment from a document.
+
+* In this page:
+
+    * [Delete attachment example](../../../client-api/operations/attachments/delete-attachment#delete-attachment-example)
+    * [Syntax](../../../client-api/operations/attachments/delete-attachment#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Delete attachment example}
+
+{CODE:nodejs delete_attachment@client-api\operations\attachments\deleteAttachment.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\operations\attachments\deleteAttachment.js /}
+
+| Parameter        | Type     | Description                                                                       |
+|------------------|----------|-----------------------------------------------------------------------------------|
+| __documentId__   | `string` | ID of document from which attachment will be removed                              |
+| __name__         | `string` | Name of attachment to delete                                                      |
+| __changeVector__ | `string` | ChangeVector of attachment,<br>used for concurrency checks (`null` to skip check) |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Put attachment](../../../client-api/operations/attachments/put-attachment) 
+- [Get attachment](../../../client-api/operations/attachments/get-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.dotnet.markdown
@@ -1,0 +1,38 @@
+# Get Attachment Operation
+
+This operation is used to get an attachment from a document. 
+
+## Syntax
+
+{CODE:csharp get_attachment_syntax@ClientApi\Operations\Attachments\Attachments.cs /}
+
+{CODE:csharp get_attachment_return_value@ClientApi\Operations\Attachments\Attachments.cs /}
+
+| Parameter        |                | |
+|------------------|----------------| ----- |
+| **documentId**   | string         | ID of a document which will contain an attachment |
+| **name**         | string     | Name of an attachment |
+| **type**         | AttachmentType | **Document** or **Revision** |
+| **changeVector** | string         | Entity changeVector, used for concurrency checks (`null` to skip check) |
+
+| Return Value | |
+| ------------- | ----- |
+| **Stream** | Stream containing an attachment |
+| **ChangeVector** | Change vector of an attachment |
+| **DocumentId** | ID of document |
+| **Name** | Name of attachment |
+| **Hash** | Hash of attachment |
+| **ContentType** | MIME content type of an attachment |
+| **Size** | Size of attachment |
+
+## Example
+
+{CODE get_1@ClientApi\Operations\Attachments\Attachments.cs /}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Put attachment](../../../client-api/operations/attachments/put-attachment) 
+- [Delete attachment](../../../client-api/operations/attachments/delete-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.java.markdown
@@ -1,0 +1,38 @@
+# Get Attachment Operation
+
+This operation is used to get an attachment from a document. 
+
+## Syntax
+
+{CODE:java get_attachment_syntax@ClientApi\Operations\Attachments\Attachments.java /}
+
+{CODE:java get_attachment_return_value@ClientApi\Operations\Attachments\Attachments.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **documentId** | String | ID of a document which will contain an attachment |
+| **name** | String | Name of an attachment |
+| **type** | AttachmentType | **DOCUMENT** or **REVISION** |
+| **changeVector** | String | Entity changeVector, used for concurrency checks (`null` to skip check) |
+
+| Return Value | |
+| ------------- | ----- |
+| **Stream** | InputStream containing an attachment |
+| **ChangeVector** | Change vector of an attachment |
+| **DocumentId** | ID of document |
+| **Name** | Name of attachment |
+| **Hash** | Hash of attachment |
+| **ContentType** | MIME content type of an attachment |
+| **Size** | Size of attachment |
+
+## Example
+
+{CODE:java get_1@ClientApi\Operations\Attachments\Attachments.java /}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Put attachment](../../../client-api/operations/attachments/put-attachment) 
+- [Delete attachment](../../../client-api/operations/attachments/delete-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.js.markdown
@@ -1,0 +1,48 @@
+# Get Attachment Operation
+---
+
+{NOTE: }
+
+* Use the `GetAttachmentOperation` to retrieve an attachment from a document. 
+
+* In this page:  
+
+  * [Get attachment example](../../../client-api/operations/attachments/get-attachment#get-attachment-example)  
+  * [Syntax](../../../client-api/operations/attachments/get-attachment#syntax)
+   
+{NOTE/}
+
+---
+
+{PANEL: Get attachment example}
+
+{CODE:nodejs get_attachment@client-api\operations\attachments\getAttachment.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\operations\attachments\getAttachment.js /}
+
+| Parameter        | Type             | Description                                                                       |
+|------------------|------------------|-----------------------------------------------------------------------------------|
+| __documentId__   | `string`         | Document ID that contains the attachment                                          |
+| __name__         | `string`         | Name of attachment to get                                                         |
+| __type__         | `AttachmentType` | __"Document"__ or __"Revision"__                                                  |
+| __changeVector__ | `string`         | ChangeVector of attachment,<br>used for concurrency checks (`null` to skip check) |
+
+| Return Value of `store.operations.send(getAttachmentOp)`  |                                         |
+|-----------------------------------------------------------|-----------------------------------------|
+| `AttachmentResult`                                        | An instance of class `AttachmentResult` |
+
+{CODE:nodejs syntax_2@client-api\operations\attachments\getAttachment.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Put attachment](../../../client-api/operations/attachments/put-attachment) 
+- [Delete attachment](../../../client-api/operations/attachments/delete-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/put-attachment.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/put-attachment.dotnet.markdown
@@ -1,0 +1,38 @@
+# Put Attachment Operation
+
+This operation is used to put an attachment to a document. 
+
+## Syntax
+
+{CODE:csharp put_attachment_syntax@ClientApi\Operations\Attachments\Attachments.cs /}
+
+{CODE:csharp put_attachment_return_value@ClientApi\Operations\Attachments\Attachments.cs /}
+
+| Parameter        |        |                                                                         |
+|------------------|--------|-------------------------------------------------------------------------|
+| **documentId**   | string | ID of a document which will contain an attachment                       |
+| **name**         | string | Name of an attachment                                                   |
+| **stream**       | Stream | Stream contains attachment raw bytes                                    |
+| **contentType**  | string | MIME type of attachment                                                 |
+| **changeVector** | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
+
+| Return Value     |                                     |
+|------------------|-------------------------------------|
+| **ChangeVector** | Change vector of created attachment |
+| **DocumentId**   | ID of document                      |
+| **Name**         | Name of created attachment          |
+| **Hash**         | Hash of created attachment          |
+| **ContentType**  | MIME content type of attachment     |
+| **Size**         | Size of attachment                  |
+
+## Example
+
+{CODE put_1@ClientApi\Operations\Attachments\Attachments.cs /}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Get attachment](../../../client-api/operations/attachments/get-attachment)
+- [Delete attachment](../../../client-api/operations/attachments/delete-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/put-attachment.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/put-attachment.java.markdown
@@ -1,0 +1,38 @@
+# Put Attachment Operation
+
+This operation is used to put an attachment to a document. 
+
+## Syntax
+
+{CODE:java put_attachment_syntax@ClientApi\Operations\Attachments\Attachments.java /}
+
+{CODE:java put_attachment_return_value@ClientApi\Operations\Attachments\Attachments.java /}
+
+| Parameter        | | |
+|------------------| ------------- | ----- |
+| **documentId**   | String | ID of a document which will contain an attachment |
+| **name**         | String | Name of an attachment |
+| **stream**       | InputStream | Stream contains attachment raw bytes |
+| **contentType**  | String | MIME type of attachment |
+| **changeVector** | String | Entity changeVector, used for concurrency checks (`null` to skip check) |
+
+| Return Value | |
+| ------------- | ----- |
+| **ChangeVector** | Change vector of created attachment |
+| **DocumentId** | ID of document |
+| **Name** | Name of created attachment |
+| **Hash** | Hash of created attachment |
+| **ContentType** | MIME content type of attachment |
+| **Size** | Size of attachment |
+
+## Example
+
+{CODE:java put_1@ClientApi\Operations\Attachments\Attachments.java /}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Get attachment](../../../client-api/operations/attachments/get-attachment)
+- [Delete attachment](../../../client-api/operations/attachments/delete-attachment)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/put-attachment.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/put-attachment.js.markdown
@@ -1,0 +1,49 @@
+# Put Attachment Operation
+---
+
+{NOTE: }
+
+* Use the `PutAttachmentOperation` to add an attachment to a document.
+
+* In this page:
+  
+  * [Put attachment example](../../../client-api/operations/attachments/put-attachment#put-attachment-example)
+  * [Syntax](../../../client-api/operations/attachments/put-attachment#syntax)
+  
+{NOTE/}
+
+---
+
+{PANEL: Put attachment example}
+
+{CODE:nodejs put_attachment@client-api\operations\attachments\putAttachment.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\operations\attachments\putAttachment.js /}
+
+| Parameter        | Type                         | Description                                                                       |
+|------------------|------------------------------|-----------------------------------------------------------------------------------|
+| __documentId__   | `string`                     | Document ID to which the attachment will be added                                 |
+| __name__         | `string`                     | Name of attachment to put                                                         |
+| __stream__       | `stream.Readable` / `Buffer` | A stream that contains the raw bytes of the attachment                            |
+| __contentType__  | `string`                     | Content type of attachment                                                        |
+| __changeVector__ | `string`                     | ChangeVector of attachment,<br>used for concurrency checks (`null` to skip check) |
+
+| Return Value of `store.operations.send(putAttachmentOp)` |                                             |
+|----------------------------------------------------------|---------------------------------------------|
+| `object`                                                 | An object with the new attachment's details |
+
+{CODE:nodejs syntax_2@client-api\operations\attachments\putAttachment.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+- [Get attachment](../../../client-api/operations/attachments/get-attachment)
+- [Delete attachment](../../../client-api/operations/attachments/delete-attachment)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Attachments/Attachments.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Attachments/Attachments.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations
+{
+    public class Attachments
+    {
+        private interface IFoo
+        {
+            /*
+            #region delete_attachment_syntax
+            public DeleteAttachmentOperation(string documentId, string name, string changeVector = null)
+            #endregion
+
+            #region put_attachment_syntax
+            public PutAttachmentOperation(string documentId, 
+                    string name, 
+                    Stream stream, 
+                    string contentType = null, 
+                    string changeVector = null)
+            #endregion
+
+            #region get_attachment_syntax
+            public GetAttachmentOperation(string documentId, string name, AttachmentType type, string changeVector)
+            #endregion
+            */
+        }
+
+        private class Foo
+        {
+            #region put_attachment_return_value
+            public class AttachmentDetails : AttachmentName
+            {
+                public string ChangeVector;
+                public string DocumentId;
+            }
+
+            public class AttachmentName
+            {
+                public string Name;
+                public string Hash;
+                public string ContentType;
+                public long Size;
+            }
+            #endregion
+        }
+
+        private class Foo2
+        {
+            #region get_attachment_return_value
+            public class AttachmentResult
+            {
+                public Stream Stream;
+                public AttachmentDetails Details;
+            }
+
+            public class AttachmentDetails : AttachmentName
+            {
+                public string ChangeVector;
+                public string DocumentId;
+            }
+
+            public class AttachmentName
+            {
+                public string Name;
+                public string Hash;
+                public string ContentType;
+                public long Size;
+            }
+            #endregion
+        }
+
+
+        public Attachments()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region delete_1
+                    store.Operations.Send(new DeleteAttachmentOperation("orders/1-A", "invoice.pdf"));
+                    #endregion
+                }
+
+                {
+                    #region get_1
+                    store.Operations.Send(new GetAttachmentOperation("orders/1-A",
+                        "invoice.pdf",
+                        AttachmentType.Document,
+                        changeVector: null));
+                    #endregion
+                }
+
+                {
+                    Stream stream = null;
+                    #region put_1
+                    AttachmentDetails attachmentDetails =
+                        store.Operations.Send(
+                            new PutAttachmentOperation("orders/1-A",
+                                "invoice.pdf",
+                                stream,
+                                "application/pdf"));
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Attachments/Attachments.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Attachments/Attachments.java
@@ -1,0 +1,204 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.attachments.AttachmentType;
+import net.ravendb.client.documents.operations.attachments.*;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Attachments {
+
+    private interface IFoo {
+        /*
+        //region delete_attachment_syntax
+        DeleteAttachmentOperation(String documentId, String name)
+
+        DeleteAttachmentOperation(String documentId, String name, String changeVector)
+        //endregion
+
+        //region put_attachment_syntax
+        PutAttachmentOperation(String documentId, String name, InputStream stream)
+
+        PutAttachmentOperation(String documentId, String name, InputStream stream, String contentType)
+
+        PutAttachmentOperation(String documentId, String name, InputStream stream, String contentType, String changeVector)
+        //endregion
+
+        //region get_attachment_syntax
+        GetAttachmentOperation(String documentId, String name, AttachmentType type, String changeVector)
+        //endregion
+        */
+    }
+
+    private class Foo {
+        //region put_attachment_return_value
+        public class AttachmentDetails extends AttachmentName {
+            private String changeVector;
+            private String documentId;
+
+            public String getChangeVector() {
+                return changeVector;
+            }
+
+            public void setChangeVector(String changeVector) {
+                this.changeVector = changeVector;
+            }
+
+            public String getDocumentId() {
+                return documentId;
+            }
+
+            public void setDocumentId(String documentId) {
+                this.documentId = documentId;
+            }
+        }
+
+        public class AttachmentName {
+            private String name;
+            private String hash;
+            private String contentType;
+            private long size;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getHash() {
+                return hash;
+            }
+
+            public void setHash(String hash) {
+                this.hash = hash;
+            }
+
+            public String getContentType() {
+                return contentType;
+            }
+
+            public void setContentType(String contentType) {
+                this.contentType = contentType;
+            }
+
+            public long getSize() {
+                return size;
+            }
+
+            public void setSize(long size) {
+                this.size = size;
+            }
+        }
+        //endregion
+    }
+
+    private class Foo2 {
+        /*
+        //region get_attachment_return_value
+        public class CloseableAttachmentResult implements AutoCloseable {
+            private AttachmentDetails details;
+            private CloseableHttpResponse response;
+
+            public InputStream getData() throws IOException {
+                return response.getEntity().getContent();
+            }
+
+            public AttachmentDetails getDetails() {
+                return details;
+            }
+        }
+
+        public class AttachmentDetails extends Foo.AttachmentName {
+            private String changeVector;
+            private String documentId;
+
+            public String getChangeVector() {
+                return changeVector;
+            }
+
+            public void setChangeVector(String changeVector) {
+                this.changeVector = changeVector;
+            }
+
+            public String getDocumentId() {
+                return documentId;
+            }
+
+            public void setDocumentId(String documentId) {
+                this.documentId = documentId;
+            }
+        }
+
+        public class AttachmentName {
+            private String name;
+            private String hash;
+            private String contentType;
+            private long size;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getHash() {
+                return hash;
+            }
+
+            public void setHash(String hash) {
+                this.hash = hash;
+            }
+
+            public String getContentType() {
+                return contentType;
+            }
+
+            public void setContentType(String contentType) {
+                this.contentType = contentType;
+            }
+
+            public long getSize() {
+                return size;
+            }
+
+            public void setSize(long size) {
+                this.size = size;
+            }
+        }
+        //endregion
+        */
+    }
+
+    public Attachments() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region delete_1
+            store.operations().send(
+                new DeleteAttachmentOperation("orders/1-A", "invoice.pdf"));
+            //endregion
+
+            //region get_1
+            store.operations().send(
+                new GetAttachmentOperation("orders/1-A", "invoice.pdf", AttachmentType.DOCUMENT, null));
+            //endregion
+
+            {
+                InputStream stream = null;
+                //region put_1
+                AttachmentDetails attachmentDetails = store
+                    .operations().send(new PutAttachmentOperation("orders/1-A",
+                        "invoice.pdf",
+                        stream,
+                        "application/pdf"));
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/deleteAttachment.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/deleteAttachment.js
@@ -1,0 +1,21 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function deleteAttachment() {
+    {
+        //region delete_attachment
+        // Define the delete attachment operation
+        const deleteAttachmentOp = new DeleteAttachmentOperation("employees/1-A", "photo.jpg");
+        
+        // Execute the operation by passing it to operations.send
+        await documentStore.operations.send(deleteAttachmentOp);
+        //endregion
+    }
+}
+
+//region syntax 
+// Available overloads:
+const deleteAttachmentOp = new DeleteAttachmentOperation(documentId, name);
+const deleteAttachmentOp = new DeleteAttachmentOperation(documentId, name, changeVector);
+//endregion

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/getAttachment.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/getAttachment.js
@@ -1,0 +1,63 @@
+import { DocumentStore } from "ravendb";
+import fs from "fs";
+
+const documentStore = new DocumentStore();
+
+async function getAttachment() {
+    {
+        //region get_attachment
+        // Define the get attachment operation
+        const getAttachmentOp = new GetAttachmentOperation("employees/1-A", "attachmentName.txt", "Document", null);
+
+        // Execute the operation by passing it to operations.send
+        const attachmentResult = await documentStore.operations.send(getAttachmentOp);
+        
+        // Retrieve attachment content:
+        attachmentResult.data
+            .pipe(fs.createWriteStream("attachment"))
+            .on("finish", () => {
+                fs.readFile("attachment", "utf8", (err, data) => {
+                    if (err) {
+                        console.error("Error reading file:", err);
+                        return;
+                    }
+                    console.log("Content of attachment:", data);
+                    next();
+                });
+            });
+        //endregion
+    }
+}
+
+//region syntax_1 
+const getAttachmentOp = new GetAttachmentOperation(documentId, name, type, changeVector);
+//endregion
+
+//region syntax_2
+class AttachmentResult {
+    data;    // Stream containing the attachment content
+    details; // The AttachmentDetails object
+}
+
+// The AttachmentDetails object:
+// =============================
+{
+    // Change vector of attachment
+    changeVector; // string
+
+    // ID of the document that contains the attachment
+    documentId?; // string
+    
+    // Name of attachment
+    name; // string;
+    
+    // Hash of attachment
+    hash; // string;
+    
+    // Content type of attachment
+    contentType; // string
+    
+    // Size of attachment
+    size; // number
+}
+//endregion

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/putAttachment.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/putAttachment.js
@@ -1,0 +1,51 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function putAttachment() {
+    {
+        //region put_attachment
+        // Prepare content to attach
+        const text = "Some content...";
+        const byteArray = Buffer.from(text);
+        
+        // Define the put attachment operation
+        const putAttachmentOp = new PutAttachmentOperation(
+            "employees/1-A", "attachmentName.txt", byteArray, "text/plain");
+        
+        // Execute the operation by passing it to operations.send
+        const attachmentDetails = await documentStore.operations.send(putAttachmentOp);
+        //endregion
+    }
+}
+
+//region syntax_1 
+// Available overloads:
+const putAttachmentOp = new PutAttachmentOperation(documentId, name, stream);
+const putAttachmentOp = new PutAttachmentOperation(documentId, name, stream, contentType);
+const putAttachmentOp = new PutAttachmentOperation(documentId, name, stream, contentType, changeVector);
+//endregion
+
+//region syntax_2
+// The AttachmentDetails object:
+// =============================
+{
+    // Change vector of attachment
+    changeVector; // string
+
+    // ID of the document that contains the attachment
+    documentId?; // string
+
+    // Name of attachment
+    name; // string;
+
+    // Hash of attachment
+    hash; // string;
+
+    // Content type of attachment
+    contentType; // string
+
+    // Size of attachment
+    size; // number
+}
+//endregion

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/attachments/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/operations/attachments/.docs.json
@@ -1,0 +1,20 @@
+[
+    {
+        "Path": "put-attachment.markdown",
+        "Name": "Put Attachment",
+        "DiscussionId": "002a2d15-8425-4a9a-a16a-78dd64c09aeb",
+        "Mappings": []
+    },
+    {
+        "Path": "get-attachment.markdown",
+        "Name": "Get Attachment",
+        "DiscussionId": "4d71988a-3bb8-47e8-bbe3-57a93780a1ae",
+        "Mappings": []
+    },
+    {
+        "Path": "delete-attachment.markdown",
+        "Name": "Delete Attachment",
+        "DiscussionId": "8ac4e36a-3e75-4a16-8cf3-e0dd08a225f6",
+        "Mappings": []
+    }
+]


### PR DESCRIPTION
**Related issues:**
https://issues.hibernatingrhinos.com/issue/RDoc-2706/Node.js-Client-API-Operations-Attachments-Get-attachment-Replace-C-samples
https://issues.hibernatingrhinos.com/issue/RDoc-2707/Node.js-Client-API-Operations-Attachments-Put-attachment-Replace-C-samples
https://issues.hibernatingrhinos.com/issue/RDoc-2708/Node.js-Client-API-Operations-Attachments-Delete-attachment-Replace-C-samples

---

**Important notes for this PR:**

* In this PR:
  * The sample code for `Node.js` was applied
  * Menu & text were organized for the `Node.js` articles

* Fixes to the C# articles will be done in separate dedicated issues:
  https://issues.hibernatingrhinos.com/issue/RDoc-2710/Client-API-Operations-Attachments-Get-attachment-Fix-article
  https://issues.hibernatingrhinos.com/issue/RDoc-2712/Client-API-Operations-Attachments-Put-attachment-Fix-article
  https://issues.hibernatingrhinos.com/issue/RDoc-2713/Client-API-Operations-Attachments-Delete-attachment-Fix-article
  
---

**Node.js**: @ml054 

* Node.js files to review:
```
Documentation/5.4/Samples/nodejs/client-api/operations/attachments/putAttachment.js
Documentation/5.4/Samples/nodejs/client-api/operations/attachments/getAttachment.js
Documentation/5.4/Samples/nodejs/client-api/operations/attachments/deleteAttachment.js
```

**C# + Java**: 

* Files were only copied over to v5.4