### PR TITLE
RDoc-2808 [Node.js] Document extensions > Time series > Client API > Session > Include > With load [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.dotnet.markdown
@@ -1,0 +1,65 @@
+﻿# Include Time Series with&nbsp;`Load`
+---
+
+{NOTE: }
+
+* When loading a document via `session.Load`,  
+  you can _include_ all entries of a time series or a specific range of entries.
+
+* The included time series data is stored within the session   
+  and can be provided instantly when requested without any additional server calls.
+
+* In this page:
+   * [Include time series when loading a document](../../../../../document-extensions/timeseries/client-api/session/include/with-session-load#include-time-series-when-loading-a-document)
+   * [Syntax](../../../../../document-extensions/timeseries/client-api/session/include/with-session-load#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Include time series when loading a document}
+
+In this example, we load a document using `session.Load`,  
+and include a selected range of entries from time series "HeartRates".
+
+{CODE timeseries_region_Load-Document-And-Include-TimeSeries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+**`session.Load`**
+
+{CODE Load-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter    | Type                         | Description    |
+|--------------|------------------------------|----------------|
+| **id**       | `string`                     | Document ID    |
+| **includes** | `Action<IIncludeBuilder<T>>` | Include Object |
+
+**`includes`** builder methods:
+
+{CODE IncludeTimeSeries-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter | Type        | Description                                                           |
+|-----------|-------------|-----------------------------------------------------------------------|
+| **name**  | `string`    | Time series name.                                                     |
+| **from**  | `DateTime?` | Time series range start (inclusive).<br>Default: `DateTime.MinValue`. |
+| **to**    | `DateTime?` | Time series range end (inclusive).<br>Default: `DateTime.MaxValue`.   |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.dotnet.markdown
@@ -37,7 +37,7 @@ and include a selected range of entries from time series "HeartRates".
 | **id**       | `string`                     | Document ID    |
 | **includes** | `Action<IIncludeBuilder<T>>` | Include Object |
 
-**`includes`** builder methods:
+**`Include`** builder methods:
 
 {CODE IncludeTimeSeries-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.js.markdown
@@ -1,0 +1,65 @@
+﻿# Include Time Series with&nbsp;`Load`
+---
+
+{NOTE: }
+
+* When loading a document via `session.load`,  
+  you can _include_ all entries of a time series or a specific range of entries.
+
+* The included time series data is stored within the session   
+  and can be provided instantly when requested without any additional server calls.
+
+* In this page:
+   * [Include time series when loading a document](../../../../../document-extensions/timeseries/client-api/session/include/with-session-load#include-time-series-when-loading-a-document)
+   * [Syntax](../../../../../document-extensions/timeseries/client-api/session/include/with-session-load#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Include time series when loading a document}
+
+In this example, we load a document using `session.load`,  
+and include a selected range of entries from time series "HeartRates".
+
+{CODE:nodejs include_1@documentExtensions\timeSeries\client-api\includeWithLoad.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+**`session.load`**
+
+{CODE:nodejs syntax_1@documentExtensions\timeSeries\client-api\includeWithLoad.js /}
+
+| Parameter    | Type     | Description                                                                                   |
+|--------------|----------|-----------------------------------------------------------------------------------------------|
+| **id**       | `string` | Document ID to load.                                                                          |
+| **options**  | `object` | object containing the `includes` builder that specifies which time series entries to include. |
+
+**`includes`** builder methods:
+
+{CODE:nodejs syntax_2@documentExtensions\timeSeries\client-api\includeWithLoad.js /}
+
+| Parameter | Type     | Description                                                          |
+|-----------|----------|----------------------------------------------------------------------|
+| **name**  | `string` | Time series name.                                                    |
+| **from**  | `Date`   | Time series range start (inclusive).<br>Default: minimum date value. |
+| **to**    | `Date`   | Time series range end (inclusive).<br>Default: maximum date value.   |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.js.markdown
@@ -1,4 +1,4 @@
-﻿# Include Time Series with&nbsp;`Load`
+﻿# Include Time Series with&nbsp;`load`
 ---
 
 {NOTE: }

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -539,16 +539,20 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 }
 
                 #region timeseries_region_Load-Document-And-Include-TimeSeries
-                // Load a document and Include a specified range of a time-series
                 using (var session = store.OpenSession())
                 {
                     var baseline = DateTime.Today;
 
-                    User user = session.Load<User>("users/1-A", includeBuilder =>
-                        includeBuilder.IncludeTimeSeries("HeartRates",
-                        baseline.AddMinutes(3), baseline.AddMinutes(8)));
+                    // Load a document
+                    User user = session.Load<User>("users/john", includeBuilder =>
+                        // Call 'IncludeTimeSeries' to include time series entries, pass:
+                        // * The time series name
+                        // * Start and end timestamps indicating the range of entries to include
+                        includeBuilder.IncludeTimeSeries("HeartRates", baseline.AddMinutes(3), baseline.AddMinutes(8)));
 
-                    IEnumerable<TimeSeriesEntry> val = session.TimeSeriesFor("users/1-A", "HeartRates")
+                    // The following call to 'Get' will Not trigger a server request,  
+                    // the entries will be retrieved from the session's cache.  
+                    IEnumerable<TimeSeriesEntry> entries = session.TimeSeriesFor("users/john", "HeartRates")
                         .Get(baseline.AddMinutes(3), baseline.AddMinutes(8));
                 }
                 #endregion

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/includeWithLoad.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/includeWithLoad.js
@@ -1,0 +1,72 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+
+async function includeWithLoad() {
+
+    const session = documentStore.openSession();
+    await session.store(new User("John"), "users/john");
+
+    const optionalTag = "watches/fitbit";
+    const baseTime = new Date();
+    baseTime.setUTCHours(0);
+
+    const tsf = session.timeSeriesFor("users/john", "HeartRates");
+    for (let i = 0; i < 10; i++)
+    {
+        const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+        const nextMeasurement = 65 + i;
+        tsf.append(nextMinute, nextMeasurement, optionalTag);
+    }
+
+    await session.saveChanges();
+
+    {
+        //region include_1
+        const session = documentStore.openSession();
+
+        const baseTime = new Date();
+        const from = new Date(baseTime.getTime() + 60_000 * 3);
+        const to = new Date(baseTime.getTime() + 60_000 * 8);
+        
+        // Load a document entity to the session
+        const user = await session.load("users/john", {
+            // Call 'includeTimeSeries' to include time series entries, pass:
+            // * The time series name
+            // * Start and end timestamps indicating the range of entries to include
+            includes: builder => builder.includeTimeSeries("HeartRates", from, to)
+        });
+
+        const numberOfRequests1 = session.advanced.numberOfRequests;
+        
+        // The following call to 'get' will Not trigger a server request,  
+        // the entries will be retrieved from the session's cache.  
+        const entries = await session
+            .timeSeriesFor("users/john", "HeartRates")
+            .get(from, to);
+
+        const numberOfRequests2 = session.advanced.numberOfRequests;
+        assert.equal(numberOfRequests1, numberOfRequests2);
+        //endregion
+    }
+}
+
+//region syntax_1
+load(id, options?);
+//endregion
+
+//region syntax_2
+includeTimeSeries(name);
+includeTimeSeries(name, from, to);
+//endregion
+
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -539,16 +539,20 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 }
 
                 #region timeseries_region_Load-Document-And-Include-TimeSeries
-                // Load a document and Include a specified range of a time-series
                 using (var session = store.OpenSession())
                 {
                     var baseline = DateTime.Today;
 
-                    User user = session.Load<User>("users/1-A", includeBuilder =>
-                        includeBuilder.IncludeTimeSeries("HeartRates",
-                        baseline.AddMinutes(3), baseline.AddMinutes(8)));
+                    // Load a document
+                    User user = session.Load<User>("users/john", includeBuilder =>
+                        // Call 'IncludeTimeSeries' to include time series entries, pass:
+                        // * The time series name
+                        // * Start and end timestamps indicating the range of entries to include
+                        includeBuilder.IncludeTimeSeries("HeartRates", baseline.AddMinutes(3), baseline.AddMinutes(8)));
 
-                    IEnumerable<TimeSeriesEntry> val = session.TimeSeriesFor("users/1-A", "HeartRates")
+                    // The following call to 'Get' will Not trigger a server request,  
+                    // the entries will be retrieved from the session's cache.  
+                    IEnumerable<TimeSeriesEntry> entries = session.TimeSeriesFor("users/john", "HeartRates")
                         .Get(baseline.AddMinutes(3), baseline.AddMinutes(8));
                 }
                 #endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2808/Node.js-Document-extensions-Time-series-Client-API-Session-Include-With-load-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
https://issues.hibernatingrhinos.com/issue/RDoc-2811/Document-extensions-Time-series-Client-API-Session-Include-With-load-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-load.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/includeWithLoad.js
```

