### PR TITLE
[Python] HowTo & Config articles batch [Replace C# samples]

### DIFF
--- a/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/patching/json-patch-syntax.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/client-api/operations/patching/json-patch-syntax.markdown
@@ -23,7 +23,7 @@
    * [JSON Patches](../../../client-api/operations/patching/json-patch-syntax#json-patches)
    * [Running JSON Patches](../../../client-api/operations/patching/json-patch-syntax#running-json-patches)  
    * [Patch Operations](../../../client-api/operations/patching/json-patch-syntax#patch-operations)  
-      * [Add Document Property](../../../client-api/operations/patching/json-patch-syntax#add-document-property)  
+      * [Add Document Property](../../../client-api/operations/patching/json-patch-syntax#add-operation)  
       * [Remove Document Property](../../../client-api/operations/patching/json-patch-syntax#remove-document-property)  
       * [Replace Document Property Contents](../../../client-api/operations/patching/json-patch-syntax#replace-document-property-contents)  
       * [Copy Document Property Contents to Another Property](../../../client-api/operations/patching/json-patch-syntax#copy-document-property-contents-to-another-property)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.dotnet.markdown
@@ -1,23 +1,31 @@
 # Session: How to Change Maximum Number of Requests per Session
 
-By default, maximum number of requests that session can send to server is **30**. This number, if everything is done correctly, should never be reached. Remote calls are expensive, and the number of remote calls per "session" should be as close to **1** as possible. If the limit is reached, it is a sure sign of either a `Select N+1` problem or other misuse of the session object.
+By default, the maximum number of requests that a session can send the server is **30**.  
+This number, if everything is done correctly, should never be reached since remote 
+calls are expensive and the number of remote calls per "session" should be as close 
+to **1** as possible.  
+If the limit is reached, it may indicate a `Select N+1` problem or some other misuse 
+of the session object.
 
-Nevertheless, if needed, this number can be changed for single session or for all sessions.
+Nevertheless, if needed, this number can be changed for a single session or for all sessions.
 
 ## Single session
 
-To change maximum number of requests in a single session just manipulate `MaxNumberOfRequestsPerSession` property value from `Advanced` session operations.
+To change the maximum number of requests in a single session, modify the `MaxNumberOfRequestsPerSession` 
+property value using the `Advanced` session operations.
 
 {CODE max_requests_1@ClientApi\Session\Configuration\MaxRequests.cs /}
 
 ## All sessions
 
-To change maximum number of requests for all sessions (on particular store) the `MaxNumberOfRequestsPerSession` property from DocumentStore `Conventions` must be changed.
+To change the maximum number of requests for **all** sessions (on a particular store), 
+the `MaxNumberOfRequestsPerSession` property from DocumentStore `Conventions` must be changed.
 
 {CODE max_requests_2@ClientApi\Session\Configuration\MaxRequests.cs /}
 
 {INFO: Injecting MaxNumberOfRequestsPerSession from the Server}
-The maximum number of requests for all sessions can also be configured via injected client configuration from the Server. You can read more about this [here](../../../studio/server/client-configuration). 
+The maximum number of requests for all sessions can also be configured via injected client 
+configuration from the Server. Read more about this [here](../../../studio/server/client-configuration).
 {INFO/}
 
 ## Related articles

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.dotnet.markdown
@@ -1,0 +1,27 @@
+# Session: How to Change Maximum Number of Requests per Session
+
+By default, maximum number of requests that session can send to server is **30**. This number, if everything is done correctly, should never be reached. Remote calls are expensive, and the number of remote calls per "session" should be as close to **1** as possible. If the limit is reached, it is a sure sign of either a `Select N+1` problem or other misuse of the session object.
+
+Nevertheless, if needed, this number can be changed for single session or for all sessions.
+
+## Single session
+
+To change maximum number of requests in a single session just manipulate `MaxNumberOfRequestsPerSession` property value from `Advanced` session operations.
+
+{CODE max_requests_1@ClientApi\Session\Configuration\MaxRequests.cs /}
+
+## All sessions
+
+To change maximum number of requests for all sessions (on particular store) the `MaxNumberOfRequestsPerSession` property from DocumentStore `Conventions` must be changed.
+
+{CODE max_requests_2@ClientApi\Session\Configuration\MaxRequests.cs /}
+
+{INFO: Injecting MaxNumberOfRequestsPerSession from the Server}
+The maximum number of requests for all sessions can also be configured via injected client configuration from the Server. You can read more about this [here](../../../studio/server/client-configuration). 
+{INFO/}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.java.markdown
@@ -1,0 +1,27 @@
+# Session: How to Change Maximum Number of Requests per Session
+
+By default, maximum number of requests that session can send to server is **30**. This number, if everything is done correctly, should never be reached. Remote calls are expensive, and the number of remote calls per "session" should be as close to **1** as possible. If the limit is reached, it is a sure sign of either a `Select N+1` problem or other misuse of the session object.
+
+Nevertheless, if needed, this number can be changed for single session or for all sessions.
+
+## Single session
+
+To change maximum number of requests in a single session just manipulate `maxNumberOfRequestsPerSession` field value from `advanced` session operations.
+
+{CODE:java max_requests_1@ClientApi\Session\Configuration\MaxRequests.java /}
+
+## All sessions
+
+To change maximum number of requests for all sessions (on particular store) the `maxNumberOfRequestsPerSession` field from DocumentStore `conventions` must be changed.
+
+{CODE:java max_requests_2@ClientApi\Session\Configuration\MaxRequests.java /}
+
+{INFO: Injecting maxNumberOfRequestsPerSession from the Server}
+The maximum number of requests for all sessions can also be configured via injected client configuration from the Server. You can read more about this [here](../../../studio/server/client-configuration). 
+{INFO/}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.js.markdown
@@ -1,0 +1,27 @@
+# Session: How to Change Maximum Number of Requests per Session
+
+By default, maximum number of requests that session can send to server is **30**. This number, if everything is done correctly, should never be reached. Remote calls are expensive, and the number of remote calls per "session" should be as close to **1** as possible. If the limit is reached, it is a sure sign of either a `Select N+1` problem or other misuse of the session object.
+
+Nevertheless, if needed, this number can be changed for single session or for all sessions.
+
+## Single session
+
+To change maximum number of requests in a single session just manipulate `maxNumberOfRequestsPerSession` field value from `advanced` session operations.
+
+{CODE:nodejs max_requests_1@client-api\session\configuration\maxRequests.js /}
+
+## All sessions
+
+To change maximum number of requests for all sessions (on particular store) the `maxNumberOfRequestsPerSession` field from DocumentStore `conventions` must be changed.
+
+{CODE:nodejs max_requests_2@client-api\session\configuration\maxRequests.js /}
+
+{INFO: Injecting maxNumberOfRequestsPerSession from the Server}
+The maximum number of requests for all sessions can also be configured via injected client configuration from the Server. You can read more about this [here](../../../studio/server/client-configuration). 
+{INFO/}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.js.markdown
@@ -1,23 +1,31 @@
 # Session: How to Change Maximum Number of Requests per Session
 
-By default, maximum number of requests that session can send to server is **30**. This number, if everything is done correctly, should never be reached. Remote calls are expensive, and the number of remote calls per "session" should be as close to **1** as possible. If the limit is reached, it is a sure sign of either a `Select N+1` problem or other misuse of the session object.
+By default, the maximum number of requests that a session can send the server is **30**.  
+This number, if everything is done correctly, should never be reached since remote 
+calls are expensive and the number of remote calls per "session" should be as close 
+to **1** as possible.  
+If the limit is reached, it may indicate a `Select N+1` problem or some other misuse 
+of the session object.
 
-Nevertheless, if needed, this number can be changed for single session or for all sessions.
+Nevertheless, if needed, this number can be changed for a single session or for all sessions.
 
 ## Single session
 
-To change maximum number of requests in a single session just manipulate `maxNumberOfRequestsPerSession` field value from `advanced` session operations.
+To change the maximum number of requests in a single session, modify the `maxNumberOfRequestsPerSession` 
+field value using the `Advanced` session operations.
 
 {CODE:nodejs max_requests_1@client-api\session\configuration\maxRequests.js /}
 
 ## All sessions
 
-To change maximum number of requests for all sessions (on particular store) the `maxNumberOfRequestsPerSession` field from DocumentStore `conventions` must be changed.
+To change the maximum number of requests for **all** sessions (on a particular store), 
+the `maxNumberOfRequestsPerSession` field from DocumentStore `conventions` must be changed.
 
 {CODE:nodejs max_requests_2@client-api\session\configuration\maxRequests.js /}
 
 {INFO: Injecting maxNumberOfRequestsPerSession from the Server}
-The maximum number of requests for all sessions can also be configured via injected client configuration from the Server. You can read more about this [here](../../../studio/server/client-configuration). 
+The maximum number of requests for all sessions can also be configured via injected client 
+configuration from the Server. Read more about this [here](../../../studio/server/client-configuration).
 {INFO/}
 
 ## Related articles
@@ -25,3 +33,4 @@ The maximum number of requests for all sessions can also be configured via injec
 ### Configuration
 
 - [Conventions](../../../client-api/configuration/conventions)
+

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.python.markdown
@@ -11,20 +11,20 @@ Nevertheless, if needed, this number can be changed for a single session or for 
 
 ## Single session
 
-To change the maximum number of requests in a single session, modify the `maxNumberOfRequestsPerSession` 
-field value using the `advanced` session operations.
+To change the maximum number of requests for a **single** session, modify the value 
+of the `session` `_max_number_of_requests_per_session` property.
 
-{CODE:java max_requests_1@ClientApi\Session\Configuration\MaxRequests.java /}
+{CODE:python max_requests_1@ClientApi\Session\Configuration\MaxRequests.py /}
 
 ## All sessions
 
 To change the maximum number of requests for **all** sessions (on a particular store), 
-the `maxNumberOfRequestsPerSession` field from DocumentStore `conventions` must be changed.
+change the value of the DocumentStore `conventions` `max_number_of_requests_per_session ` property.
 
-{CODE:java max_requests_2@ClientApi\Session\Configuration\MaxRequests.java /}
+{CODE:python max_requests_2@ClientApi\Session\Configuration\MaxRequests.py /}
 
-{INFO: Injecting maxNumberOfRequestsPerSession from the Server}
-The maximum number of requests for all sessions can also be configured via injected client 
+{INFO: Injecting `max_number_of_requests_per_session ` from the Server}
+The maximum number of requests for all sessions can also be configured by via injected client 
 configuration from the Server. Read more about this [here](../../../studio/server/client-configuration).
 {INFO/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.dotnet.markdown
@@ -1,0 +1,25 @@
+# Session: How to Customize Collection Assignment for Entities
+
+Entities are grouped into [collections](../../faq/what-is-a-collection) on the server side. In order to determine the collection name that an entity belongs to
+there are special conventions which return the collection name based on the type of an entity: [`FindCollectionName` and `FindCollectionNameForDynamic`](../../configuration/identifier-generation/global#FindCollectionName-and-FindCollectionNameForDynamic).
+
+## Example
+
+By default a collection name is pluralized form of a name of an entity type. For example objects of type `Category` will belong to `Categories` collection. However if your intention
+is to classify them as `ProductGroups` use the following code:
+
+{CODE custom_collection_name@ClientApi\Session\Configuration\CustomizeCollectionAssignmentForEntities.cs /}
+
+This can become very useful when there is a need to deal with [polymorphic data](../../../indexes/indexing-polymorphic-data).
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize the Identity Property Lookup for Entities](../../../client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities)
+
+### FAQ
+
+- [What is a Collection?](../../../client-api/faq/what-is-a-collection)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.java.markdown
@@ -1,0 +1,25 @@
+# Session: How to Customize Collection Assignment for Entities
+
+Entities are grouped into [collections](../../faq/what-is-a-collection) on the server side. In order to determine the collection name that an entity belongs to
+there is special convention which return the collection name based on the type of an entity: [`findCollectionName`](../../configuration/identifier-generation/global#findcollectionname).
+
+## Example
+
+By default a collection name is pluralized form of a name of an entity type. For example objects of type `Category` will belong to `Categories` collection. However if your intention
+is to classify them as `ProductGroups` use the following code:
+
+{CODE:java custom_collection_name@ClientApi\Session\Configuration\CustomizeCollectionAssignmentForEntities.java /}
+
+This can become very useful when there is a need to deal with [polymorphic data](../../../indexes/indexing-polymorphic-data).
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize the Identity Property Lookup for Entities](../../../client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities)
+
+### FAQ
+
+- [What is a Collection?](../../../client-api/faq/what-is-a-collection)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.js.markdown
@@ -1,0 +1,25 @@
+# Session: How to Customize Collection Assignment for Entities
+
+Entities are grouped into [collections](../../faq/what-is-a-collection) on the server side. In order to determine the collection name that an entity belongs to
+there is special convention which return the collection name based on the type of an entity: [`findCollectionName`](../../configuration/identifier-generation/global#findcollectionname).
+
+## Example
+
+By default a collection name is pluralized form of a name of an entity type. For example objects of type `Category` will belong to `Categories` collection. However if your intention
+is to classify them as `ProductGroups` you can use the following code:
+
+{CODE:nodejs custom_collection_name@client-api\session\configuration\customizeCollectionAssignmentForEntities.js /}
+
+This can become very useful when there is a need to deal with [polymorphic data](../../../indexes/indexing-polymorphic-data).
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize the Identity Property Lookup for Entities](../../../client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities)
+
+### FAQ
+
+- [What is a Collection?](../../../client-api/faq/what-is-a-collection)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.python.markdown
@@ -1,7 +1,7 @@
 # Session: How to Customize Collection Assignment for Entities
 
 Entities are grouped into [collections](../../faq/what-is-a-collection) on the server side.  
-The name of the collection that an entity belongs to can be retrieved using the `find_collection_name ` convention.  
+The name of the collection that an entity belongs to can be retrieved using the `find_collection_name` convention.  
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.python.markdown
@@ -1,0 +1,26 @@
+# Session: How to Customize Collection Assignment for Entities
+
+Entities are grouped into [collections](../../faq/what-is-a-collection) on the server side.  
+The name of the collection that an entity belongs to can be retrieved using the `find_collection_name ` convention.  
+
+## Example
+
+By default, a collection name is the pluralized form of a name of an entity type.  
+E.g., objects of type `Category` will belong to the `Categories` collection.  
+If you mean to classify them as `ProductGroups`, however, use the following code:
+
+{CODE:python custom_collection_name@ClientApi\Session\Configuration\CustomizeCollectionAssignmentForEntities.py /}
+
+This can become very useful when there is a need to deal with [polymorphic data](../../../indexes/indexing-polymorphic-data).
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize the Identity Property Lookup for Entities](../../../client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities)
+
+### FAQ
+
+- [What is a Collection?](../../../client-api/faq/what-is-a-collection)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
@@ -1,0 +1,109 @@
+# Disable Entity Tracking
+
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `SaveChanges` is called.  
+
+* __Tracking can be disabled__ by any of the following:  
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking a specific entity in session}
+
+* Tracking can be disabled for a specific entity in the session.  
+* Once tracking is disabled for the entity then:
+  * Any changes made to this entity will be ignored for `SaveChanges`.  
+  * Performing another `Load` for this entity will Not generate another call to the server.
+  
+__Example__
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_1_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+__Syntax__
+
+{CODE syntax_1@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking all entities in session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `Store` will Not be available (an exception will be thrown if used).
+  * Calling `Load` or `Query` will generate a call to the server and create new entities instances.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_2_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Disable tracking query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query-Sync disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Query-Async disable_tracking_3_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:DocumentQuery-Sync disable_tracking_3_documentQuery@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:DocumentQuery-Async disable_tracking_3_documentQuery_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+
+__Example__
+
+{CODE:csharp disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+__Syntax__
+
+{CODE syntax_2@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+| Parameter | Description |
+| - | - |
+| `InMemoryDocumentSessionOperations` | The session for which tracking is to be disabled |
+| `object` | The entity for which tracking is to be disabled |
+| `string` | The entity's document ID |
+
+| Return Type | Description |
+| - | - |
+| `bool` | `true` - Entity will Not be tracked<br>`false` - Entity will be tracked |
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
@@ -7,7 +7,7 @@
 * By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
   All changes are then persisted when `SaveChanges` is called.  
 
-* __Tracking can be disabled__ by any of the following:  
+* **Tracking can be disabled** by any of the following:  
     * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
     * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
     * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
@@ -23,14 +23,14 @@
   * Any changes made to this entity will be ignored for `SaveChanges`.  
   * Performing another `Load` for this entity will Not generate another call to the server.
   
-__Example__
+**Example**
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.cs /}
 {CODE-TAB:csharp:Async disable_tracking_1_async@ClientApi\Session\Configuration\DisableTracking.cs /}
 {CODE-TABS/}
 
-__Syntax__
+**Syntax**
 
 {CODE syntax_1@ClientApi\Session\Configuration\DisableTracking.cs /}
 
@@ -73,11 +73,11 @@ __Syntax__
   by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
 * This customization rule will apply to all sessions opened for this document store.
 
-__Example__
+**Example**
 
 {CODE:csharp disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.cs /}
 
-__Syntax__
+**Syntax**
 
 {CODE syntax_2@ClientApi\Session\Configuration\DisableTracking.cs /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
@@ -1,0 +1,98 @@
+# Disable Entity Tracking
+
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `saveChanges` is called.  
+
+* __Tracking can be disabled__ by any of the following:  
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking a specific entity in session}
+
+* Tracking can be disabled for a specific entity in the session.  
+* Once tracking is disabled for the entity then:
+  * Any changes made to this entity will be ignored for `saveChanges`.  
+  * Performing another `load` for this entity will Not generate another call to the server.
+  
+__Example__
+
+{CODE:nodejs disable_tracking_1@client-api\session\Configuration\disableTracking.js /}
+
+__Syntax__
+
+{CODE:nodejs syntax_1@client-api\session\Configuration\disableTracking.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking all entities in session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `store` will Not be available (an exception will be thrown if used).
+  * Calling `load` or `query` will generate a call to the server and create new entities instances.
+
+{CODE:nodejs disable_tracking_2@client-api\session\Configuration\disableTracking.js /}
+
+{PANEL/}
+
+{PANEL: Disable tracking query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE:nodejs disable_tracking_3@client-api\session\Configuration\disableTracking.js /}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `shouldIgnoreEntityChanges` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+
+__Example__
+
+{CODE:nodejs disable_tracking_4@client-api\session\Configuration\disableTracking.js /}
+
+__Syntax__
+
+{CODE:nodejs syntax_2@client-api\session\Configuration\disableTracking.js /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| sessionOperations | `InMemoryDocumentSessionOperations` | The session for which tracking is to be disabled |
+| entity | `object` | The entity for which tracking is to be disabled |
+| documentId | `string` | The entity's document ID |
+
+| Return Type | Description |
+| - | - |
+| `boolean` | `true` - Entity will Not be tracked<br>`false` - Entity will be tracked |
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.python.markdown
@@ -67,12 +67,14 @@
 * You can further customize and fine-tune which entities will not be tracked  
   by configuring the `should_ignore_entity_changes` convention method on the document store.
 * This customization rule will apply to all sessions opened for this document store.
+* Implement rules under your [ShouldIgnoreEntityChanges](../../../client-api/session/configuration/how-to-disable-tracking#syntax) subclass.  
+  Apply the class's `check` method to control the ignore flow.
 
-**Example**
+#### Example:
 
 {CODE:python disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.py /}
 
-**Syntax**
+#### Syntax:
 
 {CODE:python syntax_2@ClientApi\Session\Configuration\DisableTracking.py /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.python.markdown
@@ -1,0 +1,103 @@
+# Disable Entity Tracking
+
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `save_changes` is called.  
+
+* **Tracking can be disabled** by any of the following:  
+    * [Disable tracking for a specific entity in a session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-for-a-specific-entity-in-a-session)
+    * [Disable tracking for all entities in a session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-for-all-entities-in-a-session)
+    * [Disable tracking for query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-for-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking for a specific entity in a session}
+
+* Tracking can be disabled for a specific entity in the session.  
+* Once tracking is disabled for the entity then:
+  * Any changes made to this entity will be ignored for `save_changes`.  
+  * Performing another `load` for this entity will Not generate another call to the server.
+  
+**Example**
+
+{CODE-TABS}
+{CODE-TAB:python disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.py /}
+{CODE-TABS/}
+
+**Syntax**
+
+{CODE:python syntax_1@ClientApi\Session\Configuration\DisableTracking.py /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking for all entities in a session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `store` will Not be available (an exception will be thrown if used).
+  * Calling `load` or `query` will generate a call to the server and create new entities instances.  
+
+{CODE-TABS}
+{CODE-TAB:python disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.py /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Disable tracking for query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE-TABS}
+{CODE-TAB:python disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.py /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `should_ignore_entity_changes` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+
+**Example**
+
+{CODE:python disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.py /}
+
+**Syntax**
+
+{CODE:python syntax_2@ClientApi\Session\Configuration\DisableTracking.py /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| entity | `object` | The entity for which tracking is to be disabled |
+| document_id | `str` | The entity's document ID |
+
+| Return Type | Description |
+| - | - |
+| `bool` | `True` - Entity will Not be tracked<br>`False` - Entity will be tracked |
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.dotnet.markdown
@@ -1,0 +1,111 @@
+# How to Enable Optimistic Concurrency
+---
+
+{NOTE: }
+
+* By default, optimistic concurrency checks are turned **off**. Changes made outside the session object will be overwritten. 
+  Concurrent changes to the same document will use the _Last Write Wins_ strategy so a lost update anomaly is possible 
+  with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
+
+* You can enable the optimistic concurrency for either:
+  * All sessions - enable globally, at the document store level  
+  * A specific session - enable on a per-session basis  
+  * A specific document  
+
+* With optimistic concurrency __enabled__, RavenDB will generate a concurrency exception 
+  (and abort all modifications in the current transaction) when trying to save a document that has been modified on the server side after the client loaded and modified it.
+
+* The `ConcurrencyException` that might be thrown upon the `SaveChanges` call needs to be handled by the caller. 
+  The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error in a way that is suitable in a given scenario.
+
+* In this page:
+  * [Enable for specific session](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-session)
+  * [Enable globally](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-globally)
+  * [Disable for specific document (when enabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#disable-for-specific-document-(when-enabled-on-session))
+  * [Enable for specific document (when disabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-document-(when-disabled-on-session)) 
+
+{WARNING: }
+
+* Note that the `UseOptimisticConcurrency` setting only applies to documents that have been modified by the current session. 
+  For example, if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `SaveChanges`, 
+  the operation will succeed regardless of the optimistic concurrency setting, even if `users/2-A` has been changed by another process in the meantime.
+
+* However, if you modify both documents and attempt to save changes with optimistic concurrency turned on, an exception will be raised if `users/2-A` has been modified externally.  
+  In this case, the updates to both `users/1-A` and `users/2-A` will be cancelled.
+
+{WARNING/}
+
+{INFO: }
+
+For a detailed description of transactions and concurrency control in RavenDB please refer to the  
+[Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
+
+{INFO/}
+
+{NOTE/}
+
+---
+
+{PANEL: Enable for specific session}
+
+{CODE optimistic_concurrency_1@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+
+{WARNING: }
+
+* Enabling optimistic concurrency in a session will ensure that changes made to a document will only be persisted 
+  if the version of the document sent in the `SaveChanges()` call matches its version from the time it was initially read (loaded from the server).
+ 
+* Note that it's necessary to enable optimistic concurrency for ALL sessions that modify the documents for which you want to guarantee that no writes will be silently discarded.
+  If optimistic concurrency is enabled in some sessions but not in others, and they modify the same documents, the risk of the lost update anomaly still exists.
+
+{WARNING/}
+
+{PANEL/}
+
+{PANEL: Enable globally}
+
+* Optimistic concurrency can also be turned on for all sessions that are opened under a document store.
+
+* Use the [store.Conventions.UseOptimisticConcurrency](../../../client-api/configuration/conventions#useoptimisticconcurrency) convention to enable globally.
+
+{CODE optimistic_concurrency_2@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+
+{PANEL/}
+
+{PANEL: Disable for specific document (when enabled on session)}
+
+* Optimistic concurrency can be turned OFF when __storing__ a specific document,  
+  even when it is turned ON for an entire session (or globally).
+
+* This is done by passing `null` as a change vector value to the [Store](../../../client-api/session/storing-entities) method.
+
+{CODE optimistic_concurrency_3@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+
+{PANEL/}
+
+{PANEL: Enable for specific document (when disabled on session)}
+
+* Optimistic concurrency can be turned ON when __storing__ a specific document,  
+  even when it is turned OFF for an entire session (or globally).
+
+* This is done by passing `string.Empty` as the change vector value to the [Store](../../../client-api/session/storing-entities) method.  
+  Setting the change vector to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exist.
+  A `ConcurrencyException` will be thrown if the document already exists. 
+
+* If you don't supply a 'Change Vector' or if the 'Change Vector' is `null`, then optimistic concurrency will be disabled.  
+
+* Setting optimistic concurrency for a specific document overrides the `UseOptimisticConcurrency` property from the `Advanced` session operations.
+
+{CODE optimistic_concurrency_4@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+
+{PANEL/}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+
+### FAQ
+
+- [Transaction Support in RavenDB](../../../client-api/faq/transaction-support)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.java.markdown
@@ -1,6 +1,6 @@
 # Session: How to Enable Optimistic Concurrency
 
-By default, optimistic concurrency checks are turned **off**. Changes made outside our session object will be overwritten. Concurrent changes to the same document will use
+By default, optimistic concurrency checks are **disabled**. Changes made outside our session object will be overwritten. Concurrent changes to the same document will use
 the Last Write Wins strategy so a lost update anomaly is possible with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
 
 You can enable the optimistic concurrency strategy either globally, at the document store level or a per session basis.  
@@ -13,12 +13,13 @@ The operation can be retried (the document needs to be reloaded since it got cha
 {WARNING: }
 Note that `useOptimisticConcurrency` only applies to documents that has been _modified_ by the session. Loading documents `users/1-A` and `users/2-A` in a session, modifying
 `users/1-A` and then calling `saveChanges` will succeed, regardless of the optimistic concurrency setting, even if `users/2-A` has changed in the meantime. 
-If the session were to try to save to `users/2-A` as well with optimistic concurrency turned on, then an exception will be raised and the updates to both `users/1-A` and `users/2-A`
+If the session were to try to save to `users/2-A` as well with optimistic concurrency enabled, then an exception will be raised and the updates to both `users/1-A` and `users/2-A`
 will be cancelled.
 {WARNING/}
 
-You can also control optimistic concurrency per specific document. To enable it, [supply a Change Vector to Store](../../../client-api/session/storing-entities).  
-If you don't supply a 'Change Vector' or if the 'Change Vector' is null, then optimistic concurrency will be disabled.  
+You can also control optimistic concurrency per specific document. To enable it, [provide a Change Vector to Store](../../../client-api/session/storing-entities).  
+If you do not provide a change vector or if the change vector is `null`, optimistic concurrency will be disabled.  
+
 Setting the 'Change Vector' to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exists.
 
 Setting optimistic concurrency per specific document overrides the use of the `useOptimisticConcurrency` field from the `advanced` session operations.
@@ -45,19 +46,19 @@ For a detailed description of transactions and concurrency control in RavenDB pl
 ## Enabling Globally
 
 The first example shows how to enable optimistic concurrency for a particular session. 
-This can be also turned on globally, for all opened sessions by using the convention `store.getConventions().setUseOptimisticConcurrency`.
+This can be also enabled globally, for all opened sessions by using the convention `store.getConventions().setUseOptimisticConcurrency`.
 
 {CODE:java optimistic_concurrency_2@ClientApi\Session\Configuration\OptimisticConcurrency.java /}
 
-## Turning Off Optimistic Concurrency for a Single Document when it is Enabled on Session
+## Disabling Optimistic Concurrency for a Single Document when it is Enabled on Session
 
-Optimistic concurrency can be turned off for a single document by passing `null` as a change vector value to `store` method even when it is turned on for an entire session (or globally).
+Optimistic concurrency can be disabled for a single document by passing `null` as a change vector value to `store` method even when it is enabled for an entire session (or globally).
 
 {CODE:java optimistic_concurrency_3@ClientApi\Session\Configuration\OptimisticConcurrency.java /}
 
-## Turning On Optimistic Concurrency for a New Document when it is Disabled on Session
+## Enabling Optimistic Concurrency for a New Document when it is Disabled on Session
 
-Optimistic concurrency can be turned on for a new document by passing `""` as a change vector value to `store` method even when it is turned off for an entire session (or globally).
+Optimistic concurrency can be enabled for a new document by passing `""` as a change vector value to `store` method even when it is disabled for an entire session (or globally).
 It will cause to throw `ConcurrencyException` if the document already exists.
 
 {CODE:java optimistic_concurrency_4@ClientApi\Session\Configuration\OptimisticConcurrency.java /}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.java.markdown
@@ -1,0 +1,73 @@
+# Session: How to Enable Optimistic Concurrency
+
+By default, optimistic concurrency checks are turned **off**. Changes made outside our session object will be overwritten. Concurrent changes to the same document will use
+the Last Write Wins strategy so a lost update anomaly is possible with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
+
+You can enable the optimistic concurrency strategy either globally, at the document store level or a per session basis.  
+In either case, with optimistic concurrency enabled, RavenDB will generate a concurrency exception (and abort all
+modifications in the current transaction) when trying to save a document that has been modified on the server side after the client loaded and modified it.
+
+The `ConcurrencyException` that might be thrown upon the `saveChanges` call, needs to be handled by the caller.  
+The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error in a way that is suitable in a given scenario.
+
+{WARNING: }
+Note that `useOptimisticConcurrency` only applies to documents that has been _modified_ by the session. Loading documents `users/1-A` and `users/2-A` in a session, modifying
+`users/1-A` and then calling `saveChanges` will succeed, regardless of the optimistic concurrency setting, even if `users/2-A` has changed in the meantime. 
+If the session were to try to save to `users/2-A` as well with optimistic concurrency turned on, then an exception will be raised and the updates to both `users/1-A` and `users/2-A`
+will be cancelled.
+{WARNING/}
+
+You can also control optimistic concurrency per specific document. To enable it, [supply a Change Vector to Store](../../../client-api/session/storing-entities).  
+If you don't supply a 'Change Vector' or if the 'Change Vector' is null, then optimistic concurrency will be disabled.  
+Setting the 'Change Vector' to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exists.
+
+Setting optimistic concurrency per specific document overrides the use of the `useOptimisticConcurrency` field from the `advanced` session operations.
+
+{INFO: }
+For a detailed description of transactions and concurrency control in RavenDB please refer to the  
+[Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
+{INFO/}
+
+## Enabling for a specific Session
+
+{CODE:java optimistic_concurrency_1@ClientApi\Session\Configuration\OptimisticConcurrency.java /}
+
+{WARNING: }
+
+* Enabling optimistic concurrency in a session will ensure that changes made to a document will only be persisted
+  if the version of the document sent in the `saveChanges()` call matches its version from the time it was initially read (loaded from the server).
+
+* Note that it's necessary to enable optimistic concurrency for ALL sessions that modify the documents for which you want to guarantee that no writes will be silently discarded.
+  If optimistic concurrency is enabled in some sessions but not in others, and they modify the same documents, the risk of the lost update anomaly still exists.
+
+{WARNING/}
+
+## Enabling Globally
+
+The first example shows how to enable optimistic concurrency for a particular session. 
+This can be also turned on globally, for all opened sessions by using the convention `store.getConventions().setUseOptimisticConcurrency`.
+
+{CODE:java optimistic_concurrency_2@ClientApi\Session\Configuration\OptimisticConcurrency.java /}
+
+## Turning Off Optimistic Concurrency for a Single Document when it is Enabled on Session
+
+Optimistic concurrency can be turned off for a single document by passing `null` as a change vector value to `store` method even when it is turned on for an entire session (or globally).
+
+{CODE:java optimistic_concurrency_3@ClientApi\Session\Configuration\OptimisticConcurrency.java /}
+
+## Turning On Optimistic Concurrency for a New Document when it is Disabled on Session
+
+Optimistic concurrency can be turned on for a new document by passing `""` as a change vector value to `store` method even when it is turned off for an entire session (or globally).
+It will cause to throw `ConcurrencyException` if the document already exists.
+
+{CODE:java optimistic_concurrency_4@ClientApi\Session\Configuration\OptimisticConcurrency.java /}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+
+### FAQ
+
+- [Transaction Support in RavenDB](../../../client-api/faq/transaction-support)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.js.markdown
@@ -1,0 +1,111 @@
+# How to Enable Optimistic Concurrency
+---
+
+{NOTE: }
+
+* By default, optimistic concurrency checks are turned **off**. Changes made outside the session object will be overwritten.
+  Concurrent changes to the same document will use the _Last Write Wins_ strategy so a lost update anomaly is possible
+  with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
+
+* You can enable the optimistic concurrency for either:
+    * All sessions - enable globally, at the document store level
+    * A specific session - enable on a per-session basis
+    * A specific document
+
+* With optimistic concurrency __enabled__, RavenDB will generate a concurrency exception
+  (and abort all modifications in the current transaction) when trying to save a document that has been modified on the server side after the client loaded and modified it.
+
+* The `ConcurrencyException` that might be thrown upon the `saveChanges` call needs to be handled by the caller.
+  The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error in a way that is suitable in a given scenario.
+
+* In this page:
+    * [Enable for specific session](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-session)
+    * [Enable globally](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-globally)
+    * [Disable for specific document (when enabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#disable-for-specific-document-(when-enabled-on-session))
+    * [Enable for specific document (when disabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-document-(when-disabled-on-session))
+
+{WARNING: }
+
+* Note that the `useOptimisticConcurrency` setting only applies to documents that have been modified by the current session.
+  For example, if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `saveChanges`,
+  the operation will succeed regardless of the optimistic concurrency setting, even if `users/2-A` has been changed by another process in the meantime.
+
+* However, if you modify both documents and attempt to save changes with optimistic concurrency turned on, an exception will be raised if `users/2-A` has been modified externally.  
+  In this case, the updates to both `users/1-A` and `users/2-A` will be cancelled.
+
+{WARNING/}
+
+{INFO: }
+
+For a detailed description of transactions and concurrency control in RavenDB please refer to the  
+[Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
+
+{INFO/}
+
+{NOTE/}
+
+---
+
+{PANEL: Enable for specific session}
+
+{CODE:nodejs optimistic_concurrency_1@client-api\session\configuration\optimisticConcurrency.js /}
+
+{WARNING: }
+
+* Enabling optimistic concurrency in a session will ensure that changes made to a document will only be persisted
+  if the version of the document sent in the `saveChanges()` call matches its version from the time it was initially read (loaded from the server).
+
+* Note that it's necessary to enable optimistic concurrency for ALL sessions that modify the documents for which you want to guarantee that no writes will be silently discarded.
+  If optimistic concurrency is enabled in some sessions but not in others, and they modify the same documents, the risk of the lost update anomaly still exists.
+
+{WARNING/}
+
+{PANEL/}
+
+{PANEL: Enable globally}
+
+* Optimistic concurrency can also be turned on for all sessions that are opened under a document store.
+
+* Use the [store.Conventions.UseOptimisticConcurrency](../../../client-api/configuration/conventions#useoptimisticconcurrency) convention to enable globally.
+
+{CODE:nodejs optimistic_concurrency_2@client-api\session\configuration\optimisticConcurrency.js /}
+
+{PANEL/}
+
+{PANEL: Disable for specific document (when enabled on session)}
+
+* Optimistic concurrency can be turned OFF when __storing__ a specific document,  
+  even when it is turned ON for an entire session (or globally).
+
+* This is done by passing `null` as a change vector value to the [store](../../../client-api/session/storing-entities) method.
+
+{CODE:nodejs optimistic_concurrency_3@client-api\session\configuration\optimisticConcurrency.js /}
+
+{PANEL/}
+
+{PANEL: Enable for specific document (when disabled on session)}
+
+* Optimistic concurrency can be turned ON when __storing__ a specific document,  
+  even when it is turned OFF for an entire session (or globally).
+
+* This is done by passing `string.Empty` as the change vector value to the [store](../../../client-api/session/storing-entities) method.  
+  Setting the change vector to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exist.
+  A `ConcurrencyException` will be thrown if the document already exists.
+
+* If you don't supply a 'Change Vector' or if the 'Change Vector' is `null`, then optimistic concurrency will be disabled.
+
+* Setting optimistic concurrency for a specific document overrides the `useOptimisticConcurrency` property from the `advanced` session operations.
+
+{CODE:nodejs optimistic_concurrency_4@client-api\session\configuration\optimisticConcurrency.js /}
+
+{PANEL/}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+
+### FAQ
+
+- [Transaction Support in RavenDB](../../../client-api/faq/transaction-support)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.js.markdown
@@ -3,42 +3,45 @@
 
 {NOTE: }
 
-* By default, optimistic concurrency checks are turned **off**. Changes made outside the session object will be overwritten.
-  Concurrent changes to the same document will use the _Last Write Wins_ strategy so a lost update anomaly is possible
+* By default, optimistic concurrency checks are **disabled**. Changes made outside of the session object will be overwritten. 
+  Concurrent changes to the same document will use the _Last Write Wins_ strategy so a lost update anomaly is possible 
   with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
 
-* You can enable the optimistic concurrency for either:
-    * All sessions - enable globally, at the document store level
-    * A specific session - enable on a per-session basis
-    * A specific document
+* Optimistic concurrency can be **enabled** for:
+   * A specific document  
+   * A specific session (enable on a per-session basis)  
+   * All sessions (enable globally, at the document store level)  
 
-* With optimistic concurrency __enabled__, RavenDB will generate a concurrency exception
-  (and abort all modifications in the current transaction) when trying to save a document that has been modified on the server side after the client loaded and modified it.
+* With optimistic concurrency enabled, RavenDB will generate a concurrency exception (and abort all modifications in 
+  the current transaction) when trying to save a document that has been modified on the server side after the client 
+  loaded and modified it.
 
-* The `ConcurrencyException` that might be thrown upon the `saveChanges` call needs to be handled by the caller.
-  The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error in a way that is suitable in a given scenario.
+* The `ConcurrencyException` that might be thrown upon the `saveChanges` call needs to be handled by the caller. 
+  The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error 
+  in a way that is suitable in a given scenario.
 
 * In this page:
-    * [Enable for specific session](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-session)
-    * [Enable globally](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-globally)
-    * [Disable for specific document (when enabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#disable-for-specific-document-(when-enabled-on-session))
-    * [Enable for specific document (when disabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-document-(when-disabled-on-session))
+  * [Enable for specific session](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-session)
+  * [Enable globally](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-globally)
+  * [Disable for specific document (when enabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#disable-for-specific-document-(when-enabled-on-session))
+  * [Enable for specific document (when disabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-document-(when-disabled-on-session)) 
 
 {WARNING: }
 
-* Note that the `useOptimisticConcurrency` setting only applies to documents that have been modified by the current session.
-  For example, if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `saveChanges`,
+* Note that the `useOptimisticConcurrency` setting only applies to documents that have been modified by the current session. 
+  E.g., if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `saveChanges`, 
   the operation will succeed regardless of the optimistic concurrency setting, even if `users/2-A` has been changed by another process in the meantime.
 
-* However, if you modify both documents and attempt to save changes with optimistic concurrency turned on, an exception will be raised if `users/2-A` has been modified externally.  
+* However, if you modify both documents and attempt to save changes with optimistic concurrency enabled, an exception will be raised 
+  if `users/2-A` has been modified externally.  
   In this case, the updates to both `users/1-A` and `users/2-A` will be cancelled.
 
 {WARNING/}
 
 {INFO: }
 
-For a detailed description of transactions and concurrency control in RavenDB please refer to the  
-[Transaction support in RavenDB](../../../client-api/faq/transaction-support) article.
+A detailed description of transactions and concurrency control in RavenDB is available here: 
+[Transaction support in RavenDB](../../../client-api/faq/transaction-support)
 
 {INFO/}
 
@@ -64,7 +67,7 @@ For a detailed description of transactions and concurrency control in RavenDB pl
 
 {PANEL: Enable globally}
 
-* Optimistic concurrency can also be turned on for all sessions that are opened under a document store.
+* Optimistic concurrency can also be _enabled_ for all sessions that are opened under a document store.
 
 * Use the [store.Conventions.UseOptimisticConcurrency](../../../client-api/configuration/conventions#useoptimisticconcurrency) convention to enable globally.
 
@@ -74,8 +77,8 @@ For a detailed description of transactions and concurrency control in RavenDB pl
 
 {PANEL: Disable for specific document (when enabled on session)}
 
-* Optimistic concurrency can be turned OFF when __storing__ a specific document,  
-  even when it is turned ON for an entire session (or globally).
+* Optimistic concurrency can be _disabled_ when **storing** a specific document,  
+  even when it is _enabled_ for an entire session (or globally).
 
 * This is done by passing `null` as a change vector value to the [store](../../../client-api/session/storing-entities) method.
 
@@ -85,14 +88,14 @@ For a detailed description of transactions and concurrency control in RavenDB pl
 
 {PANEL: Enable for specific document (when disabled on session)}
 
-* Optimistic concurrency can be turned ON when __storing__ a specific document,  
-  even when it is turned OFF for an entire session (or globally).
+* Optimistic concurrency can be _enabled_ when **storing** a specific document,  
+  even when it is _disabled_ for an entire session (or globally).
 
 * This is done by passing `string.Empty` as the change vector value to the [store](../../../client-api/session/storing-entities) method.  
   Setting the change vector to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exist.
   A `ConcurrencyException` will be thrown if the document already exists.
 
-* If you don't supply a 'Change Vector' or if the 'Change Vector' is `null`, then optimistic concurrency will be disabled.
+* If you do not provide a change vector or if the change vector is `null`, optimistic concurrency will be disabled.  
 
 * Setting optimistic concurrency for a specific document overrides the `useOptimisticConcurrency` property from the `advanced` session operations.
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.python.markdown
@@ -16,7 +16,7 @@
   the current transaction) when trying to save a document that has been modified on the server side after the client 
   loaded and modified it.
 
-* The `ConcurrencyException` that might be thrown upon the `SaveChanges` call needs to be handled by the caller. 
+* The `ConcurrencyException` that might be thrown upon the `save_changes` call needs to be handled by the caller. 
   The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error 
   in a way that is suitable in a given scenario.
 
@@ -28,8 +28,8 @@
 
 {WARNING: }
 
-* Note that the `UseOptimisticConcurrency` setting only applies to documents that have been modified by the current session. 
-  E.g., if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `SaveChanges`, 
+* Note that the `use_optimistic_concurrency` setting only applies to documents that have been modified by the current session. 
+  E.g., if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `save_changes`, 
   the operation will succeed regardless of the optimistic concurrency setting, even if `users/2-A` has been changed by another process in the meantime.
 
 * However, if you modify both documents and attempt to save changes with optimistic concurrency enabled, an exception will be raised 
@@ -51,12 +51,12 @@ A detailed description of transactions and concurrency control in RavenDB is ava
 
 {PANEL: Enable for specific session}
 
-{CODE optimistic_concurrency_1@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+{CODE:python optimistic_concurrency_1@ClientApi\Session\Configuration\OptimisticConcurrency.py /}
 
 {WARNING: }
 
 * Enabling optimistic concurrency in a session will ensure that changes made to a document will only be persisted 
-  if the version of the document sent in the `SaveChanges()` call matches its version from the time it was initially read (loaded from the server).
+  if the version of the document sent in the `save_changes` call matches its version from the time it was initially read (loaded from the server).
  
 * Note that it's necessary to enable optimistic concurrency for ALL sessions that modify the documents for which you want to guarantee that no writes will be silently discarded.
   If optimistic concurrency is enabled in some sessions but not in others, and they modify the same documents, the risk of the lost update anomaly still exists.
@@ -67,22 +67,22 @@ A detailed description of transactions and concurrency control in RavenDB is ava
 
 {PANEL: Enable globally}
 
-* Optimistic concurrency can also be _enabled_ for all sessions that are opened under a document store.
+* Optimistic concurrency can also be enabled for all sessions that are opened under a document store.
 
-* Use the [store.Conventions.UseOptimisticConcurrency](../../../client-api/configuration/conventions#useoptimisticconcurrency) convention to enable globally.
+* Use the [store.conventions.use_optimistic_concurrency](../../../client-api/configuration/conventions#useoptimisticconcurrency) convention to enable globally.
 
-{CODE optimistic_concurrency_2@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+{CODE:python optimistic_concurrency_2@ClientApi\Session\Configuration\OptimisticConcurrency.py /}
 
 {PANEL/}
 
 {PANEL: Disable for specific document (when enabled on session)}
 
-* Optimistic concurrency can be _disabled when **storing** a specific document,  
+* Optimistic concurrency can be _disabled_ when **storing** a specific document,  
   even when it is _enabled_ for an entire session (or globally).
 
-* This is done by passing `null` as a change vector value to the [Store](../../../client-api/session/storing-entities) method.
+* This is done by passing `None` as a change vector value to the [store](../../../client-api/session/storing-entities) method.
 
-{CODE optimistic_concurrency_3@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+{CODE:python optimistic_concurrency_3@ClientApi\Session\Configuration\OptimisticConcurrency.py /}
 
 {PANEL/}
 
@@ -91,15 +91,15 @@ A detailed description of transactions and concurrency control in RavenDB is ava
 * Optimistic concurrency can be _enabled_ when **storing** a specific document,  
   even when it is _disabled_ for an entire session (or globally).
 
-* This is done by passing `string.Empty` as the change vector value to the [Store](../../../client-api/session/storing-entities) method.  
+* This is done by passing an empty `str` as the change vector value to the [store](../../../client-api/session/storing-entities) method.  
   Setting the change vector to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exist.
   A `ConcurrencyException` will be thrown if the document already exists. 
 
-* If you do not provide a change vector or if the change vector is `null`, optimistic concurrency will be disabled.  
+* If you do not provide a change vector or if the change vector is `None`, optimistic concurrency will be disabled.  
 
-* Setting optimistic concurrency for a specific document overrides the `UseOptimisticConcurrency` property from the `Advanced` session operations.
+* Setting optimistic concurrency for a specific document overrides the `use_optimistic_concurrency` property from the `advanced` session operations.
 
-{CODE optimistic_concurrency_4@ClientApi\Session\Configuration\OptimisticConcurrency.cs /}
+{CODE:python optimistic_concurrency_4@ClientApi\Session\Configuration\OptimisticConcurrency.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.dotnet.markdown
@@ -1,0 +1,56 @@
+# How to Check if an Attachment Exists
+
+---
+
+{NOTE: }
+
+* To check whether a document contains a certain attachment,  
+  use the method `Exists()` from the `Advanced.Attachments` session operations.  
+
+* Calling _'Exists'_ does not [Load](../../../client-api/session/loading-entities) the document or the attachment to the session,  
+  and the session will not track them.
+
+* In this page:  
+  * [Check if attachment exists](../../../client-api/session/how-to/check-if-attachment-exists#check-if-attachment-exists)  
+  * [Syntax](../../../client-api/session/how-to/check-if-attachment-exists#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Check if attachment exists}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync exists@ClientApi\Session\HowTo\AttachmentExists.cs /}
+{CODE-TAB:csharp:Async exists_async@ClientApi\Session\HowTo\AttachmentExists.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync syntax@ClientApi\Session\HowTo\AttachmentExists.cs /}
+{CODE-TAB:csharp:Async syntax_async@ClientApi\Session\HowTo\AttachmentExists.cs /}
+{CODE-TABS/}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **documentId** | `string` | The ID of the document you want to check |
+| **attachmentName** | `string` | The name of the attachment you are looking for |
+
+| Return Value | Description |
+| - | - |
+| `bool` | `true` - The specified attachment exists on the document<br>`false` - The attachment does not exist on the document |
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.java.markdown
@@ -1,0 +1,50 @@
+# How to Check if an Attachment Exists
+
+---
+
+{NOTE: }
+
+* To check whether a document contains a certain attachment, use the method `exists()` from the `session.advanced().attachments()` 
+operations.  
+
+* This does not [load the document](../../../client-api/session/loading-entities) or [the attachment](../../../document-extensions/attachments/loading) 
+from the server, and it does not cause the session to track the document.  
+
+* In this page:  
+  * [Syntax](../../../client-api/session/how-to/check-if-attachment-exists#syntax)  
+  * [Example](../../../client-api/session/how-to/check-if-attachment-exists#example)  
+{NOTE/}
+
+---
+
+{PANEL: Syntax}
+
+{CODE:java exists_1@ClientApi\Session\HowTo\AttachmentExists.java /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **documentId** | `String` | The ID of the document you want to check for the attachment |
+| **name** | `String` | The name of the attachment you want to check the document for |
+
+| Return Value | Description |
+| - | - |
+| `boolean` | Indicates if a document with the specified ID exists in the database |
+
+{PANEL/}
+
+{PANEL: Example}
+
+{CODE:java exists_2@ClientApi\Session\HowTo\AttachmentExists.java /}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.js.markdown
@@ -1,0 +1,50 @@
+# How to Check if an Attachment Exists
+
+---
+
+{NOTE: }
+
+* To check whether a document contains a certain attachment,  
+  use the method `exists()` from the `advanced.attachments` session operations.
+
+* Calling _'exists'_ does not [load](../../../client-api/session/loading-entities) the document or the attachment to the session,  
+  and the session will not track them.
+
+* In this page:  
+  * [Check if attachment exists](../../../client-api/session/how-to/check-if-attachment-exists#check-if-attachment-exists)  
+  * [Syntax](../../../client-api/session/how-to/check-if-attachment-exists#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Check if attachment exists}
+
+{CODE:nodejs exists@client-api\session\HowTo\attachmentExists.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\session\HowTo\attachmentExists.js /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **docId** | `string` | The ID of the document you want to check |
+| **attachmentName** | `string` | The name of the attachment you are looking for |
+
+| Return Value | Description |
+| - | - |
+| `Promise<boolean>` | `true` - The specified attachment exists on the document<br>`false` - The attachment does not exist on the document |
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-attachment-exists.python.markdown
@@ -1,0 +1,54 @@
+# How to Check if an Attachment Exists
+
+---
+
+{NOTE: }
+
+* To check whether a document contains a certain attachment,  
+  use the `session.advanced` operations `attachments.exists` method.  
+
+* Calling `exists` does not [load](../../../client-api/session/loading-entities) 
+  the document or the attachment to the session, and the session will not track them.
+
+* In this page:  
+  * [Check if attachment exists](../../../client-api/session/how-to/check-if-attachment-exists#check-if-attachment-exists)  
+  * [Syntax](../../../client-api/session/how-to/check-if-attachment-exists#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Check if attachment exists}
+
+{CODE-TABS}
+{CODE-TAB:python exists@ClientApi\Session\HowTo\AttachmentExists.py /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE-TABS}
+{CODE-TAB:python syntax@ClientApi\Session\HowTo\AttachmentExists.py /}
+{CODE-TABS/}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **document_id** | `str` | The ID of the document you want to check |
+| **name** | `str` | The name of the attachment you are looking for |
+
+| Return Value | Description |
+| - | - |
+| `bool` | `True` - The specified attachment exists for this document<br>`False` - The attachment doesn't exist for the document |
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.dotnet.markdown
@@ -1,0 +1,55 @@
+# How to Check if a Document Exists
+
+---
+
+{NOTE: }
+
+* To check whether the database contains a certain document,  
+  use the method `Exists()` from the `Advanced` session operations.  
+
+* Calling _'Exists'_ does not [Load](../../../client-api/session/loading-entities) the document entity to the session,  
+  and the session will not track it. 
+
+* In this page:
+    * [Check if document exists](../../../client-api/session/how-to/check-if-document-exists#check-if-document-exists)
+    * [Syntax](../../../client-api/session/how-to/check-if-document-exists#syntax)
+{NOTE/}
+
+---
+
+{PANEL: Check if document exists}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync exists_2@ClientApi\Session\HowTo\DocumentExists.cs /}
+{CODE-TAB:csharp:Async exists_2_async@ClientApi\Session\HowTo\DocumentExists.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync exists_1@ClientApi\Session\HowTo\DocumentExists.cs /}
+{CODE-TAB:csharp:Async exists_1_async@ClientApi\Session\HowTo\DocumentExists.cs /}
+{CODE-TABS/}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **id** | `string` | The ID of the document to check |
+
+| Return Value | Description |
+| - | - |
+| `bool` | `true` - the document exists in the database.<br>`false` - The document does Not exist in the database |
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.java.markdown
@@ -1,0 +1,47 @@
+# How to Check if a Document Exists
+
+---
+
+{NOTE: }
+
+* To check whether the database contains a certain document, use the method `exists()` from the `advanced` session operations.  
+
+* This does not [load](../../../client-api/session/loading-entities) the document from the server or cause the session to track it.  
+
+* In this page:  
+  * [Syntax](../../../client-api/session/how-to/check-if-document-exists#syntax)  
+  * [Example](../../../client-api/session/how-to/check-if-document-exists#example)  
+{NOTE/}
+
+---
+
+{PANEL: Syntax}
+
+{CODE:java exists_1@ClientApi\Session\HowTo\DocumentExists.java /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **id** | `String` | The ID of the document you want to check the database for |
+
+| Return Value | Description |
+| - | - |
+| `boolean` | Indicates whether a document with the specified ID exists in the database |
+
+{PANEL/}
+
+{PANEL: Example}
+
+{CODE:java exists_2@ClientApi\Session\HowTo\DocumentExists.java /}
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.js.markdown
@@ -1,0 +1,49 @@
+# How to Check if a Document Exists
+
+---
+
+{NOTE: }
+ 
+* To check whether the database contains a certain document,  
+  use the method `exists()` from the `advanced` session operations.
+
+* Calling _'exists'_ does not [load](../../../client-api/session/loading-entities) the document entity to the session,  
+  and the session will not track it.
+
+* In this page:
+    * [Check if document exists](../../../client-api/session/how-to/check-if-document-exists#check-if-document-exists)
+    * [Syntax](../../../client-api/session/how-to/check-if-document-exists#syntax)
+      {NOTE/}
+
+---
+
+{PANEL: Check if document exists}
+
+{CODE:nodejs exists@client-api\session\HowTo\documentExists.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\session\HowTo\documentExists.js /}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **id** | `string` | The ID of the document to check |
+
+| Return Value | Description |
+| - | - |
+| `Promise<boolean>` | `true` - the document exists in the database.<br>`false` - The document does Not exist in the database |
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-document-exists.python.markdown
@@ -1,0 +1,53 @@
+# How to Check if a Document Exists
+
+---
+
+{NOTE: }
+
+* To check whether the database contains a certain document,  
+  use the `session.advanced` operations `exists` method.  
+
+* Calling `exists` does not [load](../../../client-api/session/loading-entities) 
+  the document entity to the session, and the session will not track it.
+
+* In this page:
+    * [Check if document exists](../../../client-api/session/how-to/check-if-document-exists#check-if-document-exists)
+    * [Syntax](../../../client-api/session/how-to/check-if-document-exists#syntax)
+{NOTE/}
+
+---
+
+{PANEL: Check if document exists}
+
+{CODE-TABS}
+{CODE-TAB:python exists_2@ClientApi\Session\HowTo\DocumentExists.py /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE-TABS}
+{CODE-TAB:python exists_1@ClientApi\Session\HowTo\DocumentExists.py /}
+{CODE-TABS/}
+
+| Parameter | Type | Description |
+| - | - | - |
+| **key** | `str` | The ID of the document to look for |
+
+| Return Value | Description |
+| - | - |
+| `bool` | `True` - this document exists in the database.<br>`False` - The document does Not exist in the database |
+
+{PANEL/}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-entity-has-changed.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-entity-has-changed.js.markdown
@@ -6,7 +6,7 @@
 * The Session [tracks all changes](../../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes) made to all entities that it has either loaded, stored, or queried for,  
   and persists to the server only what is needed when `saveChanges()` is called.
 
-* This article describes how to check for changes made to a specific __entity__ within a session.  
+* This article describes how to check for changes made in a specific __entity__ within a session.  
   To check for changes on all tracked entities, see [Check for session changes](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session).
 
 * In this page:

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-entity-has-changed.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-entity-has-changed.python.markdown
@@ -4,9 +4,9 @@
 {NOTE: }
 
 * The Session [tracks all changes](../../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes) made to all entities that it has either loaded, stored, or queried for,  
-  and persists to the server only what is needed when `SaveChanges()` is called.
+  and persists to the server only what is needed when `save_changes` is called.
 
-* This article describes how to check for changes made in a specific __entity__ within a session.  
+* This article describes how to check for changes made in a specific **entity** within a session.  
   To check for changes on all tracked entities, see [Check for session changes](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session).
 
 * In this page:
@@ -20,19 +20,19 @@
 
 {PANEL: Check for entity changes }
 
-* The session's advanced property `HasChanged` indicates whether the specified entity was added, modified, or deleted within the session.
+* The session's advanced property `has_changed` indicates whether the specified entity was added, modified, or deleted within the session.
 
-* Note: The _HasChanged_ property is cleared after calling `SaveChanges()`.
+* Note: The `has_changed` property is cleared (reset to `False`) after calling `save_changes`.
 
 ---
 
-{CODE changes_1@ClientApi\Session\HowTo\EntityChanges.cs /}
+{CODE:python changes_1@ClientApi\Session\HowTo\EntityChanges.py /}
 
 {PANEL/}
 
 {PANEL: Get entity changes }
 
-* Use the session's advanced method `WhatChangedFor()` to get all changes made in the specified entity  
+* Use the advanced session `what_changed` method to get all changes made in the specified entity  
   within the session.
 
 * Details will include:
@@ -44,24 +44,24 @@
 
 ##### Example I
 
-{CODE changes_2@ClientApi\Session\HowTo\EntityChanges.cs /}
+{CODE:python changes_2@ClientApi\Session\HowTo\EntityChanges.py /}
 
 ##### Example II
 
-{CODE changes_3@ClientApi\Session\HowTo\EntityChanges.cs /}
+{CODE:python changes_3@ClientApi\Session\HowTo\EntityChanges.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax_1@ClientApi\Session\HowTo\EntityChanges.cs /}
-{CODE syntax_2@ClientApi\Session\HowTo\EntityChanges.cs /}
+{CODE:python syntax_1@ClientApi\Session\HowTo\EntityChanges.py /}
+{CODE:python syntax_2@ClientApi\Session\HowTo\EntityChanges.py /}
 
-| ReturnValue          |                                    |
-|----------------------|------------------------------------|
-| `DocumentsChanges[]` | List of changes made in the entity |
+| ReturnValue        |                                    |
+|--------------------|------------------------------------|
+| `DocumentsChanges` | List of changes made in the entity (see `ChangeType` class below for available change types) |
 
-{CODE syntax_3@ClientApi\Session\HowTo\EntityChanges.cs /}
+{CODE:python syntax_3@ClientApi\Session\HowTo\EntityChanges.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-there-are-any-changes-on-a-session.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-there-are-any-changes-on-a-session.js.markdown
@@ -3,11 +3,12 @@
 
 {NOTE: }
 
-* The Session [tracks all changes](../../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes) made to all entities that it has either loaded, stored, or queried for,  
+* The Session [tracks all changes](../../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes) 
+  made in all the entities it has either loaded, stored, or queried for,  
   and persists to the server only what is needed when `saveChanges()` is called.
 
-* This article describes how to check for changes made to all tracked entities within the __session__.  
-  To check for changes on a specific __entity__, see [Check for entity changes](../../../client-api/session/how-to/check-if-entity-has-changed).
+* This article describes how to check for changes made to all tracked entities within the **session**.  
+  To check for changes on a specific **entity**, see [Check for entity changes](../../../client-api/session/how-to/check-if-entity-has-changed).
 
 * In this page:
     * [Check for session changes](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session#check-for-session-changes)
@@ -62,12 +63,12 @@
 
 | `DocumentsChanges`  | Type    | Description                                                                                                                                                                                      |
 |---------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| __fieldOldValue__   | object  | Previous field value                                                                                                                                                                             |
-| __fieldNewValue__   | object  | Current field value                                                                                                                                                                              |
-| __change__          | string  | Type of change that occurred. Can be: <br>`"DocumentDeleted"`, `"DocumentAdded"`,`"FieldChanged"`, `"NewField"`, `"RemovedField"`, `"ArrayValueChanged"`, `"ArrayValueAdded"`, `"ArrayValueRemoved"` |
-| __fieldName__       | string  | Name of field on which the change occurred                                                                                                                                                       |
-| __fieldPath__       | string  | Path of field on which the change occurred                                                                                                                                                       |
-| __fieldFullName__   | string  | Path + Name of field on which the change occurred                                                                                                                                                |
+| **fieldOldValue**   | object  | Previous field value                                                                                                                                                                             |
+| **fieldNewValue**   | object  | Current field value                                                                                                                                                                              |
+| **change**          | string  | Type of change that occurred. Can be: <br>`"DocumentDeleted"`, `"DocumentAdded"`,`"FieldChanged"`, `"NewField"`, `"RemovedField"`, `"ArrayValueChanged"`, `"ArrayValueAdded"`, `"ArrayValueRemoved"` |
+| **fieldName**       | string  | Name of field on which the change occurred                                                                                                                                                       |
+| **fieldPath**       | string  | Path of field on which the change occurred                                                                                                                                                       |
+| **fieldFullName**   | string  | Path + Name of field on which the change occurred                                                                                                                                                |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-there-are-any-changes-on-a-session.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/check-if-there-are-any-changes-on-a-session.python.markdown
@@ -5,9 +5,9 @@
 
 * The Session [tracks all changes](../../../client-api/session/what-is-a-session-and-how-does-it-work#tracking-changes) 
   made in all the entities it has either loaded, stored, or queried for,  
-  and persists to the server only what is needed when `SaveChanges()` is called.
+  and persists to the server only what is needed when `save_changes` is called.
 
-* This article describes how to check for changes made to all tracked entities within the **session**.  
+* This article describes how to check for changes made in all tracked entities within the **session**.  
   To check for changes on a specific **entity**, see [Check for entity changes](../../../client-api/session/how-to/check-if-entity-has-changed).
  
 * In this page:
@@ -21,19 +21,19 @@
 
 {PANEL: Check for session changes }
 
-* The session's advanced property `HasChanges` indicates whether any entities were added, modified, or deleted within the session.
+* The advanced session `has_changes` property indicates whether any entities were added, modified, or deleted within the session.
 
-* Note: The _HasChanges_ property is cleared after calling `SaveChanges()`.
+* Note: The `has_changes` property is cleared (reset to `False`) after calling `save_changes`.
 
 ---
 
-{CODE changes_1@ClientApi\Session\HowTo\SessionChanges.cs /}
+{CODE:python changes_1@ClientApi\Session\HowTo\SessionChanges.py /}
 
 {PANEL/}
 
 {PANEL: Get session changes }
 
-* Use the session's advanced method `WhatChanged()` to get all changes made to all the entities tracked by the session.
+* Use the session's advanced method `what_changed` to get all changes made to all the entities tracked by the session.
 
 * For each entity that was modified, the details will include:  
   * The name and path of the changed field   
@@ -44,24 +44,24 @@
 
 ##### Example I
 
-{CODE changes_2@ClientApi\Session\HowTo\SessionChanges.cs /}
+{CODE:python changes_2@ClientApi\Session\HowTo\SessionChanges.py /}
 
 ##### Example II
 
-{CODE changes_3@ClientApi\Session\HowTo\SessionChanges.cs /}
+{CODE:python changes_3@ClientApi\Session\HowTo\SessionChanges.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax_1@ClientApi\Session\HowTo\SessionChanges.cs /}
-{CODE syntax_2@ClientApi\Session\HowTo\SessionChanges.cs /}
+{CODE:python syntax_1@ClientApi\Session\HowTo\SessionChanges.py /}
+{CODE:python syntax_2@ClientApi\Session\HowTo\SessionChanges.py /}
 
-| ReturnValue                               |                                                       |
-|-------------------------------------------|-------------------------------------------------------|
-| `IDictionary<string, DocumentsChanges[]>` | Dictionary containing list of changes per document ID |
+| ReturnValue                         |                                                       |
+|-------------------------------------|-------------------------------------------------------|
+| `Dict[str, List[DocumentsChanges]]` | Dictionary containing list of changes per document ID |
 
-{CODE syntax_3@ClientApi\Session\HowTo\SessionChanges.cs /}
+{CODE:python syntax_3@ClientApi\Session\HowTo\SessionChanges.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
@@ -4,15 +4,13 @@
 
 {NOTE: }
 
-* By default, each session tracks the changes made to all entities it has either stored, loaded, or queried for.  
+* By default, each session tracks the changes made in all the entities it has ever stored, loaded, or queried for.  
   All changes are then persisted when `SaveChanges` is called.
 
-* Entity changes can be ignored for the `SaveChanges` by disabling entity tracking.  
-
-* Tracking can be disabled by any of the following:
-    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
-    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
-    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+* To ignore entity changes when calling `SaveChanges`, **disable entity tracking** by any of the following:
+    * [Disable tracking for a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking for all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking for query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
     * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
 {NOTE/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.dotnet.markdown
@@ -1,0 +1,29 @@
+# How to Ignore Entity Changes
+
+---
+
+{NOTE: }
+
+* By default, each session tracks the changes made to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `SaveChanges` is called.
+
+* Entity changes can be ignored for the `SaveChanges` by disabling entity tracking.  
+
+* Tracking can be disabled by any of the following:
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.java.markdown
@@ -1,0 +1,30 @@
+# Session: How to Ignore Entity Changes
+
+In order to mark an entity as one that should be ignored for change tracking purposes, use the `ignoreChangesFor` method from the `advanced` session operations.  
+
+Unlike the `evict` method, performing another `Load` of that entity won't create a call to the server.  
+
+The entity will still take part in the session, but will be ignored for `saveChanges`.  
+
+## Syntax
+
+{CODE:java ignore_changes_1@ClientApi\Session\HowTo\IgnoreChanges.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **entity** | Object | Instance of entity for which changes will be ignored. |
+
+
+## Example
+
+{CODE:java ignore_changes_2@ClientApi\Session\HowTo\IgnoreChanges.java /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
@@ -1,0 +1,29 @@
+# How to Ignore Entity Changes
+
+---
+
+{NOTE: }
+
+* By default, each session tracks the changes made to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `saveChanges` is called.
+
+* Entity changes can be ignored for the `saveChanges` by disabling entity tracking.
+
+* Tracking can be disabled by any of the following:
+    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work)
+- [How to Check if Entity has Changed](../../../client-api/session/how-to/check-if-entity-has-changed)
+- [How to Check if There are Any Changes on a Session](../../../client-api/session/how-to/check-if-there-are-any-changes-on-a-session)
+- [Evict Entity From a Session](../../../client-api/session/how-to/evict-entity-from-a-session)
+- [Refresh Entity](../../../client-api/session/how-to/refresh-entity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.js.markdown
@@ -4,15 +4,13 @@
 
 {NOTE: }
 
-* By default, each session tracks the changes made to all entities it has either stored, loaded, or queried for.  
+* By default, each session tracks the changes made in all the entities it has ever stored, loaded, or queried for.  
   All changes are then persisted when `saveChanges` is called.
 
-* Entity changes can be ignored for the `saveChanges` by disabling entity tracking.
-
-* Tracking can be disabled by any of the following:
-    * [Disable tracking a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
-    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
-    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+* To ignore entity changes when calling `saveChanges`, **disable entity tracking** by any of the following:
+    * [Disable tracking for a specific entity in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-a-specific-entity-in-session)
+    * [Disable tracking for all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking for query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
     * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
 {NOTE/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/how-to/ignore-entity-changes.python.markdown
@@ -1,24 +1,25 @@
 # Session: How to Ignore Entity Changes
 
 To indicate that an entity should be ignored when tracking changes, 
-use the `advanced` session `ignoreChangesFor` method.  
+use the `advanced` session `ignore_changes_for` method.  
 
-Using `Load` again to retrieve this entity will not initiate a server call.  
+Using `load` again to retrieve this entity will not initiate a server call.  
 
 The entity will still take part in the session, but be ignored when `save_changes` is called.  
 
+See more here: [Disable Entity Tracking](../../../client-api/session/configuration/how-to-disable-tracking)
+
 ## Syntax
 
-{CODE:java ignore_changes_1@ClientApi\Session\HowTo\IgnoreChanges.java /}
+{CODE:python ignore_changes_1@ClientApi\Session\HowTo\IgnoreChanges.py /}
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **entity** | Object | Instance of entity for which changes will be ignored. |
-
+| Parameter | Type | Description |
+| - | - | - |
+| **entity** | `object` | The instance of an entity for which changes will be ignored. |
 
 ## Example
 
-{CODE:java ignore_changes_2@ClientApi\Session\HowTo\IgnoreChanges.java /}
+{CODE:python ignore_changes_2@ClientApi\Session\HowTo\IgnoreChanges.py /}
 
 ## Related Articles
 

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/CustomizeCollectionAssignmentForEntities.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/CustomizeCollectionAssignmentForEntities.cs
@@ -1,0 +1,24 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class CustomizeCollectionAssignmentForEntities
+    {
+        public CustomizeCollectionAssignmentForEntities()
+        {
+            var store = new DocumentStore();
+
+            #region custom_collection_name
+            store.Conventions.FindCollectionName = type =>
+            {
+                if (typeof(Category).IsAssignableFrom(type))
+                    return "ProductGroups";
+
+                return DocumentConventions.DefaultGetCollectionName(type);
+            };
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+using Xunit;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class DisableTracking
+    {
+        private interface IgnoreChangesEntity
+        {
+            #region syntax_1
+            void IgnoreChangesFor(object entity);
+            #endregion
+        }
+
+        private abstract class IgnoreChangesConvention
+        {
+            #region syntax_2
+            public Func<InMemoryDocumentSessionOperations, object, string, bool> ShouldIgnoreEntityChanges;
+            #endregion
+        }
+
+        public async Task DisableTrackingSamples()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region disable_tracking_1
+                    // Load a product entity, the session will track its changes
+                    Product product = session.Load<Product>("products/1-A");
+                    
+                    // Disable tracking for the loaded product entity
+                    session.Advanced.IgnoreChangesFor(product);
+                    
+                    // The following change will be ignored for SaveChanges
+                    product.UnitsInStock += 1;
+                    
+                    session.SaveChanges();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region disable_tracking_1_async
+                    // Load a product entity, the session will track its changes
+                    Product product = await asyncSession.LoadAsync<Product>("products/1-A");
+                    
+                    // Disable tracking for the loaded product entity
+                    asyncSession.Advanced.IgnoreChangesFor(product);
+                    
+                    // The following change will be ignored for SaveChanges
+                    product.UnitsInStock += 1;
+                    
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+                
+                #region disable_tracking_2
+                using (IDocumentSession session = store.OpenSession(new SessionOptions
+                {
+                    // Disable tracking for all entities in the session's options
+                    NoTracking = true
+                }))
+                {
+                    // Load any entity, it will Not be tracked by the session
+                    Employee employee1 = session.Load<Employee>("employees/1-A");
+                    
+                    // Loading again from same document will result in a new entity instance
+                    Employee employee2 = session.Load<Employee>("employees/1-A");
+                    
+                    // Entities instances are not the same
+                    Assert.NotEqual(employee1, employee2);
+                }
+                #endregion
+
+                #region disable_tracking_2_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession(new SessionOptions
+                {
+                    // Disable tracking for all entities in the session's options
+                    NoTracking = true
+                }))
+                {
+                    // Load any entity, it will Not be tracked by the session
+                    Employee employee1 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+                    
+                    // Loading again from same document will result in a new entity instance
+                    Employee employee2 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+
+                    // Entities instances are not the same
+                    Assert.NotEqual(employee1, employee2);
+                }
+                #endregion
+                
+                #region disable_tracking_3
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = session.Query<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    session.SaveChanges();
+                }
+                #endregion
+
+                #region disable_tracking_3_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = asyncSession.Query<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    await asyncSession.SaveChangesAsync();
+                }
+                #endregion
+                
+                #region disable_tracking_3_documentQuery
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = session.Advanced.DocumentQuery<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .NoTracking()
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    session.SaveChanges();
+                }
+                #endregion
+                
+                #region disable_tracking_3_documentQuery_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = asyncSession.Advanced.AsyncDocumentQuery<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .NoTracking()
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    await asyncSession.SaveChangesAsync();
+                }
+                #endregion
+            }
+
+            #region disable_tracking_4
+            using (var store = new DocumentStore()
+            {
+                // Define the 'ignore' convention on your document store
+                Conventions =
+                {
+                    ShouldIgnoreEntityChanges =
+                        // Define for which entities tracking should be disabled 
+                        // Tracking will be disabled ONLY for entities of type Employee whose FirstName is Bob
+                        (session, entity, id) => (entity is Employee e) &&
+                                                 (e.FirstName == "Bob")
+                }
+            }.Initialize())
+            {
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    var employee1 = new Employee { Id = "employees/1", FirstName = "Alice" };
+                    var employee2 = new Employee { Id = "employees/2", FirstName = "Bob" };
+
+                    session.Store(employee1);      // This entity will be tracked
+                    session.Store(employee2);      // Changes to this entity will be ignored
+
+                    session.SaveChanges();         // Only employee1 will be persisted
+
+                    employee1.FirstName = "Bob";   // Changes to this entity will now be ignored
+                    employee2.FirstName = "Alice"; // This entity will now be tracked
+
+                    session.SaveChanges();         // Only employee2 is persisted
+                }
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/MaxRequests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/MaxRequests.cs
@@ -1,0 +1,24 @@
+﻿using Raven.Client.Documents;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class MaxRequests
+    {
+        public MaxRequests()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region max_requests_1
+                    session.Advanced.MaxNumberOfRequestsPerSession = 50;
+                    #endregion
+                }
+
+                #region max_requests_2
+                store.Conventions.MaxNumberOfRequestsPerSession = 100;
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/OptimisticConcurrency.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/OptimisticConcurrency.cs
@@ -1,0 +1,94 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class OptimisticConcurrency
+    {
+        public OptimisticConcurrency()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region optimistic_concurrency_1
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Enable optimistic concurrency for this session
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    // Save a document in this session
+                    Product product = new Product { Name = "Some Name" };
+                    session.Store(product, "products/999");
+                    session.SaveChanges();
+
+                    // Modify the document 'externally' by another session 
+                    using (IDocumentSession otherSession = store.OpenSession())
+                    {
+                        Product otherProduct = otherSession.Load<Product>("products/999");
+                        otherProduct.Name = "Other Name";
+                        otherSession.SaveChanges();
+                    }
+
+                    // Trying to modify the document without reloading it first will throw
+                    product.Name = "Better Name";
+                    session.SaveChanges(); // This will throw a ConcurrencyException
+                }
+                #endregion
+
+                #region optimistic_concurrency_2
+                // Enable for all sessions that will be opened within this document store
+                store.Conventions.UseOptimisticConcurrency = true;
+
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    bool isSessionUsingOptimisticConcurrency = session.Advanced.UseOptimisticConcurrency; // will return true
+                }
+                #endregion
+
+                #region optimistic_concurrency_3
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Store document 'products/999'
+                    session.Store(new Product { Name = "Some Name" }, id: "products/999");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Enable optimistic concurrency for the session
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    // Store the same document
+                    // Pass 'null' as the changeVector to turn OFF optimistic concurrency for this document
+                    session.Store(new Product { Name = "Some Other Name" }, changeVector: null, id: "products/999");
+                    
+                    // This will NOT throw a ConcurrencyException, and the document will be saved
+                    session.SaveChanges();
+                }
+                #endregion
+
+                #region optimistic_concurrency_4
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Store document 'products/999'
+                    session.Store(new Product { Name = "Some Name" }, id: "products/999");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Disable optimistic concurrency for the session 
+                    session.Advanced.UseOptimisticConcurrency = false; // This is also the default value
+
+                    // Store the same document
+                    // Pass 'string.Empty' as the changeVector to turn ON optimistic concurrency for this document
+                    session.Store(new Product { Name = "Some Other Name" }, changeVector: string.Empty, id: "products/999");
+                    
+                    // This will throw a ConcurrencyException, and the document will NOT be saved
+                    session.SaveChanges();
+                }
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/AttachmentExists.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/AttachmentExists.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class AttachmentExists
+	{
+		private interface IExists
+		{
+            #region syntax
+            bool Exists(string documentId, string attachmentName);
+            #endregion
+
+            #region syntax_async
+            Task<bool> ExistsAsync(string documentId, string attachmentName, CancellationToken token = default);
+            #endregion
+        }
+
+        public async Task Exist()
+		{
+			using (var store = new DocumentStore())
+			{
+                using (var session = store.OpenSession())
+                {
+                    #region exists
+                    bool exists = session
+                        .Advanced
+                        .Attachments
+                        .Exists("categories/1-A", "image.jpg");
+
+                    if (exists)
+                    {
+                        // attachment 'image.jpg' exists on document 'categories/1-A'
+                    }
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region exists_async
+                    bool exists = await asyncSession
+                        .Advanced
+                        .Attachments
+                        .ExistsAsync("categories/1-A", "image.jpg");
+
+                    if (exists)
+                    {
+                        // attachment 'image.jpg' exists on document 'categories/1-A'
+                    }
+                    #endregion
+                }
+            }
+		}
+	}
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/DocumentExists.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/HowTo/DocumentExists.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.HowTo
+{
+    public class Exists
+	{
+		private interface IExists
+		{
+            #region exists_1
+		    bool Exists(string id);
+            #endregion
+
+            #region exists_1_async
+            Task<bool> ExistsAsync(string documentId, CancellationToken token = default);
+            #endregion
+        }
+
+        public async Task Existence()
+		{
+			using (var store = new DocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+				    #region exists_2
+				    bool exists = session.Advanced.Exists("employees/1-A");
+
+				    if (exists)
+				    {
+				        // document 'employees/1-A exists
+				    }
+                    #endregion
+                }
+
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region exists_2_async
+                    bool exists = await asyncSession.Advanced.ExistsAsync("employees/1-A");
+
+                    if (exists)
+                    {
+                        // document 'employees/1-A exists
+                    }
+                    #endregion
+                }
+            }
+		}
+	}
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/CustomizeCollectionAssignmentForEntities.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/CustomizeCollectionAssignmentForEntities.java
@@ -1,0 +1,23 @@
+package net.ravendb.ClientApi.Session.Configuration;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.conventions.DocumentConventions;
+
+public class CustomizeCollectionAssignmentForEntities {
+    public CustomizeCollectionAssignmentForEntities() {
+        DocumentStore store = new DocumentStore();
+
+        //region custom_collection_name
+        store.getConventions().setFindCollectionName(clazz -> {
+            if (Category.class.isAssignableFrom(clazz)) {
+                return "ProductGroups";
+            }
+
+            return DocumentConventions.defaultGetCollectionName(clazz);
+        });
+        //endregion
+    }
+
+    private static class Category {
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/MaxRequests.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/MaxRequests.java
@@ -1,0 +1,22 @@
+package net.ravendb.ClientApi.Session.Configuration;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class MaxRequests {
+    public MaxRequests() {
+
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region max_requests_1
+                session.advanced().setMaxNumberOfRequestsPerSession(50);
+                //endregion
+            }
+
+            //region max_requests_2
+            store.getConventions().setMaxNumberOfRequestsPerSession(100);
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/OptimisticConcurrency.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/OptimisticConcurrency.java
@@ -1,0 +1,93 @@
+package net.ravendb.ClientApi.Session.Configuration;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class OptimisticConcurrency {
+    private static class Product {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public OptimisticConcurrency() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region optimistic_concurrency_1
+            try (IDocumentSession session = store.openSession()) {
+                session.advanced().setUseOptimisticConcurrency(true);
+
+                Product product = new Product();
+                product.setName("Some Name");
+
+                session.store(product, "products/999");
+                session.saveChanges();
+
+                try (IDocumentSession otherSession = store.openSession()) {
+                    Product otherProduct = otherSession.load(Product.class, "products/999");
+                    otherProduct.setName("Other Name");
+
+                    otherSession.saveChanges();
+                }
+
+                product.setName("Better Name");
+                session.saveChanges(); //  will throw ConcurrencyException
+            }
+            //endregion
+
+            //region optimistic_concurrency_2
+            store.getConventions().setUseOptimisticConcurrency(true);
+
+            try (IDocumentSession session = store.openSession()) {
+                boolean isSessionUsingOptimisticConcurrency
+                    = session.advanced().isUseOptimisticConcurrency(); // will return true
+            }
+            //endregion
+
+            //region optimistic_concurrency_3
+            try (IDocumentSession session = store.openSession()) {
+                Product product = new Product();
+                product.setName("Some Name");
+
+                session.store(product, "products/999");
+                session.saveChanges();
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                session.advanced().setUseOptimisticConcurrency(true);
+
+                Product product = new Product();
+                product.setName("Some Other Name");
+
+                session.store(product, null, "products/999");
+                session.saveChanges(); // will NOT throw Concurrency exception
+            }
+            //endregion
+
+            //region optimistic_concurrency_4
+            try (IDocumentSession session = store.openSession()) {
+                Product product = new Product();
+                product.setName("Some Name");
+                session.store(product, "products/999");
+                session.saveChanges();
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                session.advanced().setUseOptimisticConcurrency(false); // default value
+
+                Product product = new Product();
+                product.setName("Some Other Name");
+
+                session.store(product, "", "products/999");
+                session.saveChanges(); // will throw Concurrency exception
+            }
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/AttachmentExists.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/AttachmentExists.java
@@ -1,0 +1,31 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class Exists {
+
+    private interface IExists {
+        //region exists_1
+        boolean exists(String documentId, String name);
+        //endregion
+    }
+
+    public Exists() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region exists_2
+                boolean exists = session
+                                    .advanced()
+                                    .attachments()
+                                    .exists("categories/1-A","image.jpg");
+
+                if (exists) {
+                    // do something
+                }
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/DocumentExists.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/DocumentExists.java
@@ -1,0 +1,28 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class Exists {
+
+    private interface IExists {
+        //region exists_1
+        boolean exists(String id);
+        //endregion
+    }
+
+    public Exists() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region exists_2
+                boolean exists = session.advanced().exists("employees/1-A");
+
+                if (exists) {
+                    // do something
+                }
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/IgnoreChanges.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/HowTo/IgnoreChanges.java
@@ -1,0 +1,40 @@
+package net.ravendb.ClientApi.Session.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class IgnoreChanges {
+
+    private class Product {
+        private int unitsInStock;
+
+        public int getUnitsInStock() {
+            return unitsInStock;
+        }
+
+        public void setUnitsInStock(int unitsInStock) {
+            this.unitsInStock = unitsInStock;
+        }
+    }
+
+    public IgnoreChanges() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region ignore_changes_2
+                Product product = session.load(Product.class, "products/1-A");
+                session.advanced().ignoreChangesFor(product);
+                product.unitsInStock++; //this will be ignored for SaveChanges
+                session.saveChanges();
+                //endregion
+            }
+        }
+    }
+
+    private interface IFoo {
+        //region ignore_changes_1
+        void ignoreChangesFor(Object entity);
+        //endregion
+    }
+
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/configuration/customizeCollectionAssignmentForEntities.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/configuration/customizeCollectionAssignmentForEntities.js
@@ -1,0 +1,17 @@
+import { DocumentStore, DocumentConventions } from "ravendb";
+
+const store = new DocumentStore();
+
+async function example() {
+    //region custom_collection_name
+    store.conventions.findCollectionName = clazz => {
+        if (clazz === Category) {
+            return "ProductGroups";
+        }
+
+        return DocumentConventions.defaultGetCollectionName(clazz);
+    };
+    //endregion
+}
+
+class Category { }

--- a/Documentation/5.4/Samples/nodejs/client-api/session/configuration/disableTracking.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/configuration/disableTracking.js
@@ -1,0 +1,111 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+async function whatIsSessionUsingAwait() {
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_1
+        const session = documentStore.openSession();        
+
+        // Load a product entity, the session will track its changes
+        const product = await session.load("products/1-A");
+
+        // Disable tracking for the loaded product entity
+        session.advanded.ignoreChangesFor(product);
+
+        // The following change will be ignored for saveChanges
+        product.unitsInStock += 1;
+        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_2
+        const session = documentStore.openSession({
+            // Disable tracking for all entities in the session's options
+            noTracking: true
+        });
+
+        // Load any entity, it will Not be tracked by the session
+        const employee1 = await session.load("employees/1-A");
+
+        // Loading again from same document will result in a new entity instance
+        const employee2 = await session.load("employees/1-A");
+
+        // Entities instances are not the same
+        assert.notStrictEqual(company1, company2);
+        
+        // Calling saveChanges will throw an exception
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_3
+        const session = documentStore.openSession();
+
+        // Define a query
+        const employeesResults = await session.query({ collection: "employees" })
+            .whereEquals("FirstName", "Robert")
+             // Set noTracking, all resulting entities will not be tracked
+            .noTracking()
+            .all();
+
+        // The following modification will not be tracked for saveChanges
+        const firstEmployee = employeesResults[0];
+        firstEmployee.lastName = "NewName";
+
+        // Change to 'firstEmployee' will not be persisted
+        session.saveChanges();
+        //endregion
+    }
+    {
+        //region disable_tracking_4
+        const customStore = new DocumentStore();
+        
+        // Define the 'ignore' convention on your document store
+        customStore.conventions.shouldIgnoreEntityChanges =
+            (sessionOperations, entity, documentId) => {
+                // Define for which entities tracking should be disabled 
+                // Tracking will be disabled ONLY for entities of type Employee whose firstName is Bob
+                return entity instanceof Employee && entity.firstName === "Bob";
+            };
+        customStore.initialize();
+
+        const session = customStore.openSession();
+
+        const employee1 = new Employee();
+        employee1.firstName = "Alice";
+
+        const employee2 = new Employee();
+        employee2.firstName = "Bob";
+
+        await session.store(employee1, "employees/1-A"); // This entity will be tracked
+        await session.store(employee2, "employees/2-A"); // Changes to this entity will be ignored
+
+        await session.saveChanges();   // Only employee1 will be persisted
+
+        employee1.firstName = "Bob";   // Changes to this entity will now be ignored
+        employee2.firstName = "Alice"; // This entity will now be tracked
+
+        session.saveChanges();         // Only employee2 is persisted
+        //endregion
+    }
+    {
+        //region syntax_1
+        session.advanced.ignoreChangesFor(entity);
+        //endregion
+    }
+    {
+        //region syntax_2
+        store.conventions.shouldIgnoreEntityChanges = (sessionOperations, entity, documentId) => {
+            // Write your logic
+            // return value:
+            //     true - entity will not be tracked 
+            //     false - entity will be tracked
+        }
+        //endregion
+    }
+}
+

--- a/Documentation/5.4/Samples/nodejs/client-api/session/configuration/maxRequests.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/configuration/maxRequests.js
@@ -1,0 +1,14 @@
+import { DocumentStore } from "ravendb";
+
+const store = new DocumentStore();
+
+{
+    const session = store.openSession();
+    //region max_requests_1
+    session.advanced.maxNumberOfRequestsPerSession = 50;
+    //endregion
+
+    //region max_requests_2
+    store.conventions.maxNumberOfRequestsPerSession = 100;
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/configuration/optimisticConcurrency.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/configuration/optimisticConcurrency.js
@@ -1,0 +1,102 @@
+import { DocumentStore, DocumentConventions } from "ravendb";
+
+const store = new DocumentStore();
+class Product { }
+
+async function example() {
+    
+    //region optimistic_concurrency_1
+    // Enable optimistic concurrency for this session
+    const session = store.openSession();
+    session.advanced.useOptimisticConcurrency = true;
+    
+    const product = new Product();
+    product.name = "Some Name";
+
+    // Save a document in this session
+    await session.store(product, "products/999");
+    await session.saveChanges();
+
+    {
+        // Modify the document 'externally' by another session 
+        const anotherSession = store.openSession();
+        
+        const otherProduct = await anotherSession.load("products/999");
+        otherProduct.name = "Other Name";
+        await anotherSession.saveChanges();
+    }
+
+    // Trying to modify the document without reloading it first will throw
+    product.name = "Better Name";
+    await session.saveChanges(); // This will throw a ConcurrencyException
+    //endregion
+                
+    //region optimistic_concurrency_2
+    // Enable for all sessions that will be opened within this document store
+    store.conventions.useOptimisticConcurrency = true;
+
+    {
+        const session = store.openSession();
+        const isSessionUsingOptimisticConcurrency
+            = session.advanced.useOptimisticConcurrency; // true
+    }
+    //endregion
+
+    //region optimistic_concurrency_3
+    {        
+        const session = store.openSession();
+        
+        const product = new Product();
+        product.name = "Some Name";
+
+        // Store document 'products/999'
+        await session.store(product, "products/999");
+        await session.saveChanges();
+    }
+    {
+        const session = store.openSession();
+        
+        // Enable optimistic concurrency for the session
+        session.advanced.useOptimisticConcurrency = true;
+
+        const product = new Product();
+        product.name = "Some Other Name";
+
+        // Store the same document
+        // Pass 'null' as the changeVector to turn OFF optimistic concurrency for this document
+        await session.store(product, "products/999", { "changeVector": null });
+
+        // This will NOT throw a ConcurrencyException, and the document will be saved
+        await session.saveChanges();
+    }
+    //endregion
+
+    //region optimistic_concurrency_4
+    {
+        const session = store.openSession();
+        
+        const product = new Product();
+        product.name = "Some Name";
+
+        // Store document 'products/999'
+        await session.store(product, "products/999");
+        await session.saveChanges();
+    }
+    {
+        const session = store.openSession();
+        
+        // Disable optimistic concurrency for the session 
+        session.advanced.useOptimisticConcurrency = false; // This is also the default value
+
+        const product = new Product();
+        product.name = "Some Other Name";
+
+        // Store the same document
+        // Pass an empty string as the changeVector to turn ON optimistic concurrency for this document
+        await session.store(product, "products/999", { "changeVector": "" });
+
+        // This will throw a ConcurrencyException, and the document will NOT be saved
+        await session.saveChanges();
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/attachmentExists.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/attachmentExists.js
@@ -1,0 +1,23 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+{
+    //region syntax
+    session.advanced.attachments.exists(docId, attachmentName);
+    //endregion
+}
+
+async function sample() {
+    //region exists
+    const exists = await session
+        .advanced
+        .attachments
+        .exists("categories/1-A", "image.jpg");
+    
+    if (exists) {
+        // attachment 'image.jpg' exists on document 'categories/1-A'
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/howTo/documentExists.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/howTo/documentExists.js
@@ -1,0 +1,19 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+{
+    //region syntax
+    session.advanced.exists(id);
+    //endregion
+}
+
+async function sample() {
+    //region exists
+    const exists = await session.advanced.exists("employees/1-A");
+    if (exists) {
+        // document 'employees/1-A exists
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/CustomizeCollectionAssignmentForEntities.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/CustomizeCollectionAssignmentForEntities.py
@@ -1,0 +1,22 @@
+from ravendb import DocumentStore
+from ravendb.documents.conventions import DocumentConventions
+
+from examples_base import ExampleBase, Category
+
+
+class CustomizeCollectionAssignmentForEntities(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_collection_assignment_for_entities(self):
+        store = DocumentStore()
+
+        # region custom_collection_name
+        def __find_collection_name(object_type: type) -> str:
+            if issubclass(object_type, Category):
+                return "ProductGroups"
+
+            return DocumentConventions.default_get_collection_name(object_type)
+
+        store.conventions.find_collection_name = __find_collection_name
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/DisableTracking.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/DisableTracking.py
@@ -1,0 +1,119 @@
+from abc import ABC, abstractmethod
+
+from ravendb import InMemoryDocumentSessionOperations, SessionOptions, DocumentStore, DocumentSession
+from ravendb.documents.conventions import ShouldIgnoreEntityChanges
+
+from examples_base import ExampleBase, Product, Employee
+
+
+class DisableTracking(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    class IgnoreChangesEntity:
+        # region syntax_1
+        def ignore_changes_for(self, entity: object) -> None: ...
+
+        # endregion
+
+    class IgnoreChangesConvention:
+        should_ignore_entity_changes = None
+
+        # region syntax_2
+        @should_ignore_entity_changes.setter
+        def should_ignore_entity_changes(self, value: ShouldIgnoreEntityChanges) -> None: ...
+
+        class ShouldIgnoreEntityChanges(ABC):
+            @abstractmethod
+            def check(
+                self,
+                session_operations: "InMemoryDocumentSessionOperations",
+                entity: object,
+                document_id: str,
+            ) -> bool:
+                pass
+
+        # endregion
+
+    def test_disable_tracking(self):
+        with self.embedded_server.get_document_store("DisableTracking") as store:
+            with store.open_session() as session:
+                # region disable_tracking_1
+                # Load a product entity, the session will track its changes
+                product = session.load("products/1-A", Product)
+
+                # Disable tracking for the loaded product entity
+                session.ignore_changes_for(product)
+
+                # The following change will be ignored for save_changes
+                product.units_in_stock += 1
+                session.save_changes()
+                # endregion
+
+            # region disable_tracking_2
+            with store.open_session(
+                SessionOptions(
+                    # Disable tracking for all entities in the session's options
+                    no_tracking=True
+                )
+            ):
+                # Load any entity, it will Not be tracked by the session
+                employee1 = session.load("employees/1-A", Employee)
+
+                # Loading again from same document will result in a new entity instance
+                employee2 = session.load("employees/1-A", Employee)
+
+                # Entities instances are not the same
+                self.assertNotEqual(employee1, employee2)
+
+            # endregion
+
+            # region disable_tracking_3
+            with store.open_session() as session:
+                # Define a query
+                employees_results = list(
+                    session.advanced.document_query(object_type=Employee)
+                    # Set no_tracking, all resulting entities will not ne tracked
+                    .no_tracking().where_equals("FirstName", "Robert")
+                )
+
+                # The following modification will not be tracked for save_changes
+                first_employee = employees_results[0]
+                first_employee.last_name = "NewName"
+
+                # Change to 'first_employee' will not be persisted
+                session.save_changes()
+            # endregion
+
+            # region disable_tracking_4
+            with DocumentStore() as store:
+                # Define the 'ignore' convention on your document store:
+
+                # Create a class that implements 'ravendb.documents.conventions.ShouldIgnoreEntityChanges'
+                # and implement 'check' method - it's going to be called to check if entity should be ignored
+
+                class MyCustomShouldIgnoreEntityChanges(ShouldIgnoreEntityChanges):
+                    def check(self, session_operations: DocumentSession, entity: object, document_id: str) -> bool:
+                        # Define for which entities tracking should be disabled
+                        # Tracking will be disabled ONLY for entities of type Employee whose FirstName is Bob
+                        return isinstance(entity, Employee) and entity.first_name == "Bob"
+
+                store.conventions.should_ignore_entity_changes = MyCustomShouldIgnoreEntityChanges
+
+                store.initialize()
+
+                with store.open_session() as session:
+                    employee1 = Employee(first_name="Alice", Id="employees/1")
+                    employee2 = Employee(first_name="Bob", Id="employees/2")
+
+                    session.store(employee1)  # This entity will be tracked
+                    session.store(employee2)  # Changes to this entity will be ignored
+
+                    session.save_changes()
+
+                    employee1.first_name = "Bob"  # Changes to this entity will now be ignored
+                    employee2.first_name = "Alice"  # This entity will now be tracked
+
+                    session.save_changes()
+
+            # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/MaxRequests.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/MaxRequests.py
@@ -1,0 +1,17 @@
+from examples_base import ExampleBase
+
+
+class MaxRequests(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_max_requests(self):
+        with self.embedded_server.get_document_store("MaxRequests") as store:
+            with store.open_session() as session:
+                # region max_requests_1
+                session._max_number_of_requests_per_session = 50
+                # endregion
+
+        # region max_requests_2
+        store.conventions.max_number_of_requests_per_session = 100
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/OptimisticConcurrency.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/Configuration/OptimisticConcurrency.py
@@ -1,0 +1,71 @@
+from examples_base import ExampleBase, Product
+
+
+class OptimisticConcurrency(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_optimistic_concurrency(self):
+        with self.embedded_server.get_document_store("OptimisticConcurrency") as store:
+            # region optimistic_concurrency_1
+            with store.open_session() as session:
+                # Enable optimistic concurrency for this session
+                session.advanced.use_optimistic_concurrency = True
+
+                # Save a document in this session
+                product = Product(name="Some name")
+                session.store(product, "products/999")
+                session.save_changes()
+
+                # Modify the document 'externally' by another session
+                with store.open_session() as other_session:
+                    other_product = other_session.load("products/999")
+                    other_product.name = "Other name"
+                    other_session.save_changes()
+
+                # Trying to modify the document without reloading it first will throw
+                product.name = "Better Name"
+                session.save_changes()  # This will throw a ConcurrencyException
+
+        # region optimistic_concurrency_2
+        # Enable for all sessions that will be opened within this document store
+        store.conventions.use_optimistic_concurrency = True
+        with store.open_session() as session:
+            is_session_using_optimistic_concurrency = session.advanced.use_optimistic_concurrency  # will return True
+        # endregion
+
+        # region optimistic_concurrency_3
+        with store.open_session() as session:
+            # Store document 'products/999'
+            session.store(Product(name="Some name", Id="products/999"))
+            session.save_changes()
+
+        with store.open_session() as session:
+            # Enable optimistic concurrency for the session
+            session.advanced.use_optimistic_concurrency = True
+
+            # Store the same document
+            # Pass 'null' as the change_vector to turn OFF optimistic concurrency for this document
+            session.store(Product(name="Some Other Name"), change_vector=None, key="products/999")
+
+            # This will NOT throw a ConcurrencyException, and the document will be saved
+            session.save_changes()
+        # endregion
+
+        # region optimistic_concurrency_4
+        with store.open_session() as session:
+            # Store document 'products/999'
+            session.store(Product(name="Some name", Id="products/999"))
+            session.save_changes()
+
+        with store.open_session() as session:
+            # Disable optimistic concurrency for the session
+            session.advanced.use_optimistic_concurrency = False
+
+            # Store the same document
+            # Pass empty str as the change_vector to turn ON optimistic concurrency for this document
+            session.store(Product(name="Some Other Name"), key="products/999", change_vector="")
+
+            # This will throw a ConcurrencyException, and the document will NOT be saved
+            session.save_changes()
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/AttachmentExists.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/AttachmentExists.py
@@ -1,0 +1,22 @@
+from examples_base import ExampleBase
+
+
+class Exists:
+    # region syntax
+    def exists(self, document_id: str, name: str) -> bool: ...
+
+    # endregion
+
+
+class AttachmentExists(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_attachment_exists(self):
+        with self.embedded_server.get_document_store("AttachmentExists") as store:
+            with store.open_session() as session:
+                # region exists
+                exists = session.advanced.attachments.exists("categories/1-A", "image.jpg")
+                if exists:
+                    ...  # attachment 'image.jpg' exists on document 'categories/1-A'
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/DocumentExists.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/DocumentExists.py
@@ -1,0 +1,23 @@
+from examples_base import ExampleBase
+
+
+class Exists:
+    # region exists_1
+    def exists(self, key: str) -> bool: ...
+
+    # endregion
+
+
+class DocumentExists(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_document_exists(self):
+        with self.embedded_server.get_document_store("DocumentExists") as store:
+            with store.open_session() as session:
+                # region exists_2
+                exists = session.advanced.exists("employees/1-A")
+
+                if exists:
+                    ...  # Document 'employees/1-A' exists
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/EntityChanges.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/EntityChanges.py
@@ -1,0 +1,128 @@
+from enum import Enum
+from typing import Dict, List
+
+from ravendb import DocumentsChanges
+
+from examples_base import ExampleBase, Employee
+
+
+class EntityChanges(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_entity_changes(self):
+        with self.embedded_server.get_document_store("EntityChanges") as store:
+            # region changes_1
+            with store.open_session() as session:
+                # Store a new entity within the session
+                # =====================================
+
+                employee = Employee(first_name="John", last_name="Doe")
+                session.store(employee, "employees/1-A")
+
+                # 'has_changed' will be True
+                self.assertTrue(session.advanced.has_changed(employee))
+
+                # 'has_changed' will reset to False after saving changes
+                session.save_changes()
+                self.assertFalse(session.advanced.has_changed(employee))
+
+                # Load & modify entity within the session
+                # =======================================
+
+                employee = session.load("employees/1-A", Employee)
+                self.assertFalse(session.advanced.has_changed(employee))  # False
+
+                employee.last_name = "Brown"
+                self.assertTrue(session.advanced.has_changed(employee))  # True
+
+                session.save_changes()
+                self.assertFalse(session.advanced.has_changed(employee))  # False
+
+            # endregion
+
+            # region changes_2
+            with store.open_session() as session:
+                # Store (add) a new entity, it will be tracked by the session
+                employee = Employee(first_name="John", last_name="Doe")
+                session.store(employee, "employees/1-A")
+
+                # Get the changes for the entity in the session
+                # Call 'WhatChangedFor', pass the entity object in the param
+                changes = session.advanced.what_changed()
+                changes_for_employee = changes["employees/1-A"]
+
+                self.assertEquals(1, len(changes_for_employee))  # a single change for this entity (adding)
+
+                # Get the change type
+                change_type = changes_for_employee[0].change
+                self.assertEquals(DocumentsChanges.ChangeType.DOCUMENT_ADDED, change_type)
+
+                session.save_changes()
+            # endregion
+
+            # region changes_3
+            with store.open_session() as session:
+                # Load the entity, it will be tracked by the session
+                employee = session.load("employees/1-A", Employee)
+
+                # Modify the entity
+                employee.first_name = "Jim"
+                employee.last_name = "Brown"
+
+                # Get the changes for the entity in the session
+                # Call 'what_changed', pass the document id as a key to a resulting dict
+                changes = session.advanced.what_changed()
+                changes_for_employee = changes["employees/1-A"]
+
+                self.assertEquals("FirstName", changes_for_employee[0].field_name)  # Field name
+                self.assertEquals("Jim", changes_for_employee[0].field_new_value)  # New value
+                self.assertEquals(
+                    changes_for_employee[0].change, DocumentsChanges.ChangeType.FIELD_CHANGED
+                )  # Change type
+
+                self.assertEquals("LastName", changes_for_employee[1].field_name)  # Field name
+                self.assertEquals("Brown", changes_for_employee[1].field_new_value)  # New value
+                self.assertEquals(
+                    changes_for_employee[1].change, DocumentsChanges.ChangeType.FIELD_CHANGED
+                )  # Change type
+
+                session.save_changes()
+            # endregion
+
+
+class Foo:
+    # region syntax_1
+    # has_changed
+    def has_changed(self, entity: object) -> bool: ...
+
+    # endregion
+    # region syntax_2
+    # what_changed
+    def what_changed(self) -> Dict[str, List[DocumentsChanges]]: ...
+
+    # endregion
+
+    # region syntax_3
+    class DocumentsChanges:
+
+        def __init__(
+            self,
+            field_old_value: object,
+            field_new_value: object,
+            change: DocumentsChanges.ChangeType,
+            field_name: str = None,
+            field_path: str = None,
+        ): ...
+
+        class ChangeType(Enum):
+            DOCUMENT_DELETED = "DocumentDeleted"
+            DOCUMENT_ADDED = "DocumentAdded"
+            FIELD_CHANGED = "FieldChanged"
+            NEW_FIELD = "NewField"
+            REMOVED_FIELD = "RemovedField"
+            ARRAY_VALUE_CHANGED = "ArrayValueChanged"
+            ARRAY_VALUE_ADDED = "ArrayValueAdded"
+            ARRAY_VALUE_REMOVED = "ArrayValueRemoved"
+
+    # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/IgnoreChanges.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/IgnoreChanges.py
@@ -1,0 +1,25 @@
+from examples_base import ExampleBase, Product
+
+
+class Foo:
+    # region ignore_changes_1
+
+    def ignore_changes_for(self, entity: object) -> None: ...
+
+    # endregion
+
+
+class IgnoreChanges(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_ignore_changes(self):
+        with self.embedded_server.get_document_store("IgnoreChanges") as store:
+            with store.open_session() as session:
+                self.add_products(session)
+                # region ignore_changes_2
+                product = session.load("products/1-A", Product)
+                session.ignore_changes_for(product)
+                product.units_in_stock += 1  # this will be ignored for save_changes
+                session.save_changes()
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/SessionChanges.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Session/HowTo/SessionChanges.py
@@ -1,0 +1,124 @@
+from enum import Enum
+from typing import Dict, List
+
+from ravendb import DocumentsChanges
+
+from examples_base import ExampleBase, Employee
+
+
+class SessionChanges(ExampleBase):
+    def test_session_changes(self):
+        with self.embedded_server.get_document_store("SessionChanges") as store:
+            # region changes_1
+            with store.open_session() as session:
+                # No changes made yet - 'has_changes' will be False
+                self.assertFalse(session.has_changes())
+
+                # Store a new entity within the session
+                session.store(Employee(first_name="John", last_name="Doe"))
+
+                # 'has_changes' will now be True
+                self.assertTrue(session.has_changes())
+
+                # 'has_changes' will reset to False after saving changes
+                session.save_changes()
+                self.assertFalse(session.has_changes())
+            # endregion
+
+            # region changes_2
+            with store.open_session() as session:
+                # Store (add) new entities, they will be tracked by the session
+                session.store(Employee(first_name="John", last_name="Doe"), "employees/1-A")
+                session.store(Employee(first_name="Jane", last_name="Doe"), "employees/2-A")
+
+                # Call 'what_changed' to get all changes in the session
+                changes = session.advanced.what_changed()
+                self.assertEquals(2, len(changes))  # 2 entites were added
+
+                # Get the change details for an entity, specify the entity ID
+                changes_for_employee = changes["employees/1-A"]
+                self.assertEquals(1, len(changes_for_employee))  # a single change for this entity (adding)
+
+                # Get the change type
+                change_type = changes_for_employee[0].change
+                self.assertEquals(DocumentsChanges.ChangeType.DOCUMENT_ADDED, change_type)
+
+                session.save_changes()
+            # endregion
+
+            # region changes_3
+            with store.open_session() as session:
+                # Load the entities, they will be tracked by the session
+                employee_1 = session.load("employees/1-A", Employee)
+                employee_2 = session.load("employees/2-A", Employee)
+
+                # Modify entities
+                employee_1.first_name = "Jim"
+                employee_1.last_name = "Brown"
+                employee_2.last_name = "Smith"
+
+                # Delete an entity
+                session.delete(employee_2)
+
+                # Call 'what_changed' to get all changes in the session
+                changes = session.advanced.what_changed()
+
+                # Get the change details for an entity, specify the entity ID
+                changes_for_employee = changes["employees/1-A"]
+
+                self.assertEquals("FirstName", changes_for_employee[0].field_name)  # Field name
+                self.assertEquals("Jim", changes_for_employee[0].field_new_value)  # New value
+                self.assertEquals(
+                    DocumentsChanges.ChangeType.FIELD_CHANGED, changes_for_employee[0].change
+                )  # Change type
+
+                self.assertEquals("LastName", changes_for_employee[1].field_name)  # Field name
+                self.assertEquals("Brown", changes_for_employee[1].field_new_value)  # New value
+                self.assertEquals(
+                    DocumentsChanges.ChangeType.FIELD_CHANGED, changes_for_employee[1].change
+                )  # Change type
+
+                # Note: for employee2 - even though the LastName was changed to 'Smith',
+                # the only reported change is the latest modification, which is the delete action.
+                changes_for_employee = changes["employees/2-A"]
+                self.assertEquals(DocumentsChanges.ChangeType.DOCUMENT_DELETED, changes_for_employee[0].change)
+
+                session.save_changes()
+            # endregion
+
+    class Foo:
+        # region syntax_1
+        # has_changes
+        def has_changes(self) -> bool: ...
+
+        # endregion
+        # region syntax_2
+        # what_changed
+        def what_changed(self) -> Dict[str, List[DocumentsChanges]]: ...
+
+        # endregion
+
+    class Foo:
+        # region syntax_3
+        class DocumentsChanges:
+
+            def __init__(
+                self,
+                field_old_value: object,
+                field_new_value: object,
+                change: DocumentsChanges.ChangeType,
+                field_name: str = None,
+                field_path: str = None,
+            ): ...
+
+            class ChangeType(Enum):
+                DOCUMENT_DELETED = "DocumentDeleted"
+                DOCUMENT_ADDED = "DocumentAdded"
+                FIELD_CHANGED = "FieldChanged"
+                NEW_FIELD = "NewField"
+                REMOVED_FIELD = "RemovedField"
+                ARRAY_VALUE_CHANGED = "ArrayValueChanged"
+                ARRAY_VALUE_ADDED = "ArrayValueAdded"
+                ARRAY_VALUE_REMOVED = "ArrayValueRemoved"
+
+        # endregion


### PR DESCRIPTION
Related issues:
[RDoc-2759](https://issues.hibernatingrhinos.com/issue/RDoc-2759/Python-Client-API-Session-How-to-Check-if-entity-has-changed-Replace-C-samples) - Check if entity has changed
[RDoc-2760](https://issues.hibernatingrhinos.com/issue/RDoc-2760/Python-Client-API-Session-How-to-Check-if-there-are-any-changes-on-session-Replace-C-samples) - Check if there are any changes on session
[RDoc-2761](https://issues.hibernatingrhinos.com/issue/RDoc-2761/Python-Client-API-Session-How-to-Check-if-document-exists-Replace-C-samples) - Check if document exists
[RDoc-2762](https://issues.hibernatingrhinos.com/issue/RDoc-2762/Python-Client-API-Session-How-to-Check-if-attachments-exists-Replace-C-samples) - Check if attachments exist
[RDoc-2763](https://issues.hibernatingrhinos.com/issue/RDoc-2763/Python-Client-API-Session-How-to-Ignore-entity-changes-Replace-C-samples) - Ignore entity changes
[RDoc-2765](https://issues.hibernatingrhinos.com/issue/RDoc-2765/Python-Client-API-Session-Configuration-Customize-collection-assignment-for-entities-Replace-C-samples) - Customize collection assignment for entities
[RDoc-2766](https://issues.hibernatingrhinos.com/issue/RDoc-2766/Python-Client-API-Session-Configuration-Change-max-number-of-requests-per-session-Replace-C-samples) - Change max number of requests per session
[RDoc-2767](https://issues.hibernatingrhinos.com/issue/RDoc-2767/Python-Client-API-Session-Configuration-Enable-optimistic-concurrency-Replace-C-samples) - Enable optimistic concurrency
[RDoc-2768](https://issues.hibernatingrhinos.com/issue/RDoc-2768/Python-Client-API-Session-Configuration-Disable-tracking-Replace-C-samples) - Disable tracking