### PR TITLE
RDoc-2790 [Node.js] Document extensions > Time series > Client API > Session > Get > Get names [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.dotnet.markdown
@@ -1,0 +1,68 @@
+﻿# Get Time Series Names
+---
+
+{NOTE: }
+
+* Use `Advanced.GetTimeSeriesFor` to get the names of all time series for the specified entity.
+
+* In this page:   
+  * [`GetTimeSeriesFor` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-names#gettimeseriesfor-usage)
+  * [Example](../../../../../document-extensions/timeseries/client-api/session/get/get-names#example)  
+  * [Syntax](../../../../../document-extensions/timeseries/client-api/session/get/get-names#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: `GetTimeSeriesFor` usage}
+
+**Flow**:  
+
+* Open a new session.
+* Load an entity to the session either using [session.Load](../../../../client-api/session/loading-entities#load) 
+  or by querying for the document via [session.Query](../../../../client-api/session/querying/how-to-query).  
+  In both cases, the resulting entity will be tracked by the session.
+* Call `Advanced.GetTimeSeriesFor`, pass the tracked entity.
+
+**Note**:  
+
+* If the entity is Not tracked by the session, an `ArgumentException` exception is thrown.
+
+{PANEL/}
+
+{PANEL: Example}
+
+{CODE timeseries_region_Retrieve-TimeSeries-Names@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+ {CODE-BLOCK:JSON}
+ List<string> GetTimeSeriesFor<T>(T instance);
+ {CODE-BLOCK/}
+ 
+| Parameter    | Type  | Description                                         |
+|--------------|-------|-----------------------------------------------------|
+| **instance** | `T`   | The entity whose time series names you want to get. |
+
+| Return value   |                                                                                                       |
+|----------------|-------------------------------------------------------------------------------------------------------|
+| `List<string>` | A list of names of all the time series associated with the entity, sorted alphabetically by the name. |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.js.markdown
@@ -1,0 +1,66 @@
+﻿# Get Time Series Names
+---
+
+{NOTE: }
+
+* Use `advanced.getTimeSeriesFor` to get the names of all time series for the specified entity.
+
+* In this page:   
+  * [`GetTimeSeriesFor` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-names#gettimeseriesfor-usage)
+  * [Example](../../../../../document-extensions/timeseries/client-api/session/get/get-names#example)  
+  * [Syntax](../../../../../document-extensions/timeseries/client-api/session/get/get-names#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: `getTimeSeriesFor` usage}
+
+**Flow**:  
+
+* Open a new session.
+* Load an entity to the session either using [session.load](../../../../client-api/session/loading-entities#load) 
+  or by querying for the document via [session.query](../../../../client-api/session/querying/how-to-query).  
+  In both cases, the resulting entity will be tracked by the session.
+* Call `advanced.getTimeSeriesFor`, pass the tracked entity.
+
+**Note**:  
+
+* If the entity is Not tracked by the session, an `ArgumentException` exception is thrown.
+
+{PANEL/}
+
+{PANEL: Example}
+
+{CODE:nodejs get_names@documentExtensions\timeSeries\client-api\getNames.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@documentExtensions\timeSeries\client-api\getNames.js /}
+
+| Parameter    | Type     | Description                                         |
+|--------------|----------|-----------------------------------------------------|
+| **instance** | `object` | The entity whose time series names you want to get. |
+
+| Return value |                                                                                                       |
+|--------------|-------------------------------------------------------------------------------------------------------|
+| `string[]`   | A list of names of all the time series associated with the entity, sorted alphabetically by the name. |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Raven.Client.Documents;
 using Xunit;
@@ -638,7 +638,6 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     TimeSeriesEntry[] val = session.TimeSeriesFor("users/john", "HeartRates")
                         .Get(DateTime.MinValue, DateTime.MaxValue);
                     #endregion
-
                 }
 
                 // Get time series HeartRates's time points data

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getNames.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getNames.js
@@ -1,0 +1,55 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getTimeSeriesNames() {
+
+    const session = documentStore.openSession();
+    await session.store(new User("John"), "users/john");
+
+    const optionalTag = "watches/fitbit";
+    const baseTime = new Date();
+    baseTime.setUTCHours(0);
+
+    const tsf1 = session.timeSeriesFor("users/john", "HeartRates1");
+    for (let i = 0; i < 10; i++)
+    {
+        const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+        const nextMeasurement = 65 + i;
+        tsf1.append(nextMinute, nextMeasurement, optionalTag);
+    }
+
+    const tsf2 = session.timeSeriesFor("users/john", "HeartRates2");
+    tsf2.append(baseTime, 60, optionalTag);
+
+    await session.saveChanges();
+
+    {
+        //region get_names
+        // Open a session
+        const session = documentStore.openSession();
+        
+        // Load a document entity to the session
+        const user = await session.load("users/john");
+
+        // Call getTimeSeriesFor, pass the entity
+        const tsNames = session.advanced.getTimeSeriesFor(user);
+
+        // Results will include the names of all time series associated with document 'users/john'
+        //endregion
+    }
+}
+
+//region syntax
+getTimeSeriesFor(instance);
+//endregion
+
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2790/Node.js-Document-extensions-Time-series-Client-API-Session-Get-Get-names-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the C# article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2805/Document-extensions-Time-series-Client-API-Session-Get-Get-names-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getNames.js
```
