### PR TITLE
RDoc-2749 [Node.js] Document extensions > Time series > Client API > Session > Delete [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.dotnet.markdown
@@ -1,0 +1,105 @@
+﻿# Delete Time Series
+
+---
+
+{NOTE: }
+
+* Use `TimeSeriesFor.Delete` for the following actions:
+
+    * __Delete a single time series entry__
+  
+    * __Delete a range of entries__
+  
+    * __Delete the whole time series__:  
+      To remove the whole time series simply delete all its entries.
+
+* In this page:  
+    * [`Delete` usage](../../../../document-extensions/timeseries/client-api/session/delete#delete-usage)
+    * [Examples](../../../../document-extensions/timeseries/client-api/session/delete#examples)
+      * [Delete single entry](../../../../document-extensions/timeseries/client-api/session/delete#delete-single-entry)
+      * [Delete range of entries](../../../../document-extensions/timeseries/client-api/session/delete#delete-range-of-entries)
+    * [Syntax](../../../../document-extensions/timeseries/client-api/session/delete#syntax)
+  
+{NOTE/}
+
+---
+
+{PANEL: `Delete` usage}
+
+__Flow__:
+
+* Open a session.  
+* Create an instance of `TimeSeriesFor` and pass it the following:
+    * Provide an explicit document ID, or -   
+      pass an [entity tracked by the session](../../../../client-api/session/loading-entities),
+      e.g. a document object returned from [session.Query](../../../../client-api/session/querying/how-to-query) or from [session.Load](../../../../client-api/session/loading-entities#load).
+    * Specify the time series name.
+* Call `TimeSeriesFor.Delete`:
+    * Provide a single timestamp to delete a specific entry, or -  
+    * Specify a range of timestamps to delete multiple entries.
+* Call `session.SaveChanges` for the action to take effect on the server.  
+
+__Note__:
+
+* If the specified document doesn't exist, a `DocumentDoesNotExistException` is thrown.
+* Attempting to delete nonexistent entries results in a no-op and generates no exception.
+* To delete the whole time series simply delete all its entries.  
+  The series is removed when all its entries are deleted.
+* Deleting a document deletes all its time series as well.
+
+{PANEL/}
+
+{PANEL: Examples}
+
+The following examples delete the time series entries that were appended in the [Append](../../../../document-extensions/timeseries/client-api/session/append) article:
+
+{NOTE: }
+
+<a id="delete-single-entry" /> __Delete single entry__:
+
+---
+
+{CODE timeseries_region_Delete-TimeSeriesFor-Single-Time-Point@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="delete-range-of-entries" /> __Delete range of entries__:
+
+---
+ 
+{CODE timeseries_region_TimeSeriesFor-Delete-Time-Points-Range@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE TimeSeriesFor-Delete-definition-single-timepoint@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{CODE TimeSeriesFor-Delete-definition-range-of-timepoints@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter | Type        | Description                                                                                                       |
+|-----------|-------------|:------------------------------------------------------------------------------------------------------------------|
+| __at__    | `DateTime`  | Timestamp of the time series entry to delete.                                                                     |
+| __from__  | `DateTime?` | Delete the range of time series entries starting from this timestamp (inclusive).<br>Default: `DateTime.MinValue` |
+| __to__    | `DateTime?` | Delete the range of time series entries ending at this timestamp (inclusive).<br>Default: `DateTime.MaxValue`     |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.js.markdown
@@ -1,0 +1,113 @@
+﻿# Delete Time Series
+
+---
+
+{NOTE: }
+
+* Use `timeSeriesFor.delete` for the following actions:
+
+    * __Delete a single time series entry__
+  
+    * __Delete a range of entries__
+  
+    * __Delete the whole time series__
+
+* In this page:  
+    * [`delete` usage](../../../../document-extensions/timeseries/client-api/session/delete#delete-usage)
+    * [Examples](../../../../document-extensions/timeseries/client-api/session/delete#examples)
+      * [Delete single entry](../../../../document-extensions/timeseries/client-api/session/delete#delete-single-entry)
+      * [Delete range of entries](../../../../document-extensions/timeseries/client-api/session/delete#delete-range-of-entries)
+      * [Delete time series](../../../../document-extensions/timeseries/client-api/session/delete#delete-time-series)
+    * [Syntax](../../../../document-extensions/timeseries/client-api/session/delete#syntax)
+  
+{NOTE/}
+
+---
+
+{PANEL: `Delete` usage}
+
+__Flow__:
+
+* Open a session.  
+* Create an instance of `timeSeriesFor` and pass it the following:
+    * Provide an explicit document ID, or -   
+      pass an [entity tracked by the session](../../../../client-api/session/loading-entities),
+      e.g. a document object returned from [session.query](../../../../client-api/session/querying/how-to-query) or from [session.load](../../../../client-api/session/loading-entities#load).
+    * Specify the time series name.
+* Call `TimeSeriesFor.Delete`:
+    * Provide a single timestamp to delete a specific entry, or -
+    * Specify a range of timestamps to delete multiple entries.
+* Call `session.saveChanges` for the action to take effect on the server.  
+
+__Note__:
+
+* If the specified document doesn't exist, a `DocumentDoesNotExistException` is thrown.
+* Attempting to delete nonexistent entries results in a no-op and generates no exception.
+* To delete the whole time series simply delete all its entries.  
+  The series is removed when all its entries are deleted.
+* Deleting a document deletes all its time series as well.
+
+{PANEL/}
+
+{PANEL: Examples}
+
+The following examples delete the time series entries that were appended in the [Append](../../../../document-extensions/timeseries/client-api/session/append) article:
+
+{NOTE: }
+
+<a id="delete-single-entry" /> __Delete single entry__:
+
+---
+
+{CODE:nodejs delete_1@documentExtensions\timeSeries\client-api\deleteTimeSeries.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="delete-range-of-entries" /> __Delete range of entries__:
+
+---
+ 
+{CODE:nodejs delete_2@documentExtensions\timeSeries\client-api\deleteTimeSeries.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="delete-time-series" /> __Delete time series__:
+
+---
+
+{CODE:nodejs delete_3@documentExtensions\timeSeries\client-api\deleteTimeSeries.js /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@documentExtensions\timeSeries\client-api\deleteTimeSeries.js /}
+
+| Parameter | Type   | Description                                                                                                                     |
+|-----------|--------|:--------------------------------------------------------------------------------------------------------------------------------|
+| __at__    | `Date` | Timestamp of the time series entry to delete.                                                                                   |
+| __from__  | `Date` | Delete the range of time series entries starting from this timestamp (inclusive).<br>Pass `null` to use the minimum date value. |
+| __to__    | `Date` | Delete the range of time series entries ending at this timestamp (inclusive).<br>Pass `null` to use the maximum date value.     |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/deleteTimeSeries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/deleteTimeSeries.js
@@ -1,0 +1,81 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function deleteTimeSeries() {
+    
+    const session = documentStore.openSession();
+    await session.store(new User("John"), "users/john");
+
+    const optionalTag = "watches/fitbit";
+    const baseTime = new Date();
+    baseTime.setUTCHours(0);
+
+    const tsf = session.timeSeriesFor("users/john", "HeartRates");
+    for (let i = 0; i < 10; i++)
+    {
+        const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+        const nextMeasurement = 65 + i;
+        tsf.append(nextMinute, nextMeasurement, optionalTag);
+    }
+    
+    await session.saveChanges();
+    
+    {
+        //region delete_1
+        // Get an instance of 'timeSeriesFor'
+        const tsf = session.timeSeriesFor("users/john", "HeartRates");
+        
+        // Call 'deleteAt' to delete a specific entry
+        timeStampOfEntry = new Date(baseTime.getTime() + 60_000);
+        tsf.deleteAt(timeStampOfEntry);
+
+        // Save changes
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region delete_2
+        // Get an instance of 'timeSeriesFor'
+        const tsf = session.timeSeriesFor("users/john", "HeartRates");
+
+        // Delete a range of 5 entries
+        FromTimeStamp = new Date(baseTime.getTime());
+        ToTimeStamp = new Date(baseTime.getTime() + 60_000 * 5);
+        tsf.delete(FromTimeStamp, ToTimeStamp);
+
+        // Save changes
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        //region delete_3
+        // Get an instance of 'timeSeriesFor'
+        const tsf = session.timeSeriesFor("users/john", "HeartRates");
+
+        // Delete ALL entries
+        // The whole time series will be removed
+        tsf.delete();
+
+        // Save changes
+        await session.saveChanges();
+        //endregion
+    }
+}
+
+//region syntax
+// Available overloads:
+delete();          // Delete all entries
+deleteAt(at);      // Delete a specific entry
+delete(from, to);  // Delete a range of enties
+//endregion
+
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2749/Node.js-Document-extensions-Time-series-Client-API-Session-Delete-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the C# article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2788/Document-extensions-Time-series-Client-API-Session-Delete-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/deleteTimeSeries.js
```
