### PR TITLE
RDoc-2789 [Node.js] Document extensions > Time series > Client API > Session > Get > Get entries [Replace C# samples]

### DIFF
--- a/Documentation/5.0/Raven.Documentation.Pages/document-extensions/timeseries/overview.markdown
+++ b/Documentation/5.0/Raven.Documentation.Pages/document-extensions/timeseries/overview.markdown
@@ -55,7 +55,9 @@ handled by time series.
   and analyzed to secure the vehicles and improve the service.  
 * _Daily changes in stock prices_ can be used to build investment plans.  
 
-## RavenDB's Time Series Implementation  
+---
+
+#### RavenDB's Time Series Implementation  
 
 Time series functionality is fully integrated into RavenDB's 
 distributed environment and document model.  
@@ -64,8 +66,8 @@ distributed environment and document model.
 
 #### Distributed Time Series
 
-Distributed clients and nodes can modify time series concurrently; the 
-modifications are merged by the cluster [without conflict](../../document-extensions/timeseries/design#no-conflicts).  
+Distributed clients and nodes can modify time series concurrently;  
+the modifications are merged by the cluster [without conflict](../../document-extensions/timeseries/design#no-conflicts).  
 
 ---
 
@@ -96,37 +98,31 @@ Notable time series features include -
 
 * **Highly-Efficient Storage Management**  
   Time series data is [compressed](../../document-extensions/timeseries/design#compression) 
-  and [segmented](../../document-extensions/timeseries/overview#time-series-segments) 
-  to minimize storage usage and transmission time.  
+  and [segmented](../../document-extensions/timeseries/overview#time-series-segments) to minimize storage usage and transmission time.  
 * **A Thorough Set of API Methods**  
-  The [time series API](../../document-extensions/timeseries/client-api/overview)**  
-  includes a variety of `session methods` and `store operations`.  
+  The [time series API](../../document-extensions/timeseries/client-api/overview) includes a variety of `session methods` and `store operations`.  
 * **Full GUI Support**  
-  Time series can be viewed and managed using the [Studio](../../studio/database/document-extensions/time-series).  
-* **Time Series Querying and Aggregation**  
-    * [High-performance common queries](../../document-extensions/timeseries/overview#common-queries-performance)  
-      The results of a set of common queries are prepared in advance in time series segments' 
-      headers, so the response to querying for a series **minimum value**, for example, is 
-      returned nearly instantly.  
-    * [LINQ and raw RQL queries](../../document-extensions/timeseries/querying/overview-and-syntax)  
-      Flexible queries and aggregations can be executed using LINQ expressions and raw RQL 
-      over time series **timestamps**, **tags** and **values**.  
+  Time series can be viewed and managed using the [Studio](../../studio/database/document-extensions/time-series).
 * **Time Series Indexing**  
   Time series can be [indexed](../../document-extensions/timeseries/indexing).  
-* [Rollup and Retention Policies](../../document-extensions/timeseries/rollup-and-retention)  
-   * **Rollup Policies**  
-     You can set time series rollup policies to aggregate large series into 
-     smaller sets by your definitions.  
-   * **Retention Policies**  
-     You can set time series retention policies to automatically remove 
-     time series entries that have reached their expiration date/time.  
-* [Including Time Series](../../document-extensions/timeseries/client-api/session/include/overview)  
-  You can include (pre-fetch) time series data while loading documents.  
-  Included data is held by the client's session, and is delivered to the 
-  user with no additional server calls.  
+* **Time Series Querying and Aggregation**  
+    * [High-performance common queries](../../document-extensions/timeseries/overview#common-queries-performance)  
+      The results of a set of common queries are prepared in advance in time series segments' headers,   
+      so the response to querying for a series minimum value, for example, is returned nearly instantly.  
+    * [LINQ and raw RQL queries](../../document-extensions/timeseries/querying/overview-and-syntax)  
+      Flexible queries and aggregations can be executed using LINQ expressions and raw RQL over  
+      time series **timestamps**, **values**, and **tags**.  
+* **Including Time Series**  
+  You can [include (pre-fetch) time series data](../../document-extensions/timeseries/client-api/session/include/overview) when loading or querying for documents.  
+  Included data is held by the client's session, and is delivered to the user with no additional server calls.
 * **Patching**  
-  You can patch time series data to your documents.  
-  (visit the [API documentation](../../document-extensions/timeseries/client-api/overview) to learn more).  
+  You can patch time series data into your documents.  
+  Learn more in [Patching time series](../../document-extensions/timeseries/client-api/session/patch).
+* **Rollup and Retention Policies**
+    * [Rollup Policies](../../document-extensions/timeseries/rollup-and-retention)  
+      You can set time series rollup policies to aggregate large series into smaller sets by your definitions.
+    * [Retention Policies](../../document-extensions/timeseries/rollup-and-retention)  
+      You can set time series retention policies to automatically remove time series entries that have reached their expiration date/time.
 
 {PANEL/}
 

--- a/Documentation/5.3/Raven.Documentation.Pages/document-extensions/timeseries/overview.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/document-extensions/timeseries/overview.markdown
@@ -55,7 +55,9 @@ handled by time series.
   and analyzed to secure the vehicles and improve the service.  
 * _Daily changes in stock prices_ can be used to build investment plans.  
 
-## RavenDB's Time Series Implementation  
+---
+
+#### RavenDB's Time Series Implementation  
 
 Time series functionality is fully integrated into RavenDB's 
 distributed environment and document model.  
@@ -64,8 +66,8 @@ distributed environment and document model.
 
 #### Distributed Time Series
 
-Distributed clients and nodes can modify time series concurrently; the 
-modifications are merged by the cluster [without conflict](../../document-extensions/timeseries/design#no-conflicts).  
+Distributed clients and nodes can modify time series concurrently;  
+the modifications are merged by the cluster [without conflict](../../document-extensions/timeseries/design#no-conflicts).  
 
 ---
 
@@ -95,38 +97,32 @@ are **document extensions**.
 Notable time series features include -  
 
 * **Highly-Efficient Storage Management**  
-  Time series data is [compressed](../../document-extensions/timeseries/design#compression) 
-  and [segmented](../../document-extensions/timeseries/overview#time-series-segments) 
-  to minimize storage usage and transmission time.  
+  Time series data is [compressed](../../document-extensions/timeseries/design#compression)
+  and [segmented](../../document-extensions/timeseries/overview#time-series-segments) to minimize storage usage and transmission time.
 * **A Thorough Set of API Methods**  
-  The [time series API](../../document-extensions/timeseries/client-api/overview)**  
-  includes a variety of `session methods` and `store operations`.  
+  The [time series API](../../document-extensions/timeseries/client-api/overview) includes a variety of `session methods` and `store operations`.
 * **Full GUI Support**  
-  Time series can be viewed and managed using the [Studio](../../studio/database/document-extensions/time-series).  
-* **Time Series Querying and Aggregation**  
-    * [High-performance common queries](../../document-extensions/timeseries/overview#common-queries-performance)  
-      The results of a set of common queries are prepared in advance in time series segments' 
-      headers, so the response to querying for a series **minimum value**, for example, is 
-      returned nearly instantly.  
-    * [LINQ and raw RQL queries](../../document-extensions/timeseries/querying/overview-and-syntax)  
-      Flexible queries and aggregations can be executed using LINQ expressions and raw RQL 
-      over time series **timestamps**, **tags** and **values**.  
+  Time series can be viewed and managed using the [Studio](../../studio/database/document-extensions/time-series).
 * **Time Series Indexing**  
-  Time series can be [indexed](../../document-extensions/timeseries/indexing).  
-* [Rollup and Retention Policies](../../document-extensions/timeseries/rollup-and-retention)  
-   * **Rollup Policies**  
-     You can set time series rollup policies to aggregate large series into 
-     smaller sets by your definitions.  
-   * **Retention Policies**  
-     You can set time series retention policies to automatically remove 
-     time series entries that have reached their expiration date/time.  
-* [Including Time Series](../../document-extensions/timeseries/client-api/session/include/overview)  
-  You can include (pre-fetch) time series data while loading documents.  
-  Included data is held by the client's session, and is delivered to the 
-  user with no additional server calls.  
+  Time series can be [indexed](../../document-extensions/timeseries/indexing).
+* **Time Series Querying and Aggregation**
+    * [High-performance common queries](../../document-extensions/timeseries/overview#common-queries-performance)  
+      The results of a set of common queries are prepared in advance in time series segments' headers,   
+      so the response to querying for a series minimum value, for example, is returned nearly instantly.
+    * [LINQ and raw RQL queries](../../document-extensions/timeseries/querying/overview-and-syntax)  
+      Flexible queries and aggregations can be executed using LINQ expressions and raw RQL over  
+      time series **timestamps**, **values**, and **tags**.
+* **Including Time Series**  
+  You can [include (pre-fetch) time series data](../../document-extensions/timeseries/client-api/session/include/overview) when loading or querying for documents.  
+  Included data is held by the client's session, and is delivered to the user with no additional server calls.
 * **Patching**  
-  You can patch time series data to your documents.  
-  (visit the [API documentation](../../document-extensions/timeseries/client-api/overview) to learn more).  
+  You can patch time series data into your documents.  
+  Learn more in [Patching time series](../../document-extensions/timeseries/client-api/session/patch).
+* **Rollup and Retention Policies**
+    * [Rollup Policies](../../document-extensions/timeseries/rollup-and-retention)  
+      You can set time series rollup policies to aggregate large series into smaller sets by your definitions.
+    * [Retention Policies](../../document-extensions/timeseries/rollup-and-retention)  
+      You can set time series retention policies to automatically remove time series entries that have reached their expiration date/time.
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/how-to/handle-document-relationships.java.markdown
@@ -112,8 +112,10 @@ and subsequent requests to load them are served directly from the session cache,
 
 {NOTE Embedded and builder variants of Include clause are essentially syntax sugar and are equivalent at the server side. /}
 
-{INFO: Streaming query results does not support the includes feature. Learn more in 
-[How to Stream Query Results](../../../client-api/session/querying/how-to-stream-query-results). /}
+{INFO: }
+Streaming query results does not support the includes feature.  
+Learn more in [How to Stream Query Results](../../client-api/session/querying/how-to-stream-query-results#stream-related-documents).  
+{INFO/}
 
 ### One to many includes
 
@@ -269,4 +271,4 @@ For most cases where denormalization is not an option, Includes are probably the
 
 ### Querying
 
-- [Basics](../../indexes/querying/basics)
+- [Querying an Index](../../indexes/querying/query-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
@@ -42,7 +42,7 @@ __Flow__:
 * Open a session.
 * Create an instance of `TimeSeriesFor` and pass it the following:
     * Provide an explicit document ID, -or-  
-      pass an [entity tracked by the session](../../../../client-api/session/loading-entities),
+      pass an [entity tracked by the session](../../../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern),
       e.g. a document object returned from [session.Query](../../../../client-api/session/querying/how-to-query) or from [session.Load](../../../../client-api/session/loading-entities#load).
     * Specify the time series name.
 * Call `TimeSeriesFor.Append` and pass it the time series entry details.

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
@@ -42,7 +42,7 @@ __Flow__:
 * Open a session.
 * Create an instance of `timeSeriesFor` and pass it the following:
     * Provide an explicit document ID, -or-  
-      pass an [entity tracked by the session](../../../../client-api/session/loading-entities), 
+      pass an [entity tracked by the session](../../../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern), 
       e.g. a document object returned from [session.query](../../../../client-api/session/querying/how-to-query) or from [session.load](../../../../client-api/session/loading-entities#load).  
     * Specify the time series name.
 * Call `timeSeriesFor.append` and pass it the time series entry details.

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.dotnet.markdown
@@ -31,7 +31,7 @@ __Flow__:
 * Open a session.  
 * Create an instance of `TimeSeriesFor` and pass it the following:
     * Provide an explicit document ID, or -   
-      pass an [entity tracked by the session](../../../../client-api/session/loading-entities),
+      pass an [entity tracked by the session](../../../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern),
       e.g. a document object returned from [session.Query](../../../../client-api/session/querying/how-to-query) or from [session.Load](../../../../client-api/session/loading-entities#load).
     * Specify the time series name.
 * Call `TimeSeriesFor.Delete`:

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/delete.js.markdown
@@ -31,7 +31,7 @@ __Flow__:
 * Open a session.  
 * Create an instance of `timeSeriesFor` and pass it the following:
     * Provide an explicit document ID, or -   
-      pass an [entity tracked by the session](../../../../client-api/session/loading-entities),
+      pass an [entity tracked by the session](../../../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern),
       e.g. a document object returned from [session.query](../../../../client-api/session/querying/how-to-query) or from [session.load](../../../../client-api/session/loading-entities#load).
     * Specify the time series name.
 * Call `TimeSeriesFor.Delete`:

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
@@ -9,14 +9,16 @@
 
 * The retrieved data can be paged to get the time series entries gradually, one custom-size page at a time.
 
-* By default, the session will track the retrieved time series data. See [disable tracking](../../../../../client-api/session/configuration/how-to-disable-tracking) to learn how to disable.
-
+* By default, the session will track the retrieved time series data. 
+  See [disable tracking](../../../../../client-api/session/configuration/how-to-disable-tracking) to learn how to disable.
+  
 * When getting the time series entries,  
-  you can also [include](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents) 
-  the series' **parent document** and/or **documents referred to by the entry tag**.
+  you can also _include_ the series' **parent document** and/or **documents referred to by the entry tag**.  
+  Learn more [below](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents).
 
 * Calling `TimeSeriesFor.Get` will result in a trip to the server unless the series' parent document was loaded  
-  (or queried for) with the time series included beforehand.  Learn more in: [Including time series](client-api/session/include/overview).
+  (or queried for) with the time series included beforehand.  
+  Learn more in: [Including time series](client-api/session/include/overview).
 
 * In this page:  
   * [`Get` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-usage)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
@@ -60,6 +60,7 @@ In this example, we query for a document and get its "Heartrate" time series dat
 {NOTE: }
 
 * Here, we check whether a stock's closing-time price is rising from day to day (over three days).  
+  This example is based on the sample entries that were entered in [this example](../../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-multiple-values).
  
 * Since each time series entry contains multiple StockPrice values,  
   we include a sample that uses [named time series values](../../../../../document-extensions/timeseries/client-api/named-time-series-values) 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
@@ -1,0 +1,126 @@
+﻿# Get Time Series Entries 
+---
+
+{NOTE: }
+
+* Use `TimeSeriesFor.Get` to retrieve a range of entries from a **single** time series.  
+  To retrieve a range of entries from **multiple** series, 
+  use the [GetMultipleTimeSeriesOperation](../../../../../document-extensions/timeseries/client-api/operations/get#getmultipletimeseriesoperation) operation.
+
+* The retrieved data can be paged to get the time series entries gradually, one custom-size page at a time.
+
+* By default, the session will track the retrieved time series data. See [disable tracking](../../../../../client-api/session/configuration/how-to-disable-tracking) to learn how to disable.
+
+* When getting the time series entries,  
+  you can also [include](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents) 
+  the series' **parent document** and/or **documents referred to by the entry tag**.
+
+* Calling `TimeSeriesFor.Get` will result in a trip to the server unless the series' parent document was loaded  
+  (or queried for) with the time series included beforehand.  Learn more in: [Including time series](client-api/session/include/overview).
+
+* In this page:  
+  * [`Get` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-usage)
+  * [Examples](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#examples)
+  * [Include parent and tagged documents](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents)
+  * [Syntax](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: `Get` usage }
+
+* Open a session.  
+* Create an instance of `TimeSeriesFor` and pass it the following:
+    * Provide an explicit document ID, -or-  
+      pass an [entity tracked by the session](../../../../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern),
+      e.g. a document object returned from [session.Query](../../../../../client-api/session/querying/how-to-query) or from [session.Load](../../../../../client-api/session/loading-entities#load).
+    * Specify the time series name.
+* Call `TimeSeriesFor.Get`.  
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+In this example, we retrieve all entries of the "Heartrate" time series.  
+The ID of the parent document is explicitly specified.  
+
+{CODE timeseries_region_Get-All-Entries-Using-Document-ID@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+{NOTE: }
+
+In this example, we query for a document and get its "Heartrate" time series data.
+
+{CODE timeseries_region_Pass-TimeSeriesFor-Get-Query-Results@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+{NOTE: }
+
+* Here, we check whether a stock's closing-time price is rising from day to day (over three days).  
+ 
+* Since each time series entry contains multiple StockPrice values,  
+  we include a sample that uses [named time series values](../../../../../document-extensions/timeseries/client-api/named-time-series-values) 
+  to make the code easier to read.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Native timeseries_region_Get-NO-Named-Values@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TAB:csharp:Named timeseries_region_Get-Named-Values@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Include parent and tagged documents}
+
+* When retrieving time series entries using `TimeSeriesFor.Get`,  
+  you can include the series' parent document and/or documents referred to by the entries [tags](../../../../../document-extensions/timeseries/overview#tags).  
+
+* The included documents will be cached in the session, and instantly retrieved from memory if loaded by the user.
+
+* Use the following syntax to include the parent or tagged documents:
+
+{CODE IncludeParentAndTaggedDocuments@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE TimeSeriesFor-Get-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{CODE TimeSeriesFor-Get-Named-Values@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter    | Type        | Description                                                                                                                                      |
+|--------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| **from**     | `DateTime?` | Get the range of time series entries starting from this timestamp (inclusive).<br/>Default: `DateTime.MinValue`                                  |
+| **to**       | `DateTime?` | Get the range of time series entries ending at this timestamp (inclusive).<br/>Default: `DateTime.MaxValue`                                      |
+| **start**    | `int`       | Paging first entry.<br>E.g. 50 means the first page would start at the 50th time series entry. <br> Default: 0, for the first time-series entry. |
+| **pageSize** | `int`       | Paging page-size.<br>E.g. set `pageSize` to 10 to retrieve pages of 10 entries.<br>Default: `int.MaxValue`, for all time series entries.         |
+
+**Return Values**
+ 
+* **`TimeSeriesEntry[]`** - an array of time series entry classes.
+
+{CODE TimeSeriesEntry-Definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+* **`TimeSeriesEntry<TValues>[]`** - Time series values that can be referred to [by name](../../../../../document-extensions/timeseries/client-api/named-time-series-values).
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
@@ -1,0 +1,126 @@
+﻿# Get Time Series Entries 
+---
+
+{NOTE: }
+
+* Use `timeSeriesFor.get` to retrieve a range of entries from a **single** time series.  
+  To retrieve a range of entries from **multiple** series, 
+  use the [GetMultipleTimeSeriesOperation](../../../../../document-extensions/timeseries/client-api/operations/get#getmultipletimeseriesoperation) operation.
+
+* The retrieved data can be paged to get the time series entries gradually, one custom-size page at a time.
+
+* By default, the session will track the retrieved time series data. See [disable tracking](../../../../../client-api/session/configuration/how-to-disable-tracking) to learn how to disable.
+
+* When getting the time series entries,  
+  you can also [include](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents)
+  the series' **parent document** and/or **documents referred to by the entry tag**.
+
+* Calling `timeSeriesFor.get` will result in a trip to the server unless the series' parent document was loaded  
+  (or queried for) with the time series included beforehand.  Learn more in: [Including time series](client-api/session/include/overview).
+
+* In this page:  
+  * [`get` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-usage)
+  * [Examples](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#examples)
+  * [Include parent and tagged documents](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents)
+  * [Syntax](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: `get` usage }
+
+* Open a session.  
+* Create an instance of `timeSeriesFor` and pass it the following:
+    * Provide an explicit document ID, -or-  
+      pass an [entity tracked by the session](../../../../../client-api/session/what-is-a-session-and-how-does-it-work#unit-of-work-pattern),
+      e.g. a document object returned from [session.query](../../../../../client-api/session/querying/how-to-query) or from [session.load](../../../../../client-api/session/loading-entities#load).
+    * Specify the time series name.
+* Call `timeSeriesFor.get`.
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+In this example, we retrieve all entries of the "Heartrate" time series.  
+The ID of the parent document is explicitly specified.  
+
+{CODE:nodejs get_Entries_1@documentExtensions\timeSeries\client-api\getEntries.js /}
+
+{NOTE/}
+{NOTE: }
+
+In this example, we query for a document and get a range of entries from its "Heartrate" time series.
+
+{CODE:nodejs get_Entries_2@documentExtensions\timeSeries\client-api\getEntries.js /}
+
+{NOTE/}
+{NOTE: }
+
+* Here, we check if a stock's closing price is rising consecutively over three days.  
+  This example is based on the sample entries that were entered in [this example](../../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-multiple-values).
+
+* Since each time series entry contains multiple StockPrice values,  
+  we include a sample that uses [named time series values](../../../../../document-extensions/timeseries/client-api/named-time-series-values)
+  to make the code easier to read.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Native get_Entries_3@documentExtensions\timeSeries\client-api\getEntries.js /}
+{CODE-TAB:nodejs:Named get_Entries_3_named@documentExtensions\timeSeries\client-api\getEntries.js /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Include parent and tagged documents}
+
+* When retrieving time series entries using `timeSeriesFor.get`,  
+  you can include the series' parent document and/or documents referred to by the entries [tags](../../../../../document-extensions/timeseries/overview#tags).  
+
+* The included documents will be cached in the session, and instantly retrieved from memory if loaded by the user.
+
+* Use the following syntax to include the parent or tagged documents:
+
+{CODE:nodejs get_Entries_4@documentExtensions\timeSeries\client-api\getEntries.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@documentExtensions\timeSeries\client-api\getEntries.js /}
+
+<br/>
+
+| Parameter        | Type                       | Description                                                                                                                                      |
+|------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| **from**         | `Date`                     | Get the range of time series entries starting from this timestamp (inclusive).<br/>Pass `null` to use the minimum date value.                    |
+| **to**           | `Date`                     | Get the range of time series entries ending at this timestamp (inclusive).<br/>Pass `null` to use the maximum date value.                        |
+| **start**        | `number`                   | Paging first entry.<br>E.g. 50 means the first page would start at the 50th time series entry. <br> Default: 0, for the first time-series entry. |
+| **pageSize**     | `number`                   | Paging page-size.<br>E.g. set `pageSize` to 10 to retrieve pages of 10 entries.<br>Default: `int.MaxValue`, for all time series entries.         |
+| **includes**     | `(includeBuilder) => void` | Builder function with a fluent API<br>containing the `includeTags` and `includeDocument` methods.                                               |
+
+| Return value                 |                                              |
+|------------------------------|----------------------------------------------|
+| `Promise<TimeSeriesEntry[]>` | A `Promise` resolving to the list of entries |
+
+{CODE:nodejs syntax_2@documentExtensions\timeSeries\client-api\getEntries.js /}
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
@@ -9,18 +9,23 @@
 
 * The retrieved data can be paged to get the time series entries gradually, one custom-size page at a time.
 
-* By default, the session will track the retrieved time series data. See [disable tracking](../../../../../client-api/session/configuration/how-to-disable-tracking) to learn how to disable.
+* By default, the session will track the retrieved time series data. 
+  See [disable tracking](../../../../../client-api/session/configuration/how-to-disable-tracking) to learn how to disable.
 
 * When getting the time series entries,  
-  you can also [include](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents)
-  the series' **parent document** and/or **documents referred to by the entry tag**.
+  you can also _include_ the series' **parent document** and/or **documents referred to by the entry tag**.  
+  Learn more [below](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents).
 
 * Calling `timeSeriesFor.get` will result in a trip to the server unless the series' parent document was loaded  
-  (or queried for) with the time series included beforehand.  Learn more in: [Including time series](client-api/session/include/overview).
+  (or queried for) with the time series included beforehand.  
+  Learn more in [Including time series](client-api/session/include/overview).
 
 * In this page:  
   * [`get` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-usage)
   * [Examples](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#examples)
+      * [Get all entries](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-all-entries)
+      * [Get range of entries](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-range-of-entries)
+      * [Get entries with multiple values](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-entries-with-multiple-values)
   * [Include parent and tagged documents](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents)
   * [Syntax](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#syntax)
 
@@ -44,6 +49,10 @@
 
 {NOTE: }
 
+<a id="get-all-entries" /> __Get all entries__:
+
+---
+
 In this example, we retrieve all entries of the "Heartrate" time series.  
 The ID of the parent document is explicitly specified.  
 
@@ -52,12 +61,20 @@ The ID of the parent document is explicitly specified.
 {NOTE/}
 {NOTE: }
 
+<a id="get-range-of-entries" /> __Get range of entries__:
+
+---
+
 In this example, we query for a document and get a range of entries from its "Heartrate" time series.
 
 {CODE:nodejs get_Entries_2@documentExtensions\timeSeries\client-api\getEntries.js /}
 
 {NOTE/}
 {NOTE: }
+
+<a id="get-entries-with-multiple-values" /> __Get entries with multiple values__:
+
+---
 
 * Here, we check if a stock's closing price is rising consecutively over three days.  
   This example is based on the sample entries that were entered in [this example](../../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-multiple-values).

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.dotnet.markdown
@@ -18,9 +18,9 @@
 
 **Flow**:  
 
-* Open a new session.
-* Load an entity to the session either using [session.Load](../../../../client-api/session/loading-entities#load) 
-  or by querying for the document via [session.Query](../../../../client-api/session/querying/how-to-query).  
+* Open a session.
+* Load an entity to the session either using [session.Load](../../../../../client-api/session/loading-entities#load) 
+  or by querying for the document via [session.Query](../../../../../client-api/session/querying/how-to-query).  
   In both cases, the resulting entity will be tracked by the session.
 * Call `Advanced.GetTimeSeriesFor`, pass the tracked entity.
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-names.js.markdown
@@ -18,9 +18,9 @@
 
 **Flow**:  
 
-* Open a new session.
-* Load an entity to the session either using [session.load](../../../../client-api/session/loading-entities#load) 
-  or by querying for the document via [session.query](../../../../client-api/session/querying/how-to-query).  
+* Open a session.
+* Load an entity to the session either using [session.load](../../../../../client-api/session/loading-entities#load) 
+  or by querying for the document via [session.query](../../../../../client-api/session/querying/how-to-query).  
   In both cases, the resulting entity will be tracked by the session.
 * Call `advanced.getTimeSeriesFor`, pass the tracked entity.
 

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendTimeSeries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendTimeSeries.js
@@ -140,6 +140,9 @@ async function appendTimeSeries() {
 }
 
 //region syntax_1
+// Available overloads:
+// ====================
+
 append(timestamp, value);
 append(timestamp, value, tag);
 //endregion

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/deleteTimeSeries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/deleteTimeSeries.js
@@ -65,6 +65,8 @@ async function deleteTimeSeries() {
 
 //region syntax
 // Available overloads:
+// ====================
+
 delete();          // Delete all entries
 deleteAt(at);      // Delete a specific entry
 delete(from, to);  // Delete a range of enties

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getEntries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getEntries.js
@@ -1,0 +1,175 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getTimeSeriesEntries() {
+
+    const session = documentStore.openSession();
+    await session.store(new User("John"), "users/john");
+
+    const optionalTag = "watches/fitbit";
+    const baseTime = new Date();
+    baseTime.setUTCHours(0);
+
+    const tsf = session.timeSeriesFor("users/john", "HeartRates");
+    for (let i = 0; i < 10; i++)
+    {
+        const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+        const nextMeasurement = 65 + i;
+        tsf.append(nextMinute, nextMeasurement, optionalTag);
+    }
+    
+    await session.saveChanges();
+
+    {
+        const session = documentStore.openSession();
+
+        //region get_entries_1
+        // Get all time series entries
+        const allEntries = await session
+            .timeSeriesFor("users/john", "HeartRates")
+            .get();
+        //endregion
+    }
+    {
+        const session = documentStore.openSession();
+
+        //region get_entries_2
+        // Query for a document
+        const user = await session.query({ collection: "users" })
+            .whereEquals("name", "John")
+            .first();
+        
+        const from = new Date();
+        const to = new Date(baseTime.getTime() + 60_000 * 5);
+        
+        // Retrieve a range of 6 entries
+        const tsEntries = await session
+            .timeSeriesFor(user, "HeartRates")
+            .get(from, to);
+        //endregion
+    }
+    {
+        // the below code was tested with entries entered from file: appendTimeSeries.js 
+        const session = documentStore.openSession();
+        
+        //region get_entries_3
+        let goingUp = false;
+
+        const allEntries = await session
+            .timeSeriesFor("users/john", "StockPrices")
+            .get();
+            
+        const closePriceDay1 = allEntries[0].values[1];
+        const closePriceDay2 = allEntries[1].values[1];
+        const closePriceDay3 = allEntries[2].values[1];
+
+        // Check if the stock's closing price is rising
+        if ((closePriceDay2 > closePriceDay1) && (closePriceDay3 > closePriceDay2)) {
+                goingUp = true;
+        }
+        //endregion
+    }
+    {
+        // the below code was tested with entries entered from file: appendTimeSeries.js 
+        const session = documentStore.openSession();
+
+        //region get_entries_3_named
+        let goingUp = false;
+
+        const allEntries = await session
+            .timeSeriesFor("users/john", "StockPrices")
+            .get();
+
+        // Call 'asTypedEntry' to be able to access the entry's values by their names
+        // Pass the class type (StockPrice)
+        const typedEntry1 = allEntries[0].asTypedEntry(StockPrice);
+        
+        // Access the entry value by its StockPrice class property name (close)
+        const closePriceDay1 = typedEntry1.value.close;
+
+        const typedEntry2 = allEntries[1].asTypedEntry(StockPrice);
+        const closePriceDay2 = typedEntry2.value.close;
+
+        const typedEntry3 = allEntries[2].asTypedEntry(StockPrice);
+        const closePriceDay3 = typedEntry3.value.close;
+
+        // Check if the stock's closing price is rising
+        if ((closePriceDay2 > closePriceDay1) && (closePriceDay3 > closePriceDay2)) {
+            goingUp = true;
+        }
+        //endregion
+    }
+    {
+        //region get_entries_4
+        const allEntries = await session
+            .timeSeriesFor("users/john", "HeartRates")
+             // Get all entries
+            .get(null, null, builder => builder
+                .includeDocument() // include the parent document
+                .includeTags());   // include documents referenced in the entries tags
+            
+        // The following 'load' call will not trigger a server request
+        const user = await session.load("users/john");
+        //endregion
+    }
+}
+
+//region syntax_1
+// Available overloads:
+// ====================
+
+get(); // Get all entries
+
+get(from, to);
+get(from, to, start);
+
+get(start, pageSize);
+get(from, to, start, pageSize);
+
+get(from, to, includes);
+get(from, to, includes, start);
+get(from, to, includes, start, pageSize);
+//endregion
+
+//region syntax_2
+class TimeSeriesEntry {
+    // The entry's time stamp
+    timestamp; // Date
+    
+    // The entry's tag, can contain a related document ID
+    tag; // string
+    
+    // List of up to 32 values for this entry
+    values; // number[]
+    
+    // Is this an entry that belongs to a "rollup" time series
+    isRollup; // boolean
+    
+    // Nodes info for incremental time series
+    nodeValues; // Record<string, number[]>;
+    
+    // A method that returns the entry as a typed entry (TypedTimeSeriesEntry)
+    asTypedEntry(clazz); // 'clazz' designates the type for the value  
+}
+
+class TypedTimeSeriesEntry {
+    timestamp; // Date
+    tag;       // string
+    values;    // number[]
+    isRollup;  // boolean
+    
+    // Access the value of a typed entry as an object
+    value;     // object of type clazz
+}
+//endregion
+
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/overview.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/overview.markdown
@@ -55,7 +55,9 @@ handled by time series.
   and analyzed to secure the vehicles and improve the service.  
 * _Daily changes in stock prices_ can be used to build investment plans.  
 
-## RavenDB's Time Series Implementation  
+---
+
+#### RavenDB's Time Series Implementation  
 
 Time series functionality is fully integrated into RavenDB's 
 distributed environment and document model.  
@@ -64,8 +66,8 @@ distributed environment and document model.
 
 #### Distributed Time Series
 
-Distributed clients and nodes can modify time series concurrently; the 
-modifications are merged by the cluster [without conflict](../../document-extensions/timeseries/design#no-conflicts).  
+Distributed clients and nodes can modify time series concurrently;  
+the modifications are merged by the cluster [without conflict](../../document-extensions/timeseries/design#no-conflicts).  
 
 ---
 
@@ -95,38 +97,32 @@ are **document extensions**.
 Notable time series features include -  
 
 * **Highly-Efficient Storage Management**  
-  Time series data is [compressed](../../document-extensions/timeseries/design#compression) 
-  and [segmented](../../document-extensions/timeseries/overview#time-series-segments) 
-  to minimize storage usage and transmission time.  
+  Time series data is [compressed](../../document-extensions/timeseries/design#compression)
+  and [segmented](../../document-extensions/timeseries/overview#time-series-segments) to minimize storage usage and transmission time.
 * **A Thorough Set of API Methods**  
-  The [time series API](../../document-extensions/timeseries/client-api/overview)**  
-  includes a variety of `session methods` and `store operations`.  
+  The [time series API](../../document-extensions/timeseries/client-api/overview) includes a variety of `session methods` and `store operations`.
 * **Full GUI Support**  
-  Time series can be viewed and managed using the [Studio](../../studio/database/document-extensions/time-series).  
-* **Time Series Querying and Aggregation**  
-    * [High-performance common queries](../../document-extensions/timeseries/overview#common-queries-performance)  
-      The results of a set of common queries are prepared in advance in time series segments' 
-      headers, so the response to querying for a series **minimum value**, for example, is 
-      returned nearly instantly.  
-    * [LINQ and raw RQL queries](../../document-extensions/timeseries/querying/overview-and-syntax)  
-      Flexible queries and aggregations can be executed using LINQ expressions and raw RQL 
-      over time series **timestamps**, **tags** and **values**.  
+  Time series can be viewed and managed using the [Studio](../../studio/database/document-extensions/time-series).
 * **Time Series Indexing**  
-  Time series can be [indexed](../../document-extensions/timeseries/indexing).  
-* [Rollup and Retention Policies](../../document-extensions/timeseries/rollup-and-retention)  
-   * **Rollup Policies**  
-     You can set time series rollup policies to aggregate large series into 
-     smaller sets by your definitions.  
-   * **Retention Policies**  
-     You can set time series retention policies to automatically remove 
-     time series entries that have reached their expiration date/time.  
-* [Including Time Series](../../document-extensions/timeseries/client-api/session/include/overview)  
-  You can include (pre-fetch) time series data while loading documents.  
-  Included data is held by the client's session, and is delivered to the 
-  user with no additional server calls.  
+  Time series can be [indexed](../../document-extensions/timeseries/indexing).
+* **Time Series Querying and Aggregation**
+    * [High-performance common queries](../../document-extensions/timeseries/overview#common-queries-performance)  
+      The results of a set of common queries are prepared in advance in time series segments' headers,   
+      so the response to querying for a series minimum value, for example, is returned nearly instantly.
+    * [LINQ and raw RQL queries](../../document-extensions/timeseries/querying/overview-and-syntax)  
+      Flexible queries and aggregations can be executed using LINQ expressions and raw RQL over  
+      time series **timestamps**, **values**, and **tags**.
+* **Including Time Series**  
+  You can [include (pre-fetch) time series data](../../document-extensions/timeseries/client-api/session/include/overview) when loading or querying for documents.  
+  Included data is held by the client's session, and is delivered to the user with no additional server calls.
 * **Patching**  
-  You can patch time series data to your documents.  
-  (visit the [API documentation](../../document-extensions/timeseries/client-api/overview) to learn more).  
+  You can patch time series data into your documents.  
+  Learn more in [Patching time series](../../document-extensions/timeseries/client-api/session/patch).
+* **Rollup and Retention Policies**
+    * [Rollup Policies](../../document-extensions/timeseries/rollup-and-retention)  
+      You can set time series rollup policies to aggregate large series into smaller sets by your definitions.
+    * [Retention Policies](../../document-extensions/timeseries/rollup-and-retention)  
+      You can set time series retention policies to automatically remove time series entries that have reached their expiration date/time.
 
 {PANEL/}
 


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2789/Node.js-Document-extensions-Time-series-Client-API-Session-Get-Get-entries-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the C# article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2806/Document-extensions-Time-series-Client-API-Session-Get-Get-entries-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getEntries.js
```

In addition, links were fixed + a few other minor fixes.