### PR TITLE
RDoc-2718 GetAttachmentOperation: Fix description of ChangeVector

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.dotnet.markdown
@@ -12,13 +12,13 @@ This operation is used to get an attachment from a document.
 |------------------|----------------| ----- |
 | **documentId**   | string         | ID of a document which will contain an attachment |
 | **name**         | string     | Name of an attachment |
-| **type**         | AttachmentType | **Document** or **Revision** |
-| **changeVector** | string         | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **type**         | AttachmentType | Specify whether getting an attachment from a document or from a revision.<br>(`Document` or `Revision`). |
+| **changeVector** | string         | The ChangeVector of the document or the revision to which the attachment belongs.<br>Mandatory when getting an attachment from a revision.<br>Used for concurrency checks (use `null` to skip the check). |
 
 | Return Value | |
 | ------------- | ----- |
 | **Stream** | Stream containing an attachment |
-| **ChangeVector** | Change vector of an attachment |
+| **ChangeVector** | Change vector of document |
 | **DocumentId** | ID of document |
 | **Name** | Name of attachment |
 | **Hash** | Hash of attachment |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.java.markdown
@@ -12,13 +12,13 @@ This operation is used to get an attachment from a document.
 | ------------- | ------------- | ----- |
 | **documentId** | String | ID of a document which will contain an attachment |
 | **name** | String | Name of an attachment |
-| **type** | AttachmentType | **DOCUMENT** or **REVISION** |
-| **changeVector** | String | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **type** | AttachmentType | Specify whether getting an attachment from a document or from a revision.<br>(`DOCUMENT` or `REVISION`). |
+| **changeVector** | String | The ChangeVector of the document or the revision to which the attachment belongs.<br>Mandatory when getting an attachment from a revision.<br>Used for concurrency checks (use `null` to skip the check). |
 
 | Return Value | |
 | ------------- | ----- |
 | **Stream** | InputStream containing an attachment |
-| **ChangeVector** | Change vector of an attachment |
+| **ChangeVector** | Change vector of document |
 | **DocumentId** | ID of document |
 | **Name** | Name of attachment |
 | **Hash** | Hash of attachment |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/attachments/get-attachment.js.markdown
@@ -24,12 +24,12 @@
 
 {CODE:nodejs syntax_1@client-api\operations\attachments\getAttachment.js /}
 
-| Parameter        | Type             | Description                                                                       |
-|------------------|------------------|-----------------------------------------------------------------------------------|
-| __documentId__   | `string`         | Document ID that contains the attachment                                          |
-| __name__         | `string`         | Name of attachment to get                                                         |
-| __type__         | `AttachmentType` | __"Document"__ or __"Revision"__                                                  |
-| __changeVector__ | `string`         | ChangeVector of attachment,<br>used for concurrency checks (`null` to skip check) |
+| Parameter        | Type     | Description                                                                                                                                                                                               |
+|------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| __documentId__   | `string` | Document ID that contains the attachment.                                                                                                                                                                 |
+| __name__         | `string` | Name of attachment to get.                                                                                                                                                                                |
+| __type__         | `string` | Specify whether getting an attachment from a document or from a revision.<br>(`"Document"` or `"Revision"`).                                                                                              |
+| __changeVector__ | `string` | The ChangeVector of the document or the revision to which the attachment belongs.<br>Mandatory when getting an attachment from a revision.<br>Used for concurrency checks (use `null` to skip the check). |
 
 | Return Value of `store.operations.send(getAttachmentOp)`  |                                         |
 |-----------------------------------------------------------|-----------------------------------------|

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/getAttachment.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/attachments/getAttachment.js
@@ -42,7 +42,7 @@ class AttachmentResult {
 // The AttachmentDetails object:
 // =============================
 {
-    // Change vector of attachment
+    // Change vector of the document that contains the attachment
     changeVector; // string
 
     // ID of the document that contains the attachment


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2718/GetAttachmentOperation-Fix-description-of-ChangeVector