### PR TITLE
RDoc-2748 [Node.js] Document extensions > Time series > Client API > Session > Append [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
@@ -1,0 +1,121 @@
+﻿# Append & Update Time Series
+
+---
+
+{NOTE: }
+
+* Use `TimeSeriesFor.Append` for the following actions:
+
+    * __Create a new time series__:  
+      Appending an entry to a time series that doesn't exist yet  
+      will create the time series and add it the new entry.
+
+    * __Create a new time series entry__:  
+      Appending a new entry to an existing time series  
+      will add the entry to the series at the specified timestamp.
+
+    * __Modify an existing time series entry__:  
+      Use _Append_ to update the data of an existing entry with the specified timestamp.
+
+* Each call to `Append` handles a single [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).
+
+* To append multiple entries in a single transaction,  
+  call `Append` as many times as needed before calling `session.SaveChanges`.
+
+---
+
+* In this page:
+    * [`Append` usage](../../../../document-extensions/timeseries/client-api/session/append#append-usage)
+    * [Examples](../../../../document-extensions/timeseries/client-api/session/append#examples)
+        * [Append entries with single value](../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-single-value)
+        * [Append entries with multiple values](../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-multiple-values)
+    * [Syntax](../../../../document-extensions/timeseries/client-api/session/append#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: `Append` usage}
+
+__Flow__:
+
+* Open a session.
+* Create an instance of `TimeSeriesFor` and pass it the following:
+    * Provide an explicit document ID, -or-  
+      pass an [entity tracked by the session](../../../../client-api/session/loading-entities),
+      e.g. a document object returned from [session.Query](../../../../client-api/session/querying/how-to-query) or from [session.Load](../../../../client-api/session/loading-entities#load).
+    * Specify the time series name.
+* Call `TimeSeriesFor.Append` and pass it the time series entry details.
+* Call `session.SaveChanges` for the action to take effect on the server.
+
+__Note__:
+
+* A `DocumentDoesNotExistException` exception is thrown if the specified document does not exist.
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+<a id="append-entries-with-single-value" /> __Append entries with single value__:
+
+---
+
+* In this example, entries are appended with a single value.
+
+* Although a loop is used to append multiple entries,  
+  all entries are appended in a single transaction when `SaveChanges` is executed.
+
+{CODE timeseries_region_TimeSeriesFor-Append-TimeSeries-Range@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="append-entries-with-multiple-values" /> __Append entries with multiple values__:
+
+---
+
+* In this example, we append multi-value StockPrice entries.
+
+* Notice the clarity gained by [naming the values](../../../../document-extensions/timeseries/client-api/named-time-series-values).
+
+  {CODE-TABS}
+  {CODE-TAB:csharp:Native timeseries_region_Append-Unnamed-Values-2@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+  {CODE-TAB:csharp:Using_named_values timeseries_region_Append-Named-Values-2@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+  {CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE TimeSeriesFor-Append-definition-double@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{CODE TimeSeriesFor-Append-definition-inum@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter     | Type                  | Description                   |
+|---------------|-----------------------|-------------------------------|
+| __timestamp__ | `DateTime`            | Time series entry's timestamp |
+| __value__     | `double`              | Entry's value                 |
+| __values__    | `IEnumerable<double>` | Entry's values                |
+| __tag__       | `string`              | An optional tag for the entry |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
@@ -1,0 +1,125 @@
+﻿# Append & Update Time Series
+
+---
+
+{NOTE: }
+
+* Use `timeSeriesFor.append` for the following actions:
+
+  * __Create a new time series__:  
+    Appending an entry to a time series that doesn't exist yet  
+    will create the time series and add the new entry to it.
+  
+  * __Create a new time series entry__:  
+    Appending a new entry to an existing time series  
+    will add the entry to the series at the specified timestamp.  
+
+  * __Modify an existing time series entry__:  
+    Use _append_ to update the data of an existing entry with the specified timestamp.
+
+* Each call to `append` handles a single [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).  
+
+* To append multiple entries in a single transaction,  
+  call `append` as many times as needed before calling `session.saveChanges`.
+
+---
+
+* In this page:  
+  * [`append` usage](../../../../document-extensions/timeseries/client-api/session/append#append-usage)  
+  * [Examples](../../../../document-extensions/timeseries/client-api/session/append#examples)
+      * [Append entries with single value](../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-single-value)  
+      * [Append entries with multiple values](../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-multiple-values)  
+  * [Syntax](../../../../document-extensions/timeseries/client-api/session/append#syntax)
+  
+{NOTE/}
+
+---
+
+{PANEL: `append` usage}
+
+__Flow__:  
+
+* Open a session.
+* Create an instance of `timeSeriesFor` and pass it the following:
+    * Provide an explicit document ID, -or-  
+      pass an [entity tracked by the session](../../../../client-api/session/loading-entities), 
+      e.g. a document object returned from [session.query](../../../../client-api/session/querying/how-to-query) or from [session.load](../../../../client-api/session/loading-entities#load).  
+    * Specify the time series name.
+* Call `timeSeriesFor.append` and pass it the time series entry details.
+* Call `session.saveChanges` for the action to take effect on the server.
+
+__Note__:  
+
+* A `DocumentDoesNotExistException` exception is thrown if the specified document does not exist.
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+<a id="append-entries-with-single-value" /> __Append entries with single value__:
+
+---
+
+* In this example, entries are appended with a single value.
+
+* Although a loop is used to append multiple entries,  
+  all entries are appended in a single transaction when `saveChanges` is executed.  
+
+{CODE:nodejs append_1@documentExtensions\timeSeries\client-api\appendTimeSeries.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="append-entries-with-multiple-values" /> __Append entries with multiple values__:
+
+---
+
+* In this example, we append multi-value StockPrice entries.  
+
+* Notice the clarity gained by [naming the values](../../../../document-extensions/timeseries/client-api/named-time-series-values).
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Native append_2@documentExtensions\timeSeries\client-api\appendTimeSeries.js /}
+{CODE-TAB:nodejs:Using_named_values append_3@documentExtensions\timeSeries\client-api\appendTimeSeries.js /}
+{CODE-TAB:nodejs:StockPrice_class stockPrice_class@documentExtensions\timeSeries\client-api\appendTimeSeries.js /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@documentExtensions\timeSeries\client-api\appendTimeSeries.js /}
+      
+{CODE:nodejs syntax_2@documentExtensions\timeSeries\client-api\appendTimeSeries.js /}
+
+{CODE:nodejs syntax_3@documentExtensions\timeSeries\client-api\appendTimeSeries.js /}
+
+| Parameter     | Type     | Description                    |
+|---------------|----------|--------------------------------|
+| __timestamp__ | Date     | Time series entry's timestamp  |
+| __value__     | number   | Entry's value                  |
+| __values__    | number[] | Entry's values                 |
+| __tag__       | string   | An optional tag for the entry  |
+| __entry__     | object   | object with the entry's values |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendTimeSeries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendTimeSeries.js
@@ -1,0 +1,193 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function appendTimeSeries() {
+    {
+        //region append_1
+        // Open a session and store a new document
+        const session = documentStore.openSession();
+        await session.store(new User("John"), "users/john");
+
+        // Get an instance of 'timeSeriesFor'
+        // Pass the document ID and the time series name
+        const timeSeriesName = "HeartRates";
+        const tsf = session.timeSeriesFor("users/john", timeSeriesName);
+  
+        // Create time series and add entries:
+        // ===================================
+
+        // Define an optional tag and some base time for the first entry:
+        const optionalTag = "watches/fitbit";
+        const baseTime = new Date();
+        baseTime.setUTCHours(0);
+        
+        // The first 'append' call will create the 'HeartRates' time series on the document
+        // (since this series doesn't exist yet on the document) and insert the first entry
+        tsf.append(baseTime, 65, optionalTag);
+        
+        // The next 'append' calls will add more entries to the 'HeartRates' time series
+        for (let i = 1; i < 10; i++)
+        {
+            const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+            const nextMeasurement = 65 + i;
+            tsf.append(nextMinute, nextMeasurement, optionalTag);
+        }
+
+        // Modify an existing entry:
+        // =========================
+
+        // Modify the last entry that was added
+        // The entry with the specified time stamp will be updated
+        tsf.append(new Date(baseTime.getTime() + 60_000 * 9), 60, optionalTag);
+
+        // Save changes
+        await session.saveChanges();
+        
+        // Results:
+        // ========
+        // The document will contain a time series named "HeartRates" with 10 entries.
+        //endregion
+
+        //region append_2
+        const session = documentStore.openSession();
+        await session.store(new User("John"), "users/john");
+
+        const tsf = session.timeSeriesFor("users/john", "StockPrices");
+
+        const optionalTag = "companies/kitchenAppliances";
+        const baseTime = new Date();
+        baseTime.setUTCHours(0);
+
+        const oneDay = 24 * 60 * 60 * 1000;
+        let nextDay = new Date(baseTime.getTime() + oneDay);
+        
+        // Provide multiple values to the entity
+        tsf.append(nextDay, [ 52, 54, 63.5, 51.4, 9824 ], optionalTag);
+
+        nextDay = new Date(baseTime.getTime() + oneDay * 2);
+        tsf.append(nextDay, [ 54, 55, 61.5, 49.4, 8400 ], optionalTag);
+
+        nextDay = new Date(baseTime.getTime() + oneDay * 3);
+        tsf.append(nextDay, [ 55, 57, 65.5, 50, 9020 ], optionalTag);
+
+        await session.saveChanges();
+
+        // Results:
+        // ========
+        // The document will contain a time series called "StockPrices" with 3 entries.
+        // Each entry will have 5 values.
+        //endregion
+
+        //region append_3
+        // Register the named values for the 'StockPrices' series on the server
+        await documentStore.timeSeries.register("Users",
+            "StockPrices", ["open", "close", "high", "low", "volume"]);
+        
+        const session = documentStore.openSession();
+        await session.store(new User("John"), "users/john");
+
+        // Get an instance of 'timeSeriesFor', pass:
+        // * the document ID
+        // * the time series name
+        // * the class that will hold the entry's values
+        const tsf = session.timeSeriesFor("users/john", "StockPrices", StockPrice);
+
+        const optionalTag = "companies/kitchenAppliances";
+        const baseTime = new Date();
+        baseTime.setUTCHours(0);
+        const oneDay = 24 * 60 * 60 * 1000;
+
+        // Provide the multiple values via the StockPrice class
+        const price1 = new StockPrice();
+        price1.open = 52;
+        price1.close = 54;
+        price1.high = 63.5;
+        price1.low = 51.4;
+        price1.volume = 9824;
+
+        let nextDay = new Date(baseTime.getTime() + oneDay);
+        tsf.append(nextDay, price1, optionalTag);
+
+        const price2 = new StockPrice();
+        price2.open = 54;
+        price2.close = 55;
+        price2.high = 61.5;
+        price2.low = 49.4;
+        price2.volume = 8400;
+
+        nextDay = new Date(baseTime.getTime() + oneDay * 2);
+        tsf.append(nextDay, price2, optionalTag);
+
+        const price3 = new StockPrice();
+        price3.open = 55;
+        price3.close = 57;
+        price3.high = 65.5;
+        price3.low = 50;
+        price3.volume = 9020;
+
+        nextDay = new Date(baseTime.getTime() + oneDay * 3);
+        tsf.append(nextDay, price3, optionalTag);
+
+        await session.saveChanges();
+
+        // Results:
+        // ========
+        // The document will contain a time series called "StockPrices" with 3 entries.
+        // Each entry will have 5 named values.
+        //endregion
+    }
+}
+
+//region syntax_1
+append(timestamp, value);
+append(timestamp, value, tag);
+//endregion
+
+//region syntax_2
+append(timestamp, values);
+append(timestamp, values, tag); 
+//endregion
+
+//region syntax_3
+append(timestamp, entry);
+append(timestamp, entry, tag);
+append(entry);
+//endregion
+
+//region stockPrice_class
+// This class is used in the "Named Values" example
+class StockPrice {
+
+    // Define the names for the entry values
+    static TIME_SERIES_VALUES = ["open", "close", "high", "low", "volume"];
+    
+    constructor(
+        open = 0,
+        close = 0,
+        high = 0,
+        low = 0,
+        volume = 0
+    ) {
+        Object.assign(this, {
+            open,
+            close,
+            high,
+            low,
+            volume
+        });
+    }
+}
+//endregion
+
+//region user_class
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}
+//endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2748/Node.js-Document-extensions-Time-series-Client-API-Session-Append-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the C# article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2780/Document-extensions-Time-series-Client-API-Session-Append-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendTimeSeries.js
```

