### PR TITLE
[Python] Client API HowTo articles batch [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.dotnet.markdown
@@ -1,0 +1,20 @@
+# Session: How to Clear a Session
+
+To clear session state, to stop tracking entities and remove all pending commands, etc. the `Clear` method is used from the `Advanced` session operations.
+
+## Syntax
+
+{CODE clear_1@ClientApi\Session\HowTo\Clear.cs /}
+
+## Example
+
+{CODE clear_2@ClientApi\Session\HowTo\Clear.cs /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.dotnet.markdown
@@ -1,6 +1,7 @@
 # Session: How to Clear a Session
 
-To clear session state, to stop tracking entities and remove all pending commands, etc. the `Clear` method is used from the `Advanced` session operations.
+To clear session state, stop tracking entities, and remove all pending commands, 
+use the `Clear` method from the `Advanced` session operations.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.java.markdown
@@ -1,0 +1,20 @@
+# Session: How to Clear a Session
+
+To clear session state, to stop tracking entities and remove all pending commands, etc. the `clear` method is used from the `advanced` session operations.
+
+## Syntax
+
+{CODE:java clear_1@ClientApi\Session\HowTo\Clear.java /}
+
+## Example
+
+{CODE:java clear_2@ClientApi\Session\HowTo\Clear.java /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.java.markdown
@@ -1,6 +1,7 @@
 # Session: How to Clear a Session
 
-To clear session state, to stop tracking entities and remove all pending commands, etc. the `clear` method is used from the `advanced` session operations.
+To clear session state, stop tracking entities, and remove all pending commands, 
+use the  `clear` method from the `advanced` session operations.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.js.markdown
@@ -1,6 +1,7 @@
 # Session: How to Clear a Session
 
-To clear session state, to stop tracking entities and remove all pending commands, etc. the `clear()` method is used from the `advanced` session operations.
+To clear session state, stop tracking entities, and remove all pending commands, 
+use the `clear()` method from the `advanced` session operations.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.js.markdown
@@ -1,0 +1,20 @@
+# Session: How to Clear a Session
+
+To clear session state, to stop tracking entities and remove all pending commands, etc. the `clear()` method is used from the `advanced` session operations.
+
+## Syntax
+
+{CODE:nodejs clear_1@client-api\session\howTo\clear.js /}
+
+## Example
+
+{CODE:nodejs clear_2@client-api\session\howTo\clear.js /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.python.markdown
@@ -1,6 +1,7 @@
 # Session: How to Clear a Session
 
-To clear session state, to stop tracking entities and remove all pending commands, etc. the `Clear` method is used from the `Advanced` session operations.
+To clear session state, stop tracking entities, and remove all pending commands, 
+use the `clear` method from the `advanced` session operations.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/clear-a-session.python.markdown
@@ -1,0 +1,20 @@
+# Session: How to Clear a Session
+
+To clear session state, to stop tracking entities and remove all pending commands, etc. the `Clear` method is used from the `Advanced` session operations.
+
+## Syntax
+
+{CODE:python clear_1@ClientApi\Session\HowTo\Clear.py /}
+
+## Example
+
+{CODE:python clear_2@ClientApi\Session\HowTo\Clear.py /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.dotnet.markdown
@@ -1,0 +1,65 @@
+# How to Defer Commands
+
+---
+
+{NOTE: }
+
+* `Defer` allows you to register server commands via the session.
+
+* All the deferred requests will be stored in the session and sent to the server in a single batch when SaveChanges is called,
+  along with any other changes/operations made on the session.  
+  Thus, all deferred commands are __executed as part of the session's SaveChanges transaction__.
+
+* In this page:   
+    * [Defer commands example](../../../client-api/session/how-to/defer-operations#defer-commands-example)  
+    * [Commands that can be deferred](../../../client-api/session/how-to/defer-operations#commands-that-can-be-deferred)
+    * [Syntax](../../../client-api/session/how-to/defer-operations#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Defer commands example}
+
+{CODE defer_1@ClientApi\Session\HowTo\Defer.cs /}
+
+{PANEL/}
+
+{PANEL: Commands that can be deferred}
+
+The following commands implement the `ICommandData` interface and can be deferred:  
+
+  - [PutCommandData](../../../glossary/put-command-data)
+  - [DeleteCommandData](../../../glossary/delete-command-data)
+  - DeletePrefixedCommandData
+  - [PatchCommandData](../../../glossary/patch-command-data)
+  - BatchPatchCommandData
+  - PutAttachmentCommandData
+  - DeleteAttachmentCommandData
+  - [CopyAttachmentCommandData](../../../glossary/copy-attachment-command-data)
+  - [MoveAttachmentCommandData](../../../glossary/move-attachment-command-data)
+  - [CountersBatchCommandData](../../../glossary/counters-batch-command-data)
+  - PutCompareExchangeCommandData
+  - DeleteCompareExchangeCommandData
+  - CopyTimeSeriesCommandData
+  - TimeSeriesBatchCommandData
+  - ForceRevisionCommandData
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\HowTo\Defer.cs /}
+
+| Parameter | Type | Description |
+| - |-|-|
+| **command** | A command that implements the `ICommandData` interface | The command to be executed |
+| **commands** | `ICommandData[]` | Array of commands to be executed |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.java.markdown
@@ -1,0 +1,37 @@
+# Session: How to Defer Commands
+
+Commands can be deferred till `saveChanges` is called by using `defer` method in `advanced` session operations.  
+All of the operations will update teh session state appropriately after `saveChanges` is called.
+
+Types of commands that can be deferred:
+
+- [PutCommandData](../../../glossary/put-command-data)
+- [DeleteCommandData](../../../glossary/delete-command-data)
+- DeletePrefixedCommandData
+- [PatchCommandData](../../../glossary/patch-command-data)
+- PutAttachmentCommandData
+- DeleteAttachmentCommandData
+- [CopyAttachmentCommandData](../../../glossary/copy-attachment-command-data)
+- [MoveAttachmentCommandData](../../../glossary/move-attachment-command-data)
+- [CountersBatchCommandData](../../../glossary/counters-batch-command-data)
+
+## Syntax
+
+{CODE:java defer_1@ClientApi\Session\HowTo\Defer.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| `ICommandData` | Command to be executed. |
+| `ICommandData[]` | Array of commands implementing `ICommandData` interface. |
+
+## Example
+
+{CODE:java defer_2@ClientApi\Session\HowTo\Defer.java /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.js.markdown
@@ -1,0 +1,64 @@
+# How to Defer Commands
+
+---
+
+{NOTE: }
+
+* `Defer` allows you to register server commands via the session.
+
+* All the deferred requests will be stored in the session and sent to the server in a single batch when saveChanges is called,
+  along with any other changes/operations made on the session.  
+  Thus, all deferred commands are __executed as part of the session's saveChanges transaction__.
+
+* In this page:
+    * [Defer commands example](../../../client-api/session/how-to/defer-operations#defer-commands-example)
+    * [Commands that can be deferred](../../../client-api/session/how-to/defer-operations#commands-that-can-be-deferred)
+    * [Syntax](../../../client-api/session/how-to/defer-operations#syntax)  
+      {NOTE/}
+
+---
+
+{PANEL: Defer commands example}
+
+{CODE:nodejs defer_1@client-api\session\HowTo\defer.js /}
+
+{PANEL/}
+
+{PANEL: Commands that can be deferred}
+
+The following commands implement the `ICommandData` interface and can be deferred:
+
+- PutCommandDataBase
+- DeleteCommandData
+- DeletePrefixedCommandData
+- PatchCommandData
+- BatchPatchCommandData
+- PutAttachmentCommandData
+- DeleteAttachmentCommandData
+- CopyAttachmentCommandData
+- MoveAttachmentCommandData
+- CountersBatchCommandData
+- PutCompareExchangeCommandData
+- DeleteCompareExchangeCommandData
+- CopyTimeSeriesCommandData
+- TimeSeriesBatchCommandData
+- ForceRevisionCommandData
+  {PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\session\HowTo\defer.js /}
+
+| Parameter | Type | Description |
+| - |-|-|
+| **commands** | `ICommandData[]` | Commands to be executed |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.python.markdown
@@ -1,0 +1,65 @@
+# How to Defer Commands
+
+---
+
+{NOTE: }
+
+* `Defer` allows you to register server commands via the session.
+
+* All the deferred requests will be stored in the session and sent to the server in a single batch when SaveChanges is called,
+  along with any other changes/operations made on the session.  
+  Thus, all deferred commands are __executed as part of the session's SaveChanges transaction__.
+
+* In this page:   
+    * [Defer commands example](../../../client-api/session/how-to/defer-operations#defer-commands-example)  
+    * [Commands that can be deferred](../../../client-api/session/how-to/defer-operations#commands-that-can-be-deferred)
+    * [Syntax](../../../client-api/session/how-to/defer-operations#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Defer commands example}
+
+{CODE:python defer_1@ClientApi\Session\HowTo\Defer.py /}
+
+{PANEL/}
+
+{PANEL: Commands that can be deferred}
+
+The following commands implement the `ICommandData` interface and can be deferred:  
+
+  - [PutCommandData](../../../glossary/put-command-data)
+  - [DeleteCommandData](../../../glossary/delete-command-data)
+  - DeletePrefixedCommandData
+  - [PatchCommandData](../../../glossary/patch-command-data)
+  - BatchPatchCommandData
+  - PutAttachmentCommandData
+  - DeleteAttachmentCommandData
+  - [CopyAttachmentCommandData](../../../glossary/copy-attachment-command-data)
+  - [MoveAttachmentCommandData](../../../glossary/move-attachment-command-data)
+  - [CountersBatchCommandData](../../../glossary/counters-batch-command-data)
+  - PutCompareExchangeCommandData
+  - DeleteCompareExchangeCommandData
+  - CopyTimeSeriesCommandData
+  - TimeSeriesBatchCommandData
+  - ForceRevisionCommandData
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:python syntax@ClientApi\Session\HowTo\Defer.py /}
+
+| Parameter | Type | Description |
+| - |-|-|
+| **command** | A command that implements the `ICommandData` interface | The command to be executed |
+| **commands** | `ICommandData[]` | Array of commands to be executed |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/defer-operations.python.markdown
@@ -4,11 +4,12 @@
 
 {NOTE: }
 
-* `Defer` allows you to register server commands via the session.
+* The `defer` method allows you to register server commands via the session.
 
-* All the deferred requests will be stored in the session and sent to the server in a single batch when SaveChanges is called,
-  along with any other changes/operations made on the session.  
-  Thus, all deferred commands are __executed as part of the session's SaveChanges transaction__.
+* All the deferred requests will be stored in the session and sent to the server 
+  in a single batch when `save_changes` is called, along with any other changes/operations 
+  made on the session.  
+  Thus, all deferred commands are **executed as part of the session's `save_changes` transaction**.
 
 * In this page:   
     * [Defer commands example](../../../client-api/session/how-to/defer-operations#defer-commands-example)  
@@ -50,9 +51,8 @@ The following commands implement the `ICommandData` interface and can be deferre
 {CODE:python syntax@ClientApi\Session\HowTo\Defer.py /}
 
 | Parameter | Type | Description |
-| - |-|-|
-| **command** | A command that implements the `ICommandData` interface | The command to be executed |
-| **commands** | `ICommandData[]` | Array of commands to be executed |
+| --------- | ---- | ----------- |
+| **\*commands** | `CommandData` | An array of commands to be executed |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.dotnet.markdown
@@ -1,0 +1,28 @@
+# Session: How to Evict Single Entity from a Session
+
+We can clear all session operations and stop tracking of all entities by the using [Clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is need to only to do a cleanup only for one entity. For this purpose `Evict` was introduced.
+
+## Syntax
+
+{CODE evict_1@ClientApi\Session\HowTo\Evict.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | T | Instance of an entity that will be evicted |
+
+## Example I
+
+{CODE evict_2@ClientApi\Session\HowTo\Evict.cs /}
+
+## Example II
+
+{CODE evict_3@ClientApi\Session\HowTo\Evict.cs /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.dotnet.markdown
@@ -1,6 +1,8 @@
 # Session: How to Evict Single Entity from a Session
 
-We can clear all session operations and stop tracking of all entities by the using [Clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is need to only to do a cleanup only for one entity. For this purpose `Evict` was introduced.
+We can clear all session operations and stop tracking of all entities using the 
+[Clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes 
+there's a need to do cleanup only for one entity. This is what `Evict` is for.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.java.markdown
@@ -1,6 +1,8 @@
 # Session: How to Evict Single Entity from a Session
 
-We can clear all session operations and stop tracking of all entities by the using [clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is need to only to do a cleanup only for one entity. For this purpose `evict` was introduced.
+We can clear all session operations and stop tracking of all entities using the 
+[clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes 
+there's a need to do cleanup only for one entity. This is what `evict` is for.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.java.markdown
@@ -1,0 +1,28 @@
+# Session: How to Evict Single Entity from a Session
+
+We can clear all session operations and stop tracking of all entities by the using [clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is need to only to do a cleanup only for one entity. For this purpose `evict` was introduced.
+
+## Syntax
+
+{CODE:java evict_1@ClientApi\Session\HowTo\Evict.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | T | Instance of an entity that will be evicted |
+
+## Example I
+
+{CODE:java evict_2@ClientApi\Session\HowTo\Evict.java /}
+
+## Example II
+
+{CODE:java evict_3@ClientApi\Session\HowTo\Evict.java /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.js.markdown
@@ -1,6 +1,8 @@
 # Session: How to Evict Single Entity from a Session
 
-We can clear all session operations and stop tracking of all entities by the using [session.advanced.clear()](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is a need to only to do a cleanup for a single entity. For this purpose `evict()` was introduced.
+We can clear all session operations and stop tracking of all entities using the 
+[session.advanced.clear()](../../../client-api/session/how-to/clear-a-session) method, 
+there's a need to do cleanup only for one entity. This is what `evict()` is for.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.js.markdown
@@ -1,0 +1,28 @@
+# Session: How to Evict Single Entity from a Session
+
+We can clear all session operations and stop tracking of all entities by the using [session.advanced.clear()](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is a need to only to do a cleanup for a single entity. For this purpose `evict()` was introduced.
+
+## Syntax
+
+{CODE:nodejs evict_1@client-api\session\howTo\evict.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | object | Entity that will be evicted |
+
+## Example I
+
+{CODE:nodejs evict_2@client-api\session\howTo\evict.js /}
+
+## Example II
+
+{CODE:nodejs evict_3@client-api\session\howTo\evict.js /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.python.markdown
@@ -1,14 +1,16 @@
 # Session: How to Evict Single Entity from a Session
 
-We can clear all session operations and stop tracking of all entities by the using [Clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is need to only to do a cleanup only for one entity. For this purpose `Evict` was introduced.
+We can clear all session operations and stop tracking of all entities using the 
+[clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes 
+there's a need to do cleanup only for one entity. This is what `evict` is for.
 
 ## Syntax
 
 {CODE:python evict_1@ClientApi\Session\HowTo\Evict.py /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **entity** | T | Instance of an entity that will be evicted |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| **entity** | `object` | Instance of an entity that will be evicted |
 
 ## Example I
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/evict-entity-from-a-session.python.markdown
@@ -1,0 +1,28 @@
+# Session: How to Evict Single Entity from a Session
+
+We can clear all session operations and stop tracking of all entities by the using [Clear](../../../client-api/session/how-to/clear-a-session) method, but sometimes there is need to only to do a cleanup only for one entity. For this purpose `Evict` was introduced.
+
+## Syntax
+
+{CODE:python evict_1@ClientApi\Session\HowTo\Evict.py /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | T | Instance of an entity that will be evicted |
+
+## Example I
+
+{CODE:python evict_2@ClientApi\Session\HowTo\Evict.py /}
+
+## Example II
+
+{CODE:python evict_3@ClientApi\Session\HowTo\Evict.py /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.dotnet.markdown
@@ -1,0 +1,28 @@
+# Session: How to Get Entity Change-Vector
+
+The change-vector reflects the cluster wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
+When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `GetChangeVectorFor` method from the `Advanced` session operations.
+
+## Syntax
+
+{CODE get_change_vector_1@ClientApi\Session\HowTo\GetChangeVector.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | T | Instance of an entity for which an Etag will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| string | Returns the current change-vector for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+## Example
+
+{CODE get_change_vector_2@ClientApi\Session\HowTo\GetChangeVector.cs /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Last Modified](../../../client-api/session/how-to/get-entity-last-modified)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.dotnet.markdown
@@ -1,7 +1,11 @@
 # Session: How to Get Entity Change-Vector
 
-The change-vector reflects the cluster wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
-When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `GetChangeVectorFor` method from the `Advanced` session operations.
+* The change-vector reflects the cluster-wide point in time in which a change occured, and 
+  includes the unique database ID, node identifier, and document Etag in the specific node.  
+* When a document is downloaded from the server, it contains various metadata information.  
+  E.g. ID or current change-vector.  
+* The current change-vector is stored within the session metadata and is available for each 
+  entity using the `GetChangeVectorFor` method from the `Advanced` session operations.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.java.markdown
@@ -1,0 +1,28 @@
+# Session: How to Get Entity Change-Vector
+
+The change-vector reflects the cluster wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
+When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `getChangeVectorFor` method from the `advanced` session operations.
+
+## Syntax
+
+{CODE:java get_change_vector_1@ClientApi\Session\HowTo\GetChangeVector.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | T | Instance of an entity for which an Etag will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| String | Returns the current change-vector for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+## Example
+
+{CODE:java get_change_vector_2@ClientApi\Session\HowTo\GetChangeVector.java /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Last Modified](../../../client-api/session/how-to/get-entity-last-modified)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.java.markdown
@@ -1,7 +1,11 @@
 # Session: How to Get Entity Change-Vector
 
-The change-vector reflects the cluster wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
-When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `getChangeVectorFor` method from the `advanced` session operations.
+* The change-vector reflects the cluster-wide point in time in which a change occured, and 
+  includes the unique database ID, node identifier, and document Etag in the specific node.  
+* When a document is downloaded from the server, it contains various metadata information.  
+  E.g. ID or current change-vector.  
+* The current change-vector is stored within the session metadata and is available for each 
+  entity using the `getChangeVectorFor` method from the `advanced` session operations.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.js.markdown
@@ -1,0 +1,28 @@
+# Session: How to Get Entity Change-Vector
+
+The change-vector reflects the cluster-wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
+When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `getChangeVectorFor()` method from the `advanced` session operations.
+
+## Syntax
+
+{CODE:nodejs get_change_vector_1@client-api\session\howTo\getChangeVector.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | object | Instance of an entity for which an Etag will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| string | Returns the current change-vector for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+## Example
+
+{CODE:nodejs get_change_vector_2@client-api\session\howTo\getChangeVector.js /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Last Modified](../../../client-api/session/how-to/get-entity-last-modified)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.js.markdown
@@ -1,7 +1,11 @@
 # Session: How to Get Entity Change-Vector
 
-The change-vector reflects the cluster-wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
-When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `getChangeVectorFor()` method from the `advanced` session operations.
+* The change-vector reflects the cluster-wide point in time in which a change occured, and 
+  includes the unique database ID, node identifier, and document Etag in the specific node.  
+* When a document is downloaded from the server, it contains various metadata information.  
+  E.g. ID or current change-vector.  
+* The current change-vector is stored within the session metadata and is available for each 
+  entity using the `getChangeVectorFor()` method from the `advanced` session operations.
 
 ## Syntax
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.python.markdown
@@ -1,0 +1,28 @@
+# Session: How to Get Entity Change-Vector
+
+The change-vector reflects the cluster wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
+When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `GetChangeVectorFor` method from the `Advanced` session operations.
+
+## Syntax
+
+{CODE:python get_change_vector_1@ClientApi\Session\HowTo\GetChangeVector.py /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | T | Instance of an entity for which an Etag will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| string | Returns the current change-vector for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+## Example
+
+{CODE:python get_change_vector_2@ClientApi\Session\HowTo\GetChangeVector.py /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Last Modified](../../../client-api/session/how-to/get-entity-last-modified)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.python.markdown
@@ -1,19 +1,23 @@
 # Session: How to Get Entity Change-Vector
 
-The change-vector reflects the cluster wide point in time where something happened. It includes the unique database ID, node identifier, and the Etag of the document in the specific node.
-When a document is downloaded from the server, it contains various metadata information e.g. ID or current change-vector. Current change-vector is stored within the metadata in session and is available for each entity using the `GetChangeVectorFor` method from the `Advanced` session operations.
+* The change-vector reflects the cluster-wide point in time in which a change occured, and 
+  includes the unique database ID, node identifier, and document Etag in the specific node.  
+* When a document is downloaded from the server, it contains various metadata information.  
+  E.g. ID or current change-vector.  
+* The current change-vector is stored within the session metadata and is available for each 
+  entity using the `get_change_vector_for` method from the `advanced` session operations.
 
 ## Syntax
 
 {CODE:python get_change_vector_1@ClientApi\Session\HowTo\GetChangeVector.py /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **instance** | T | Instance of an entity for which an Etag will be returned. |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| **entity** | `object` | Instance of an entity for which an Etag will be returned |
 
-| Return Value | |
-| ------------- | ----- |
-| string | Returns the current change-vector for an entity. Throws an exception if the `instance` is not tracked by the session. |
+| Return Type | Description |
+| ----------- | ----------- |
+| `str` | Returns the current change-vector for an entity. Throws an exception if the `instance` is not tracked by the session. |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-change-vector.python.markdown
@@ -17,7 +17,7 @@
 
 | Return Type | Description |
 | ----------- | ----------- |
-| `str` | Returns the current change-vector for an entity. Throws an exception if the `instance` is not tracked by the session. |
+| `str` | Returns the current change-vector for an entity. Throws an exception if the entity is not tracked by the session. |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.dotnet.markdown
@@ -1,0 +1,50 @@
+# How to Get Entity Counters
+
+---
+
+{NOTE: }
+
+* When a document is loaded to the session,  
+  the loaded entity will contain various metadata information such as ID, current change-vector, and more.
+
+* If the document has __Counters__, the document metadata will also contain its counter names.  
+  The counter names are available for each entity using the `GetCountersFor()` method from the `Advanced` session operations.
+
+* In this page:
+    * [Get entity counters](../../../client-api/session/how-to/get-entity-counters#get-entity-counters)
+    * [Syntax](../../../client-api/session/how-to/get-entity-counters#syntax)
+{NOTE/}
+
+---
+
+{PANEL: Get entity counters}
+
+{CODE example@ClientApi\Session\HowTo\GetCountersFor.cs /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Session\HowTo\GetCountersFor.cs /}
+
+
+| Parameters | | |
+| - | - | - |
+| **instance** | T | Instance of an entity for which counter names will be returned. |
+
+| Return Value | |
+| - | - |
+| `List<string>` | Returns the counter names for the specified entity, or `null` if the entity has no counters.<br>An exception is thrown if the `instance` is not tracked by the session. |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+
+### Counters
+
+- [Counters Overview](../../../document-extensions/counters/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.dotnet.markdown
@@ -28,12 +28,12 @@
 {CODE syntax@ClientApi\Session\HowTo\GetCountersFor.cs /}
 
 
-| Parameters | | |
-| - | - | - |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
 | **instance** | T | Instance of an entity for which counter names will be returned. |
 
-| Return Value | |
-| - | - |
+| Return Type | Description |
+| ----------- | ----------- |
 | `List<string>` | Returns the counter names for the specified entity, or `null` if the entity has no counters.<br>An exception is thrown if the `instance` is not tracked by the session. |
 
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.js.markdown
@@ -1,0 +1,50 @@
+# How to Get Entity Counters
+
+---
+
+{NOTE: }
+
+* When a document is loaded to the session,  
+  the loaded entity will contain various metadata information such as ID, current change-vector, and more.
+
+* If the document has __Counters__, the document metadata will also contain its counter names.  
+  The counter names are available for each entity using the `getCountersFor()` method from the `advanced` session operations.
+
+* In this page:
+    * [Get entity counters](../../../client-api/session/how-to/get-entity-counters#get-entity-counters)
+    * [Syntax](../../../client-api/session/how-to/get-entity-counters#syntax)
+{NOTE/}
+
+---
+
+{PANEL: Get entity counters}
+
+{CODE:nodejs example@client-api\session\HowTo\getCountersFor.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\session\HowTo\getCountersFor.js /}
+
+
+| Parameters | | |
+| - | - | - |
+| **entity** | T | The entity for which counter names will be returned. |
+
+| Return Value | |
+| - | - |
+| `string[]` | Returns the counter names for the specified entity, or `null` if the entity has no counters.<br>An exception is thrown if the entity is not tracked by the session. |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+
+### Counters
+
+- [Counters Overview](../../../document-extensions/counters/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.js.markdown
@@ -27,13 +27,12 @@
 
 {CODE:nodejs syntax@client-api\session\HowTo\getCountersFor.js /}
 
-
-| Parameters | | |
-| - | - | - |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
 | **entity** | T | The entity for which counter names will be returned. |
 
-| Return Value | |
-| - | - |
+| Return Type | Description |
+| ----------- | ----------- |
 | `string[]` | Returns the counter names for the specified entity, or `null` if the entity has no counters.<br>An exception is thrown if the entity is not tracked by the session. |
 
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.python.markdown
@@ -1,0 +1,50 @@
+# How to Get Entity Counters
+
+---
+
+{NOTE: }
+
+* When a document is loaded to the session,  
+  the loaded entity will contain various metadata information such as ID, current change-vector, and more.
+
+* If the document has __Counters__, the document metadata will also contain its counter names.  
+  The counter names are available for each entity using the `GetCountersFor()` method from the `Advanced` session operations.
+
+* In this page:
+    * [Get entity counters](../../../client-api/session/how-to/get-entity-counters#get-entity-counters)
+    * [Syntax](../../../client-api/session/how-to/get-entity-counters#syntax)
+{NOTE/}
+
+---
+
+{PANEL: Get entity counters}
+
+{CODE:python example@ClientApi\Session\HowTo\GetCountersFor.py /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:python syntax@ClientApi\Session\HowTo\GetCountersFor.py /}
+
+
+| Parameters | | |
+| - | - | - |
+| **instance** | T | Instance of an entity for which counter names will be returned. |
+
+| Return Value | |
+| - | - |
+| `List<string>` | Returns the counter names for the specified entity, or `null` if the entity has no counters.<br>An exception is thrown if the `instance` is not tracked by the session. |
+
+{PANEL/}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+
+### Counters
+
+- [Counters Overview](../../../document-extensions/counters/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.python.markdown
@@ -36,7 +36,7 @@
 
 | Return Type | Description |
 | ----------- | ----------- |
-| `List[str]` | Returns the counter names for the specified entity, or `None` if the entity has no counters.<br>An exception is thrown if the `object` is not tracked by the session. |
+| `List[str]` | Returns the counter names for the specified entity, or `None` if the entity has no counters.<br>An exception is thrown if the entity is not tracked by the session. |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-counters.python.markdown
@@ -4,11 +4,13 @@
 
 {NOTE: }
 
-* When a document is loaded to the session,  
-  the loaded entity will contain various metadata information such as ID, current change-vector, and more.
+* When a document is loaded to the session, the loaded entity will include 
+  various metadata details such as ID, current change-vector, etc.
 
-* If the document has __Counters__, the document metadata will also contain its counter names.  
-  The counter names are available for each entity using the `GetCountersFor()` method from the `Advanced` session operations.
+* If the document has **Counters**, the document metadata will also contain 
+  its counter names.  
+  The counter names are available for each entity using the `get_counters_for()` 
+  method from the `advanced` session operations.
 
 * In this page:
     * [Get entity counters](../../../client-api/session/how-to/get-entity-counters#get-entity-counters)
@@ -28,13 +30,13 @@
 {CODE:python syntax@ClientApi\Session\HowTo\GetCountersFor.py /}
 
 
-| Parameters | | |
-| - | - | - |
-| **instance** | T | Instance of an entity for which counter names will be returned. |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| **entity** | `object` | Instance of an entity for which counter names will be returned. |
 
-| Return Value | |
-| - | - |
-| `List<string>` | Returns the counter names for the specified entity, or `null` if the entity has no counters.<br>An exception is thrown if the `instance` is not tracked by the session. |
+| Return Type | Description |
+| ----------- | ----------- |
+| `List[str]` | Returns the counter names for the specified entity, or `None` if the entity has no counters.<br>An exception is thrown if the `object` is not tracked by the session. |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.dotnet.markdown
@@ -1,0 +1,30 @@
+# Session: How to Get Entity Last Modified 
+
+When a document is downloaded from the server it contains various metadata information, including the last modified date of the document.  
+
+Last modified date is stored within the metadata in session and is available for each entity using the `GetLastModifiedFor` method from the `Advanced` session operations.
+
+## Syntax
+
+{CODE get_last_modified_1@ClientApi\Session\HowTo\GetLastModified.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | T | Instance of an entity for which the last modified date will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| DateTime? | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+
+## Example
+
+{CODE get_last_modified_2@ClientApi\Session\HowTo\GetLastModified.cs /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Change-Vector](../../../client-api/session/how-to/get-entity-change-vector)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.dotnet.markdown
@@ -8,12 +8,12 @@ Last modified date is stored within the metadata in session and is available for
 
 {CODE get_last_modified_1@ClientApi\Session\HowTo\GetLastModified.cs /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
 | **instance** | T | Instance of an entity for which the last modified date will be returned. |
 
-| Return Value | |
-| ------------- | ----- |
+| Return Type | Description |
+| ----------- | ----------- |
 | DateTime? | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
 
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.java.markdown
@@ -8,12 +8,12 @@ Last modified date is stored within the metadata in session and is available for
 
 {CODE:java get_last_modified_1@ClientApi\Session\HowTo\GetLastModified.java /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
 | **instance** | T | Instance of an entity for which the last modified date will be returned. |
 
-| Return Value | |
-| ------------- | ----- |
+| Return Type | Description |
+| ----------- | ----------- |
 | Date | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
 
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.java.markdown
@@ -1,0 +1,30 @@
+# Session: How to Get Entity Last Modified 
+
+When a document is downloaded from the server it contains various metadata information, including the last modified date of the document.  
+
+Last modified date is stored within the metadata in session and is available for each entity using the `getLastModifiedFor` method from the `advanced` session operations.
+
+## Syntax
+
+{CODE:java get_last_modified_1@ClientApi\Session\HowTo\GetLastModified.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | T | Instance of an entity for which the last modified date will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| Date | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+
+## Example
+
+{CODE:java get_last_modified_2@ClientApi\Session\HowTo\GetLastModified.java /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Change-Vector](../../../client-api/session/how-to/get-entity-change-vector)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.js.markdown
@@ -8,12 +8,12 @@ Last modified date is stored within the metadata in session and is available for
 
 {CODE:nodejs get_last_modified_1@client-api\session\howTo\getLastModified.js /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
 | **instance** | object | Instance of an entity for which the last modified date will be returned. |
 
-| Return Value | |
-| ------------- | ----- |
+| Return Type | Description |
+| ----------- | ----------- |
 | Date | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
 
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.js.markdown
@@ -1,0 +1,30 @@
+# Session: How to Get Entity Last Modified 
+
+When a document is downloaded from the server it contains various metadata information, including the last modified date of the document.  
+
+Last modified date is stored within the metadata in session and is available for each entity using the `getLastModifiedFor()` method from the `advanced` session operations.
+
+## Syntax
+
+{CODE:nodejs get_last_modified_1@client-api\session\howTo\getLastModified.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | object | Instance of an entity for which the last modified date will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| Date | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+
+## Example
+
+{CODE:nodejs get_last_modified_2@client-api\session\howTo\getLastModified.js /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Change-Vector](../../../client-api/session/how-to/get-entity-change-vector)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.python.markdown
@@ -1,21 +1,22 @@
 # Session: How to Get Entity Last Modified 
 
-When a document is downloaded from the server it contains various metadata information, including the last modified date of the document.  
+When a document is downloaded from the server it contains various metadata details, 
+including the last modified date of the document.  
 
-Last modified date is stored within the metadata in session and is available for each entity using the `GetLastModifiedFor` method from the `Advanced` session operations.
+Last modified date is stored within the session metadata and is available for each 
+entity using the `get_last_modified_for` method from the `advanced` session operations.
 
 ## Syntax
 
 {CODE:python get_last_modified_1@ClientApi\Session\HowTo\GetLastModified.py /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **instance** | T | Instance of an entity for which the last modified date will be returned. |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| **entity** | `object` | Instance of an entity for which the last modified date will be returned. |
 
-| Return Value | |
-| ------------- | ----- |
-| DateTime? | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
-
+| Return Type | Description |
+| ----------- | ----------- |
+| `datetime` | Returns the last modified date for an entity. Throws an exception if the `object` is not tracked by the session. |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.python.markdown
@@ -16,7 +16,7 @@ entity using the `get_last_modified_for` method from the `advanced` session oper
 
 | Return Type | Description |
 | ----------- | ----------- |
-| `datetime` | Returns the last modified date for an entity. Throws an exception if the `object` is not tracked by the session. |
+| `datetime` | Returns the last modified date for an entity. Throws an exception if the entity is not tracked by the session. |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/get-entity-last-modified.python.markdown
@@ -1,0 +1,30 @@
+# Session: How to Get Entity Last Modified 
+
+When a document is downloaded from the server it contains various metadata information, including the last modified date of the document.  
+
+Last modified date is stored within the metadata in session and is available for each entity using the `GetLastModifiedFor` method from the `Advanced` session operations.
+
+## Syntax
+
+{CODE:python get_last_modified_1@ClientApi\Session\HowTo\GetLastModified.py /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **instance** | T | Instance of an entity for which the last modified date will be returned. |
+
+| Return Value | |
+| ------------- | ----- |
+| DateTime? | Returns the last modified date for an entity. Throws an exception if the `instance` is not tracked by the session. |
+
+
+## Example
+
+{CODE:python get_last_modified_2@ClientApi\Session\HowTo\GetLastModified.py /}
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Get and Modify Entity Metadata](../../../client-api/session/how-to/get-and-modify-entity-metadata)
+- [How to Get Entity Change-Vector](../../../client-api/session/how-to/get-entity-change-vector)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.dotnet.markdown
@@ -1,0 +1,135 @@
+# Perform requests lazily
+---
+
+{NOTE: }
+
+* __Lazy request__:
+
+    * You can define a lazy request within a session (e.g. a lazy-query or a lazy-load request)  
+      and defer its execution until actually needed.
+
+    * The lazy request definition is stored in the session and a `Lazy<T>` instance is returned.  
+      The request will be sent to the server and executed only when you access the value of this instance.
+
+* __Multiple lazy requests__:
+
+    * Multiple lazy requests can be defined within the same session.
+
+    * When triggering the deferred execution (whether implicitly or explicitly),  
+      ALL pending lazy requests held up by the session will be sent to the server in a single call.  
+      This can help reduce the number of remote calls made to the server over the network.
+
+* In this page:
+    * [Requests that can be executed lazily:](../../../client-api/session/how-to/perform-operations-lazily#requests-that-can-be-executed-lazily)
+        * [Load entities](../../../client-api/session/how-to/perform-operations-lazily#loadEntities)
+        * [Load entities with include](../../../client-api/session/how-to/perform-operations-lazily#loadWithInclude)
+        * [Load entities starting with](../../../client-api/session/how-to/perform-operations-lazily#loadStartingWith)
+        * [Conditional load](../../../client-api/session/how-to/perform-operations-lazily#conditionalLoad)
+        * [Run query](../../../client-api/session/how-to/perform-operations-lazily#runQuery)
+        * [Get revisions](../../../client-api/session/how-to/perform-operations-lazily#getRevisions)
+        * [Get compare-exchange value](../../../client-api/session/how-to/perform-operations-lazily#getCompareExchange)
+    * [Multiple lazy requests](../../../client-api/session/how-to/perform-operations-lazily#multiple-lazy-requests)
+        * [Execute all requests - implicitly](../../../client-api/session/how-to/perform-operations-lazily#implicit)
+        * [Execute all requests - explicitly](../../../client-api/session/how-to/perform-operations-lazily#explicit)
+
+{NOTE/}
+
+---
+
+{PANEL: Operations that can be executed lazily}
+
+{NOTE: }
+<a id="loadEntities" /> __Load entities__
+
+* [Load](../../../client-api/session/loading-entities#load) loads a document entity from the database into the session.  
+  Loading entities can be executed __lazily__.   
+
+{CODE lazy_Load@ClientApi\Session\HowTo\Lazy.cs /}
+{NOTE/}
+
+{NOTE: }
+<a id="loadWithInclude" /> __Load entities with include__
+
+* [Load with include](../../../client-api/session/loading-entities#load-with-includes) loads both the document and the specified related document.    
+  Loading entities with include can be executed __lazily__.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Lazy_load_with_include lazy_LoadWithInclude@ClientApi\Session\HowTo\Lazy.cs /}
+{CODE-TAB:csharp:The_document lazy_productClass@ClientApi\Session\HowTo\Lazy.cs /}
+{CODE-TABS/}
+{NOTE/}
+
+{NOTE: }
+<a id="loadStartingWith" /> __Load entities starting with__
+
+* [LoadStartingWith](../../../client-api/session/loading-entities#loadstartingwith) loads entities whose ID starts with the specified prefix.  
+  Loading entities with a common prefix can be executed __lazily__.
+
+{CODE lazy_LoadStartingWith@ClientApi\Session\HowTo\Lazy.cs /}
+{NOTE/}
+
+{NOTE: }
+<a id="conditionalLoad" /> __Conditional load__
+
+* [ConditionalLoad](../../../client-api/session/loading-entities#conditionalload) logic is: 
+  * If the entity is already loaded to the session:  
+    no server call is made, the tracked entity is returned.    
+  * If the entity is Not already loaded to the session:  
+    the document will be loaded from the server only if the change-vector provided to the method is older than the one in the server
+    (i.e. if the document in the server is newer).
+  * Loading entities conditionally can be executed __lazily__.  
+
+{CODE lazy_ConditionalLoad@ClientApi\Session\HowTo\Lazy.cs /}
+{NOTE/}
+
+{NOTE: }
+<a id="runQuery" /> __Run query__
+
+* A Query can be executed __lazily__.  
+  Learn more about running queries lazily in [lazy queries](../../../client-api/session/querying/how-to-perform-queries-lazily).
+
+{CODE lazy_Query@ClientApi\Session\HowTo\Lazy.cs /}
+{NOTE/}
+
+{NOTE: }
+<a id="getRevisions" /> __Get revisions__
+
+* All methods for [getting revisions](../../../document-extensions/revisions/client-api/session/loading) and their metadata can be executed __lazily__.
+
+{CODE lazy_Revisions@ClientApi\Session\HowTo\Lazy.cs /}
+{NOTE/}
+
+{NOTE: }
+<a id="getCompareExchange" /> __Get compare-exchange value__
+
+* [Getting compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange) values can be executed __lazily__.
+
+{CODE lazy_CompareExchange@ClientApi\Session\HowTo\Lazy.cs /}
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Multiple lazy requests }
+
+{NOTE: }
+<a id="implicit" /> __Execute all requests - implicitly__
+
+{CODE lazy_ExecuteAll_Implicit@ClientApi\Session\HowTo\Lazy.cs /}
+
+{NOTE/}
+
+{NOTE: }
+<a id="explicit" /> __Execute all requests - explicitly__
+
+{CODE lazy_ExecuteAll_Explicit@ClientApi\Session\HowTo\Lazy.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [How to Perform Queries Lazily](../../../client-api/session/querying/how-to-perform-queries-lazily)
+- [Cluster Transaction - Overview](../../../client-api/session/cluster-transaction/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.dotnet.markdown
@@ -3,7 +3,7 @@
 
 {NOTE: }
 
-* __Lazy request__:
+* **Lazy request**:
 
     * You can define a lazy request within a session (e.g. a lazy-query or a lazy-load request)  
       and defer its execution until actually needed.
@@ -11,7 +11,7 @@
     * The lazy request definition is stored in the session and a `Lazy<T>` instance is returned.  
       The request will be sent to the server and executed only when you access the value of this instance.
 
-* __Multiple lazy requests__:
+* **Multiple lazy requests**:
 
     * Multiple lazy requests can be defined within the same session.
 
@@ -20,17 +20,17 @@
       This can help reduce the number of remote calls made to the server over the network.
 
 * In this page:
-    * [Requests that can be executed lazily:](../../../client-api/session/how-to/perform-operations-lazily#requests-that-can-be-executed-lazily)
-        * [Load entities](../../../client-api/session/how-to/perform-operations-lazily#loadEntities)
-        * [Load entities with include](../../../client-api/session/how-to/perform-operations-lazily#loadWithInclude)
-        * [Load entities starting with](../../../client-api/session/how-to/perform-operations-lazily#loadStartingWith)
-        * [Conditional load](../../../client-api/session/how-to/perform-operations-lazily#conditionalLoad)
-        * [Run query](../../../client-api/session/how-to/perform-operations-lazily#runQuery)
-        * [Get revisions](../../../client-api/session/how-to/perform-operations-lazily#getRevisions)
-        * [Get compare-exchange value](../../../client-api/session/how-to/perform-operations-lazily#getCompareExchange)
+    * [Requests that can be executed lazily](../../../client-api/session/how-to/perform-operations-lazily#operations-that-can-be-executed-lazily)
+        * [Load entities](../../../client-api/session/how-to/perform-operations-lazily#load-entities)
+        * [Load entities with include](../../../client-api/session/how-to/perform-operations-lazily#load-entities-with-include)
+        * [Load entities starting with](../../../client-api/session/how-to/perform-operations-lazily#load-entities-starting-with)
+        * [Conditional load](../../../client-api/session/how-to/perform-operations-lazily#conditional-load)
+        * [Run query](../../../client-api/session/how-to/perform-operations-lazily#run-query)
+        * [Get revisions](../../../client-api/session/how-to/perform-operations-lazily#get-revisions)
+        * [Get compare-exchange value](../../../client-api/session/how-to/perform-operations-lazily#get-compare-exchange-value)
     * [Multiple lazy requests](../../../client-api/session/how-to/perform-operations-lazily#multiple-lazy-requests)
-        * [Execute all requests - implicitly](../../../client-api/session/how-to/perform-operations-lazily#implicit)
-        * [Execute all requests - explicitly](../../../client-api/session/how-to/perform-operations-lazily#explicit)
+        * [Execute all requests - implicitly](../../../client-api/session/how-to/perform-operations-lazily#execute-all-requests---implicitly)
+        * [Execute all requests - explicitly](../../../client-api/session/how-to/perform-operations-lazily#execute-all-requests---explicitly)
 
 {NOTE/}
 
@@ -38,92 +38,96 @@
 
 {PANEL: Operations that can be executed lazily}
 
-{NOTE: }
-<a id="loadEntities" /> __Load entities__
+### Load entities
 
-* [Load](../../../client-api/session/loading-entities#load) loads a document entity from the database into the session.  
-  Loading entities can be executed __lazily__.   
+[Load](../../../client-api/session/loading-entities#load) loads a document entity from 
+the database into the session.  
+Loading entities can be executed **lazily**.   
 
 {CODE lazy_Load@ClientApi\Session\HowTo\Lazy.cs /}
-{NOTE/}
 
-{NOTE: }
-<a id="loadWithInclude" /> __Load entities with include__
+---
 
-* [Load with include](../../../client-api/session/loading-entities#load-with-includes) loads both the document and the specified related document.    
-  Loading entities with include can be executed __lazily__.
+### Load entities with include
+
+[Load with include](../../../client-api/session/loading-entities#load-with-includes) loads both the document and the specified related document.    
+Loading entities with include can be executed **lazily**.
 
 {CODE-TABS}
 {CODE-TAB:csharp:Lazy_load_with_include lazy_LoadWithInclude@ClientApi\Session\HowTo\Lazy.cs /}
 {CODE-TAB:csharp:The_document lazy_productClass@ClientApi\Session\HowTo\Lazy.cs /}
 {CODE-TABS/}
-{NOTE/}
 
-{NOTE: }
-<a id="loadStartingWith" /> __Load entities starting with__
+---
 
-* [LoadStartingWith](../../../client-api/session/loading-entities#loadstartingwith) loads entities whose ID starts with the specified prefix.  
-  Loading entities with a common prefix can be executed __lazily__.
+### Load entities starting with
+
+[LoadStartingWith](../../../client-api/session/loading-entities#loadstartingwith) loads entities whose ID starts with the specified prefix.  
+Loading entities with a common prefix can be executed **lazily**.
 
 {CODE lazy_LoadStartingWith@ClientApi\Session\HowTo\Lazy.cs /}
-{NOTE/}
 
-{NOTE: }
-<a id="conditionalLoad" /> __Conditional load__
+---
 
-* [ConditionalLoad](../../../client-api/session/loading-entities#conditionalload) logic is: 
-  * If the entity is already loaded to the session:  
-    no server call is made, the tracked entity is returned.    
-  * If the entity is Not already loaded to the session:  
-    the document will be loaded from the server only if the change-vector provided to the method is older than the one in the server
-    (i.e. if the document in the server is newer).
-  * Loading entities conditionally can be executed __lazily__.  
+### Conditional load
+
+[ConditionalLoad](../../../client-api/session/loading-entities#conditionalload) logic is: 
+
+* If the entity is already loaded to the session:  
+  no server call is made, the tracked entity is returned.  
+* If the entity is Not already loaded to the session:  
+  the document will be loaded from the server only if the change-vector provided to the 
+  method is older than the one in the server (i.e. if the document in the server is newer).  
+* Loading entities conditionally can be executed **lazily**.  
 
 {CODE lazy_ConditionalLoad@ClientApi\Session\HowTo\Lazy.cs /}
-{NOTE/}
 
-{NOTE: }
-<a id="runQuery" /> __Run query__
+---
 
-* A Query can be executed __lazily__.  
-  Learn more about running queries lazily in [lazy queries](../../../client-api/session/querying/how-to-perform-queries-lazily).
+### Run query
+
+A Query can be executed **lazily**.  
+Learn more about running queries lazily in [lazy queries](../../../client-api/session/querying/how-to-perform-queries-lazily).
 
 {CODE lazy_Query@ClientApi\Session\HowTo\Lazy.cs /}
-{NOTE/}
 
-{NOTE: }
-<a id="getRevisions" /> __Get revisions__
+---
 
-* All methods for [getting revisions](../../../document-extensions/revisions/client-api/session/loading) and their metadata can be executed __lazily__.
+### Get revisions
+
+All methods for [getting revisions](../../../document-extensions/revisions/client-api/session/loading) and their metadata can be executed **lazily**.
 
 {CODE lazy_Revisions@ClientApi\Session\HowTo\Lazy.cs /}
-{NOTE/}
 
-{NOTE: }
-<a id="getCompareExchange" /> __Get compare-exchange value__
+---
 
-* [Getting compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange) values can be executed __lazily__.
+### Get compare-exchange value
+
+[Getting compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange) 
+values can be executed **lazily**.
 
 {CODE lazy_CompareExchange@ClientApi\Session\HowTo\Lazy.cs /}
-{NOTE/}
 
 {PANEL/}
 
 {PANEL: Multiple lazy requests }
 
-{NOTE: }
-<a id="implicit" /> __Execute all requests - implicitly__
+### Execute all requests - implicitly
+
+Accessing the value of ANY of the lazy instances will trigger
+the execution of ALL pending lazy requests held up by the session, 
+in a SINGLE server call.  
 
 {CODE lazy_ExecuteAll_Implicit@ClientApi\Session\HowTo\Lazy.cs /}
 
-{NOTE/}
+---
 
-{NOTE: }
-<a id="explicit" /> __Execute all requests - explicitly__
+### Execute all requests - explicitly
+
+Explicitly calling `ExecuteAllPendingLazyOperations` will execute 
+ALL pending lazy requests held up by the session, in a SINGLE server call.  
 
 {CODE lazy_ExecuteAll_Explicit@ClientApi\Session\HowTo\Lazy.cs /}
-
-{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.js.markdown
@@ -112,7 +112,12 @@
 {PANEL: Multiple lazy requests }
 
 {NOTE: }
+
 <a id="implicit" /> __Execute all requests - implicitly__
+
+Accessing the value of ANY of the lazy instances will trigger
+the execution of ALL pending lazy requests held up by the session, 
+in a SINGLE server call.  
 
 {CODE:nodejs lazy_ExecuteAll_Implicit@client-api\Session\HowTo\lazy.js /}
 
@@ -120,6 +125,9 @@
 
 {NOTE: }
 <a id="explicit" /> __Execute all requests - explicitly__
+
+Explicitly calling `executeAllPendingLazyOperations` will execute 
+ALL pending lazy requests held up by the session, in a SINGLE server call.  
 
 {CODE:nodejs lazy_ExecuteAll_Explicit@client-api\Session\HowTo\lazy.js /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.js.markdown
@@ -1,0 +1,135 @@
+# Perform requests lazily
+---
+
+{NOTE: }
+
+* __Lazy request__:
+
+    * You can define a lazy request within a session (e.g. a lazy-query or a lazy-load request)  
+      and defer its execution until actually needed.
+
+    * The lazy request definition is stored in the session and a `Lazy` instance is returned.  
+      The request will be sent to the server and executed only when you access the value of this instance.
+
+* __Multiple lazy requests__:
+
+    * Multiple lazy requests can be defined within the same session.
+
+    * When triggering the deferred execution (whether implicitly or explicitly),  
+      ALL pending lazy requests held up by the session will be sent to the server in a single call.  
+      This can help reduce the number of remote calls made to the server over the network.
+
+* In this page:
+    * [Requests that can be executed lazily:](../../../client-api/session/how-to/perform-operations-lazily#requests-that-can-be-executed-lazily)
+        * [Load entities](../../../client-api/session/how-to/perform-operations-lazily#loadEntities)
+        * [Load entities with include](../../../client-api/session/how-to/perform-operations-lazily#loadWithInclude)
+        * [Load entities starting with](../../../client-api/session/how-to/perform-operations-lazily#loadStartingWith)
+        * [Conditional load](../../../client-api/session/how-to/perform-operations-lazily#conditionalLoad)
+        * [Run query](../../../client-api/session/how-to/perform-operations-lazily#runQuery)
+        * [Get revisions](../../../client-api/session/how-to/perform-operations-lazily#getRevisions)
+        * [Get compare-exchange value](../../../client-api/session/how-to/perform-operations-lazily#getCompareExchange)
+    * [Multiple lazy requests](../../../client-api/session/how-to/perform-operations-lazily#multiple-lazy-requests)
+        * [Execute all requests - implicitly](../../../client-api/session/how-to/perform-operations-lazily#implicit)
+        * [Execute all requests - explicitly](../../../client-api/session/how-to/perform-operations-lazily#explicit)
+
+{NOTE/}
+
+---
+
+{PANEL: Operations that can be executed lazily}
+
+{NOTE: }
+<a id="loadEntities" /> __Load entities__
+
+* ['load'](../../../client-api/session/loading-entities#load) loads a document entity from the database into the session.  
+  Loading entities can be executed __lazily__.   
+
+{CODE:nodejs lazy_load@client-api\Session\HowTo\lazy.js /}
+{NOTE/}
+
+{NOTE: }
+<a id="loadWithInclude" /> __Load entities with include__
+
+* ['load' with include](../../../client-api/session/loading-entities#load-with-includes) loads both the document and the specified related document.    
+  Loading entities with include can be executed __lazily__.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Lazy_load_with_include lazy_loadWithInclude@client-api\Session\HowTo\lazy.js /}
+{CODE-TAB:nodejs:The_document lazy_productClass@client-api\Session\HowTo\lazy.js /}
+{CODE-TABS/}
+{NOTE/}
+
+{NOTE: }
+<a id="loadStartingWith" /> __Load entities starting with__
+
+* ['loadStartingWith'](../../../client-api/session/loading-entities#loadstartingwith) loads entities whose ID starts with the specified prefix.  
+  Loading entities with a common prefix can be executed __lazily__.
+
+{CODE:nodejs lazy_loadStartingWith@client-api\Session\HowTo\lazy.js /}
+{NOTE/}
+
+{NOTE: }
+<a id="conditionalLoad" /> __Conditional load__
+
+* ['conditionalLoad'](../../../client-api/session/loading-entities#conditionalload) logic is: 
+  * If the entity is already loaded to the session:  
+    no server call is made, the tracked entity is returned.    
+  * If the entity is Not already loaded to the session:  
+    the document will be loaded from the server only if the change-vector provided to the method is older than the one in the server
+    (i.e. if the document in the server is newer).
+  * Loading entities conditionally can be executed __lazily__.  
+
+{CODE:nodejs lazy_conditionalLoad@client-api\Session\HowTo\lazy.js /}
+{NOTE/}
+
+{NOTE: }
+<a id="runQuery" /> __Run query__
+
+* A Query can be executed __lazily__.  
+  Learn more about running queries lazily in [lazy queries](../../../client-api/session/querying/how-to-perform-queries-lazily).
+
+{CODE:nodejs lazy_query@client-api\Session\HowTo\lazy.js /}
+{NOTE/}
+
+{NOTE: }
+<a id="getRevisions" /> __Get revisions__
+
+* All methods for [getting revisions](../../../document-extensions/revisions/client-api/session/loading) and their metadata can be executed __lazily__.
+
+{CODE:nodejs lazy_revisions@client-api\Session\HowTo\lazy.js /}
+{NOTE/}
+
+{NOTE: }
+<a id="getCompareExchange" /> __Get compare-exchange value__
+
+* [Getting compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange) values can be executed __lazily__.
+
+{CODE:nodejs lazy_compareExchange@client-api\Session\HowTo\lazy.js /}
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Multiple lazy requests }
+
+{NOTE: }
+<a id="implicit" /> __Execute all requests - implicitly__
+
+{CODE:nodejs lazy_ExecuteAll_Implicit@client-api\Session\HowTo\lazy.js /}
+
+{NOTE/}
+
+{NOTE: }
+<a id="explicit" /> __Execute all requests - explicitly__
+
+{CODE:nodejs lazy_ExecuteAll_Explicit@client-api\Session\HowTo\lazy.js /}
+
+{NOTE/}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [How to Perform Queries Lazily](../../../client-api/session/querying/how-to-perform-queries-lazily)
+- [Cluster Transaction - Overview](../../../client-api/session/cluster-transaction/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.python.markdown
@@ -1,0 +1,135 @@
+# Perform requests lazily
+---
+
+{NOTE: }
+
+* __Lazy request__:
+
+    * You can define a lazy request within a session (e.g. a lazy-query or a lazy-load request)  
+      and defer its execution until actually needed.
+
+    * The lazy request definition is stored in the session and a `Lazy<T>` instance is returned.  
+      The request will be sent to the server and executed only when you access the value of this instance.
+
+* __Multiple lazy requests__:
+
+    * Multiple lazy requests can be defined within the same session.
+
+    * When triggering the deferred execution (whether implicitly or explicitly),  
+      ALL pending lazy requests held up by the session will be sent to the server in a single call.  
+      This can help reduce the number of remote calls made to the server over the network.
+
+* In this page:
+    * [Requests that can be executed lazily:](../../../client-api/session/how-to/perform-operations-lazily#requests-that-can-be-executed-lazily)
+        * [Load entities](../../../client-api/session/how-to/perform-operations-lazily#loadEntities)
+        * [Load entities with include](../../../client-api/session/how-to/perform-operations-lazily#loadWithInclude)
+        * [Load entities starting with](../../../client-api/session/how-to/perform-operations-lazily#loadStartingWith)
+        * [Conditional load](../../../client-api/session/how-to/perform-operations-lazily#conditionalLoad)
+        * [Run query](../../../client-api/session/how-to/perform-operations-lazily#runQuery)
+        * [Get revisions](../../../client-api/session/how-to/perform-operations-lazily#getRevisions)
+        * [Get compare-exchange value](../../../client-api/session/how-to/perform-operations-lazily#getCompareExchange)
+    * [Multiple lazy requests](../../../client-api/session/how-to/perform-operations-lazily#multiple-lazy-requests)
+        * [Execute all requests - implicitly](../../../client-api/session/how-to/perform-operations-lazily#implicit)
+        * [Execute all requests - explicitly](../../../client-api/session/how-to/perform-operations-lazily#explicit)
+
+{NOTE/}
+
+---
+
+{PANEL: Operations that can be executed lazily}
+
+{NOTE: }
+<a id="loadEntities" /> __Load entities__
+
+* [Load](../../../client-api/session/loading-entities#load) loads a document entity from the database into the session.  
+  Loading entities can be executed __lazily__.   
+
+{CODE:python lazy_Load@ClientApi\Session\HowTo\Lazy.py /}
+{NOTE/}
+
+{NOTE: }
+<a id="loadWithInclude" /> __Load entities with include__
+
+* [Load with include](../../../client-api/session/loading-entities#load-with-includes) loads both the document and the specified related document.    
+  Loading entities with include can be executed __lazily__.
+
+{CODE-TABS}
+{CODE-TAB:python:Lazy_load_with_include lazy_LoadWithInclude@ClientApi\Session\HowTo\Lazy.py /}
+{CODE-TAB:python:The_document lazy_productClass@ClientApi\Session\HowTo\Lazy.py /}
+{CODE-TABS/}
+{NOTE/}
+
+{NOTE: }
+<a id="loadStartingWith" /> __Load entities starting with__
+
+* [LoadStartingWith](../../../client-api/session/loading-entities#loadstartingwith) loads entities whose ID starts with the specified prefix.  
+  Loading entities with a common prefix can be executed __lazily__.
+
+{CODE:python lazy_LoadStartingWith@ClientApi\Session\HowTo\Lazy.py /}
+{NOTE/}
+
+{NOTE: }
+<a id="conditionalLoad" /> __Conditional load__
+
+* [ConditionalLoad](../../../client-api/session/loading-entities#conditionalload) logic is: 
+  * If the entity is already loaded to the session:  
+    no server call is made, the tracked entity is returned.    
+  * If the entity is Not already loaded to the session:  
+    the document will be loaded from the server only if the change-vector provided to the method is older than the one in the server
+    (i.e. if the document in the server is newer).
+  * Loading entities conditionally can be executed __lazily__.  
+
+{CODE:python lazy_ConditionalLoad@ClientApi\Session\HowTo\Lazy.py /}
+{NOTE/}
+
+{NOTE: }
+<a id="runQuery" /> __Run query__
+
+* A Query can be executed __lazily__.  
+  Learn more about running queries lazily in [lazy queries](../../../client-api/session/querying/how-to-perform-queries-lazily).
+
+{CODE:python lazy_Query@ClientApi\Session\HowTo\Lazy.py /}
+{NOTE/}
+
+{NOTE: }
+<a id="getRevisions" /> __Get revisions__
+
+* All methods for [getting revisions](../../../document-extensions/revisions/client-api/session/loading) and their metadata can be executed __lazily__.
+
+{CODE:python lazy_Revisions@ClientApi\Session\HowTo\Lazy.py /}
+{NOTE/}
+
+{NOTE: }
+<a id="getCompareExchange" /> __Get compare-exchange value__
+
+* [Getting compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange) values can be executed __lazily__.
+
+{CODE:python lazy_CompareExchange@ClientApi\Session\HowTo\Lazy.py /}
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Multiple lazy requests }
+
+{NOTE: }
+<a id="implicit" /> __Execute all requests - implicitly__
+
+{CODE:python lazy_ExecuteAll_Implicit@ClientApi\Session\HowTo\Lazy.py /}
+
+{NOTE/}
+
+{NOTE: }
+<a id="explicit" /> __Execute all requests - explicitly__
+
+{CODE:python lazy_ExecuteAll_Explicit@ClientApi\Session\HowTo\Lazy.py /}
+
+{NOTE/}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [How to Perform Queries Lazily](../../../client-api/session/querying/how-to-perform-queries-lazily)
+- [Cluster Transaction - Overview](../../../client-api/session/cluster-transaction/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/perform-operations-lazily.python.markdown
@@ -3,15 +3,15 @@
 
 {NOTE: }
 
-* __Lazy request__:
+* **Lazy request**:
 
     * You can define a lazy request within a session (e.g. a lazy-query or a lazy-load request)  
       and defer its execution until actually needed.
 
-    * The lazy request definition is stored in the session and a `Lazy<T>` instance is returned.  
+    * The lazy request definition is stored in the session and a `Lazy` instance is returned.  
       The request will be sent to the server and executed only when you access the value of this instance.
 
-* __Multiple lazy requests__:
+* **Multiple lazy requests**:
 
     * Multiple lazy requests can be defined within the same session.
 
@@ -20,17 +20,17 @@
       This can help reduce the number of remote calls made to the server over the network.
 
 * In this page:
-    * [Requests that can be executed lazily:](../../../client-api/session/how-to/perform-operations-lazily#requests-that-can-be-executed-lazily)
-        * [Load entities](../../../client-api/session/how-to/perform-operations-lazily#loadEntities)
-        * [Load entities with include](../../../client-api/session/how-to/perform-operations-lazily#loadWithInclude)
-        * [Load entities starting with](../../../client-api/session/how-to/perform-operations-lazily#loadStartingWith)
-        * [Conditional load](../../../client-api/session/how-to/perform-operations-lazily#conditionalLoad)
-        * [Run query](../../../client-api/session/how-to/perform-operations-lazily#runQuery)
-        * [Get revisions](../../../client-api/session/how-to/perform-operations-lazily#getRevisions)
-        * [Get compare-exchange value](../../../client-api/session/how-to/perform-operations-lazily#getCompareExchange)
+    * [Requests that can be executed lazily](../../../client-api/session/how-to/perform-operations-lazily#operations-that-can-be-executed-lazily)
+        * [Load entities](../../../client-api/session/how-to/perform-operations-lazily#load-entities)
+        * [Load entities with include](../../../client-api/session/how-to/perform-operations-lazily#load-entities-with-include)
+        * [Load entities starting with](../../../client-api/session/how-to/perform-operations-lazily#load-entities-starting-with)
+        * [Conditional load](../../../client-api/session/how-to/perform-operations-lazily#conditional-load)
+        * [Run query](../../../client-api/session/how-to/perform-operations-lazily#run-query)
+        * [Get revisions](../../../client-api/session/how-to/perform-operations-lazily#get-revisions)
+        * [Get compare-exchange value](../../../client-api/session/how-to/perform-operations-lazily#get-compare-exchange-value)
     * [Multiple lazy requests](../../../client-api/session/how-to/perform-operations-lazily#multiple-lazy-requests)
-        * [Execute all requests - implicitly](../../../client-api/session/how-to/perform-operations-lazily#implicit)
-        * [Execute all requests - explicitly](../../../client-api/session/how-to/perform-operations-lazily#explicit)
+        * [Execute all requests - implicitly](../../../client-api/session/how-to/perform-operations-lazily#execute-all-requests---implicitly)
+        * [Execute all requests - explicitly](../../../client-api/session/how-to/perform-operations-lazily#execute-all-requests---explicitly)
 
 {NOTE/}
 
@@ -38,92 +38,98 @@
 
 {PANEL: Operations that can be executed lazily}
 
-{NOTE: }
-<a id="loadEntities" /> __Load entities__
+### Load entities
 
-* [Load](../../../client-api/session/loading-entities#load) loads a document entity from the database into the session.  
-  Loading entities can be executed __lazily__.   
+[load](../../../client-api/session/loading-entities#load) loads a document entity from 
+the database into the session.  
+Loading entities can be executed **lazily**.   
 
 {CODE:python lazy_Load@ClientApi\Session\HowTo\Lazy.py /}
-{NOTE/}
 
-{NOTE: }
-<a id="loadWithInclude" /> __Load entities with include__
+---
 
-* [Load with include](../../../client-api/session/loading-entities#load-with-includes) loads both the document and the specified related document.    
-  Loading entities with include can be executed __lazily__.
+### Load entities with include
+
+[load with include](../../../client-api/session/loading-entities#load-with-includes) loads 
+both the document and the specified related document.  
+Loading entities with include can be executed **lazily**.
 
 {CODE-TABS}
 {CODE-TAB:python:Lazy_load_with_include lazy_LoadWithInclude@ClientApi\Session\HowTo\Lazy.py /}
 {CODE-TAB:python:The_document lazy_productClass@ClientApi\Session\HowTo\Lazy.py /}
 {CODE-TABS/}
-{NOTE/}
 
-{NOTE: }
-<a id="loadStartingWith" /> __Load entities starting with__
+---
 
-* [LoadStartingWith](../../../client-api/session/loading-entities#loadstartingwith) loads entities whose ID starts with the specified prefix.  
-  Loading entities with a common prefix can be executed __lazily__.
+### Load entities starting with
+
+[load_starting_with](../../../client-api/session/loading-entities#loadstartingwith) loads 
+entities whose ID starts with the specified prefix.  
+Loading entities with a common prefix can be executed **lazily**.
 
 {CODE:python lazy_LoadStartingWith@ClientApi\Session\HowTo\Lazy.py /}
-{NOTE/}
 
-{NOTE: }
-<a id="conditionalLoad" /> __Conditional load__
+---
 
-* [ConditionalLoad](../../../client-api/session/loading-entities#conditionalload) logic is: 
-  * If the entity is already loaded to the session:  
-    no server call is made, the tracked entity is returned.    
-  * If the entity is Not already loaded to the session:  
-    the document will be loaded from the server only if the change-vector provided to the method is older than the one in the server
-    (i.e. if the document in the server is newer).
-  * Loading entities conditionally can be executed __lazily__.  
+### Conditional load
+
+[conditional_load](../../../client-api/session/loading-entities#conditionalload) logic is: 
+
+* If the entity is already loaded to the session:  
+  no server call is made, the tracked entity is returned.    
+* If the entity is Not already loaded to the session:  
+  the document will be loaded from the server only if the change-vector provided to the 
+  method is older than the one in the server (i.e. if the document in the server is newer).
+* Loading entities conditionally can be executed **lazily**.  
 
 {CODE:python lazy_ConditionalLoad@ClientApi\Session\HowTo\Lazy.py /}
-{NOTE/}
 
-{NOTE: }
-<a id="runQuery" /> __Run query__
+---
 
-* A Query can be executed __lazily__.  
-  Learn more about running queries lazily in [lazy queries](../../../client-api/session/querying/how-to-perform-queries-lazily).
+### Run query
+
+A query can be executed **lazily**.  
+Learn more about running queries lazily in [lazy queries](../../../client-api/session/querying/how-to-perform-queries-lazily).
 
 {CODE:python lazy_Query@ClientApi\Session\HowTo\Lazy.py /}
-{NOTE/}
 
-{NOTE: }
-<a id="getRevisions" /> __Get revisions__
+---
 
-* All methods for [getting revisions](../../../document-extensions/revisions/client-api/session/loading) and their metadata can be executed __lazily__.
+### Get revisions
+
+All methods for [getting revisions](../../../document-extensions/revisions/client-api/session/loading) and their metadata can be executed **lazily**.
 
 {CODE:python lazy_Revisions@ClientApi\Session\HowTo\Lazy.py /}
-{NOTE/}
 
-{NOTE: }
-<a id="getCompareExchange" /> __Get compare-exchange value__
+---
 
-* [Getting compare-exchange](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange) values can be executed __lazily__.
+### Get compare-exchange value
+
+[get_compare_exchange_value](../../../client-api/session/cluster-transaction/compare-exchange#get-compare-exchange) 
+can be executed **lazily**.
 
 {CODE:python lazy_CompareExchange@ClientApi\Session\HowTo\Lazy.py /}
-{NOTE/}
 
 {PANEL/}
 
 {PANEL: Multiple lazy requests }
 
-{NOTE: }
-<a id="implicit" /> __Execute all requests - implicitly__
+### Execute all requests - implicitly
+
+Accessing the value of ANY of the lazy instances will trigger
+the execution of ALL pending lazy requests held up by the session, 
+in a SINGLE server call.  
 
 {CODE:python lazy_ExecuteAll_Implicit@ClientApi\Session\HowTo\Lazy.py /}
 
-{NOTE/}
+---
 
-{NOTE: }
-<a id="explicit" /> __Execute all requests - explicitly__
+### Execute all requests - explicitly
+
+Explicitly calling `execute_all_pending_lazy_operations` will execute 
+ALL pending lazy requests held up by the session, in a SINGLE server call.  
 
 {CODE:python lazy_ExecuteAll_Explicit@ClientApi\Session\HowTo\Lazy.py /}
-
-{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.dotnet.markdown
@@ -1,13 +1,14 @@
 # Session: How to Refresh an Entity
 
-To update an entity with the latest changes from the server, use the `Refresh` method from `Advanced` session operations.
+To update an entity with the latest changes from the server, use the `Refresh` method 
+from `Advanced` session operations.
 
 ## Syntax
 
 {CODE refresh_1@ClientApi\Session\HowTo\Refresh.cs /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
 | **entity** | T | Instance of an entity that will be refreshed |
 
 ## Example

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.dotnet.markdown
@@ -1,0 +1,28 @@
+# Session: How to Refresh an Entity
+
+To update an entity with the latest changes from the server, use the `Refresh` method from `Advanced` session operations.
+
+## Syntax
+
+{CODE refresh_1@ClientApi\Session\HowTo\Refresh.cs /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | T | Instance of an entity that will be refreshed |
+
+## Example
+
+{CODE refresh_2@ClientApi\Session\HowTo\Refresh.cs /}
+
+## Remarks
+
+Refreshing a transient entity (not attached) or an entity that was deleted on server-side will result in a `InvalidOperationException`.
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.java.markdown
@@ -1,0 +1,28 @@
+# Session: How to Refresh an Entity
+
+To update an entity with the latest changes from the server, use the `refresh` method from `advanced` session operations.
+
+## Syntax
+
+{CODE:java refresh_1@ClientApi\Session\HowTo\Refresh.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | T | Instance of an entity that will be refreshed |
+
+## Example
+
+{CODE:java refresh_2@ClientApi\Session\HowTo\Refresh.java /}
+
+## Remarks
+
+Refreshing a transient entity (not attached) or an entity that was deleted on server-side will result in a `IllegalStateException`.
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.java.markdown
@@ -1,14 +1,15 @@
 # Session: How to Refresh an Entity
 
-To update an entity with the latest changes from the server, use the `refresh` method from `advanced` session operations.
+To update an entity with the latest changes from the server, use the `refresh` method 
+from `advanced` session operations.
 
 ## Syntax
 
 {CODE:java refresh_1@ClientApi\Session\HowTo\Refresh.java /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **entity** | T | Instance of an entity that will be refreshed |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| **entity** | `T` | Instance of an entity that will be refreshed |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.js.markdown
@@ -1,14 +1,15 @@
 # Session: How to Refresh an Entity
 
-To update an entity with the latest changes from the server, use the `refresh()` method from `advanced` session operations.
+To update an entity with the latest changes from the server, use the `refresh()` method 
+from `advanced` session operations.
 
 ## Syntax
 
 {CODE:nodejs refresh_1@client-api\session\howTo\refresh.js /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **entity** | object | Instance of an entity that will be refreshed |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| **entity** | `object` | Instance of an entity that will be refreshed |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.js.markdown
@@ -1,0 +1,28 @@
+# Session: How to Refresh an Entity
+
+To update an entity with the latest changes from the server, use the `refresh()` method from `advanced` session operations.
+
+## Syntax
+
+{CODE:nodejs refresh_1@client-api\session\howTo\refresh.js /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | object | Instance of an entity that will be refreshed |
+
+## Example
+
+{CODE:nodejs refresh_2@client-api\session\howTo\refresh.js /}
+
+## Remarks
+
+Refreshing a transient entity (not attached) or an entity that was deleted server-side will result in an `InvalidOperationException` error.
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.python.markdown
@@ -8,7 +8,7 @@ To update an entity with the latest changes from the server, use the `refresh` m
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| **entity** | `object` | Instance of an entity that will be refreshed |
+| **entity** | `object` | An entity that will be refreshed |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.python.markdown
@@ -1,0 +1,28 @@
+# Session: How to Refresh an Entity
+
+To update an entity with the latest changes from the server, use the `Refresh` method from `Advanced` session operations.
+
+## Syntax
+
+{CODE:python refresh_1@ClientApi\Session\HowTo\Refresh.py /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | T | Instance of an entity that will be refreshed |
+
+## Example
+
+{CODE:python refresh_2@ClientApi\Session\HowTo\Refresh.py /}
+
+## Remarks
+
+Refreshing a transient entity (not attached) or an entity that was deleted on server-side will result in a `InvalidOperationException`.
+
+## Related articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Clear a Session](../../../client-api/session/how-to/clear-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/refresh-entity.python.markdown
@@ -1,14 +1,14 @@
 # Session: How to Refresh an Entity
 
-To update an entity with the latest changes from the server, use the `Refresh` method from `Advanced` session operations.
+To update an entity with the latest changes from the server, use the `refresh` method from `advanced` session operations.
 
 ## Syntax
 
 {CODE:python refresh_1@ClientApi\Session\HowTo\Refresh.py /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **entity** | T | Instance of an entity that will be refreshed |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| **entity** | `object` | Instance of an entity that will be refreshed |
 
 ## Example
 

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Clear.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Clear.cs
@@ -1,0 +1,36 @@
+﻿using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class Clear
+    {
+        private interface IFoo
+        {
+            #region clear_1
+            void Clear();
+            #endregion
+        }
+
+        public Clear()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region clear_2
+                    session.Store(new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    });
+
+                    session.Advanced.Clear();
+
+                    session.SaveChanges(); // nothing will happen
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Defer.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Defer.cs
@@ -1,0 +1,65 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Operations;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class Defer
+    {
+        public Defer()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region defer_1
+
+                    // Defer is available in the session's Advanced methods 
+                    session.Advanced.Defer(
+                        
+                        // Define commands to be executed:
+                        // i.e. Put a new document
+                        new PutCommandData("products/999-A", null, new DynamicJsonValue
+                            {
+                                ["Name"] = "My Product",
+                                ["Supplier"] = "suppliers/1-A",
+                                ["@metadata"] = new DynamicJsonValue
+                                {
+                                    ["@collection"] = "Products"
+                                }
+                            }),
+                        
+                        // Patch document
+                        new PatchCommandData("products/999-A", null, new PatchRequest
+                                {
+                                    Script = "this.Supplier = 'suppliers/2-A';"
+                                },
+                                null),
+                        
+                        // Force a revision to be created
+                        new ForceRevisionCommandData("products/999-A"),
+                        
+                        // Delete a document
+                        new DeleteCommandData("products/1-A", null)
+                    );
+                    
+                    // All deferred commands will be sent to the server upon calling SaveChanges
+                    session.SaveChanges();
+
+                    #endregion
+                }
+            }
+        }
+
+        private interface IFoo
+        {
+            #region syntax
+
+            void Defer(ICommandData command, params ICommandData[] commands);
+            void Defer(ICommandData[] commands);
+
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Evict.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Evict.cs
@@ -1,0 +1,55 @@
+﻿using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class Evict
+    {
+        private interface IFoo
+        {
+            #region evict_1
+            void Evict<T>(T entity);
+            #endregion
+        }
+
+        public Evict()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region evict_2
+                    Employee employee1 = new Employee
+                    {
+                        FirstName = "John",
+                        LastName = "Doe"
+                    };
+
+                    Employee employee2 = new Employee
+                    {
+                        FirstName = "Joe",
+                        LastName = "Shmoe"
+                    };
+
+                    session.Store(employee1);
+                    session.Store(employee2);
+
+                    session.Advanced.Evict(employee1);
+
+                    session.SaveChanges(); // only 'Joe Shmoe' will be saved
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region evict_3
+                    Employee employee = session.Load<Employee>("employees/1-A"); // loading from server
+                    employee = session.Load<Employee>("employees/1-A"); // no server call
+                    session.Advanced.Evict(employee);
+                    employee = session.Load<Employee>("employees/1-A"); // loading from server
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/GetChangeVector.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/GetChangeVector.cs
@@ -1,0 +1,29 @@
+﻿using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class GetChangeVector
+    {
+        private interface IFoo
+        {
+            #region get_change_vector_1
+            string GetChangeVectorFor<T>(T instance);
+            #endregion
+        }
+
+        public GetChangeVector()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region get_change_vector_2
+                    Employee employee = session.Load<Employee>("employees/1-A");
+                    string changeVector = session.Advanced.GetChangeVectorFor(employee);
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/GetCountersFor.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/GetCountersFor.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class GetCountersFor
+    {
+        public GetCountersFor()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region example
+
+                    // Load a document
+                    var employee = session.Load<Employee>("employees/1-A");
+                    
+                    // Get counter names from the loaded entity
+                    List<string> counterNames = session.Advanced.GetCountersFor(employee);
+
+                    #endregion
+                }
+            }
+        }
+
+        private interface IFoo
+        {
+            #region syntax
+
+            List<string> GetCountersFor<T>(T instance);
+
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/GetLastModified.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/GetLastModified.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class GetLastModified
+    {
+        private interface IFoo
+        {
+            #region get_last_modified_1
+            DateTime? GetLastModifiedFor<T>(T instance);
+            #endregion
+        }
+
+        public GetLastModified()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region get_last_modified_2
+                    Employee employee = session.Load<Employee>("employees/1-A");
+                    DateTime? lastModified = session.Advanced.GetLastModifiedFor(employee);
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Lazy.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Lazy.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class Lazy
+    {
+        public Lazy()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region lazy_Load
+                    Lazy<Employee> lazyEmployee = session
+                         // Add a call to Lazily 
+                        .Advanced.Lazily
+                         // Document will Not be loaded from the database here, no server call is made
+                        .Load<Employee>("employees/1-A");
+
+                    Employee employee = lazyEmployee.Value; // 'Load' operation is executed here
+                    // The employee entity is now loaded & tracked by the session
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region lazy_LoadWithInclude
+                    Lazy<Product> lazyProduct = session
+                         // Add a call to Lazily 
+                        .Advanced.Lazily
+                         // Request to include the related Supplier document
+                         // Documents will Not be loaded from the database here, no server call is made
+                        .Include<Product>(x => x.SupplierId) 
+                        .Load<Product>("products/1-A"); 
+
+                    // 'Load with include' operation will be executed here
+                    // Both documents will be retrieved from the database
+                    Product product = lazyProduct.Value;
+                    // The product entity is now loaded & tracked by the session
+
+                    // Access the related document, no additional server call is made
+                    Supplier supplier = session.Load<Supplier>(product.SupplierId);
+                    // The supplier entity is now also loaded & tracked by the session
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region lazy_LoadStartingWith
+                    Lazy<Dictionary<string, Employee>> lazyEmployees = session
+                         // Add a call to Lazily 
+                        .Advanced.Lazily
+                         // Request to load entities whose ID starts with 'employees/'
+                         // Documents will Not be loaded from the database here, no server call is made
+                        .LoadStartingWith<Employee>("employees/");
+
+                    var employees = lazyEmployees.Value; // 'Load' operation is executed here
+                    // The employee entities are now loaded & tracked by the session
+                    #endregion
+                }
+                
+                #region lazy_ConditionalLoad
+                // Create document and get its change-vector:
+                string changeVector; 
+                using (var session1 = store.OpenSession())
+                {
+                    Employee employee = new Employee();
+                    session1.Store(employee, "employees/1-A");
+                    session1.SaveChanges();
+                    
+                    // Get the tracked entity change-vector
+                    changeVector = session1.Advanced.GetChangeVectorFor(employee);
+                }
+                
+                // Conditionally lazy-load the document:
+                using (var session2 = store.OpenSession())
+                {
+                    var lazyEmployee = session2
+                         // Add a call to Lazily 
+                        .Advanced.Lazily
+                         // Document will Not be loaded from the database here, no server call is made
+                        .ConditionalLoad<Employee>("employees/1-A", changeVector);
+
+                    var loadedItem = lazyEmployee.Value; // 'ConditionalLoad' operation is executed here
+                    Employee employee = loadedItem.Entity;
+                    
+                    // If ConditionalLoad has actually fetched the document from the server (logic described above)
+                    // then the employee entity is now loaded & tracked by the session
+                    
+                }
+                #endregion
+
+                using (var session = store.OpenSession())
+                {
+                    #region lazy_Query
+                    // Define a lazy query:
+                    Lazy<IEnumerable<Employee>> lazyEmployees = session
+                        .Query<Employee>()
+                        .Where( x => x.FirstName == "John")
+                         // Add a call to Lazily, the query will Not be executed here 
+                        .Lazily();
+
+                    IEnumerable<Employee> employees = lazyEmployees.Value; // Query is executed here
+                    
+                    // Note: Since query results are not projected,
+                    // then the resulting employee entities will be tracked by the session.
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region lazy_Revisions 
+                    Lazy<List<Employee>> lazyRevisions = session
+                         // Add a call to Lazily 
+                        .Advanced.Revisions.Lazily
+                         // Revisions will Not be fetched here, no server call is made
+                        .GetFor<Employee>("employees/1-A");
+                    
+                         // Usage is the same for the other get revisions methods:
+                         // .Get()
+                         // .GetMetadataFor()
+
+                    List<Employee> revisions = lazyRevisions.Value; // Getting revisions is executed here
+                    #endregion
+                }
+                
+                #region lazy_CompareExchange
+                using (var session =
+                       store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    // Create compare-exchange value:
+                    session.Advanced.ClusterTransaction
+                        .CreateCompareExchangeValue(key: "someKey", value: "someValue");
+                    session.SaveChanges();
+
+                    // Get the compare-exchange value lazily: 
+                    Lazy<CompareExchangeValue<string>> lazyCmpXchg = session
+                        // Add a call to Lazily 
+                        .Advanced.ClusterTransaction.Lazily
+                        // Compare-exchange values will Not be fetched here, no server call is made
+                        .GetCompareExchangeValue<string>("someKey");
+                    
+                    // Usage is the same for the other method:
+                    // .GetCompareExchangeValues()
+
+                    CompareExchangeValue<string> cmpXchgValue =
+                        lazyCmpXchg.Value; // Getting compare-exchange value is executed here
+                }
+                #endregion
+
+                using (var session = store.OpenSession())
+                {
+                    #region lazy_ExecuteAll_Implicit
+                    // Define multiple lazy requests
+                    Lazy<User> lazyUser1 = session.Advanced.Lazily.Load<User>("users/1-A");
+                    Lazy<User> lazyUser2 = session.Advanced.Lazily.Load<User>("users/2-A");
+                    
+                    Lazy<IEnumerable<Employee>> lazyEmployees = session.Query<Employee>()
+                        .Lazily();
+                    Lazy<IEnumerable<Product>> lazyProducts = session.Query<Product>()
+                        .Search(x => x.Name, "Ch*")
+                        .Lazily();
+                    
+                    // Accessing the value of ANY of the lazy instances will trigger
+                    // the execution of ALL pending lazy requests held up by the session
+                    // This is done in a SINGLE server call
+                    User user1 = lazyUser1.Value;
+                    
+                    // ALL the other values are now also available
+                    // No additional server calls are made when accessing these values
+                    User user2 = lazyUser2.Value;
+                    IEnumerable<Employee> employees = lazyEmployees.Value;
+                    IEnumerable<Product> products = lazyProducts.Value;
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region lazy_ExecuteAll_Explicit
+                    // Define multiple lazy requests
+                    Lazy<User> lazyUser1 = session.Advanced.Lazily.Load<User>("users/1-A");
+                    Lazy<User> lazyUser2 = session.Advanced.Lazily.Load<User>("users/2-A");
+                    
+                    Lazy<IEnumerable<Employee>> lazyEmployees = session.Query<Employee>()
+                        .Lazily();
+                    Lazy<IEnumerable<Product>> lazyProducts = session.Query<Product>()
+                        .Search(x => x.Name, "Ch*")
+                        .Lazily();
+
+                    // Explicitly call 'ExecuteAllPendingLazyOperations'
+                    // ALL pending lazy requests held up by the session will be executed in a SINGLE server call
+                    session.Advanced.Eagerly.ExecuteAllPendingLazyOperations();
+                    
+                    // ALL values are now available
+                    // No additional server calls are made when accessing the values
+                    User user1 = lazyUser1.Value;
+                    User user2 = lazyUser2.Value;
+                    IEnumerable<Employee> employees = lazyEmployees.Value;
+                    IEnumerable<Product> products = lazyProducts.Value;
+                    #endregion
+                }
+            }
+        }
+        
+        #region lazy_productClass
+        public class Product
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string SupplierId { get; set; } // The related document ID
+        }
+        #endregion
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Refresh.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/Refresh.cs
@@ -1,0 +1,35 @@
+﻿using Raven.Client.Documents;
+using Raven.Documentation.Samples.Orders;
+using Xunit;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class Refresh
+	{
+		private interface IFoo
+		{
+			#region refresh_1
+			void Refresh<T>(T entity);
+			#endregion
+		}
+
+		public Refresh()
+		{
+			using (var store = new DocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					#region refresh_2
+					Employee employee = session.Load<Employee>("employees/1");
+					Assert.Equal("Doe", employee.LastName);
+
+					// LastName changed to 'Shmoe'
+
+					session.Advanced.Refresh(employee);
+					Assert.Equal("Shmoe", employee.LastName);
+					#endregion
+				}
+			}
+		}
+	}
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Clear.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Clear.java
@@ -1,0 +1,53 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class Clear {
+
+    private interface IFoo {
+        //region clear_1
+        void clear()
+        //endregion
+        ;
+    }
+
+    public Clear() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region clear_2
+                Employee employee = new Employee();
+                employee.setFirstName("John");
+                employee.setLastName("Doe");
+                session.store(employee);
+
+                session.advanced().clear();
+
+                session.saveChanges(); // nothing will hapen
+                //endregion
+            }
+        }
+    }
+
+    private static class Employee {
+        private String firstName;
+        private String lastName;
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Defer.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Defer.java
@@ -1,0 +1,56 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.batches.DeleteCommandData;
+import net.ravendb.client.documents.commands.batches.ICommandData;
+import net.ravendb.client.documents.commands.batches.PutCommandDataWithJson;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Defer {
+    public Defer() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region defer_2
+
+                Map<String, Object> value1 = new HashMap<>();
+                value1.put("Name", "My Product");
+                value1.put("Supplier", "suppliers/999-A");
+                value1.put("@metadata", Collections.singletonMap("@collection", "Users"));
+
+                PutCommandDataWithJson putCommand1 =
+                    new PutCommandDataWithJson("products/999-A",
+                        null,
+                        store.getConventions().getEntityMapper().valueToTree(value1));
+
+                HashMap<String, Object> value2 = new HashMap<>();
+                value2.put("Name", "My Product");
+                value2.put("Supplier", "suppliers/999-A");
+                value2.put("@metadata", Collections.singletonMap("@collection", "Suppliers"));
+
+                PutCommandDataWithJson putCommand2 =
+                    new PutCommandDataWithJson("suppliers/999-A",
+                        null,
+                        store.getConventions().getEntityMapper().valueToTree(value2));
+
+                DeleteCommandData command3 = new DeleteCommandData("products/1-A", null);
+
+                session.advanced().defer(putCommand1, putCommand2, command3);
+                //endregion
+            }
+        }
+    }
+
+    private interface IFoo {
+        //region defer_1
+        void defer(ICommandData command, ICommandData... commands);
+
+        void defer(ICommandData[] commands);
+        //endregion
+    }
+
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Evict.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Evict.java
@@ -1,0 +1,66 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class Evict {
+    private static class Employee {
+        private String firstName;
+        private String lastName;
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+
+    private interface IFoo {
+        //region evict_1
+        <T> void evict(T entity);
+        //endregion
+    }
+
+    public Evict() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region evict_2
+                Employee employee1 = new Employee();
+                employee1.setFirstName("John");
+                employee1.setLastName("Doe");
+
+                Employee employee2 = new Employee();
+                employee2.setFirstName("Joe");
+                employee2.setLastName("Shmoe");
+
+                session.store(employee1);
+                session.store(employee2);
+
+                session.advanced().evict(employee1);
+
+                session.saveChanges(); // only 'Joe Shmoe' will be saved
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region evict_3
+                Employee employee = session.load(Employee.class, "employees/1-A");//loading from serer
+                employee = session.load(Employee.class, "employees/1-A"); // no server call
+                session.advanced().evict(employee);
+                employee = session.load(Employee.class, "employees/1-A"); // loading form server
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/GetChangeVector.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/GetChangeVector.java
@@ -1,0 +1,30 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class GetChangeVector {
+
+    private interface IFoo {
+        //region get_change_vector_1
+        <T> String getChangeVectorFor(T instance)
+        //endregion
+        ;
+    }
+
+    public GetChangeVector() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region get_change_vector_2
+                Employee employee = session.load(Employee.class, "employees/1-A");
+                String changeVector = session.advanced().getChangeVectorFor(employee);
+                //endregion
+            }
+        }
+    }
+
+    private static class Employee {
+
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/GetLastModified.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/GetLastModified.java
@@ -1,0 +1,51 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.Date;
+
+public class GetLastModified {
+
+    private static class Employee {
+        private String firstName;
+        private String lastName;
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+
+
+    private interface IFoo {
+        //region get_last_modified_1
+        <T> Date getLastModifiedFor(T instance)
+        //endregion
+        ;
+    }
+
+    public GetLastModified() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region get_last_modified_2
+                Employee employee = session.load(Employee.class, "employees/1-A");
+                Date lastModified = session.advanced().getLastModifiedFor(employee);
+                //endregion
+            }
+        }
+    }
+
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Refresh.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/Refresh.java
@@ -1,0 +1,43 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+import org.junit.Assert;
+
+public class Refresh {
+    private static class Employee {
+        private String lastName;
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+
+    public Refresh() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region refresh_2
+                Employee employee = session.load(Employee.class, "employees/1");
+                Assert.assertEquals("Doe", employee.getLastName());
+
+                // LastName changed to 'Shmoe'
+
+                session.advanced().refresh(employee);
+
+                Assert.assertEquals("Shmoe", employee.getLastName());
+                //endregion
+            }
+        }
+    }
+
+    private interface IFoo {
+        //region refresh_1
+        <T> void refresh(T entity);
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/clear.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/clear.js
@@ -1,0 +1,27 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+{
+    //region clear_1
+    session.advanced.clear();
+    //endregion
+}
+
+async function example() {
+    class Employee {}
+
+    {
+        //region clear_2
+        const employee = new Employee();
+        employee.firstName = "John";
+        employee.lastName = "Doe";
+        await session.store(employee);
+
+        session.advanced.clear();
+
+        await session.saveChanges(); // nothing will hapen
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/defer.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/defer.js
@@ -1,0 +1,45 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+{
+    //region syntax
+    session.advanced.defer(...commands);
+    //endregion
+}
+
+async function defer() {
+    //region defer_1
+    const session = documentStore.openSession();
+    
+    // Define a patchRequest object for the PatchCommandData used in the 'defer' below
+    const patchRequest = new PatchRequest();
+    patchRequest.script = "this.Supplier = 'suppliers/2-A';";
+
+    // 'defer' is available in the session's advanced methods 
+    session.advanced.defer(
+
+        // Define commands to be executed:
+        // i.e. Put a new document
+        new PutCommandDataBase("products/999-A", null, null, {
+            "Name": "My Product",
+            "Supplier": "suppliers/1-A"
+            "@metadata": { "@collection": "Products" }
+        }),
+        
+        // Patch document
+        new PatchCommandData("products/999-A", null, patchRequest, null),
+
+        // Force a revision to be created
+        new ForceRevisionCommandData("products/999-A"),
+
+        // Delete a document
+        new DeleteCommandData("products/1-A", null)
+    );
+
+    // All deferred commands will be sent to the server upon calling SaveChanges
+    await session.saveChanges();
+    
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/evict.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/evict.js
@@ -1,0 +1,44 @@
+import * as assert from "assert";
+import { DocumentStore } from "ravendb";
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+class Employee {}
+
+{
+    let entity;
+    //region evict_1
+    session.advanced.evict(entity);
+    //endregion
+}
+
+async function examples() {
+    {
+        //region evict_2
+        const employee1 = new Employee();
+        employee1.firstName = "John";
+        employee1.lastName = "Doe";
+
+        const employee2 = new Employee();
+        employee2.firstName = "Joe";
+        employee2.lastName = "Shmoe";
+
+        await session.store(employee1);
+        await session.store(employee2);
+
+        session.advanced.evict(employee1);
+
+        await session.saveChanges();        // only 'Joe Shmoe' will be saved
+        //endregion
+    }
+
+    {
+        //region evict_3
+        let employee = await session.load("employees/1-A"); // loading from serer
+        employee = await session.load("employees/1-A");     // no server call
+        session.advanced.evict(employee);
+        employee = await session.load("employees/1-A");     // loading from server
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/getChangeVector.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/getChangeVector.js
@@ -1,0 +1,20 @@
+import * as assert from "assert";
+import { DocumentStore } from "ravendb";
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+{
+    let entity;
+    //region get_change_vector_1
+    session.advanced.getChangeVectorFor(entity);
+    //endregion
+}
+
+async function sample() {
+    //region get_change_vector_2
+    const employee = await session.load("employees/1-A");
+    const changeVector = session.advanced.getChangeVectorFor(employee);
+    //endregion
+}
+

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/getCountersfor.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/getCountersfor.js
@@ -1,0 +1,20 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+{
+    //region syntax
+    getCountersFor(entity);
+    //endregion
+}
+
+async function getCountersFor() {
+    //region example
+    // Load a document
+    const employee = await session.load("employees/1-A");
+    
+    // Get counter names from the loaded entity
+    const counterNames = session.advanced.getCountersFor(employee);    
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/getLastModified.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/getLastModified.js
@@ -1,0 +1,21 @@
+import * as assert from "assert";
+import { DocumentStore } from "ravendb";
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+{
+    let instance;
+    //region get_last_modified_1
+    session.advanced.getLastModifiedFor(instance);
+    //endregion
+}
+
+async function sample() {
+    {
+        //region get_last_modified_2
+        const employee = await session.load("employees/1-A");
+        const lastModified = session.advanced.getLastModifiedFor(employee);
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/lazy.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/lazy.js
@@ -1,0 +1,205 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function lazyExamples() {
+    {
+        //region lazy_load
+        const lazyEmployee = session
+             // Add a call to lazily 
+            .advanced.lazily
+             // Document will Not be loaded from the database here, no server call is made
+            .load("employees/1-A");
+        
+        const employee = await lazyEmployee.getValue(); // 'load' operation is executed here
+        // The employee entity is now loaded & tracked by the session
+        //endregion
+    }
+    {        
+        //region lazy_loadWithInclude
+        const lazyProduct = session
+             // Add a call to lazily 
+            .advanced.lazily
+             // Request to include the related Supplier document
+             // Documents will Not be loaded from the database here, no server call is made
+            .include("supplierId")
+            .load("products/1-A");
+
+        // 'load with include' operation will be executed here
+        // Both documents will be retrieved from the database
+        const product = await lazyProduct.getValue();
+        // The product entity is now loaded & tracked by the session
+
+        // Access the related document, no additional server call is made
+        const supplier = await session.load(product.supplierId)
+        // The supplier entity is now also loaded & tracked by the session
+        //endregion
+    }
+    {
+        //region lazy_loadStartingWith
+        const lazyEmployees = session
+             // Add a call to lazily 
+            .advanced.lazily
+             // Request to load entities whose ID starts with 'employees/'
+             // Documents will Not be loaded from the database here, no server call is made
+            .loadStartingWith("employees/");
+
+        const employees = await lazyEmployees.getValue(); // 'load' operation is executed here
+        // The employee entities are now loaded & tracked by the session
+        //endregion
+    }
+    {
+        //region lazy_conditionalLoad
+        // Create document and get its change-vector:
+        {
+            const session1 = documentStore.openSession();
+
+            const employee = new Employee();
+            await session1.store(employee, "employees/1-A");
+            await session.saveChanges();
+            
+            // Get the tracked entity change-vector
+            const changeVector = session.advanced.getChangeVectorFor(employee);
+        }
+        
+        // Conditionally lazy-load the document:
+        {
+            const session2 = documentStore.openSession();
+
+            const lazyEmployee = session2
+                 // Add a call to lazily 
+                .advanced.lazily
+                 // Document will Not be loaded from the database here, no server call is made
+                .conditionalLoad("employees/1-A", changeVector, Employee);
+
+            const loadedItem = await lazyEmployee.getValue(); // 'conditionalLoad' operation is executed here
+            const employee = loadeditem.entity;
+            
+            // If conditionalLoad has actually fetched the document from the server (logic described above)
+            // then the employee entity is now loaded & tracked by the session
+        }
+        //endregion
+    }
+    {
+        //region lazy_query
+        // Define a lazy query:
+        const lazyEmployees = session
+            .query({ collection: "employees" })
+            .whereEquals("FirstName", "John")
+             // Add a call to lazily, the query will Not be executed here 
+            .lazily();
+        
+        const employees = await lazyEmployees.getValue(); // Query is executed here
+        
+        // Note: Since query results are not projected,
+        // then the resulting employee entities will be tracked by the session.
+        //endregion
+    }
+    {
+        //region lazy_revisions
+        var lazyRevisions = session
+             // Add a call to lazily 
+            .advanced.revisions.lazily
+             // Revisions will Not be fetched here, no server call is made
+            .getFor("employees/1-A");
+
+             // Usage is the same for the other get revisions methods:
+             // .get()
+             // .getMetadataFor()
+
+        const revisions = lazyRevisions.getValue(); // Getting revisions is executed here
+        //endregion
+    }
+    {
+        //region lazy_CompareExchange        
+        const session = documentStore.openSession({ transactionMode: "ClusterWide" });
+        
+        // Create compare-exchange value:
+        session.advanced.clusterTransaction.createCompareExchangeValue("someKey", "someValue");
+        await session.saveChanges();
+        
+        // Get the compare-exchange value lazily:
+        const lazyCmpXchg = session
+            // Add a call to lazily 
+            .advanced.clusterTransaction.lazily
+            // Compare-exchange values will Not be fetched here, no server call is made
+            .getCompareExchangeValue("someKey");
+        
+        // Usage is the same for the other method:
+        // .getCompareExchangeValues()
+        
+        const cmpXchgValue =
+            await lazyCmpXchg.getValue(); // Getting compare-exchange value is executed here            
+        //endregion
+    }
+    {
+        //region lazy_ExecuteAll_Implicit
+        // Define multiple lazy requests
+        const lazyUser1 = session.advanced.lazily.load("users/1-A");
+        const lazyUser2 = session.advanced.lazily.load("users/2-A");
+
+        const lazyEmployees = session.query({ collection: "employees" })
+            .lazily();
+        const lazyProducts = session.query({ collection: "products" })
+            .search("Name", "Ch*")
+            .lazily();
+
+        // Accessing the value of ANY of the lazy instances will trigger
+        // the execution of ALL pending lazy requests held up by the session
+        // This is done in a SINGLE server call
+        const user1 = await lazyUser1.getValue();
+
+        // ALL the other values are now also available
+        // No additional server calls are made when accessing these values
+        const user2 = await lazyUser2.getValue();
+        const employees = await lazyEmployees.getValue();
+        const products = await lazyProducts.getValue();
+        //endregion
+    }
+    {
+        //region lazy_ExecuteAll_Explicit
+        // Define multiple lazy requests
+        const lazyUser1 = session.advanced.lazily.load("users/1-A");
+        const lazyUser2 = session.advanced.lazily.load("users/2-A");
+
+        const lazyEmployees = session.query({ collection: "employees" })
+            .lazily();
+        const lazyProducts = session.query({ collection: "products" })
+            .search("Name", "Ch*")
+            .lazily();
+
+        // Explicitly call 'executeAllPendingLazyOperations'
+        // ALL pending lazy requests held up by the session will be executed in a SINGLE server call
+        await session.advanced.eagerly.executeAllPendingLazyOperations();
+
+        // ALL values are now available
+        // No additional server calls are made when accessing the values
+        const user1 = await lazyUser1.getValue();
+        const user2 = await lazyUser2.getValue();
+        const employees = await lazyEmployees.getValue();
+        const products = await lazyProducts.getValue();
+        //endregion
+    }
+    {
+        //region lazy_productClass
+        // Sample product document
+        class Product {
+            constructor(name, supplierId) {
+                this.id = null;
+                this.name = name;
+                this.supplierId = supplierId; // The related document ID
+            }
+        }
+        //endregion
+
+        class Employee {
+            constructor(name) {
+                this.id = null;
+                this.name = name;
+            }
+        }
+    }
+}
+
+

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/refresh.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/refresh.js
@@ -1,0 +1,27 @@
+import * as assert from "assert";
+import { DocumentStore } from "ravendb";
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+async function refresh() {
+    {
+        //region refresh_2
+        const employee = await session.load("employees/1");
+        assert.strictEqual("Doe", employee.lastName);
+
+        // lastName changed to 'Shmoe'
+
+        session.advanced.refresh(employee);
+
+        assert.strictEqual("Shmoe", employee.lastName);
+        //endregion
+    }
+}
+
+{
+    let entity;
+    //region refresh_1
+    session.advanced.refresh(entity);
+    //endregion
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Clear.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Clear.py
@@ -1,0 +1,24 @@
+from examples_base import ExampleBase, Employee
+
+
+class Foo:
+    # region clear_1
+    def clear(self) -> None: ...
+
+    # endregion
+
+
+class ClearExample(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_example1(self):
+        with self.embedded_server.get_document_store("Clear") as store:
+            with store.open_session() as session:
+                # region clear_2
+                session.store(Employee(first_name="John", last_name="Doe"))
+
+                session.advanced.clear()
+
+                session.save_changes()  # nothing will happen
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Defer.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Defer.py
@@ -1,0 +1,48 @@
+from ravendb import CommandData, PatchRequest
+from ravendb.documents.commands.batches import (
+    PutCommandDataBase,
+    PatchCommandData,
+    ForceRevisionCommandData,
+    DeleteCommandData,
+)
+
+from examples_base import ExampleBase
+
+
+class DeferExample(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_defer(self):
+        with self.embedded_server.get_document_store("Defer") as store:
+            with store.open_session() as session:
+                # region defer_1
+
+                # Defer is available in the session's advanced methods
+                session.advanced.defer(
+                    # Define commands to be executed:
+                    # i.e. Put a new document
+                    PutCommandDataBase(
+                        "products/999-A",
+                        None,
+                        {"Name": "My Product", "Supplier": "suppliers/1-A", "@metadata": {"@collection": "Products"}},
+                    ),
+                    # Patch document
+                    PatchCommandData("products/999-A", None, PatchRequest("this.Supplier = 'suppliers/2-A'"), None),
+                    # Force a revision to be created
+                    ForceRevisionCommandData("products/999-A"),
+                    # Delete a document
+                    DeleteCommandData("products/1-A", None),
+                )
+
+                # All deferred commands will be sent to the server upon calling save_changes
+                session.save_changes()
+
+                # endregion
+
+
+class Foo:
+    # region syntax
+    def defer(self, *commands: CommandData) -> None: ...
+
+    # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Evict.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Evict.py
@@ -1,0 +1,36 @@
+from examples_base import ExampleBase, Employee
+
+
+class Foo:
+    # region evict_1
+    def evict(self, entity: object) -> None: ...
+
+    # endregion
+
+
+class EvictExample(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_evict(self):
+        with self.embedded_server.get_document_store("Evict") as store:
+            with store.open_session() as session:
+                # region evict_2
+                employee_1 = Employee(first_name="John", last_name="Doe")
+                employee_2 = Employee(first_name="Joe", last_name="Shmoe")
+
+                session.store(employee_1)
+                session.store(employee_2)
+
+                session.advanced.evict(employee_1)
+
+                session.save_changes()  # only 'Joe Shmoe' will be saved
+                # endregion
+
+            with store.open_session() as session:
+                # region evict_3
+                employee = session.load("employees/1-A")  # loading from server
+                employee = session.load("employees/1-A")  # no server call
+                session.advanced.evict(employee)
+                employee = session.load("employees/1-A")  # loading form server
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/GetChangeVector.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/GetChangeVector.py
@@ -1,0 +1,21 @@
+from examples_base import ExampleBase
+
+
+class Foo:
+    # region get_change_vector_1
+    def get_change_vector_for(self, entity: object) -> str: ...
+
+    # endregion
+
+
+class GetChangeVector(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_change_vector(self):
+        with self.embedded_server.get_document_store("GetChangeVector") as store:
+            with store.open_session() as session:
+                # region get_change_vector_2
+                employee = session.load("employees/1-A")
+                change_vector = session.advanced.get_change_vector_for(employee)
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/GetCountersFor.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/GetCountersFor.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from examples_base import ExampleBase
+
+
+class GetCountersFor(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_counters_for(self):
+        with self.embedded_server.get_document_store("GetCountersFor") as store:
+            with store.open_session() as session:
+                # region example
+                # Load a document
+                employee = session.load("employees/1-A")
+
+                # Get counter names from the loaded entity
+                counter_names = session.advanced.get_counters_for(employee)
+                # endregion
+
+    class Foo:
+        # region syntax
+        def get_counters_for(self, entity: object) -> List[str]: ...
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/GetLastModified.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/GetLastModified.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from examples_base import ExampleBase
+
+
+class Foo:
+    # region get_last_modified_1
+    def get_last_modified_for(self, entity: object) -> datetime: ...
+
+    # endregion
+
+
+class GetLastModified(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_last_modified(self):
+        with self.embedded_server.get_document_store("GetLastModified") as store:
+            with store.open_session() as session:
+                # region get_last_modified_2
+                employee = session.load("employees/1-A")
+                last_modified = session.advanced.get_last_modified_for(employee)
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Lazy.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Lazy.py
@@ -1,0 +1,192 @@
+from typing import Optional
+
+from ravendb import SessionOptions, TransactionMode
+
+from examples_base import ExampleBase, Employee, Product
+
+
+class HowToLazy(ExampleBase):
+    def test_lazy(self):
+        with self.embedded_server.get_document_store("Lazy") as store:
+            with store.open_session() as session:
+                # region lazy_Load
+                lazy_employee = (
+                    session
+                    # Add a call to lazily
+                    .advanced.lazily.
+                    # Document will not be loaded from the database here, no server call in made
+                    load("employees/1-A", Employee)
+                )
+
+                employee = lazy_employee.value  # 'load' operation is executed here
+                # The employee entity is now loaded & tracked by the session
+                # endregion
+
+            with store.open_session() as session:
+                # region lazy_LoadWithInclude
+                lazy_product = (
+                    session
+                    # Add a call to lazily
+                    .advanced.lazily
+                    # Request to include the related Supplier document
+                    # Documents will Not be loaded from the database here, no server call is made
+                    .include("SupplierId").load("products/1-A")
+                )
+
+                # 'Load with include' operation will be executed here
+                # Both documents will be retrieved from the database
+                product = lazy_product.value
+                # The product entity is now loaded & tracked by the session
+
+                # Access the related document, no additional server call is made
+                supplier = session.load(product.SupplierId)
+                # The supplier entity is now also loaded & tracked by the session
+                # endregion
+
+            with store.open_session() as session:
+                # region lazy_LoadStartingWith
+                lazy_employees = (
+                    session
+                    # Add a call to lazily
+                    .advanced.lazily
+                    # Request to load entities whose ID starts with 'employees/'
+                    # Documents will Not be loaded from the database here, no server call is made
+                    .load_starting_with("employees/")
+                )
+
+                employees = lazy_employees.value  # 'load' operation is executed here
+                # The employee entities is now also loaded & tracked by the session
+                # endregion
+
+            # region lazy_ConditionalLoad
+            # Create document and get is change-vector:
+            change_vector: Optional[str] = None
+            with store.open_session() as session1:
+                employee = Employee()
+                session1.store(employee, "employees/1-A")
+                session1.save_changes()
+
+                # Get the tracked entity change-vector
+                change_vector = session1.advanced.get_change_vector_for(employee)
+
+            # Conditionally lazy-load the document
+            with store.open_session() as session2:
+                lazy_employee = (
+                    session2
+                    # Add a call to lazily
+                    .advanced.lazily
+                    # Document will Not be loaded from the database here, no server call is made
+                    .conditional_load("employees/1-A", change_vector)
+                )
+
+                loaded_item = lazy_employee.value  # 'conditional_load' operation is executed here
+                employee = loaded_item.entity
+
+                #  If conditional_load has actually fetched the document from the server (logic described above)
+                #  then the employee entity is now loaded & tracked by the session
+            # endregion
+
+            with store.open_session() as session:
+                # region lazy_Query
+                # Define a lazy query:
+                lazy_employees = (
+                    session.query(object_type=Employee).where_equals("FirstName", "John")
+                    # Add a call to lazily, the query will not be executed here
+                    .lazily()
+                )
+
+                employees = lazy_employees.value  # query is executed here
+                # Note: Since query results are not projected,
+                # then the resulting employee entities will be tracked by the session.
+                # endregion
+
+            with store.open_session() as session:
+                # region lazy_Revisions
+                lazy_revisions = (
+                    session.
+                    # Add a call to lazily
+                    advanced.revisions.lazily
+                    # Revisions will Not be fetched here, no sever call is made
+                    .get_for("employees/1-A", Employee)
+                )
+
+                # Usage is the same for the other get revisions methods:
+                # .get()
+                # .get_metadata_for()
+
+                revisions = lazy_revisions.value  # Getting revisions is executed here
+                # endregion
+
+            # region lazy_CompareExchange
+            with store.open_session(
+                session_options=SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
+            ) as session:
+                # Create compare-exchange value:
+                session.advanced.cluster_transaction.create_compare_exchange_value("someKey", "someValue")
+                session.save_changes()
+
+                # Get the compare-exchange value lazily:
+                lazy_cmp_xchg = (
+                    session
+                    # Adda a call to lazily
+                    .advanced.cluster_transaction.lazily
+                    # Compare-exchange values will Not be fetched here, no server call is made
+                    .get_compare_exchange_value("someKey")
+                )
+
+                # Usage is the same for the other method:
+                # .get_compare_exchange_values()
+
+                cmp_xchg_value = lazy_cmp_xchg.value  # Getting compare-exchange value is executed here
+            # endregion
+
+            with store.open_session() as session:
+                # region lazy_ExecuteAll_Implicit
+                # Define multiple lazy requests
+                lazy_user_1 = session.advanced.lazily.load("users/1-A")
+                lazy_user_2 = session.advanced.lazily.load("users/2-A")
+
+                lazy_employees = session.query(object_type=Employee).lazily()
+                lazy_products = session.query(object_type=Product).search("Name", "Ch*").lazily()
+
+                # Accessing the value of ANY of the lazy instances will trigger
+                # the execution of ALL pending lazy requests held up by the session
+                # This is done in a SINGLE server call
+                user1 = lazy_user_1.value
+
+                # ALL the other values are now also available
+                # No additional server calls are made when accessing these values
+                user2 = lazy_user_2.value
+                employees = lazy_employees.value
+                products = lazy_products.value
+                # endregion
+
+            with store.open_session() as session:
+                # region lazy_ExecuteAll_Explicit
+                # Define multiple lazy requests
+                lazy_user_1 = session.advanced.lazily.load("users/1-A")
+                lazy_user_2 = session.advanced.lazily.load("users/2-A")
+
+                lazy_employees = session.query(object_type=Employee).lazily()
+                lazy_products = session.query(object_type=Product).search("Name", "Ch*").lazily()
+
+                # Explicitly call 'execute_all_pending_lazy_operations'
+                # ALL pending lazy requests held up by the session will be executed in a SINGLE server call
+                session.advanced.eagerly.execute_all_pending_lazy_operations()
+
+                # ALL values are now available
+                # No additional server calls are made when accessing the values
+                user1 = lazy_user_1.value
+                user2 = lazy_user_2.value
+                employees = lazy_employees.value
+                products = lazy_products.value
+                # endregion
+
+    # region lazy_productClass
+    class Product:
+        def __init__(self, Id: str = None, Name: str = None, SupplierId: str = None):
+            self.Id = Id
+            self.Name = Name
+            self.SupplierId = SupplierId  # The related document ID
+
+    # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Refresh.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/Refresh.py
@@ -1,0 +1,26 @@
+from examples_base import ExampleBase, Employee
+
+
+class Foo:
+    # region refresh_1
+    def refresh(self, entity: object) -> object: ...
+
+    # endregion
+
+
+class HowToRefresh(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_refresh(self):
+        with self.embedded_server.get_document_store("Refresh") as store:
+            with store.open_session() as session:
+                # region refresh_2
+                employee = session.load("employees/1", Employee)
+                self.assertEquals("Doe", employee.last_name)
+
+                # LastName changed to "Shmoe"
+
+                session.advanced.refresh(employee)
+                self.assertEquals("Shmoe", employee.last_name)
+                # endregion


### PR DESCRIPTION
Related issues: 
[RDoc-2750](https://issues.hibernatingrhinos.com/issue/RDoc-2750/Python-Client-API-Session-How-to-Clear-a-session-Replace-C-samples) - Clear a session
[RDoc-2751](https://issues.hibernatingrhinos.com/issue/RDoc-2751/Python-Client-API-Session-How-to-Evict-entity-from-a-session-Replace-C-samples) - Evict entity from a session
[RDoc-2752](https://issues.hibernatingrhinos.com/issue/RDoc-2752/Python-Client-API-Session-How-to-Refresh-entity-Replace-C-samples) - Refresh entity
[RDoc-2753](https://issues.hibernatingrhinos.com/issue/RDoc-2753/Python-Client-API-Session-How-to-defer-commands-Replace-C-samples) - defer commands
[RDoc-2754](https://issues.hibernatingrhinos.com/issue/RDoc-2754/Python-Client-API-Session-How-to-Perform-requests-lazily-Replace-C-samples) - Perform requests lazily
[RDoc-2755](https://issues.hibernatingrhinos.com/issue/RDoc-2755/Python-Client-API-Session-How-to-Get-entity-change-vector-Replace-C-samples) - Get entity change vector
[RDoc-2756](https://issues.hibernatingrhinos.com/issue/RDoc-2756/Python-Client-API-Session-How-to-Get-entity-last-modified-Replace-C-samples) - Get entity last modified
[RDoc-2757](https://issues.hibernatingrhinos.com/issue/RDoc-2757/Python-Client-API-Session-How-to-Get-entity-counters-Replace-C-samples) - Get entity counters