### PR TITLE
RDoc-2716 [Node.js] Client API > Operations > Patching > Set based [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/set-based.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/set-based.dotnet.markdown
@@ -1,0 +1,118 @@
+# Set-Based Patch Operations
+
+{NOTE: }
+Sometimes we need to update a large number of documents matching certain criteria. A simple SQL query doing that will look like this:
+
+`UPDATE Users SET IsActive = 0 WHERE LastLogin < '2020-01-01'`   
+
+This is usually not the case for NoSQL databases where set based operations are not supported. RavenDB does support them by passing it a query and an operation definition. It will run the query and perform that operation on its results.
+
+The same queries and indexes that are used for data retrieval are used for the set based operations. The syntax defining which documents to work on is exactly the same as you'd specified for those documents to be pulled from the store.
+
+In this page:  
+[Syntax overview](../../../client-api/operations/patching/set-based#syntax-overview)  
+[Examples](../../../client-api/operations/patching/set-based#examples)  
+[Additional notes](../../../client-api/operations/patching/set-based#additional-notes)  
+{NOTE/}
+
+
+{PANEL: Syntax overview}
+
+### Sending a Patch Request
+
+{CODE sendingSetBasedPatchRequest@Common.cs /}
+
+| Parameter | | |
+| ------------- | ------------- | ----- |
+| **operation** | `PatchByQueryOperation` | PatchByQueryOperation object, describing the query and the patch that will be performed |
+
+| Return Value | |
+| ------------- | ----- |
+| `Operation` | Object that allows waiting for operation to complete. It also may return information about a performed patch: see examples below. |
+
+### PatchByQueryOperation
+
+{CODE patchBeQueryOperationCtor1@Common.cs /}
+
+{CODE patchBeQueryOperationCtor2@Common.cs /}
+
+| Parameter | | |
+| ------------- | ------------- | ----- |
+| **queryToUpdate** | `string` or `IndexQuery` | RQL query defining the update operation. The RQL query starts as any other RQL query with "from" and "update" statements. Later, it continues with an "update" clause in which you describe the Javascript patch code
+| **options** | `QueryOperationOptions` | Options defining how the operation will be performed and various constraints on how it is performed
+
+{PANEL/}
+
+{PANEL: Examples}
+
+### Update whole collection
+{CODE update_value_in_whole_collection@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Update by dynamic query
+{CODE update-value-by-dynamic-query@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Update by static index query result
+{CODE update-value-by-index-query@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Updating a collection name
+{CODE change-collection-name@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Updating by document ID
+{CODE patch-by-id@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Updating by document ID using parameters
+{CODE patch-by-id-using-parameters@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Updating all documents
+{CODE change-all-documents@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Patch on stale results
+{CODE update-on-stale-results@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Report progress on patch
+{CODE report_progress_on_patch@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+### Process patch results details
+{CODE patch-request-with-details@ClientApi\Operations\Patches\PatchRequests.cs /}
+
+{PANEL/}
+
+{PANEL: Additional notes}
+
+{SAFE:Safe By Default}
+
+By default, set based operations will **not work** on indexes that are stale. The operations will **only succeed** if the specified **index is not stale**. This is to make sure you only delete what you intended to delete. 
+
+For indexes that are updated all the time, you can set the AllowStale field of QueryOperationOptions to true if you want to patch on stale results. 
+
+{SAFE/}
+
+{WARNING: Patching and Concurrency} 
+
+The patching of documents matching a specified query is run in batches of size 1024. RavenDB doesn't do concurrency checks during the operation so it can happen than a document has been updated or deleted meanwhile.
+
+{WARNING/}
+
+{WARNING: Patching and Transaction} 
+
+The patching of documents matching a specified query is run in batches of size 1024.  
+Each batch is handled in a separate write transaction.
+
+{WARNING/}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Patching
+
+- [Single document patch operations](../../../client-api/operations/patching/single-document)
+
+### Knowledge Base
+
+- [JavaScript engine](../../../server/kb/javascript-engine)
+- [Numbers in JavaScript engine](../../../server/kb/numbers-in-ravendb#numbers-in-javascript-engine)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/set-based.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/set-based.java.markdown
@@ -1,0 +1,112 @@
+# Set-Based Patch Operations
+
+{NOTE: }
+Sometimes we need to update a large number of documents matching certain criteria. A simple SQL query doing that will look like this:
+
+`UPDATE Users SET IsActive = 0 WHERE LastLogin < '2020-01-01'`   
+
+This is usually not the case for NoSQL databases where set based operations are not supported. RavenDB does support them by passing it a query and an operation definition. It will run the query and perform that operation on its results.
+
+The same queries and indexes that are used for data retrieval are used for the set based operations. The syntax defining which documents to work on is exactly the same as you'd specified for those documents to be pulled from the store.
+
+In this page:  
+[Syntax overview](../../../client-api/operations/patching/set-based#syntax-overview)  
+[Examples](../../../client-api/operations/patching/set-based#examples)  
+[Additional notes](../../../client-api/operations/patching/set-based#additional-notes)  
+{NOTE/}
+
+
+{PANEL: Syntax overview}
+
+### Sending a Patch Request
+
+{CODE:java sendingSetBasedPatchRequest@Common.java /}
+
+| Parameter | | |
+| ------------- | ------------- | ----- |
+| **operation** | `PatchByQueryOperation` | PatchByQueryOperation object, describing the query and the patch that will be performed |
+
+| Return Value | |
+| ------------- | ----- |
+| `Operation` | Object that allows waiting for operation to complete. It also may return information about a performed patch: see examples below. |
+
+### PatchByQueryOperation
+
+{CODE:java patchBeQueryOperationCtor1@Common.java /}
+
+{CODE:java patchBeQueryOperationCtor2@Common.java /}
+
+| Parameter | | |
+| ------------- | ------------- | ----- |
+| **queryToUpdate** | `String` or `IndexQuery` | RQL query defining the update operation. The RQL query starts as any other RQL query with "from" and "update" statements. Later, it continues with an "update" clause in which you describe the Javascript patch code
+| **options** | `QueryOperationOptions` | Options defining how the operation will be performed and various constraints on how it is performed
+
+{PANEL/}
+
+{PANEL: Examples}
+
+### Update whole collection
+{CODE:java update_value_in_whole_collection@ClientApi\Operations\Patches\PatchRequests.java /}
+
+### Update by dynamic query
+{CODE:java update-value-by-dynamic-query@ClientApi\Operations\Patches\PatchRequests.java /}
+
+### Update by static index query result
+{CODE:java update-value-by-index-query@ClientApi\Operations\Patches\PatchRequests.java /}
+
+### Updating a collection name
+{CODE:java change-collection-name@ClientApi\Operations\Patches\PatchRequests.java /}
+
+### Updating by document ID
+{CODE:java patch-by-id@ClientApi\Operations\Patches\PatchRequests.java /}
+
+### Updating by document ID using parameters
+{CODE:java patch-by-id-using-parameters@ClientApi\Operations\Patches\PatchRequests.java /}
+
+### Updating all documents
+{CODE:java change-all-documents@ClientApi\Operations\Patches\PatchRequests.java /}
+
+### Patch on stale results
+{CODE:java update-on-stale-results@ClientApi\Operations\Patches\PatchRequests.java /}
+
+{PANEL/}
+
+{PANEL: Additional notes}
+
+{SAFE:Safe By Default}
+
+By default, set based operations will **not work** on indexes that are stale. The operations will **only succeed** if the specified **index is not stale**. This is to make sure you only delete what you intended to delete. 
+
+For indexes that are updated all the time, you can set the AllowStale field of QueryOperationOptions to true if you want to patch on stale results. 
+
+{SAFE/}
+
+{WARNING: Patching and Concurrency} 
+
+The patching of documents matching a specified query is run in batches of size 1024. RavenDB doesn't do concurrency checks during the operation so it can happen than a document has been updated or deleted meanwhile.
+
+{WARNING/}
+
+{WARNING: Patching and Transaction}
+
+The patching of documents matching a specified query is run in batches of size 1024.  
+Each batch is handled in a separate write transaction.
+
+{WARNING/}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Patching
+
+- [Single document patch operations](../../../client-api/operations/patching/single-document)
+
+### Knowledge Base
+
+- [JavaScript engine](../../../server/kb/javascript-engine)
+- [Numbers in JavaScript engine](../../../server/kb/numbers-in-ravendb#numbers-in-javascript-engine)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/set-based.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/set-based.js.markdown
@@ -1,0 +1,233 @@
+# Set-Based Patch Operations
+---
+
+{NOTE: }
+
+* Set-based patch operations allow you to apply changes to a set of documents that match specific criteria instead of separately targeting each document.
+
+* To perform patch operations on a single document see [Single Document Patch Operations](../../../client-api/operations/patching/single-document).  
+  Set-based patching can also be done from the [Studio](../../../studio/database/documents/patch-view).
+
+* In this page: 
+  * [Overview](../../../client-api/operations/patching/set-based#overview)
+      * [Defining set-based patching](../../../client-api/operations/patching/set-based#defining-set-based-patching)
+      * [Important characteristics](../../../client-api/operations/patching/set-based#important-characteristics)
+  * [Examples](../../../client-api/operations/patching/set-based#examples)
+      * [Update by collection query](../../../client-api/operations/patching/set-based#update-by-collection-query)
+      * [Update by collection query - access metadata](../../../client-api/operations/patching/set-based#update-by-collection-query---access-metadata)
+      * [Update by dynamic query](../../../client-api/operations/patching/set-based#update-by-dynamic-query)
+      * [Update by static index query](../../../client-api/operations/patching/set-based#update-by-static-index-query)
+      * [Update all documents](../../../client-api/operations/patching/set-based#update-all-documents)
+      * [Update by document ID](../../../client-api/operations/patching/set-based#update-by-document-id)
+      * [Update by document ID using parameters](../../../client-api/operations/patching/set-based#update-by-document-id-using-parameters)
+      * [Allow updating stale results](../../../client-api/operations/patching/set-based#allow-updating-stale-results)
+  * [Syntax](../../../client-api/operations/patching/set-based#syntax)  
+      * [Send syntax](../../../client-api/operations/patching/set-based#send-syntax)  
+      * [PatchByQueryOperation syntax](../../../client-api/operations/patching/set-based#syntax)  
+
+{NOTE/}
+
+---
+
+{PANEL: Overview}
+
+{NOTE: }
+
+<a id="defining-set-based-patching" /> __Defining set-based patching__:  
+
+---
+
+  * In other databases, a simple SQL query that updates a set of documents can look like this:  
+    `UPDATE Users SET IsActive = 0 WHERE LastLogin < '2020-01-01'`  
+
+  * To achieve that in RavenDB, define the following two components within a `PatchByQueryOperation`:  
+  
+      1. __The query__:  
+         An [RQL](../../../client-api/session/querying/what-is-rql) query that defines the set of documents to update.  
+         Use the exact same syntax as you would when querying the database/indexes for usual data retrieval.  
+    
+      2. __The update__:  
+         A JavaScript clause that defines the updates to perform on the documents resulting from the query.  
+
+  * When sending the `PatchByQueryOperation` to the server, the server will run the query and perform the requested update on the query results.
+  
+      {CODE-BLOCK:sql}
+// A "query & update" sample
+// Update the set of documents from the Orders collection that match the query criteria:
+// =====================================================================================
+
+// The RQL part:
+from Orders where Freight < 10
+
+// The UPDATE part:
+update  {
+    this.Freight += 10;
+} 
+      {CODE-BLOCK/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="important-characteristics" /> __Important characteristics__:
+
+---
+
+* __Transactional batches__:  
+  The patching of documents matching a specified query is run in batches of size 1024.  
+  Each batch is handled in a separate write transaction.
+
+* __Dynamic behavior__:  
+  During the patching process, documents that are added/modified after the patching operation has started  
+  may also be patched if they match the query criteria.
+
+* __Concurrency__:  
+  RavenDB doesn't perform concurrency checks during the patching process so it can happen that a document  
+  has been modified or deleted while patching is in progress.
+
+* __Patching stale indexes__:  
+  By default, set-based patch operations will only succeed if the index is Not [stale](../../../indexes/stale-indexes).  
+  For indexes that are frequently updated, you can explicitly allow patching on stale results if needed.  
+  An example can be seen in the [Allow updating stale results](../../../client-api/operations/patching/set-based#allow-updating-stale-results) example.
+
+* __Manage lengthy patch operations__:  
+  The set-based patch operation (`PatchByQueryOperation`) runs in the server background may take a long time to complete.  
+  Executing the operation via the `Send` method return an object that can be __awaited for completion__ or __aborted__ (killed). 
+  Learn more about this and see dedicated examples in [Manage length operations](../../../client-api/operations/what-are-operations#manage-lengthy-operations).
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+<a id="update-by-collection-query" /> __Update by collection query__:
+
+---
+
+{CODE:nodejs update_whole_collection@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="update-by-collection-query---access-metadata" /> __Update by collection query - access metadata__:
+
+---
+
+{CODE:nodejs update_collection_name@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="update-by-dynamic-query" /> __Update by dynamic query__:
+
+---
+
+{CODE:nodejs update_by_dynamic_query@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="update-by-static-index-query" /> __Update by static index query__:
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Update_by_static_index_query update_by_index_query@client-api\operations\patches\setBasedPatchRequests.js /}
+{CODE-TAB:nodejs:Index index@client-api\operations\patches\setBasedPatchRequests.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="update-all-documents" /> __Update all documents__:
+
+---
+
+{CODE:nodejs update_all_documents@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="update-by-document-id" /> __Update by document ID__:
+
+---
+
+{CODE:nodejs update_by_id@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="update-by-document-id-using-parameters" /> __Update by document ID using parameters__:
+
+---
+
+{CODE:nodejs update_by_id_using_parameters@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="allow-updating-stale-results" /> __Allow updating stale results__:
+
+---
+
+* Set `allowStale` to _true_ to allow patching of stale results.
+
+* The RQL in this example is using an auto-index.  
+  Use _allowStale_ in exactly the same way when querying a static-index.
+
+{CODE:nodejs update_stale_results@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+---
+
+#### Send syntax
+
+{CODE:nodejs syntax_1@client-api\operations\patches\setBasedPatchRequests.js /}
+
+| Parameter     | Type                    | Description                                                         |
+|---------------|-------------------------|---------------------------------------------------------------------|
+| __operation__ | `PatchByQueryOperation` | The operation object describing the query and the patch to perform. |
+
+| Return value                          |                                                                                         |
+|---------------------------------------|-----------------------------------------------------------------------------------------|
+| `Promise<OperationCompletionAwaiter>` | A promise that resolves to an object that allows waiting for the operation to complete. |
+
+---
+
+#### PatchByQueryOperation syntax
+
+{CODE:nodejs syntax_2@client-api\operations\patches\setBasedPatchRequests.js /}
+
+| Parameter         | Type         | Description                                                |
+|-------------------|--------------|------------------------------------------------------------|
+| __queryToUpdate__ | `string`     | The query & patch definition.                              | 
+| __queryToUpdate__ | `IndexQuery` | Object that allows adding parameters to the query & patch. | 
+| __options__       | `object`     | Options for the _PatchByQueryOperation_.                   |
+
+
+{CODE:nodejs syntax_3@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{CODE:nodejs syntax_4@client-api\operations\patches\setBasedPatchRequests.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Patching
+
+- [Single document patch operations](../../../client-api/operations/patching/single-document)
+
+### Knowledge Base
+
+- [JavaScript engine](../../../server/kb/javascript-engine)
+- [Numbers in JavaScript engine](../../../server/kb/numbers-in-ravendb#numbers-in-javascript-engine)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Patches/PatchRequests.cs
@@ -1,0 +1,885 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Patches
+{
+    public class PatchRequests
+    {
+        private interface IFoo
+        {
+            #region patch_generic_interface_increment
+            void Increment<T, U>(T entity, Expression<Func<T, U>> fieldPath, U delta);
+
+            void Increment<T, U>(string id, Expression<Func<T, U>> fieldPath, U delta);
+
+            #endregion
+
+            #region patch_generic_interface_set_value
+
+            void Patch<T, U>(string id, Expression<Func<T, U>> fieldPath, U value);
+
+            void Patch<T, U>(T entity, Expression<Func<T, U>> fieldPath, U value);
+            #endregion
+
+            #region patch_generic_interface_array_modification_lambda
+            void Patch<T, U>(T entity, Expression<Func<T, IEnumerable<U>>> fieldPath,
+                Expression<Func<JavaScriptArray<U>, object>> arrayMofificationLambda);
+
+            void Patch<T, U>(string id, Expression<Func<T, IEnumerable<U>>> fieldPath,
+                Expression<Func<JavaScriptArray<U>, object>> arrayMofificationLambda);
+            #endregion
+
+            #region patch_non_generic_interface_in_session
+            void Defer(ICommandData[] commands);
+            #endregion
+
+            #region patch_non_generic_interface_in_store            
+            PatchStatus Send(PatchOperation operation);
+
+            Task<PatchStatus> SendAsync(PatchOperation operation, 
+                                        SessionInfo sessionInfo = null, 
+                                        CancellationToken token = default(CancellationToken));
+
+            #endregion
+        }
+
+        public PatchRequests()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region patch_firstName_generic
+                // change FirstName to Robert                
+                session.Advanced.Patch<Employee, string>(
+                    "employees/1",
+                    x => x.FirstName, "Robert");
+
+                session.SaveChanges();
+                #endregion
+
+                #region patch_firstName_non_generic_session
+                // change FirstName to Robert                
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.FirstName = args.FirstName;",
+                        Values =
+                        {
+                            {"FirstName", "Robert"}
+                        }
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region patch_firstName_non_generic_store
+                // change FirstName to Robert                
+                store.Operations.Send(new PatchOperation(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.FirstName = args.FirstName;",
+                        Values =
+                        {
+                            {"FirstName", "Robert"}
+                        }
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region patch_firstName_and_lastName_generic
+                // change FirstName to Robert and LastName to Carter in single request
+                // note that in this case, we create single request, but two seperate batch operations
+                // in order to achieve atomicity, please use the non generic APIs
+                session.Advanced.Patch<Employee, string>("employees/1", x => x.FirstName, "Robert");
+                session.Advanced.Patch<Employee, string>("employees/1", x => x.LastName, "Carter");
+
+                session.SaveChanges();
+                #endregion
+
+                #region pathc_firstName_and_lastName_non_generic_session
+                // change FirstName to Robert and LastName to Carter in single request
+                // note that here we do maintain the atomicity of the operation
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"
+                                this.FirstName = args.UserName.FirstName
+                                this.LastName = args.UserName.LastName",
+                        Values =
+                        {
+                            {
+                                "UserName", new
+                                {
+                                    FirstName = "Robert",
+                                    LastName = "Carter"
+                                }
+                            }
+                        }
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region pathc_firstName_and_lastName_store
+                // change FirstName to Robert and LastName to Carter in single request
+                // note that here we do maintain the atomicity of the operation
+                store.Operations.Send(new PatchOperation(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"
+                                this.FirstName = args.UserName.FirstName
+                                this.LastName = args.UserName.LastName",
+                        Values =
+                        {
+                            {
+                                "UserName", new
+                                {
+                                    FirstName = "Robert",
+                                    LastName = "Carter"
+                                }
+                            }
+                        }
+                    }, patchIfMissing: null));
+                #endregion
+
+                #region increment_age_generic
+                // increment UnitsInStock property value by 10
+                session.Advanced.Increment<Product, int>("products/1-A", x => x.UnitsInStock, 10);
+
+                session.SaveChanges();
+                #endregion
+
+                #region increment_age_non_generic_session
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "products/1-A",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.UnitsInStock += args.UnitsToAdd",
+                        Values =
+                        {
+                            {"UnitsToAdd", 10}
+                        }
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region increment_age_non_generic_store
+
+                store.Operations.Send(new PatchOperation(
+                    id: "products/1-A",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.UnitsInStock += args.UnitsToAdd",
+                        Values =
+                        {
+                            {"UnitsToAdd", 10}
+                        }
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region remove_property_age_non_generic_session
+                // remove property Age
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"delete this.Age"
+                    },
+                    patchIfMissing: null));
+                session.SaveChanges();
+                #endregion
+
+                #region remove_property_age_store
+                // remove property Age
+                store.Operations.Send(new PatchOperation(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"delete this.Age"
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region rename_property_age_non_generic_session
+                // rename FirstName to First
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @" var firstName = this[args.Rename.Old];
+                                delete this[args.Rename.Old];
+                                this[args.Rename.New] = firstName",
+                        Values =
+                        {
+                            {
+                                "Rename", new
+                                {
+                                    Old = "FirstName",
+                                    New = "Name"
+                                }
+                            }
+                        }
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region rename_property_age_store
+
+                store.Operations.Send(new PatchOperation(
+                    id: "employees/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @" var firstName = this[args.Rename.Old];
+                                delete this[args.Rename.Old];
+                                this[args.Rename.New] = firstName",
+                        Values =
+                        {
+                            {
+                                "Rename", new
+                                {
+                                    Old = "FirstName",
+                                    New = "Name"
+                                }
+                            }
+                        }
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region add_new_comment_to_comments_generic_session
+                // add a new comment to Comments
+                session.Advanced.Patch<BlogPost, BlogComment>("blogposts/1",
+                    x => x.Comments,
+                    comments => comments.Add(new BlogComment
+                    {
+                        Content = "Lore ipsum",
+                        Title = "Some title"
+                    }));
+
+                session.SaveChanges();
+                #endregion
+
+                #region add_new_comment_to_comments_non_generic_session
+                // add a new comment to Comments
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = "this.Comments.push(args.Comment)",
+                        Values =
+                        {
+                            {
+                                "Comment", new BlogComment
+                                {
+                                    Content = "Lore ipsum",
+                                    Title = "Some title"
+                                }
+                            }
+                        }
+
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion 
+
+                #region add_new_comment_to_comments_store
+                // add a new comment to Comments
+                store.Operations.Send(new PatchOperation(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = "this.Comments.push(args.Comment)",
+                        Values =
+                        {
+                            {
+                                "Comment", new BlogComment
+                                {
+                                    Content = "Lore ipsum",
+                                    Title = "Some title"
+                                }
+                            }
+                        }
+
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region insert_new_comment_at_position_1_session
+                // insert a new comment at position 1 to Comments
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
+                        Values =
+                        {
+                            {
+                                "Comment", new BlogComment
+                                {
+                                    Content = "Lore ipsum",
+                                    Title = "Some title"
+                                }
+                            }
+                        }
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region insert_new_comment_at_position_1_store
+                store.Operations.Send(new PatchOperation(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = "this.Comments.splice(1, 0, args.Comment)",
+                        Values =
+                        {
+                            {
+                                "Comment", new BlogComment
+                                {
+                                    Content = "Lore ipsum",
+                                    Title = "Some title"
+                                }
+                            }
+                        }
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region modify_a_comment_at_position_3_in_comments_session
+                // modify a comment at position 3 in Comments
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
+                        Values =
+                        {
+                            {
+                                "Comment", new BlogComment
+                                {
+                                    Content = "Lore ipsum",
+                                    Title = "Some title"
+                                }
+                            }
+                        }
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region modify_a_comment_at_position_3_in_comments_store
+                // modify a comment at position 3 in Comments
+                store.Operations.Send(new PatchOperation(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = "this.Comments.splice(3, 1, args.Comment)",
+                        Values =
+                        {
+                            {
+                                "Comment", new BlogComment
+                                {
+                                    Content = "Lore ipsum",
+                                    Title = "Some title"
+                                }
+                            }
+                        }
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region filter_items_from_array_session
+                // filter out all comments of a blogpost which contains the word "wrong" in their contents 
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.Comments = this.Comments.filter(comment=>
+                                comment.Content.includes(args.TitleToRemove));",
+                        Values =
+                        {
+                            {"TitleToRemove", "wrong"}
+                        }
+                    },
+                    patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region filter_items_from_array_session_generic
+                // filter out all comments of a blogpost which contains the word "wrong" in their contents 
+                session.Advanced.Patch<BlogPost, BlogComment>("blogposts/1",
+                    x => x.Comments,
+                    comments => comments.RemoveAll(y => y.Content.Contains("wrong")));
+
+                session.SaveChanges();
+                #endregion
+
+                #region filter_items_from_array_store
+                // filter out all comments of a blogpost which contains the word "wrong" in their contents
+                store.Operations.Send(new PatchOperation(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.Comments = this.Comments.filter(comment=>
+                                comment.Content.includes(args.TitleToRemove));",
+                        Values =
+                        {
+                            {"TitleToRemove", "wrong"}
+                        }
+                    },
+                    patchIfMissing: null));
+                #endregion
+
+                #region update_product_name_in_order_session
+                // update product names in order, according to loaded product documents
+                session.Advanced.Defer(new PatchCommandData(
+                    id: "orders/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.Lines.forEach(line=> { 
+                                var productDoc = load(line.Product);
+                                line.ProductName = productDoc.Name;
+                                });"
+                    }, patchIfMissing: null));
+
+                session.SaveChanges();
+                #endregion
+
+                #region update_product_name_in_order_store
+                // update product names in order, according to loaded product documents
+                store.Operations.Send(new PatchOperation(
+                    id: "blogposts/1",
+                    changeVector: null,
+                    patch: new PatchRequest
+                    {
+                        Script = @"this.Lines.forEach(line=> { 
+                                var productDoc = load(line.Product);
+                                line.ProductName = productDoc.Name;
+                                });"
+                    },
+                    patchIfMissing: null));
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region update_value_in_whole_collection
+                // increase by 10 Freight field in all orders
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(@"from Orders as o
+                                                      update
+                                                      {
+                                                          o.Freight += 10;
+                                                      }"));
+                // Wait for the operation to be complete on the server side.
+                // Not waiting for completion will not harm the patch process and it will continue running to completion.
+                operation.WaitForCompletion();
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region update-value-by-dynamic-query
+                // set discount to all orders that was processed by a specific employee
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(@"from Orders as o
+                                                      where o.Employee = 'employees/4-A'
+                                                      update
+                                                      {
+                                                          o.Lines.forEach(line=> line.Discount = 0.3);
+                                                      }"));
+                operation.WaitForCompletion();
+
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region update-value-by-index-query
+                // switch all products with supplier 'suppliers/12-A' with 'suppliers/13-A'
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        Query = @"from index 'Product/Search' as p
+                                  where p.Supplier = 'suppliers/12-A'
+                                  update
+                                  {
+                                      p.Supplier = 'suppliers/13-A'
+                                  }"
+                    }));
+
+                operation.WaitForCompletion();
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region update-on-stale-results
+                // patch on stale results
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        Query = @"from Orders as o
+                                  where o.Company = 'companies/12-A'
+                                  update
+                                  {
+                                      o.Company = 'companies/13-A'
+                                  }"
+                    },
+                    new QueryOperationOptions
+                    {
+                        AllowStale = true
+                    }));
+
+                operation.WaitForCompletion();
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region report_progress_on_patch
+                // report progress during patch processing
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        Query = @"from Orders as o
+                                  where o.Company = 'companies/12-A'
+                                  update
+                                  {
+                                      o.Company = 'companies/13-A'
+                                  }"
+                    },
+                    new QueryOperationOptions
+                    {
+                        AllowStale = true
+                    }));
+
+                operation.OnProgressChanged = x =>
+                {
+                    DeterminateProgress progress = (DeterminateProgress)x;
+                    Console.WriteLine($"Progress: Processed: {progress.Processed}; Total: {progress.Total}");
+                };
+
+                operation.WaitForCompletion();
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region patch-request-with-details     
+                // perform patch and create summary of processing statuses
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        Query = @"from Orders as o
+                                  where o.Company = 'companies/12-A'
+                                  update
+                                  {
+                                      o.Company = 'companies/13-A'
+                                  }"
+                    },
+                    new QueryOperationOptions
+                    {
+                        RetrieveDetails = true
+                    }));
+
+                var result = operation.WaitForCompletion<BulkOperationResult>();
+                var formattedResults =
+                    result.Details
+                    .Select(x => (BulkOperationResult.PatchDetails)x)
+                    .GroupBy(x => x.Status)
+                    .Select(x => $"{x.Key}: {x.Count()}").ToList();
+
+                formattedResults.ForEach(Console.WriteLine);
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region change-collection-name   
+
+                // delete the document before recreating it with a different collection name
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        Query = @"from Orders as c
+                                  update
+                                  {
+                                      del(id(c));
+                                      this[""@metadata""][""@collection""] = ""New_Orders"";
+                                      put(id(c), this);
+                                  }"
+                    }));
+
+                operation.WaitForCompletion();
+
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region change-all-documents   
+
+                // perform a patch on all documents using @all_docs keyword
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        Query = @"from @all_docs
+                                  update
+                                  {
+                                      this.Updated = true;
+                                  }"
+                    }));
+
+                operation.WaitForCompletion();
+
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region patch-by-id
+
+                // perform a patch by document ID
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        Query = @"from @all_docs as d
+                                  where id() in ('orders/1-A', 'companies/1-A')
+                                  update
+                                  {
+                                      d.Updated = true;
+                                  }"
+                    }));
+
+                operation.WaitForCompletion();
+
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region patch-by-id-using-parameters 
+
+                // perform a patch by document ID
+                var operation = store
+                    .Operations
+                    .Send(new PatchByQueryOperation(new IndexQuery
+                    {
+                        QueryParameters = new Parameters
+                        {
+                            {"ids", new[] {"orders/1-A", "companies/1-A"}}
+                        },
+                        Query = @"from @all_docs as d
+                                  where id() in ($ids)
+                                  update
+                                  {
+                                      d.Updated = true;
+                                  }"
+                    }));
+
+                operation.WaitForCompletion();
+
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region add_document_session
+                    session.Advanced.Defer(new PatchCommandData("employees/1-A", null,
+                        new PatchRequest
+                        {
+                            Script = "put('orders/', { Employee: id(this) });",
+                        }, null));
+
+                    session.SaveChanges();
+                    #endregion
+
+                    #region clone_document_session
+                    session.Advanced.Defer(new PatchCommandData("employees/1-A", null,
+                        new PatchRequest
+                        {
+                            Script = "put('employees/', this);",
+                        }, null));
+
+                    session.SaveChanges();
+                    #endregion
+                }
+
+                #region add_document_store
+                store.Operations.Send(new PatchOperation("employees/1-A", null, new PatchRequest
+                {
+                    Script = "put('orders/', { Employee: id(this) });",
+                }));
+                #endregion
+
+                #region clone_document_store
+                store.Operations.Send(new PatchOperation("employees/1-A", null, new PatchRequest
+                {
+                    Script = "put('employees/', this);",
+                }));
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    {
+                        #region increment_counter_by_document_reference_generic_session
+                        var order = session.Load<Order>("orders/1-A");
+                        session.CountersFor(order).Increment("Likes", 1);
+                        session.SaveChanges();
+                        #endregion
+                    }
+
+                    #region increment_counter_by_document_id_non_generic_session
+                    session.Advanced.Defer(new PatchCommandData("orders/1-A", null,
+                        new PatchRequest
+                        {
+                            Script = "incrementCounter(this.Company, args.name, args.val);",
+                            Values =
+                            {
+                                { "name", "Likes" },
+                                { "val", 20 }
+                            }
+                        }, null));
+                    session.SaveChanges();
+                    #endregion
+
+                    #region delete_counter_by_document_id_generic_session
+                    session.CountersFor("orders/1-A").Delete("Likes");
+                    session.SaveChanges();
+                    #endregion
+
+                    #region delete_counter_by_document_refference_non_generic_session
+                    session.Advanced.Defer(new PatchCommandData("products/1-A", null,
+                        new PatchRequest
+                        {
+                            Script = "deleteCounter(this, args.name);",
+                            Values =
+                            {
+                                { "name", "Likes" },
+                            }
+                        }, null));
+                    session.SaveChanges();
+                    #endregion
+
+                    {
+                        #region get_counter_by_document_id_generic_session
+                        var order = session.Load<Order>("orders/1-A");
+                        var counters = session.Advanced.GetCountersFor(order);
+                        #endregion
+                    }
+
+
+                    #region get_counter_by_document_id_non_generic_session
+                    session.Advanced.Defer(new PatchCommandData("orders/1-A", null,
+                        new PatchRequest
+                        {
+                            Script = @"var likes = counter(this.Company, args.name);
+                                       put('result/', {company: this.Company, likes: likes});",
+                            Values =
+                            {
+                                { "name", "Likes" },
+                            }
+                        }, null));
+                    session.SaveChanges();
+                    #endregion
+                }
+
+                #region increment_counter_by_document_id_store
+                store.Operations.Send(new PatchOperation("orders/1-A", null, new PatchRequest
+                {
+                    Script = "incrementCounter(this.Company, args.name, args.val);",
+                    Values =
+                    {
+                        { "name", "Likes" },
+                        { "val", -1 }
+                    }
+                }));
+                #endregion
+
+                #region delete_counter_by_document_refference_store
+                store.Operations.Send(new PatchOperation("products/1-A", null, new PatchRequest
+                {
+                    Script = "deleteCounter(this, args.name);",
+                    Values =
+                    {
+                        { "name", "Likes" },
+                    }
+                }));
+                #endregion
+
+                #region get_counter_by_document_id_store
+                store.Operations.Send(new PatchOperation("orders/1-A", null, new PatchRequest
+                {
+                    Script = @"var likes = counter(this.Company, args.name);
+                               put('result/', {company: this.Company, likes: likes});",
+                    Values =
+                    {
+                        { "name", "Likes" },
+                    }
+                }));
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Common.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Common.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+
+namespace Raven.Documentation.Samples
+{
+    public class CodeOmitted : Exception
+    {
+        public class PatchCommandData
+        {
+            #region patch_command_data
+            public PatchCommandData(
+                    string id,
+                    string changeVector,
+                    PatchRequest patch,
+                    PatchRequest patchIfMissing)
+            #endregion
+            {
+            }
+        }
+
+        #region patch_request
+        public class PatchRequest
+        {
+            /// JavaScript function to use to patch a document
+            public string Script { get; set; }
+
+            /// Additional arguments passed to JavaScript function from Script.
+            public Dictionary<string, object> Values { get; set; }
+        }
+        #endregion
+
+
+        public class PatchOperation
+        {
+            #region patch_operation
+            public PatchOperation(
+                    string id,
+                    string changeVector,
+                    PatchRequest patch,
+                    PatchRequest patchIfMissing = null,
+                    bool skipPatchIfChangeVectorMismatch = false)
+            #endregion
+            {
+
+            }
+        }
+
+        public interface OperationSend
+        {
+            #region sendingSetBasedPatchRequest
+            Operation Send(PatchByQueryOperation operation);
+            #endregion
+        }
+
+        public class PatchByQueryOperation
+        {
+            #region patchBeQueryOperationCtor1
+            public PatchByQueryOperation(string queryToUpdate)
+            #endregion
+            {
+
+            }
+
+
+            #region patchBeQueryOperationCtor2
+            public PatchByQueryOperation(IndexQuery queryToUpdate, QueryOperationOptions options = null)
+            #endregion
+            {
+
+            }
+
+        }
+
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Patches/PatchRequests.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Patches/PatchRequests.java
@@ -1,0 +1,690 @@
+package net.ravendb.ClientApi.Operations.Patches;
+
+import net.ravendb.client.Parameters;
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.batches.ICommandData;
+import net.ravendb.client.documents.commands.batches.PatchCommandData;
+import net.ravendb.client.documents.operations.*;
+import net.ravendb.client.documents.queries.IndexQuery;
+import net.ravendb.client.documents.queries.QueryOperationOptions;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.client.documents.session.JavaScriptArray;
+import net.ravendb.client.documents.session.SessionInfo;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class PatchRequests {
+
+
+    private static class BlogComment {
+        private String content;
+        private String title;
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+    }
+
+
+    private interface IFoo {
+        //region patch_generic_interface_increment
+        <T, U> void increment(String id, String path, U valueToAdd);
+
+        <T, U> void increment(T entity, String path, U valueToAdd);
+        //endregion
+
+        //region patch_generic_interface_set_value
+        <T, U> void patch(String id, String path, U value);
+
+        <T, U> void patch(T entity, String path, U value);
+        //endregion
+
+        //region patch_generic_interface_array_modification_lambda
+        <T, U> void patch(T entity, String pathToArray, Consumer<JavaScriptArray<U>> arrayAdder);
+
+        <T, U> void patch(String id, String pathToArray, Consumer<JavaScriptArray<U>> arrayAdder);
+        //endregion
+
+        //region patch_non_generic_interface_in_session
+        void defer(ICommandData[] commands);
+        //endregion
+
+        //region patch_non_generic_interface_in_store
+        PatchStatus send(PatchOperation operation);
+
+        PatchStatus send(PatchOperation operation, SessionInfo sessionInfo);
+
+        <TEntity> PatchOperation.Result<TEntity> send(Class<TEntity> entityClass, PatchOperation operation);
+
+        <TEntity> PatchOperation.Result<TEntity> send(Class<TEntity> entityClass, PatchOperation operation, SessionInfo sessionInfo);
+        //endregion
+    }
+
+    public PatchRequests() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region patch_firstName_generic
+                // change firstName to Robert
+                session
+                    .advanced()
+                    .patch("employees/1", "FirstName", "Robert");
+                //endregion
+
+                session.saveChanges();
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region patch_firstName_non_generic_session
+                // change firstName to Robert
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.FirstName = args.firstName");
+                patchRequest.setValues(Collections.singletonMap("firstName", "Robert"));
+                PatchCommandData patchCommandData = new PatchCommandData("employees/1", null, patchRequest, null);
+                session.advanced().defer(patchCommandData);
+
+                session.saveChanges();
+                //endregion
+            }
+
+            {
+                //region patch_firstName_non_generic_store
+                // change firstName to Robert
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.FirstName = args.firstName;");
+                patchRequest.setValues(Collections.singletonMap("firstName", "Robert"));
+                PatchOperation patchOperation = new PatchOperation("employees/1", null, patchRequest);
+                store.operations().send(patchOperation);
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region patch_firstName_and_lastName_generic
+                // change firstName to Robert and lastName to Carter in single request
+                // note that in this case, we create single request, but two separate batch operations
+                // in order to achieve atomicity, please use the non generic APIs
+                session.advanced().patch("employees/1", "FirstName", "Robert");
+                session.advanced().patch("employees/1", "LastName", "Carter");
+
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region pathc_firstName_and_lastName_non_generic_session
+                // change firstName to Robert and lastName to Carter in single request
+                // note that here we do maintain the atomicity of the operation
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.FirstName = args.firstName;" +
+                    "this.LastName = args.lastName");
+
+                Map<String, Object> values = new HashMap<>();
+                values.put("firstName", "Robert");
+                values.put("lastName", "Carter");
+                patchRequest.setValues(values);
+
+                session.advanced().defer(new PatchCommandData("employees/1", null, patchRequest, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            {
+                //region pathc_firstName_and_lastName_store
+                // change FirstName to Robert and LastName to Carter in single request
+                // note that here we do maintain the atomicity of the operation
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.FirstName = args.firstName; " +
+                    "this.LastName = args.lastName");
+
+                Map<String, Object> values = new HashMap<>();
+                values.put("firstName", "Robert");
+                values.put("lastName", "Carter");
+                patchRequest.setValues(values);
+
+                store.operations().send(new PatchOperation("employees/1", null, patchRequest));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region increment_age_generic
+                // increment UnitsInStock property value by 10
+                session.advanced().increment("products/1-A", "UnitsInStock", 10);
+
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region increment_age_non_generic_session
+                PatchRequest request = new PatchRequest();
+                request.setScript("this.UnitsInStock += args.unitsToAdd");
+                request.setValues(Collections.singletonMap("unitsToAdd", 10));
+
+                session.advanced().defer(
+                    new PatchCommandData("products/1-A", null, request, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            {
+                //region increment_age_non_generic_store
+                PatchRequest request = new PatchRequest();
+                request.setScript("this.UnitsInStock += args.unitsToAdd");
+                request.setValues(Collections.singletonMap("unitsToAdd", 10));
+                store.operations().send(new PatchOperation("products/1-A", null, request));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region remove_property_age_non_generic_session
+                // remove property Age
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("delete this.Age");
+                session.advanced().defer(
+                    new PatchCommandData("employees/1", null, patchRequest, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            {
+                //region remove_property_age_store
+                //remove property age
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("delete this.Age");
+                store.operations().send(new PatchOperation("employees/1", null, patchRequest));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region rename_property_age_non_generic_session
+                // rename firstName to First
+
+                Map<String, Object> value = new HashMap<>();
+                value.put("old", "FirstName");
+                value.put("new", "Name");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("var firstName = this[args.rename.old];" +
+                    "delete this[args.rename.old];" +
+                    "this[args.rename.new] = firstName;");
+                patchRequest.setValues(Collections.singletonMap("rename", value));
+
+                session.advanced().defer(new PatchCommandData("employees/1", null, patchRequest, null));
+
+                session.saveChanges();
+                //endregion
+            }
+
+            {
+                //region rename_property_age_store
+                Map<String, Object> value = new HashMap<>();
+                value.put("old", "FirstName");
+                value.put("new", "Name");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("var firstName = this[args.rename.old];" +
+                    "delete this[args.rename.old];" +
+                    "this[args.rename.new] = firstName;");
+                patchRequest.setValues(Collections.singletonMap("rename", value));
+
+                store.operations().send(new PatchOperation("employees/1", null, patchRequest));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region add_new_comment_to_comments_generic_session
+                BlogComment comment = new BlogComment();
+                comment.setContent("Lore ipsum");
+                comment.setTitle("Some title");
+
+                session.advanced()
+                    .patch("blogposts/1", "comments", comments -> comments.add(comment));
+
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region add_new_comment_to_comments_non_generic_session
+                // add a new comment to comments
+                BlogComment comment = new BlogComment();
+                comment.setContent("Lore ipsum");
+                comment.setTitle("Some title");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments.push(args.comment");
+                patchRequest.setValues(Collections.singletonMap("comment", comment));
+
+                session.advanced().defer(new PatchCommandData("blogposts/1", null, patchRequest, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region add_new_comment_to_comments_store
+                // add a new comment to comments
+                BlogComment comment = new BlogComment();
+                comment.setContent("Lore ipsum");
+                comment.setTitle("Some title");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments.push(args.comment");
+                patchRequest.setValues(Collections.singletonMap("comment", comment));
+
+                store.operations().send(new PatchOperation("blogposts/1", null, patchRequest));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region insert_new_comment_at_position_1_session
+                BlogComment comment = new BlogComment();
+                comment.setContent("Lore ipsum");
+                comment.setTitle("Some title");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments.splice(1, 0, args.comment)");
+                patchRequest.setValues(Collections.singletonMap("comment", comment));
+
+                session.advanced().defer(new PatchCommandData("blogposts/1", null, patchRequest, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region insert_new_comment_at_position_1_store
+                BlogComment comment = new BlogComment();
+                comment.setContent("Lore ipsum");
+                comment.setTitle("Some title");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments.splice(1, 0, args.comment)");
+                patchRequest.setValues(Collections.singletonMap("comment", comment));
+
+                store.operations().send(new PatchOperation("blogposts/1", null, patchRequest));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region modify_a_comment_at_position_3_in_comments_session
+                // modify a comment at position 3 in Comments
+                BlogComment comment = new BlogComment();
+                comment.setContent("Lore ipsum");
+                comment.setTitle("Some title");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments.splice(3, 1, args.comment)");
+                patchRequest.setValues(Collections.singletonMap("comment", comment));
+
+                session.advanced().defer(new PatchCommandData("blogposts/1", null, patchRequest, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region modify_a_comment_at_position_3_in_comments_store
+                // modify a comment at position 3 in Comments
+                BlogComment comment = new BlogComment();
+                comment.setContent("Lore ipsum");
+                comment.setTitle("Some title");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments.splice(3, 1, args.comment)");
+                patchRequest.setValues(Collections.singletonMap("comment", comment));
+
+                store.operations().send(new PatchOperation("blogposts/1", null, patchRequest));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region filter_items_from_array_session
+                //filter out all comments of a blogpost which contains the word "wrong" in their contents
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments = this.comments.filter(comment " +
+                    "=> comment.content.includes(args.titleToRemove));");
+                patchRequest.setValues(Collections.singletonMap("titleToRemove", "wrong"));
+
+                session.advanced().defer(
+                    new PatchCommandData("blogposts/1", null, patchRequest, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region filter_items_from_array_store
+                // filter out all comments of a blogpost which contains the word "wrong" in their contents
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.comments = this.comments.filter(comment " +
+                    "=> comment.content.includes(args.titleToRemove));");
+                patchRequest.setValues(Collections.singletonMap("titleToRemove", "wrong"));
+
+                store.operations().send(new PatchOperation("blogposts/1", null, patchRequest));
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region update_product_name_in_order_session
+                // update product names in order, according to loaded product documents
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.Lines.forEach(line => {" +
+                    " var productDoc = load(line.Product);" +
+                    " line.ProductName = productDoc.Name;" +
+                    "});");
+
+                session.advanced().defer(
+                    new PatchCommandData("orders/1", null, patchRequest, null));
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region update_product_name_in_order_store
+                // update product names in order, according to loaded product documents
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("this.Lines.forEach(line => {" +
+                    " var productDoc = load(line.Product);" +
+                    " line.ProductName = productDoc.Name;" +
+                    "});");
+
+                store.operations().send(new PatchOperation("blogposts/1", null, patchRequest));
+                //endregion
+            }
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region update_value_in_whole_collection
+            // increase by 10 Freight field in all orders
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation("from Orders as o update  {" +
+                    "   o.Freight += 10;" +
+                    "}"));
+
+            // Wait for the operation to be complete on the server side.
+            // Not waiting for completion will not harm the patch process and it will continue running to completion.
+            operation.waitForCompletion();
+
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region update-value-by-dynamic-query
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation("from Orders as o" +
+                    " where o.Employee = 'employees/1-A'" +
+                    " update " +
+                    "{ " +
+                    "  o.Lines.forEach(line => line.Discount = 0.3);" +
+                    "}"));
+
+            operation.waitForCompletion();
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region update-value-by-index-query
+            // switch all products with supplier 'suppliers/12-A' with 'suppliers/13-A'
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation(new IndexQuery("" +
+                    "from index 'Product/Search' as p " +
+                    " where p.Supplier = 'suppliers/12-A'" +
+                    " update {" +
+                    "  p.Supplier = 'suppliers/13-A'" +
+                    "}")));
+
+
+            operation.waitForCompletion();
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region update-on-stale-results
+            // patch on stale results
+
+            QueryOperationOptions options = new QueryOperationOptions();
+            options.setAllowStale(true);
+
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation(new IndexQuery(
+                    "from Orders as o " +
+                        "where o.Company = 'companies/12-A' " +
+                        "update " +
+                        "{ " +
+                        "    o.Company = 'companies/13-A';" +
+                        "} "
+                ), options));
+
+
+            operation.waitForCompletion();
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region change-collection-name
+            // delete the document before recreating it with a different collection name
+
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation(new IndexQuery(
+                    "from Orders as c " +
+                        "update {" +
+                        " del(id(c));" +
+                        " this['@metadata']['collection'] = 'New_Orders'; " +
+                        " put(id(c), this); " +
+                        "}"
+                )));
+
+            operation.waitForCompletion();
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region change-all-documents
+            // perform a patch on all documents using @all_docs keyword
+
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation(new IndexQuery(
+                    "from @all_docs " +
+                        " update " +
+                        "{ " +
+                        "  this.Updated = true;" +
+                        "}"
+                )));
+
+            operation.waitForCompletion();
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region patch-by-id
+            // perform a patch by document ID
+
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation(new IndexQuery(
+                    "from @all_docs as d " +
+                        " where id() in ('orders/1-A', 'companies/1-A')" +
+                        " update " +
+                        "{" +
+                        "  d.Updated = true; " +
+                        "} "
+                )));
+
+            operation.waitForCompletion();
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region patch-by-id-using-parameters
+            // perform a patch by document ID
+            IndexQuery indexQuery = new IndexQuery(
+                "from @all_docs as d " +
+                    " where id() in ($ids)" +
+                    " update " +
+                    " {" +
+                    "    d.Updated = true; " +
+                    "} "
+            );
+            Parameters parameters = new Parameters();
+            parameters.put("ids", new String[]{"orders/1-A", "companies/1-A"});
+            indexQuery.setQueryParameters(parameters);
+            Operation operation = store
+                .operations()
+                .sendAsync(new PatchByQueryOperation(indexQuery));
+
+            operation.waitForCompletion();
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region add_document_session
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("put('orders/', { Employee: id(this) });");
+                PatchCommandData commandData =
+                    new PatchCommandData("employees/1-A", null, patchRequest, null);
+                session.advanced().defer(commandData);
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region clone_document_session
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("put('employees/', this);");
+                PatchCommandData commandData =
+                    new PatchCommandData("employees/1-A", null, patchRequest, null);
+                session.advanced().defer(commandData);
+                session.saveChanges();
+                //endregion
+            }
+
+            {
+                //region add_document_store
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("put('orders/', { Employee: id(this) });");
+
+                store.operations().send(new PatchOperation("employees/1-A", null, patchRequest));
+                //endregion
+            }
+
+
+            {
+                //region clone_document_store
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("put('employees/', this);");
+
+                store.operations().send(new PatchOperation("employees/1-A", null, patchRequest));
+                //endregion
+            }
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region increment_counter_by_document_id_non_generic_session
+                HashMap<String, Object> scriptValues = new HashMap<>();
+                scriptValues.put("name", "likes");
+                scriptValues.put("val", 20);
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("incrementCounter(this.Company, args.name, args.val);");
+                patchRequest.setValues(scriptValues);
+
+                new PatchCommandData("orders/1-A", null, patchRequest, null);
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region delete_counter_by_document_refference_non_generic_session
+                HashMap<String, Object> scriptValues = new HashMap<>();
+                scriptValues.put("name", "Likes");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("deleteCounter(this, args.name);");
+                patchRequest.setValues(scriptValues);
+
+                new PatchCommandData("products/1-A", null, patchRequest, null);
+                session.saveChanges();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region get_counter_by_document_id_non_generic_session
+                HashMap<String, Object> scriptValues = new HashMap<>();
+                scriptValues.put("name", "Likes");
+
+                PatchRequest patchRequest = new PatchRequest();
+                patchRequest.setScript("var likes = counter(this.Company, args.name);\n" +
+                    "put('result/', {company: this.Company, likes: likes});");
+                patchRequest.setValues(scriptValues);
+
+                new PatchCommandData("orders/1-A", null, patchRequest, null);
+                session.saveChanges();
+                //endregion
+            }
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region increment_counter_by_document_id_store
+            HashMap<String, Object> scriptValues = new HashMap<>();
+            scriptValues.put("name", "likes");
+            scriptValues.put("val", -1);
+
+            PatchRequest patchRequest = new PatchRequest();
+            patchRequest.setScript("incrementCounter(this.Company, args.name, args.val);");
+            patchRequest.setValues(scriptValues);
+
+            PatchOperation patchOperation = new PatchOperation("orders/1-A", null, patchRequest);
+            store.operations().send(patchOperation);
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region delete_counter_by_document_refference_store
+            HashMap<String, Object> scriptValues = new HashMap<>();
+            scriptValues.put("name", "Likes");
+
+            PatchRequest patchRequest = new PatchRequest();
+            patchRequest.setScript("deleteCounter(this, args.name);");
+            patchRequest.setValues(scriptValues);
+
+            PatchOperation patchOperation = new PatchOperation("products/1-A", null, patchRequest);
+            store.operations().send(patchOperation);
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region get_counter_by_document_id_store
+            HashMap<String, Object> scriptValues = new HashMap<>();
+            scriptValues.put("name", "Likes");
+
+            PatchRequest patchRequest = new PatchRequest();
+            patchRequest.setScript("var likes = counter(this.Company, args.name);\n" +
+                "put('result/', {company: this.Company, likes: likes});");
+            patchRequest.setValues(scriptValues);
+
+            PatchOperation patchOperation = new PatchOperation("orders/1-A", null, patchRequest);
+            store.operations().send(patchOperation);
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Common.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Common.java
@@ -1,0 +1,31 @@
+package net.ravendb;
+
+import net.ravendb.client.documents.operations.Operation;
+import net.ravendb.client.documents.operations.PatchByQueryOperation;
+import net.ravendb.client.documents.queries.IndexQuery;
+import net.ravendb.client.documents.queries.QueryOperationOptions;
+
+public class Common {
+    public interface OperationSend
+    {
+        //region sendingSetBasedPatchRequest
+        Operation sendAsync(PatchByQueryOperation operation);
+        //endregion
+    }
+
+    public static class PatchByQueryOperation {
+        //region patchBeQueryOperationCtor1
+        public PatchByQueryOperation(String queryToUpdate)
+        //endregion
+        {
+        }
+
+        /*
+        //region patchBeQueryOperationCtor2
+        public PatchByQueryOperation(IndexQuery queryToUpdate);
+
+        public PatchByQueryOperation(IndexQuery queryToUpdate, QueryOperationOptions options);
+        //endregion
+        */
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/patches/setBasedPatchRequests.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/patches/setBasedPatchRequests.js
@@ -1,0 +1,226 @@
+import { DocumentStore, PatchByQueryOperation } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+//region index
+class Products_BySupplier extends AbstractJavaScriptIndexCreationTask {
+    constructor() {
+        super();
+
+        // Define the index-fields 
+        this.map("Products", p => ({
+            Supplier : e.Supplier
+        }));
+    }
+}
+//endregion
+
+async function setBasedPatchRequests() {
+    {
+        //region update_whole_collection
+        // Update all documents in a collection
+        // ====================================
+        
+        // Define the Patch by Query Operation, pass the "query & update" string:
+        const patchByQueryOp = new PatchByQueryOperation(
+            `from Orders as o
+             update
+             {
+                 // Increase the Freight in ALL documents in the Orders collection:
+                 o.Freight += 10;
+             }`);
+
+        // Execute the operation by passing it to operations.send:
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        //endregion
+    }
+    {
+        //region update_collection_name
+        // Update the collection name for all documents in the collection
+        // ==============================================================
+
+        // Delete the document before recreating it with a different collection name:
+        const patchByQueryOp = new PatchByQueryOperation(
+            `from Orders as c
+             update
+             {
+                 del(id(c));
+                 this["@metadata"]["@collection"] = "New_Orders";
+                 put(id(c), this);
+             }`);
+
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        //endregion
+    }
+    {
+        //region update_by_dynamic_query
+        // Update all documents matching a dynamic query
+        // =============================================
+        
+        // Update the Discount in all orders that match the dynamic query predicate:
+        const patchByQueryOp = new PatchByQueryOperation(`from Orders as o
+                                                          where o.Employee = 'employees/4-A'
+                                                          update
+                                                          {
+                                                              o.Lines.forEach(line=> line.Discount = 0.3);
+                                                          }`);
+
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        
+        // Note: An AUTO-INDEX will be created when the dynamic query is executed on the server.
+        //endregion
+    }
+    {
+        //region update_by_index_query
+        // Update all documents matching a static index query
+        // ==================================================
+        
+        // Modify the Supplier to 'suppliers/13-A' for all products that have 'suppliers/12-A': 
+        const patchByQueryOp = new PatchByQueryOperation(`from index 'Products/BySupplier' as p
+                                                          where p.Supplier = 'suppliers/12-A'
+                                                          update
+                                                          {
+                                                              p.Supplier = 'suppliers/13-A'
+                                                          }`);
+
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        //endregion
+    }
+    {
+        //region update_all_documents
+        // Update all documents matching an @all_docs query
+        // ================================================
+
+        // Patch the 'Updated' field to ALL documents (query is using the @all_docs keyword):
+        const patchByQueryOp = new PatchByQueryOperation(`from @all_docs
+                                                          update
+                                                          {
+                                                              this.Updated = true;
+                                                          }`);
+
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        //endregion
+    }
+    {
+        //region update_by_id
+        // Update all documents matching a query by ID
+        // ===========================================
+
+        // Patch the 'Updated' field to all documents that have the specified IDs:
+        const patchByQueryOp = new PatchByQueryOperation(`from @all_docs as d
+                                                          where id() in ('orders/1-A', 'companies/1-A')
+                                                          update
+                                                          {
+                                                              d.Updated = true;
+                                                          }`);
+
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        //endregion
+    }
+    {
+        //region update_by_id_using_parameters
+        // Update all documents matching a query by ID using query parmeters
+        // =================================================================
+        
+        // Define an IndexQuery object:
+        const indexQuery = new IndexQuery();
+        
+        // Define the "query & update" string
+        // Patch the 'Updated' field to all documents that have the specified IDs
+        // Parameter ($ids) contains the listed IDs:
+        indexQuery.query = `from @all_docs as d 
+                            where id() in ($ids)
+                            update {
+                                d.Updated = true
+                            }`;
+        
+        // Define the parameters for the script:
+        indexQuery.queryParameters = {
+            ids: ["orders/830-A", "companies/91-A"]
+        };
+        
+        // Pass the indexQuery to the operation definition
+        const patchByQueryOp = new PatchByQueryOperation(indexQuery);
+        
+        // Execute the operation
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        //endregion
+    }
+    {
+        //region update_stale_results
+        // Update documents matching a dynamic query even if auot-index is stale
+        // =====================================================================
+        
+        // Define an IndexQuery object:
+        const indexQuery = new IndexQuery();
+
+        // Define the "query & update" string
+        // Modify company to 'companies/13-A' for all orders that have 'companies/12-A':
+        indexQuery.query = `from Orders as o
+                            where o.Company = 'companies/12-A'
+                            update
+                            {
+                                o.Company = 'companies/13-A'
+                            }`;
+
+        // Define query options:
+        const queryOptions = {
+            // The query uses an auto-index (index is created if it doesn't exist yet).
+            // Allow patching on all matching documents even if the auto-index is still stale.
+            allowStale: true
+        };
+
+        // Pass indexQuery & queryOptions to the operation definition
+        const patchByQueryOp = new PatchByQueryOperation(indexQuery, queryOptions);
+
+        // Execute the operation
+        const operation = await documentStore.operations.send(patchByQueryOp);
+        //endregion
+    }
+
+//region syntax
+    
+    {
+        //region syntax_1
+        await send(operation);
+        //endregion
+    }
+    {
+        //region syntax_2
+        // Available overload:
+        // ===================
+        patchByQueryOp = new PatchByQueryOperation(queryToUpdate);
+        patchByQueryOp = new PatchByQueryOperation(queryToUpdate, options);
+        //endregion
+    }
+    {
+        //region syntax_3
+        class IndexQuery {
+            query;           // string
+            queryParameters; // Record<string, object>
+        }        
+        //endregion
+    }
+    {
+        //region syntax_4
+        // Options for 'PatchByQueryOperation'
+        {
+            // Limit the amount of base operation per second allowed.
+            maxOpsPerSecond; // number
+
+            // Indicate whether operations are allowed on stale indexes.
+            allowStale;      // boolean
+
+            // If AllowStale is set to false and index is stale, 
+            // then this is the maximum timeout to wait for index to become non-stale. 
+            // If timeout is exceeded then exception is thrown.
+            staleTimeout;    // number
+
+            // Set whether operation details about each document should be returned by server.
+            retrieveDetails; // boolean
+        }
+        //endregion
+    }
+
+//endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2716/Node.js-Client-API-Operations-Patching-Set-based-Replace-C-samples

---


**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied + 
   the Node.js article's text & flow WAS organized & improved from the original C# article .

* Fixes to the C# article and other languages will be done in a separate dedicated issue:
   https://issues.hibernatingrhinos.com/issue/RDoc-2721/Client-API-Operations-Patching-Set-based-Fix-article

---

**Node.js**: @ml054 

* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/client-api/operations/patching/set-based.js.markdown
Documentation/5.4/Samples/nodejs/client-api/operations/patches/setBasedPatchRequests.js
```

**C# + Java**: 

* Files were only copied over to v5.4
