### PR TITLE
RDoc-2715 [Node.js] Client API > Operations > Patching > Single document [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.dotnet.markdown
@@ -1,0 +1,487 @@
+# Single Document Patch Operations
+
+{NOTE: }
+
+* The __Patch__ operation is used to perform _partial_ document updates with __one trip to the server__, 
+  instead of loading, modifying, and saving a full document.  
+  The whole operation is executed on the server-side and is useful as a performance enhancement or for 
+  updating denormalized data in entities.
+
+* Since the operation is executed in a single request to the database,  
+  the patch command is performed in a single write [transaction](../../../client-api/faq/transaction-support).  
+
+* The current page covers patch operations on single documents.
+
+* Patching has three possible interfaces: [Session API](../../../client-api/operations/patching/single-document#session-api), 
+[Session API using Defer](../../../client-api/operations/patching/single-document#session-api-using-defer), 
+and [Operations API](../../../client-api/operations/patching/single-document#operations-api).
+
+* Patching can be done from the [client API](../../../client-api/operations/patching/single-document#examples) as well as in the [studio](../../../studio/database/documents/patch-view).  
+
+In this page:  
+
+* [API overview](../../../client-api/operations/patching/single-document#api-overview)  
+  * [Session API](../../../client-api/operations/patching/single-document#session-api)
+  * [Session API using Defer](../../../client-api/operations/patching/single-document#session-api-using-defer)
+  * [Operations API](../../../client-api/operations/patching/single-document#operations-api)
+  * [List of script methods](../../../client-api/operations/patching/single-document#list-of-script-methods)
+* [Examples](../../../client-api/operations/patching/single-document#examples)  
+  * [Change value of single field](../../../client-api/operations/patching/single-document#change-value-of-single-field)  
+  * [Change values of two fields](../../../client-api/operations/patching/single-document#change-values-of-two-fields)  
+  * [Increment value](../../../client-api/operations/patching/single-document#increment-value)  
+  * [Add or increment](../../../client-api/operations/patching/single-document#add-or-increment)  
+  * [Add or patch](../../../client-api/operations/patching/single-document#add-or-patch)  
+  * [Add or patch to an existing array](../../../client-api/operations/patching/single-document#add-or-patch-to-an-existing-array)  
+  * [Add item to array](../../../client-api/operations/patching/single-document#add-item-to-array)  
+  * [Insert item into specific position in array](../../../client-api/operations/patching/single-document#insert-item-into-specific-position-in-array)  
+  * [Modify item in specific position in array](../../../client-api/operations/patching/single-document#modify-item-in-specific-position-in-array)  
+  * [Remove items from array](../../../client-api/operations/patching/single-document#remove-items-from-array)  
+  * [Loading documents in a script](../../../client-api/operations/patching/single-document#loading-documents-in-a-script)  
+  * [Remove property](../../../client-api/operations/patching/single-document#remove-property)  
+  * [Rename property](../../../client-api/operations/patching/single-document#rename-property)  
+  * [Add document](../../../client-api/operations/patching/single-document#add-document)  
+  * [Clone document](../../../client-api/operations/patching/single-document#clone-document)  
+  * [Increment counter](../../../client-api/operations/patching/single-document#increment-counter)  
+  * [Delete counter](../../../client-api/operations/patching/single-document#delete-counter)  
+  * [Get counter](../../../client-api/operations/patching/single-document#get-counter)  
+
+{NOTE/}
+
+## API Overview
+
+{PANEL: Session API}
+
+A type-safe session interface that allows performing the most common patch operations.  
+The patch request will be sent to the server only when calling `SaveChanges`.  
+This way it's possible to perform multiple operations in one request to the server.  
+
+{NOTE: }
+
+### Increment field value
+
+---
+
+`Session.Advanced.Increment`
+{CODE patch_generic_interface_increment@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **T** | `Type` | Entity type |
+| **U** | `Type` | Field type, must be of numeric type or a `string` of `char` for string concatenation |
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `Load` or `Query` operation, this way, the session can track down the entity's ID |
+| **entity id** | `string` | Entity ID on which the operation should be performed. |
+| **fieldPath** | `Expression<Func<T, U>>` | Lambda describing the path to the field. |
+| **delta** | `U` | Value to be added. |
+
+* Note how numbers are handled with the [JavaScript engine](../../../server/kb/numbers-in-ravendb) in RavenDB.
+
+---
+
+`Session.Advanced.AddOrIncrement`
+{CODE add_or_increment_generic@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **T** | `Type` | Entity type |
+| **TU** | `Type` | Field type, must be of numeric type or a `string` of `char` for string concatenation |
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `Load` or `Query` operation, this way, the session can track down the entity's ID |
+| **entity id** | `string` | Entity ID on which the operation should be performed. |
+| **path** | `Expression<Func<T, TU>>` | Lambda describing the path to the field. |
+| **valToAdd** | `U` | Value to be added. |
+
+{NOTE/}
+
+{NOTE: }
+
+### Set field value
+
+---
+
+`Session.Advanced.Patch`
+{CODE patch_generic_interface_set_value@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **T** | `Type` | Entity type |
+| **U** | `Type` | Field type|
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `Load` or `Query` operation. This way the session can track down the entity's ID. |
+| **entity id** | `string` | Entity ID on which the operation should be performed. |
+| **fieldPath** | `Expression<Func<T, U>>` | Lambda describing the path to the field. |
+| **delta** | `U` | Value to set. |
+
+---
+
+`Session.Advanced.AddOrPatch`
+
+{CODE add_or_patch_generic@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **T** | `Type` | Entity type |
+| **TU** | `Type` | Field type|
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `Load` or `Query` operation. This way the session can track down the entity's ID. |
+| **entity id** | `string` | Entity ID on which the operation should be performed. |
+| **fieldPath** | `Expression<Func<T, TU>>` | Lambda describing the path to the field. |
+| **value** | `U` | Value to set. |
+
+{NOTE/}
+
+{NOTE: }
+
+### Array manipulation
+
+---
+
+`Session.Advanced.Patch`
+{CODE patch_generic_interface_array_modification_lambda@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+| Parameters                   | Type | Description |
+|------------------------------| ------------- | ----- |
+| **T**                        | `Type` | Entity type |
+| **U**                        | `Type` | Field type|
+| **entity**                   | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `Load` or `Query` operation. This way the session can track down the entity's ID. |
+| **entity id**                | `string` | Entity ID on which the operation should be performed. |
+| **fieldPath**                | `Expression<Func<T, U>>` | Lambda describing the path to the field. |
+| **arrayModificationLambda** | `Expression<Func<JavaScriptArray<U>, object>>` | Lambda that modifies the array, see `JavaScriptArray` below. |
+
+---
+
+`Session.Advanced.AddOrPatch`
+{CODE add_or_patch_array_generic@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **T** | `Type` | Entity type |
+| **TU** | `Type` | Field type|
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `Load` or `Query` operation. This way the session can track down the entity's ID. |
+| **entity id** | `string` | Entity ID on which the operation should be performed. |
+| **path** | `Expression<Func<T, TU>>` | Lambda describing the path to the field. |
+| **Expression<Func<JavaScriptArray>** | `Expression<Func<JavaScriptArray<TU>, object>>` | Lambda that modifies the array, see `JavaScriptArray` below. |
+| **arrayAdder** | `Add()` | Values to add to array. |
+
+{INFO: JavaScriptArray}
+
+`JavaScriptArray` allows building lambdas representing array manipulations for patches.  
+
+| Method Signature| Return Type | Description |
+|--------|:-----|-------------| 
+| **Put(T item)** | `JavaScriptArray` | Allows adding `item` to an array. |
+| **Put(params T[] items)** | `JavaScriptArray` | Items to be added to the array. |
+| **RemoveAt(int index)** | `JavaScriptArray` | Removes item in position `index` in array. |
+| **RemoveAll(Func<T, bool> predicate)** | `JavaScriptArray` | Removes all the items in the array that satisfy the given predicate. |
+
+{INFO/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Session API using Defer}
+
+The non-typed Session API for patches uses the `Session.Advanced.Defer` function which allows registering one or more commands.  
+One of the possible commands is the `PatchCommandData`, describing single document patch command.  
+The patch request will be sent to the server only when calling `SaveChanges`, this way it's possible to perform multiple operations in one request to the server.  
+
+`Session.Advanced.Defer`
+{CODE patch_non_generic_interface_in_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+{INFO: PatchCommandData}
+
+| Constructor        | Type           | Description                                                                                                                              |
+|--------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| **id**             | `string`       | ID of the document to be patched.                                                                                                        |
+| **changeVector**   | `string`       | [Can be null] Change vector of the document to be patched, used to verify that the document was not changed before the patch reached it. |
+| **patch**          | `PatchRequest` | Patch request to be performed on the document.                                                                                           |
+| **patchIfMissing** | `PatchRequest` | [Can be null] Patch request to be performed if no document with the given ID was found.                                                  |
+
+{INFO/}
+
+{INFO: PatchRequest}
+
+We highly recommend using scripts with parameters. This allows RavenDB to cache scripts and boost performance. 
+Parameters can be accessed in the script through the `args` object and passed using PatchRequest's "Values" parameter.
+
+| Members    | Type                         | Description                                                                                                                                                                  |
+|------------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Script** | `string`                     | JavaScript code to be run.                                                                                                                                                   |
+| **Values** | `Dictionary<string, object>` | Parameters to be passed to the script. The parameters can be accessed using the '$' prefix. Parameter starting with a '$' will be used as is, without further concatenation. |
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Operations API}
+
+An operations interface that exposes the full functionality and allows performing ad-hoc patch operations without creating a session.  
+
+`Raven.Client.Documents.Operations.Send`  
+`Raven.Client.Documents.Operations.SendAsync`  
+
+{CODE patch_non_generic_interface_in_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+{INFO: PatchOperation}
+
+| Constructor| Type | Description |
+|--------|:-----|-------------|
+| **id** | `string` | ID of the document to be patched. |
+| **changeVector** | `string` | [Can be null] Change vector of the document to be patched, used to verify that the document was not changed before the patch reached it. |
+| **patch** | `PatchRequest` | Patch request to be performed on the document. |
+| **patchIfMissing** | `PatchRequest` | [Can be null] Patch request to be performed if no document with the given ID was found. Will run only if no `changeVector` was passed. |
+| **skipPatchIfChangeVectorMismatch** | `bool` | If false and `changeVector` has value, and document with that ID and change vector was not found, will throw an exception. |
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: List of script methods}
+
+This is a list of a few of the javascript methods that can be used in patch scripts.  
+See the more comprehensive list at [Knowledge Base: JavaScript Engine](../../../server/kb/javascript-engine#predefined-javascript-functions).  
+
+| Method               | Arguments                                           | Description                                                                                                                                                                                                                                            |
+|----------------------|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **load**             | `string` or `string[]`                              | Loads one or more documents into the context of the script by their document IDs                                                                                                                                                                       |
+| **loadPath**         | A document and a path to an ID within that document | Loads a related document by the path to its ID                                                                                                                                                                                                         |
+| **del**              | Document ID; change vector                          | Delete the given document by its ID. If you add the expected change vector and the document's current change vector does not match, the document will _not_ be deleted.                                                                                |
+| **put**              | Document ID; document; change vector                | Create or overwrite a document with a specified ID and entity. If you try to overwrite an existing document and pass the expected change vector, the put will fail if the specified change vector does not match the document's current change vector. |
+| **cmpxchg**          | Key                                                 | Load a compare exchange value into the context of the script using its key                                                                                                                                                                             |
+| **getMetadata**      | Document                                            | Returns the document's metadata                                                                                                                                                                                                                        |
+| **id**               | Document                                            | Returns the document's ID                                                                                                                                                                                                                              |
+| **lastModified**     | Document                                            | Returns the `DateTime` of the most recent modification made to the given document                                                                                                                                                                      |
+| **counter**          | Document; counter name                              | Returns the value of the specified counter in the specified document                                                                                                                                                                                   |
+| **counterRaw**       | Document; counter name                              | Returns the specified counter in the specified document as a key-value pair                                                                                                                                                                            |
+| **incrementCounter** | Document; counter name                              | Increases the value of the counter by one                                                                                                                                                                                                              |
+| **deleteCounter**    | Document; counter name                              | Deletes the counter                                                                                                                                                                                                                                    |
+| **spatial.distance** | Two points by latitude and longitude; spatial units | Find the distance between to points on the earth                                                                                                                                                                                                       |
+| **timeseries**       | Document; the time series' name                     | Returns the specified time series object                                                                                                                                                                                                               |
+
+{PANEL/}
+
+{PANEL: Examples}
+
+### Change value of single field
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax patch_firstName_generic@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax patch_firstName_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax patch_firstName_non_generic_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Change values of two fields
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax patch_firstName_and_lastName_generic@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax pathc_firstName_and_lastName_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax pathc_firstName_and_lastName_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Increment value
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax increment_age_generic@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax increment_age_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax increment_age_non_generic_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Add or increment
+
+`AddOrIncrement` increments an existing field or adds a new one in documents where they didn't exist.
+
+{CODE Add_Or_Increment_Sample@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+---
+
+### Add or patch
+
+`AddOrPatch` adds or edits field(s) in a single document.  
+
+If the document doesn't yet exist, this operation adds the document but doesn't patch it.  
+
+{CODE Add_Or_Patch_Sample@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+---
+
+### Add or patch to an existing array
+
+This sample shows how to patch an existing array or add it to documents where it doesn't yet exist.
+
+{CODE Add_Or_Patch_Array_Sample@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+---
+
+### Add item to array
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax add_new_comment_to_comments_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax add_new_comment_to_comments_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax add_new_comment_to_comments_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Insert item into specific position in array
+
+Inserting item into specific position is supported only by the non-typed APIs.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_defer_syntax insert_new_comment_at_position_1_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax insert_new_comment_at_position_1_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Modify item in specific position in array
+
+Inserting item into specific position is supported only by the non-typed APIs.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_defer_syntax modify_a_comment_at_position_3_in_comments_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax modify_a_comment_at_position_3_in_comments_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Remove items from array
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax filter_items_from_array_session_generic@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax filter_items_from_array_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax filter_items_from_array_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Loading documents in a script
+
+Loading documents is supported only by the non-typed APIs.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_defer_syntax update_product_name_in_order_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax update_product_name_in_order_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Remove property
+
+Removing property supported only by the non-typed APIs.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_defer_syntax remove_property_age_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax remove_property_age_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Rename property
+
+Renaming property supported only by the non-typed APIs.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_defer_syntax rename_property_age_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax rename_property_age_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Add document
+
+Adding a new document is supported only by the non-typed APIs.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_defer_syntax add_document_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax add_document_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+---
+
+### Clone document
+
+In order to clone a document use put method as follows.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_defer_syntax clone_document_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax clone_document_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+{INFO: }
+
+__Attachments, Counters, Time Series, and Revisions:__
+
+Attachments, counters, time series data, and revisions from the source document will Not be copied  
+to the new document automatically.
+
+{INFO/}
+
+---
+
+### Increment counter
+
+In order to increment or create a counter use <code>incrementCounter</code> method as follows:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax increment_counter_by_document_reference_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax increment_counter_by_document_id_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax increment_counter_by_document_id_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+{INFO: Method overloading & value restrictions}
+
+The method can be called by document ID or by document reference and the value can be negative.
+
+{INFO/}
+
+---
+
+### Delete counter
+
+In order to delete a counter use <code>deleteCounter</code> method as follows:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax delete_counter_by_document_id_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax delete_counter_by_document_refference_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operation_syntax delete_counter_by_document_refference_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+{INFO: Method overloading}
+
+The method can be called by document ID or by document reference
+
+{INFO/}
+
+---
+
+### Get counter
+
+In order to get a counter while patching use <code>counter</code> method as follows:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Session_syntax get_counter_by_document_id_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Session_defer_syntax get_counter_by_document_id_non_generic_session@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TAB:csharp:Operations_syntax get_counter_by_document_id_store@ClientApi\Operations\Patches\PatchRequests.cs /}
+{CODE-TABS/}
+
+{INFO: Method overloading}
+
+The method can be called by document ID or by document reference.
+
+{INFO/}
+
+{PANEL/}
+
+## Related Articles
+
+### Patching
+
+- [Set based patch operation](../../../client-api/operations/patching/set-based)  
+
+### Knowledge Base
+
+- [JavaScript engine](../../../server/kb/javascript-engine)
+- [Numbers in JavaScript engine](../../../server/kb/numbers-in-ravendb#numbers-in-javascript-engine)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.java.markdown
@@ -1,0 +1,304 @@
+# Single Document Patch Operations
+
+{NOTE: }
+The **Patch** operation is used to perform partial document updates without having to load, modify, and save a full document.  
+The whole operation is executed on the server side and is useful as a performance enhancement or for updating denormalized data in entities.
+
+The current page deals with patch operations on single documents.
+
+Patching has three possible interfaces: [Session API](../../../client-api/operations/patching/single-document#session-api), [Session API using defer](../../../client-api/operations/patching/single-document#session-api-using-defer), and [Operations API](../../../client-api/operations/patching/single-document#operations-api).
+
+Patching can be done from the client as well as in the studio.  
+
+In this page:  
+[API overview](../../../client-api/operations/patching/single-document#api-overview)  
+[Examples](../../../client-api/operations/patching/single-document#examples)  
+{NOTE/}
+
+## API overview
+
+{PANEL: Session API}
+
+A session interface that allows performing the most common patch operations.  
+The patch request will be sent to server only when calling `saveChanges`, this way it's possible to perform multiple operations in one request to the server.  
+
+### Increment Field Value
+`session.advanced().increment`
+{CODE:java patch_generic_interface_increment@ClientApi\Operations\Patches\PatchRequests.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **T** | `Class` | Entity class |
+| **U** | `Class` | Field class, must be of numeric type, or a `String` of `char` for string concatenation |
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `load` or `query` operation, this way, the session can track down the entity's ID |
+| **entity id** | `String` | Entity ID on which the operation should be performed. |
+| **delta** | `U` | Value to be added. |
+
+* Note how numbers are handled with the [JavaScript engine](../../../server/kb/numbers-in-ravendb) in RavenDB.
+
+### Set Field Value
+`session.advanced().patch`
+{CODE:java patch_generic_interface_set_value@ClientApi\Operations\Patches\PatchRequests.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **T** | `Class` | Entity Class |
+| **U** | `Class` | Field class |
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `load` or `query` operation, this way, the session can track down the entity's ID |
+| **entity id** | `String` | Entity ID on which the operation should be performed. |
+| **delta** | `U` | Value to set. |
+
+### Array Manipulation
+`session.advanced().patch`
+{CODE:java patch_generic_interface_array_modification_lambda@ClientApi\Operations\Patches\PatchRequests.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **T** | `Class` | Entity class |
+| **U** | `Class` | Field class |
+| **entity** | `T` | Entity on which the operation should be performed. The entity should be one that was returned by the current session in a `Load` or `Query` operation, this way, the session can track down the entity's ID |
+| **entity id** | `String` | Entity ID on which the operation should be performed. |
+| **arrayAdder** | `Consumer<JavaScriptArray<U>>` | Lambda that modifies the array, see `JavaScriptArray` below. |
+
+{INFO:JavaScriptArray}
+`JavaScriptArray` allows building lambdas representing array manipulations for patches.  
+
+| Method Signature| Return Type | Description |
+|--------|:-----|-------------| 
+| **put(T item)** | `JavaScriptArray` | Allows adding `item` to an array. |
+| **put(T... items)** | `JavaScriptArray` | Items to be added to the array. |
+| **put(Collection<T> items)** | `JavaScriptArray` | Items to be added to the array. |
+| **removeAt(int index)** | `JavaScriptArray` | Removes item in position `index` in array. |
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL:Session API using defer}
+The low level session api for patches uses the `session.advanced().defer` function that allows registering single or several commands.  
+One of the possible commands is the `PatchCommandData`, describing single document patch command.  
+The patch request will be sent to server only when calling `saveChanges`, this way it's possible to perform multiple operations in one request to the server.  
+
+`session.advanced().defer`
+{CODE:java patch_non_generic_interface_in_session@ClientApi\Operations\Patches\PatchRequests.java /}
+
+{INFO: PatchCommandData}
+
+| Constructor|  | |
+|--------|:-----|-------------|
+| **id** | `String` | ID of the document to be patched. |
+| **changeVector** | `String` | [Can be null] Change vector of the document to be patched, used to verify that the document was not changed before the patch reached it. |
+| **patch** | `PatchRequest` | Patch request to be performed on the document. |
+| **patchIfMissing** | `PatchRequest` | [Can be null] Patch request to be performed if no document with the given ID was found. |
+
+{INFO/}
+
+{INFO: PatchRequest}
+
+We highly recommend using scripts with parameters. This allows RavenDB to cache scripts and boost performance. Parameters can be accessed in the script through the "args" object, and passed using PatchRequest's "Values" parameter.
+
+| Members | | |
+| ------------- | ------------- | ----- |
+| **Script** | `String` | JavaScript code to be run. |
+| **Values** | `Map<String, Object>` | Parameters to be passed to the script. The parameters can be accessed using the '$' prefix. Parameter starting with a '$' will be used as is, without further concatenation . |
+
+{INFO/}
+
+{PANEL/}
+
+
+{PANEL: Operations API}
+An operations interface that exposes the full functionality and allows performing ad-hoc patch operations without creating a session.  
+
+{CODE:java patch_non_generic_interface_in_store@ClientApi\Operations\Patches\PatchRequests.java /}
+
+{INFO: PatchOperation}
+
+| Constructor|  | |
+|--------|:-----|-------------|
+| **id** | `String` | ID of the document to be patched. |
+| **changeVector** | `String` | [Can be null] Change vector of the document to be patched, used to verify that the document was not changed before the patch reached it. |
+| **patch** | `PatchRequest` | Patch request to be performed on the document. |
+| **patchIfMissing** | `PatchRequest` | [Can be null] Patch request to be performed if no document with the given ID was found. Will run only if no `changeVector` was passed. |
+| **skipPatchIfChangeVectorMismatch** | `boolean` | If false and `changeVector` has value, and document with that ID and change vector was not found, will throw exception. |
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: List of Script Methods}
+
+This is a list of a few of the javascript methods that can be used in patch scripts. See the 
+more comprehensive list at [Knowledge Base: JavaScript Engine](../../../server/kb/javascript-engine#predefined-javascript-functions).  
+
+| Method | Arguments | Description |
+| - | - | - |
+| **load** | `string` or `string[]` | Loads one or more documents into the context of the script by their document IDs |
+| **loadPath** | A document and a path to an ID within that document | Loads a related document by the path to its ID |
+| **del** | Document ID; change vector | Delete the given document by its ID. If you add the expected change vector and the document's current change vector does not match, the document will _not_ be deleted. |
+| **put** | Document ID; document; change vector | Create or overwrite a document with a specified ID and entity. If you try to overwrite an existing document and pass the expected change vector, the put will fail if the specified change vector does not match the document's current change vector. |
+| **cmpxchg** | Key | Load a compare exchange value into the context of the script using its key |
+| **getMetadata** | Document | Returns the document's metadata |
+| **id** | Document | Returns the document's ID |
+| **lastModified** | Document | Returns the `DateTime` of the most recent modification made to the given document |
+| **counter** | Document; counter name | Returns the value of the specified counter in the specified document |
+| **counterRaw** | Document; counter name | Returns the specified counter in the specified document as a key-value pair |
+| **incrementCounter** | Document; counter name | Increases the value of the counter by one |
+| **deleteCounter** | Document; counter name | Deletes the counter |
+
+{PANEL/}
+
+{PANEL: Examples}
+
+###Change Field's Value
+
+{CODE-TABS}
+{CODE-TAB:java:Session-syntax patch_firstName_generic@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Session-defer-syntax patch_firstName_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax patch_firstName_non_generic_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Change Values of Two Fields
+
+{CODE-TABS}
+{CODE-TAB:java:Session-syntax patch_firstName_and_lastName_generic@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Session-defer-syntax pathc_firstName_and_lastName_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax pathc_firstName_and_lastName_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Increment Value
+
+{CODE-TABS}
+{CODE-TAB:java:Session-syntax increment_age_generic@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Session-defer-syntax increment_age_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax increment_age_non_generic_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Add Item to Array
+
+{CODE-TABS}
+{CODE-TAB:java:Session-syntax add_new_comment_to_comments_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Session-defer-syntax add_new_comment_to_comments_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax add_new_comment_to_comments_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Insert Item into Specific Position in Array
+
+Inserting item into specific position is supported only by the non-typed APIs
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax insert_new_comment_at_position_1_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax insert_new_comment_at_position_1_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Modify Item in Specific Position in Array
+
+Inserting item into specific position is supported only by the non-typed APIs
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax modify_a_comment_at_position_3_in_comments_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax modify_a_comment_at_position_3_in_comments_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Remove Items from Array
+
+Filtering items from an array supported only by the non-typed APIs
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax filter_items_from_array_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax filter_items_from_array_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Loading Documents in a Script
+
+Loading documents supported only by non-typed APIs
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax update_product_name_in_order_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax update_product_name_in_order_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Remove Property
+
+Removing property supported only by the non-typed APIs
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax rename_property_age_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax rename_property_age_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Rename Property
+
+Renaming property supported only by the non-typed APIs
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax rename_property_age_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax rename_property_age_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Add Document
+
+Adding a new document is supported only by the non-typed APIs
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax add_document_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax add_document_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+###Clone Document
+
+In order to clone a document use put method as follows
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax clone_document_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax clone_document_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+{INFO: }
+
+__Attachments, Counters, Time Series, and Revisions:__
+
+Attachments, counters, time series data, and revisions from the source document will Not be copied to the new document automatically.
+
+{INFO/}
+
+###Increment Counter
+
+In order to increment or create a counter use <code>incrementCounter</code> method as follows
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax increment_counter_by_document_id_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax increment_counter_by_document_id_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+{INFO:Method Overloading & Value restrictions}
+The method can be called by document ID or by document reference and the value can be negative
+{INFO/}
+
+###Delete Counter
+
+In order to delete a counter use <code>deleteCounter</code> method as follows
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax delete_counter_by_document_refference_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax delete_counter_by_document_refference_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+{INFO:Method Overloading}
+The method can be called by document ID or by document reference
+{INFO/}
+
+###Get Counter
+
+In order to get a counter while patching use <code>counter</code> method as follows
+{CODE-TABS}
+{CODE-TAB:java:Session-defer-syntax get_counter_by_document_id_non_generic_session@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TAB:java:Operations-syntax get_counter_by_document_id_store@ClientApi\Operations\Patches\PatchRequests.java /}
+{CODE-TABS/}
+
+{INFO:Method Overloading}
+The method can be called by document ID or by document reference
+{INFO/}
+
+{PANEL/}
+
+## Related Articles
+
+### Patching
+
+- [Set based patch operation](../../../client-api/operations/patching/set-based)  
+
+### Knowledge Base
+
+- [JavaScript engine](../../../server/kb/javascript-engine)
+- [Numbers in JavaScript engine](../../../server/kb/numbers-in-ravendb#numbers-in-javascript-engine)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.js.markdown
@@ -1,0 +1,538 @@
+# Single Document Patch Operations
+---
+
+{NOTE: }
+
+* Patching allows __updating only parts of a document__ in a single trip to the server,  
+  without having to load, modify, and save the entire document back to the database.
+ 
+* This is particularly efficient for large documents or when only a small portion of the document needs to be changed, 
+  reducing the amount of data transferred over the network.
+
+* The patching operation is executed on the server-side within a [Single write transaction](../../../client-api/faq/transaction-support).
+
+* This article covers patch operations on single documents from the Client API.  
+  To patch multiple documents that match certain criteria see [Set based patching](../../../client-api/operations/patching/set-based).  
+  Patching can also be done from the [Studio](../../../studio/database/documents/patch-view).  
+
+* In this page:  
+
+  * [API overview](../../../client-api/operations/patching/single-document#api-overview)    
+  
+  * [Examples](../../../client-api/operations/patching/single-document#examples)  
+      * [Change value of single field](../../../client-api/operations/patching/single-document#change-value-of-single-field)  
+      * [Change values of two fields](../../../client-api/operations/patching/single-document#change-values-of-two-fields)  
+      * [Increment value](../../../client-api/operations/patching/single-document#increment-value)  
+      * [Add or increment](../../../client-api/operations/patching/single-document#add-or-increment)  
+      * [Add or patch](../../../client-api/operations/patching/single-document#add-or-patch)
+      * [Add item to array](../../../client-api/operations/patching/single-document#add-item-to-array)
+      * [Add or patch to an existing array](../../../client-api/operations/patching/single-document#add-or-patch-to-an-existing-array)  
+      * [Insert item into specific position in array](../../../client-api/operations/patching/single-document#insert-item-into-specific-position-in-array)  
+      * [Modify item in specific position in array](../../../client-api/operations/patching/single-document#modify-item-in-specific-position-in-array)  
+      * [Remove items from array](../../../client-api/operations/patching/single-document#remove-items-from-array)  
+      * [Load documents in a script](../../../client-api/operations/patching/single-document#load-documents-in-a-script)  
+      * [Remove property](../../../client-api/operations/patching/single-document#remove-property)  
+      * [Rename property](../../../client-api/operations/patching/single-document#rename-property)  
+      * [Add document](../../../client-api/operations/patching/single-document#add-document)  
+      * [Clone document](../../../client-api/operations/patching/single-document#clone-document)  
+      * [Create/Increment counter](../../../client-api/operations/patching/single-document#createincrement-counter)  
+      * [Delete counter](../../../client-api/operations/patching/single-document#delete-counter)  
+      * [Get counter](../../../client-api/operations/patching/single-document#get-counter)  
+  
+  * [Syntax](../../../client-api/operations/patching/single-document#syntax)
+      * [Session API syntax](../../../client-api/operations/patching/single-document#session-api-syntax)
+      * [Session API using defer syntax](../../../client-api/operations/patching/single-document#session-api-using-defer-syntax)
+      * [Operations API syntax](../../../client-api/operations/patching/single-document#operations-api-syntax)
+      * [List of script methods syntax](../../../client-api/operations/patching/single-document#list-of-script-methods-syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: API overview}
+
+Patching can be performed using either of the following interfaces (detailed syntax is provided [below](../../../client-api/operations/patching/single-document#syntax)):
+
+* __Session API__
+* __Session API using defer__ 
+* __Operations API__
+
+---
+
+{NOTE: }
+
+#### Session API
+
+* This interface allows performing most common patch operations.
+
+* Multiple patch methods can be defined on the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+  and are sent to the server for execution in a single batch (along with any other modified documents) only when calling [SaveChanges](../../../client-api/session/saving-changes).
+
+* This API includes the following patching methods (see examples [below](../../../client-api/operations/patching/single-document#examples)):
+  * `patch`
+  * `addOrPatch`
+  * `increment`
+  * `addOrIncrement`
+  * `patchArray`
+  * `addOrPatchArray`
+
+{NOTE/}
+{NOTE: }
+
+#### Session API using defer
+
+* Use `defer` to manipulate the patch request directly without wrapper methods.  
+  Define the patch request yourself with a __script__ and optional variables.  
+
+* The patch request constructs the `PatchCommandData` command,  
+  which is then added to the session using the `defer` function.
+
+* Similar to the above Session API,  
+  all patch requests done via `defer` are sent to the server for execution only when _saveChanges_ is called.
+
+{NOTE/}
+{NOTE: }
+
+#### Operations API
+
+* [Operations](../../../client-api/operations/what-are-operations) allow performing ad-hoc requests directly on the document store __without__ creating a session.
+
+* Similar to the above _defer_ usage, define the patch request yourself with a script and optional variables.  
+
+* The patch requests constructs the `PatchOperation`, which is sent to the server for execution only when _saveChanges_ is called.
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+<a id="change-value-of-single-field" /> __Change value of single field__:  
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax patch_firstName_session@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Session_defer_syntax patch_firstName_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax patch_firstName_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="change-values-of-two-fields" /> __Change values of two fields__:
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax patch_firstName_and_lastName_session@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Session_defer_syntax patch_firstName_and_lastName_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax patch_firstName_and_lastName_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="increment-value" /> __Increment value__:
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax increment_value_session@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Session_defer_syntax increment_value_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax increment_value_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="add-or-increment" /> __Add or increment__:
+
+---
+
+`addOrIncrement` behavior:
+
+* If document exists + has the specified field =>
+    * A numeric field will be __incremented__ by the specified value.
+    * A string field will be __concatenated__ with the specified value.
+* If document exists + does Not contain the specified field =>
+    * The field will be __added__ to the document with the specified value.
+* If document does Not exist =>
+    * A new document will be __created__ from the provided entity.
+    * The value to increment by is disregarded.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax add_or_increment@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:User_class user_class@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="add-or-patch" /> __Add or patch__:  
+
+---
+
+`addOrPatch` behavior:
+
+* If document exists + has the specified field =>
+    * The field will be __patched__, the specified value will replace the existing value.
+* If document exists + does Not contain the specified field =>
+    * The field will be __added__ to the document with the specified value.
+* If document does Not exist =>
+    * A new document will be __created__ from the provided entity.
+    * The value to patch by is disregarded.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax add_or_patch@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:User_class user_class@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="add-item-to-array" /> __Add item to array__:  
+
+---
+
+`patchArray` behavior:
+
+* If document exists + has the specified array =>
+    * Item will be __added__ to the array.
+* If document exists + does Not contain the specified array field =>
+    * No exception is thrown, no patching is done, a new array is Not created.
+* If document does Not exist =>
+    * No exception is thrown, no patching is done, a new document is Not created.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax add_item_to_array_session@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Session_defer_syntax add_item_to_array_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax add_item_to_array_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Blog_classes Blog_classes@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="add-or-patch-to-an-existing-array" /> __Add or patch to an existing array__:  
+
+---
+
+`addOrPatchArray` behavior:
+
+* If document exists + has the specified array field =>
+    * The specified values will be __added__ to the existing array values.
+* If document exists + does Not contain the specified array field =>
+    * The array field is Not added to the document, no patching is done.
+* If document does Not exist =>
+    * A new document will be __created__ from the provided entity.
+    * The value to patch by is disregarded.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax add_or_patch_array@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:User_class user_class@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="insert-item-into-specific-position-in-array" /> __Insert item into specific position in array__:  
+
+---
+
+* Inserting an item in a specific position is supported only by the _defer_ or the _operations_ syntax.  
+* No exception is thrown if either the document or the specified array does not exist.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax insert_item_in_array_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax insert_item_in_array_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Blog_classes Blog_classes@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="modify-item-in-specific-position-in-array" /> __Modify item in specific position in array__:  
+
+---
+
+* Inserting an item in a specific position is supported only by the _defer_ or the _operations_ syntax.
+* No exception is thrown if either the document or the specified array does not exist.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax modify_item_in_array_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax modify_item_in_array_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Blog_classes Blog_classes@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="remove-items-from-array" /> __Remove items from array__:  
+
+---
+
+* Removing all items that match some predicate from an array is supported only by the _defer_ or the _operations_ syntax.
+* No exception is thrown if either the document or the specified array does not exist.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax filter_items_from_array_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax filter_items_from_array_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Blog_classes Blog_classes@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="load-documents-in-a-script" /> __Load documents in a script__:  
+
+---
+
+* Loading documents is supported only by the _defer_ or the _operations_ syntax.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax load_and_update_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax load_and_update_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="remove-property" /> __Remove property__:  
+
+---
+
+* Removing a property is supported only by the _defer_ or the _operations_ syntax.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax remove_property_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax remove_property_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="rename-property" /> __Rename property__:  
+
+---
+
+* Renaming a property is supported only by the _defer_ or the _operations_ syntax.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax rename_property_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax rename_property_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="add-document" /> __Add document__:  
+
+---
+
+* Adding a new document is supported only by the _defer_ or the _operations_ syntax.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax add_document_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax add_document_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="clone-document" /> __Clone document__:  
+
+---
+
+* Cloning a new document is supported only by the _defer_ or the _operations_ syntax.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_defer_syntax clone_document_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax clone_document_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{INFO: }
+
+__Attachments, Counters, Time Series, and Revisions:__
+
+Attachments, counters, time series data, and revisions from the source document will Not be copied to the new document automatically.
+
+{INFO/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="createincrement-counter" /> __Create/Increment counter__:  
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax increment_counter_session@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Session_defer_syntax increment_counter_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax increment_counter_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{INFO: }
+
+Learn more about Counters in this [Counters Overview](../../../document-extensions/counters/overview).
+
+{INFO/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="delete-counter" /> __Delete counter__:  
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax delete_counter_session@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Session_defer_syntax delete_counter_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax delete_counter_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="get-counter" /> __Get counter__:  
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Session_syntax get_counter_session@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Session_defer_syntax get_counter_defer@client-api\operations\patches\patchRequests.js /}
+{CODE-TAB:nodejs:Operations_syntax get_counter_operation@client-api\operations\patches\patchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+---
+
+### Session API syntax
+
+
+{CODE:nodejs patch_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Parameter  | Type     | Description                                                                                                                                       |
+|------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| __id__     | `string` | Document ID on which patching should be performed.                                                                                                |
+| __entity__ | `object` | Entity on which patching should be performed. The entity should be one that was returned by the current session in a `load` or `query` operation. |
+| __Path__   | `string` | The path to the field.                                                                                                                            |
+| __value__  | `object` | Value to set.                                                                                                                                     |
+
+{CODE:nodejs add_or_patch_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Parameter  | Type     | Description                                                                              |
+|------------|----------|------------------------------------------------------------------------------------------|
+| __id__     | `string` | Document ID on which patching should be performed.                                       |
+| __entity__ | `object` | If the specified document is Not found, a new document will be created from this entity. |
+| __Path__   | `string` | The path to the field.                                                                   |
+| __value__  | `object` | Value to set.                                                                            |
+
+{CODE:nodejs increment_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Parameter        | Type     | Description                                                                                                                                       |
+|------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| __id__           | `string` | Document ID on which patching should be performed.                                                                                                |
+| __entity__       | `object` | Entity on which patching should be performed. The entity should be one that was returned by the current session in a `load` or `query` operation. |
+| __path__         | `string` | The path to the field.                                                                                                                            |
+| __valueToAdd__   | `object` | Value to increment by.<br>Note how numbers are handled with the [JavaScript engine](../../../server/kb/numbers-in-ravendb) in RavenDB.            |
+
+{CODE:nodejs add_or_increment_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Parameter        | Type     | Description                                                                              |
+|------------------|----------|------------------------------------------------------------------------------------------|
+| __id__           | `string` | Document ID on which patching should be performed.                                       |
+| __entity__       | `object` | If the specified document is Not found, a new document will be created from this entity. |
+| __path__         | `string` | The path to the field.                                                                   |
+| __valueToAdd__   | `object` | Value to increment by.                                                                   |
+
+{CODE:nodejs patch_array_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Parameter              | Type                        | Description                                                                                                                                       |
+|------------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| __id__                 | `string`                    | Document ID on which patching should be performed.                                                                                                |
+| __entity__             | `object`                    | Entity on which patching should be performed. The entity should be one that was returned by the current session in a `load` or `query` operation. |
+| __pathToArray__        | `string`                    | The path to the array field.                                                                                                                      |
+| __arrayAdder__         | `(JavaScriptArray) => void` | Function that modifies the array.                                                                                                                 |
+
+{CODE:nodejs add_or_patch_array_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Parameter              | Type                        | Description                                                                              |
+|------------------------|-----------------------------|------------------------------------------------------------------------------------------|
+| __id__                 | `string`                    | Document ID on which patching should be performed.                                       |
+| __entity__             | `object`                    | If the specified document is Not found, a new document will be created from this entity. |
+| __pathToArray__        | `string`                    | The path to the array field.                                                             |
+| __arrayAdder__         | `(JavaScriptArray) => void` | Function that modifies the array.                                                        |                                                                                                                                 |
+
+{CODE:nodejs class_JavaScriptArray@client-api\operations\patches\patchRequests.js /}
+
+---
+
+### Session API using defer syntax
+
+{CODE:nodejs defer_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Parameter      | Type       | Description                                                                                               |
+|----------------|------------|-----------------------------------------------------------------------------------------------------------|
+| __commands__   | `object[]` | List of commands that will be executed on the server.<br>Use the `PatchCommandData` command for patching. |
+
+{CODE:nodejs class_PatchCommandData@client-api\operations\patches\patchRequests.js /}
+
+{CODE:nodejs class_PatchRequest@client-api\operations\patches\patchRequests.js /}
+
+---
+
+### Operations API syntax
+
+* Learn more about using operations in this [Operations overview](../../../client-api/operations/what-are-operations).
+
+{CODE:nodejs operations_syntax@client-api\operations\patches\patchRequests.js /}
+
+| Constructor                         | Type           | Description                                                                                                                                 |
+|-------------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| __id__                              | `string`       | ID of document to be patched.                                                                                                               |
+| __changeVector__                    | `string`       | Change vector of the document to be patched.<br>Used to verify that the document was not changed before the patch is executed. Can be null. |
+| __patch__                           | `PatchRequest` | Patch request to be performed on the document.                                                                                              |
+| __patchIfMissing__                  | `PatchRequest` | Patch request to be performed if no document with the given ID was found. Will run only if no `changeVector` was passed. Can be null.       |
+| __skipPatchIfChangeVectorMismatch__ | `boolean`      | An exception is thrown if:<br>this param is `false` + `changeVector` has value + document with that ID and change vector was not found.     |
+
+---
+
+### List of script methods syntax
+
+* This is a partial list of some javascript methods that can be used in patch scripts.  
+* For a more comprehensive list, please refer to [Knowledge Base: JavaScript Engine](../../../server/kb/javascript-engine#predefined-javascript-functions).  
+
+| Method               | Arguments                                           | Description                                                                                                                                                                                                                                            |
+|----------------------|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| __load__             | `string` / `string[]`                               | Loads one or more documents into the context of the script by their document IDs.                                                                                                                                                                      |
+| __loadPath__         | A document and a path to an ID within that document | Loads a related document by the path to its ID.                                                                                                                                                                                                        |
+| __del__              | Document ID; change vector;                         | Delete the given document by its ID. If you add the expected change vector and the document's current change vector does not match, the document will _not_ be deleted.                                                                                |
+| __put__              | Document ID; document; change vector;               | Create or overwrite a document with a specified ID and entity. If you try to overwrite an existing document and pass the expected change vector, the put will fail if the specified change vector does not match the document's current change vector. |
+| __cmpxchg__          | Key                                                 | Load a compare exchange value into the context of the script using its key.                                                                                                                                                                            |
+| __getMetadata__      | Document                                            | Returns the document's metadata.                                                                                                                                                                                                                       |
+| __id__               | Document                                            | Returns the document's ID.                                                                                                                                                                                                                             |
+| __lastModified__     | Document                                            | Returns the `DateTime` of the most recent modification made to the given document.                                                                                                                                                                     |
+| __counter__          | Document; counter name;                             | Returns the value of the specified counter in the specified document.                                                                                                                                                                                  |
+| __counterRaw__       | Document; counter name;                             | Returns the specified counter in the specified document as a key-value pair.                                                                                                                                                                           |
+| __incrementCounter__ | Document; counter name;                             | Increases the value of the counter by one.                                                                                                                                                                                                             |
+| __deleteCounter__    | Document; counter name;                             | Deletes the counter.                                                                                                                                                                                                                                   |
+| __timeseries__       | Document; the time series' name;                    | Returns the specified time series object.                                                                                                                                                                                                              |
+
+{PANEL/}
+
+## Related Articles
+
+### Patching
+
+- [Set based patch operation](../../../client-api/operations/patching/set-based)  
+
+### Knowledge Base
+
+- [JavaScript engine](../../../server/kb/javascript-engine)
+- [Numbers in JavaScript engine](../../../server/kb/numbers-in-ravendb#numbers-in-javascript-engine)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.js.markdown
@@ -26,7 +26,7 @@
       * [Add or increment](../../../client-api/operations/patching/single-document#add-or-increment)  
       * [Add or patch](../../../client-api/operations/patching/single-document#add-or-patch)
       * [Add item to array](../../../client-api/operations/patching/single-document#add-item-to-array)
-      * [Add or patch to an existing array](../../../client-api/operations/patching/single-document#add-or-patch-to-an-existing-array)  
+      * [Add or patch an existing array](../../../client-api/operations/patching/single-document#add-or-patch-an-existing-array)  
       * [Insert item into specific position in array](../../../client-api/operations/patching/single-document#insert-item-into-specific-position-in-array)  
       * [Modify item in specific position in array](../../../client-api/operations/patching/single-document#modify-item-in-specific-position-in-array)  
       * [Remove items from array](../../../client-api/operations/patching/single-document#remove-items-from-array)  
@@ -156,8 +156,10 @@ Patching can be performed using either of the following interfaces (detailed syn
 * If document exists + has the specified field =>
     * A numeric field will be __incremented__ by the specified value.
     * A string field will be __concatenated__ with the specified value.
+    * The entity passed is disregarded.
 * If document exists + does Not contain the specified field =>
     * The field will be __added__ to the document with the specified value.
+    * The entity passed is disregarded.
 * If document does Not exist =>
     * A new document will be __created__ from the provided entity.
     * The value to increment by is disregarded.
@@ -178,8 +180,10 @@ Patching can be performed using either of the following interfaces (detailed syn
 
 * If document exists + has the specified field =>
     * The field will be __patched__, the specified value will replace the existing value.
+    * The entity passed is disregarded.
 * If document exists + does Not contain the specified field =>
     * The field will be __added__ to the document with the specified value.
+    * The entity passed is disregarded.
 * If document does Not exist =>
     * A new document will be __created__ from the provided entity.
     * The value to patch by is disregarded.
@@ -215,7 +219,7 @@ Patching can be performed using either of the following interfaces (detailed syn
 {NOTE/}
 {NOTE: }
 
-<a id="add-or-patch-to-an-existing-array" /> __Add or patch to an existing array__:  
+<a id="add-or-patch-an-existing-array" /> __Add or patch an existing array__:  
 
 ---
 
@@ -223,8 +227,10 @@ Patching can be performed using either of the following interfaces (detailed syn
 
 * If document exists + has the specified array field =>
     * The specified values will be __added__ to the existing array values.
+    * The entity passed is disregarded.
 * If document exists + does Not contain the specified array field =>
     * The array field is Not added to the document, no patching is done.
+    * The entity passed is disregarded.
 * If document does Not exist =>
     * A new document will be __created__ from the provided entity.
     * The value to patch by is disregarded.

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Blog.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Blog.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Raven.Documentation.Samples
+{
+	#region blog_post
+	public class BlogPost
+	{
+		public string Id { get; set; }
+
+		public string Title { get; set; }
+
+		public string Category { get; set; }
+
+		public string Content { get; set; }
+
+		public DateTime PublishedAt { get; set; }
+
+		public string[] Tags { get; set; }
+
+		public BlogComment[] Comments { get; set; }
+	}
+	#endregion
+
+	#region blog_comment
+	public class BlogComment
+	{
+		public string Title { get; set; }
+
+		public string Content { get; set; }
+	}
+	#endregion
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Northwind.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Northwind.cs
@@ -6,6 +6,7 @@ namespace Raven.Documentation.Samples
     namespace Orders
     {
         #region northwind
+        
         public class Company
         {
             public string Id { get; set; }
@@ -132,5 +133,15 @@ namespace Raven.Documentation.Samples
             public string Phone { get; set; }
         }
         #endregion
+
+        public class User
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            public List<DateTime> LoginTimes { get; set; }
+            public DateTime LastLogin { get; set; }
+            public int LoginCount { get; set; }
+            public string Supplies { get; set; }
+        }
     }
 }

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/patches/patchRequests.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/patches/patchRequests.js
@@ -1,0 +1,892 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function patchRequests() {
+    {
+        //region patch_firstName_session
+        // Modify FirstName to Robert using the 'patch' method
+        // ===================================================
+        
+        session.advanced.patch("employees/1-A", "FirstName", "Robert");        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region patch_firstName_defer
+        // Modify FirstName to Robert using 'defer' with 'PatchCommandData'
+        // ================================================================
+        
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.FirstName = args.FirstName;";
+        patchRequest.values = { FirstName: "Robert" };
+                
+        const patchCommand = new PatchCommandData("employees/1-A", null, patchRequest);        
+        session.advanced.defer(patchCommand);
+        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region patch_firstName_operation
+        // Modify FirstName to Robert via 'PatchOperation' on the documentStore
+        // ====================================================================
+        
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.FirstName = args.FirstName;";
+        patchRequest.values = { FirstName: "Robert" };
+        
+        const patchOp = new PatchOperation("employees/1-A", null, patchRequest);        
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region patch_firstName_and_lastName_session
+        // Modify FirstName to Robert and LastName to Carter in single request
+        // ===================================================================
+        
+        // The two Patch operations below are sent via 'saveChanges()' which complete transactionally,
+        // as this call generates a single HTTP request to the database. 
+        // Either both will succeed - or both will be rolled back - since they are applied within the same
+        // transaction.
+        
+        // However, on the server side, the two Patch operations are still executed separately.
+        // To achieve atomicity at the level of a single server-side operation, use 'defer' or an 'operation'.
+
+        session.advanced.patch("employees/1-A", "FirstName", "Robert");
+        session.advanced.patch("employees/1-A", "LastName", "Carter");
+        
+        await session.saveChanges();
+        
+        //endregion
+    }
+    {
+        //region patch_firstName_and_lastName_defer
+        // Modify FirstName to Robert and LastName to Carter in single request
+        // ===================================================================
+
+        // Note that here we do maintain the operation's atomicity
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `this.FirstName = args.FirstName;
+                               this.LastName = args.LastName;`;
+        patchRequest.values = { 
+            FirstName: "Robert",
+            LastName: "Carter"
+        };
+ 
+        const patchCommand = new PatchCommandData("employees/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region patch_firstName_and_lastName_operation
+        // Modify FirstName to Robert and LastName to Carter in single request
+        // ===================================================================
+
+        // Note that here we do maintain the operation's atomicity
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `this.FirstName = args.FirstName;
+                               this.LastName = args.LastName;`;
+        patchRequest.values = {
+            FirstName: "Robert",
+            LastName: "Carter"
+        };
+
+        const patchOp = new PatchOperation("employees/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region increment_value_session
+        // Increment UnitsInStock property value by 10
+        // ===========================================
+        
+        session.advanced.increment("products/1-A", "UnitsInStock", 10);
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region increment_value_defer
+        // Increment UnitsInStock property value by 10
+        // ===========================================
+        
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.UnitsInStock += args.UnitsToAdd;";
+        patchRequest.values = {
+            UnitsToAdd: 10
+        };
+
+        const patchCommand = new PatchCommandData("products/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region increment_value_operation
+        // Increment UnitsInStock property value by 10
+        // ===========================================
+        
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.UnitsInStock += args.UnitsToAdd;";
+        patchRequest.values = {
+            UnitsToAdd: 10
+        };
+
+        const patchOp = new PatchOperation("products/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region add_or_increment
+        const newUser = new User();
+        newUser.firstName = "John";
+        newUser.lastName = "Doe";
+        newUser.loginCount = 1;
+
+        session.advanced.addOrIncrement(
+            // Specify document id on which the operation should be performed
+            "users/1",
+            // Specify an entity,
+            // if the specified document is Not found, a new document will be created from this entity
+            newUser,
+            // The field that should be incremented
+            "loginCount",
+            // The value to increment by
+            2);
+        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region add_or_patch
+        const newUser = new User();
+        newUser.firstName = "John";
+        newUser.lastName = "Doe";
+        newUser.lastLogin = new Date(2024, 0, 1);
+
+        session.advanced.addOrPatch(
+            // Specify document id on which the operation should be performed
+            "users/1",
+            // Specify an entity,
+            // if the specified document is Not found, a new document will be created from this entity
+            newUser,
+            // The field that should be patched
+            "lastLogin",
+            // Set the current date and time as the new value
+            new Date());
+
+        await session.saveChanges();        
+        //endregion
+    }
+    {
+        //region add_or_patch_array
+        const newUser = new User();
+        newUser.firstName = "John";
+        newUser.lastName = "Doe";
+        newUser.loginTimes = [new Date(2024, 0, 1)];
+        
+        session.advanced.addOrPatchArray(
+            // Specify document id on which the operation should be performed
+            "users/1",
+            // Specify an entity,
+            // if the specified document is Not found, a new document will be created from this entity
+            newUser,
+            // The field that should be patched
+            "loginTimes",
+            // Add values to the list
+            a => a.push(new Date(2024, 2, 2), new Date(2024, 3, 3)));
+        
+        await session.saveChanges();
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region add_item_to_array_session
+        // Add a new comment to an array
+        // =============================
+        
+        // The new comment to add:
+        const newBlogComment = new BlogComment();
+        newBlogComment.content = "Some content";
+        newBlogComment.title = "Some title";
+        
+        // Call 'patchArray':
+        session.advanced.patchArray(
+            "blogPosts/1",  // Document id to patch
+            "comments",     // The array to add the comment to
+            comments => {   // Adding the new comment
+                comments.push(newBlogComment); 
+            });
+        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region add_item_to_array_defer
+        // Add a new comment to an array
+        // =============================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.comments.push(args.comment);";
+        patchRequest.values = {
+            comment: {
+                title: "Some title",
+                content: "Some content",
+            }
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("blogPosts/1", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region add_item_to_array_operation
+        // Add a new comment to an array
+        // =============================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.comments.push(args.comment);";
+        patchRequest.values = {
+            comment: {
+                title: "Some title",
+                content: "Some content",
+            }
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("blogPosts/1", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region insert_item_in_array_defer
+        // Insert a new comment at position 1
+        // ==================================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.comments.splice(1, 0, args.comment);";
+        patchRequest.values = {
+            comment: {
+                title: "Some title",
+                content: "Some content",
+            }
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("blogPosts/1", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region insert_item_in_array_operation
+        // Insert a new comment at position 1
+        // ==================================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.comments.splice(1, 0, args.comment);";
+        patchRequest.values = {
+            comment: {
+                title: "Some title",
+                content: "Some content",
+            }
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("blogPosts/1", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region modify_item_in_array_defer
+        // Modify comment at position 3
+        // ============================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.comments.splice(3, 1, args.comment);";
+        patchRequest.values = {
+            comment: {
+                title: "Some title",
+                content: "Some content",
+            }
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("blogPosts/1", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region modify_item_in_array_operation
+        // Modify comment at position 3
+        // ============================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = "this.comments.splice(3, 1, args.comment);";
+        patchRequest.values = {
+            comment: {
+                title: "Some title",
+                content: "Some content",
+            }
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("blogPosts/1", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region filter_items_from_array_defer
+        // Remove all comments that contain the word "wrong" in their content
+        // ==================================================================
+        
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `this.comments = this.comments.filter(comment => 
+                               !comment.content.includes(args.text));`;
+        patchRequest.values = {
+            text: "wrong"
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("blogPosts/1", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region filter_items_from_array_operation
+        // Remove all comments that contain the word "wrong" in their content
+        // ==================================================================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `this.comments = this.comments.filter(comment => 
+                               !comment.content.includes(args.text));`;
+        patchRequest.values = {
+            text: "wrong"
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("blogPosts/1", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region load_and_update_defer
+        // Load a related document and update a field
+        // ==========================================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `this.Lines.forEach(line => { 
+                                   const productDoc = load(line.Product);
+                                   line.ProductName = productDoc.Name;
+                               });`;
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("orders/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region load_and_update_operation
+        // Load a related document and update a field
+        // ==========================================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `this.Lines.forEach(line => { 
+                                   const productDoc = load(line.Product);
+                                   line.ProductName = productDoc.Name;
+                               });`;
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("orders/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    /////////////////////////////////////////////////////////////////////////
+    {
+        //region remove_property_defer
+        // Remove a document property
+        // ==========================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `delete this.Address.PostalCode;`;
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("employees/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region remove_property_operation
+        // Remove a document property
+        // ==========================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `delete this.Address.PostalCode;`;
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("employees/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region rename_property_defer
+        // Rename property Name to ProductName
+        // ===================================
+        
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `const propertyValue = this[args.currentProperty];
+                               delete this[args.currentProperty];
+                               this[args.newProperty] = propertyValue;`;
+        patchRequest.values = {
+            currentProperty: "Name",
+            newProperty: "ProductName"
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("products/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region rename_property_operation
+        // Rename property Name to ProductName
+        // ===================================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        patchRequest.script = `const propertyValue = this[args.currentProperty];
+                               delete this[args.currentProperty];
+                               this[args.newProperty] = propertyValue;`;
+        patchRequest.values = {
+            currentProperty: "Name",
+            newProperty: "ProductName"
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("products/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region add_document_defer
+        // Add a new document
+        // ==================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // Add a new document (projects/1) to collection Projects
+        // The id of the patched document (employees/1-A) is used as content for ProjectLeader property
+        patchRequest.script = `put('projects/1', { 
+                                   ProjectLeader: id(this),
+                                   ProjectDesc: 'Some desc..', 
+                                   '@metadata': { '@collection': 'Projects'} 
+                               });`;
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("employees/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region add_document_operation
+        // Add a new document
+        // ==================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // Add a new document (projects/1) to collection Projects
+        // The id of the patched document (employees/1-A) is used as content for ProjectLeader property
+        patchRequest.script = `put('projects/1', { 
+                                   ProjectLeader: id(this),
+                                   ProjectDesc: 'Some desc..', 
+                                   '@metadata': { '@collection': 'Projects'} 
+                               });`;
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("employees/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region clone_document_defer
+        // Clone a document
+        // ================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // The new document will be in the same collection as 'employees/1-A'
+        // By specifying 'employees/' the server will generate a "server-side ID' to the new document
+        patchRequest.script = `put('employees/', this);`;
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("employees/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region clone_document_operation
+        // Clone a document
+        // ================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // The new document will be in the same collection as 'employees/1-A'
+        // By specifying 'employees/' the server will generate a "server-side ID' to the new document
+        patchRequest.script = `put('employees/', this);`;
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("employees/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region increment_counter_session
+        // Increment/Create counter
+        // ========================
+        
+        // Increase counter "Likes" by 10, or create it with a value of 10 if it doesn't exist
+        session.countersFor("products/1-A").increment("Likes", 10);
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region increment_counter_defer
+        // Create/Increment counter
+        // ========================
+        
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // Use the 'incrementCounter' method to create/increment a counter 
+        patchRequest.script = `incrementCounter(this, args.counterName, args.counterValue);`;
+        patchRequest.values = {
+            counterName: "Likes",
+            counterValue: 10
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("products/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region increment_counter_operation
+        // Create/Increment counter
+        // ========================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // Use the 'incrementCounter' method to create/increment a counter 
+        patchRequest.script = `incrementCounter(this, args.counterName, args.counterValue);`;
+        patchRequest.values = {
+            counterName: "Likes",
+            counterValue: 10
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("products/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region delete_counter_session
+        // Delete counter
+        // ==============
+
+        session.countersFor("products/1-A").delete("Likes");
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region delete_counter_defer
+        // Delete counter
+        // ==============
+        
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // Use the 'deleteCounter' method to delete a counter 
+        patchRequest.script = `deleteCounter(this, args.counterName);`;
+        patchRequest.values = {
+            counterName: "Likes"
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("products/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region delete_counter_operation
+        // Delete counter
+        // ==============
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // Use the 'deleteCounter' method to delete a counter 
+        patchRequest.script = `deleteCounter(this, args.counterName);`;
+        patchRequest.values = {
+            counterName: "Likes"
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("products/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+    //////////////////////////////////////////////////////////////////////////
+    {
+        //region get_counter_session
+        // Get counter value
+        // =================
+        
+        const counters = await session.counterFor("products/1-A").get("Likes");
+        //endregion
+    }
+    {
+        //region get_counter_defer
+        // Get counter value
+        // =================
+        
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+        
+        // Use the 'counter' method to get the value of the specified counter 
+        // and then put the results into a new document 'productLikes/'
+        patchRequest.script = `const numberOfLikes = counter(this, args.counterName);
+                               put('productLikes/', {ProductName: this.Name, Likes: numberOfLikes});`;
+        
+        patchRequest.values = {
+            counterName: "Likes"
+        };
+
+        // Define the 'PatchCommandData':
+        const patchCommand = new PatchCommandData("products/1-A", null, patchRequest);
+        session.advanced.defer(patchCommand);
+
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region get_counter_operation
+        // Get counter value
+        // =================
+
+        // Define the 'PatchRequest':
+        const patchRequest = new PatchRequest();
+
+        // Use the 'counter' method to get the value of the specified counter 
+        // and then put the results into a new document 'productLikes/'
+        patchRequest.script = `const numberOfLikes = counter(this, args.counterName);
+                               put('productLikes/', {ProductName: this.Name, Likes: numberOfLikes});`;
+
+        patchRequest.values = {
+            counterName: "Likes"
+        };
+
+        // Define and send the 'PatchOperation':
+        const patchOp = new PatchOperation("products/1-A", null, patchRequest);
+        await documentStore.operations.send(patchOp);
+        //endregion
+    }
+
+//region syntax
+    
+    {
+        //region patch_syntax
+        patch(id, path, value);
+        patch(entity, path, value);
+        //endregion
+    }
+    {
+        //region add_or_patch_syntax
+        addOrPatch(id, entity, pathToObject, value);
+        //endregion
+    }
+    {
+        //region increment_syntax
+        increment(id, path, valueToAdd);
+        increment(entity, path, valueToAdd);
+        //endregion
+    }
+    {
+        //region add_or_increment_syntax
+        addOrIncrement(id, entity, pathToObject, valToAdd);
+        //endregion
+    }
+    {
+        //region patch_array_syntax
+        patchArray(id, pathToArray, arrayAdder);
+        patchArray(entity, pathToArray, arrayAdder);
+        //endregion
+    }
+    {
+        //region add_or_patch_array_syntax
+        addOrPatchArray(id, entity, pathToObject, arrayAdder);
+        //endregion
+    }
+    {
+        //region class_JavaScriptArray
+        class JavaScriptArray {
+            push(...u);      // Add a list of values to add to the array
+            removeAt(index); // Remove an item from position 'index' in the array
+        }
+        //endregion
+    }
+    {
+        //region defer_syntax
+        session.advanced.defer(...commands);
+        //endregion
+    }
+    {
+        //region class_PatchCommandData
+        class PatchCommandData {
+            // ID of document to be patched
+            id; // string
+            
+            // Change vector of document to be patched, can be null.
+            // Used to verify that the document was not changed before the patch is executed.
+            changeVector // string;
+            
+            // Patch request to be performed on the document
+            patch; // A PatchRequest object
+            
+            // Patch request to perform if no document with the specified ID was found
+            patchIfMissing; // A PatchRequest object
+        }
+        //endregion
+    }
+    {
+        //region class_PatchRequest
+        class PatchRequest {
+            //  The JavaScript code to be run on the server
+            script; // string
+            
+            // Parameters to be passed to the script
+            values:; // Dictionary<string, object>
+
+            // It is highly recommend to use the script with the parameters. 
+            // This allows RavenDB to cache scripts and boost performance.
+            // The parameters are accessed in the script via the `args` object.
+        }
+        //endregion
+    }
+    {
+        //region operations_syntax
+        const patchOperation = new PatchOperation(id, changeVector, patch);
+        
+        const patchOperation = new PatchOperation(id, changeVector, patch, patchIfMissing,
+            skipPatchIfChangeVectorMismatch);
+        //endregion
+    }
+
+//endregion
+
+//region user_class
+    class User {
+        constructor(
+            id = null,
+            firstName = "",
+            lastName = "",
+            loginCount = 0,
+            lastLogin = new Date(),
+            loginTimes = []
+        ) {
+            Object.assign(this, {
+                id,
+                firstName,
+                lastName,
+                loginCount,
+                lastLogin,
+                loginTimes
+            });
+        }
+    }
+//endregion
+
+//region blog_classes
+    class BlogPost {
+        constructor(
+            id = null,
+            title = "",
+            body = "",
+            comments = []
+        ) {
+            Object.assign(this, {
+                id,
+                title,
+                body,
+                comments
+            });
+        }
+    }
+    
+    class BlogComment {
+        constructor(
+            title = "",
+            content = ""
+        ) {
+            Object.assign(this, {
+                title,
+                content
+            });
+        }
+    }
+//endregion

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/patches/patchRequests.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/patches/patchRequests.js
@@ -59,7 +59,6 @@ async function patchRequests() {
         session.advanced.patch("employees/1-A", "LastName", "Carter");
         
         await session.saveChanges();
-        
         //endregion
     }
     {

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/patches/patchRequests.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/patches/patchRequests.js
@@ -144,6 +144,7 @@ async function patchRequests() {
     //////////////////////////////////////////////////////////////////////////
     {
         //region add_or_increment
+        // An entity that will be used in case the specified document is not found:
         const newUser = new User();
         newUser.firstName = "John";
         newUser.lastName = "Doe";
@@ -157,7 +158,7 @@ async function patchRequests() {
             newUser,
             // The field that should be incremented
             "loginCount",
-            // The value to increment by
+            // Increment the specified field by this value
             2);
         
         await session.saveChanges();
@@ -165,6 +166,7 @@ async function patchRequests() {
     }
     {
         //region add_or_patch
+        // An entity that will be used in case the specified document is not found:
         const newUser = new User();
         newUser.firstName = "John";
         newUser.lastName = "Doe";
@@ -178,7 +180,7 @@ async function patchRequests() {
             newUser,
             // The field that should be patched
             "lastLogin",
-            // Set the current date and time as the new value
+            // Set the current date and time as the new value for the specified field
             new Date());
 
         await session.saveChanges();        
@@ -186,6 +188,7 @@ async function patchRequests() {
     }
     {
         //region add_or_patch_array
+        // An entity that will be used in case the specified document is not found:
         const newUser = new User();
         newUser.firstName = "John";
         newUser.lastName = "Doe";
@@ -197,9 +200,9 @@ async function patchRequests() {
             // Specify an entity,
             // if the specified document is Not found, a new document will be created from this entity
             newUser,
-            // The field that should be patched
+            // The array field that should be patched
             "loginTimes",
-            // Add values to the list
+            // Add values to the list of the specified array field
             a => a.push(new Date(2024, 2, 2), new Date(2024, 3, 3)));
         
         await session.saveChanges();


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2715/Node.js-Client-API-Operations-Patching-Single-document-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied + 
   the Node.js article's text & flow WAS organized & improved from the original C# article .

* Fixes to the C# article and other languages will be done in a separate dedicated issue:
   https://issues.hibernatingrhinos.com/issue/RDoc-2719/Client-API-Operations-Patching-Single-document-Fix-article

---

**Node.js**: @ml054 

* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/single-document.js.markdown
Documentation/5.4/Samples/nodejs/client-api/operations/patches/patchRequests.js
```

**C# + Java**: 

* Files were only copied over to v5.4