### PR TITLE
RDoc-2809 [Node.js] Document extensions > Time series > Client API > Session > Include > With query [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/overview.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/overview.dotnet.markdown
@@ -4,11 +4,9 @@
 
 {NOTE: }
 
-{NOTE: }
-
 * When retrieving documents that contain time series, you can request to _include_ their time series data.
 
-* The included data is held by the client's session, so it can be handed to the user instantly when requested without issuing an additional request to the server.
+* The included time series data is held by the client's session, so it can be handed to the user instantly when requested without issuing an additional request to the server.
 
 * Time series data can be _included_ when -
     * [Loading a document using `session.Load`](../../../../../document-extensions/timeseries/client-api/session/include/with-session-load)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/overview.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/overview.js.markdown
@@ -6,7 +6,7 @@
 
 * When retrieving documents that contain time series, you can request to _include_ their time series data.
 
-* The included data is held by the client's session, so it can be handed to the user instantly when requested without issuing an additional request to the server.  
+* The included time series data is held by the client's session, so it can be handed to the user instantly when requested without issuing an additional request to the server.  
 
 * Time series data can be _included_ when -  
    * [Loading a document using `session.load`](../../../../../document-extensions/timeseries/client-api/session/include/with-session-load)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.dotnet.markdown
@@ -1,0 +1,56 @@
+﻿# Include Time Series with&nbsp;`Query`
+---
+
+{NOTE: }
+
+* When querying via `session.Query` for documents that contain time series,  
+  you can request to include their time series data in the server response.
+
+* The included time series data is stored within the session   
+  and can be provided instantly when requested without any additional server calls.
+
+* In this page:  
+   * [Include time series when making a query](../../../../../document-extensions/timeseries/client-api/session/include/with-session-query#include-time-series-when-making-a-query)
+   * [Syntax](../../../../../document-extensions/timeseries/client-api/session/include/with-session-query#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Include time series when making a query}
+
+In this example, we retrieve a document using `session.Query`   
+and _include_ its time series entries from time series "HeartRates".  
+
+{CODE timeseries_region_Query-Document-And-Include-TimeSeries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+**`Include`** builder methods:
+
+{CODE IncludeTimeSeries-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter | Type        | Description                                                           |
+|-----------|-------------|-----------------------------------------------------------------------|
+| **name**  | `string`    | Time series Name.                                                     |
+| **from**  | `DateTime?` | Time series range start (inclusive).<br>Default: `DateTime.MinValue`. |
+| **to**    | `DateTime?` | Time series range end (inclusive).<br>Default: `DateTime.MaxValue`.   |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.js.markdown
@@ -1,0 +1,64 @@
+﻿# Include Time Series with&nbsp;`query`
+---
+
+{NOTE: }
+
+* When querying via `session.query` for documents that contain time series,  
+  you can request to include their time series data in the server response.
+
+* The included time series data is stored within the session   
+  and can be provided instantly when requested without any additional server calls.
+
+* In this page:  
+   * [Include time series when making a query](../../../../../document-extensions/timeseries/client-api/session/include/with-session-query#include-time-series-when-making-a-query)
+   * [Syntax](../../../../../document-extensions/timeseries/client-api/session/include/with-session-query#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Include time series when making a query}
+
+In this example, we retrieve a document using `session.query`   
+and _include_ its time series entries from time series "HeartRates".  
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query include_1@documentExtensions\timeSeries\client-api\includeWithQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "users"
+where name = "John" 
+include timeseries("HeartRates", null, null)
+limit null, 1
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+**`include`** builder methods:
+
+{CODE:nodejs syntax@documentExtensions\timeSeries\client-api\includeWithQuery.js /}
+
+| Parameter | Type     | Description                                                          |
+|-----------|----------|----------------------------------------------------------------------|
+| **name**  | `string` | Time series Name.                                                    |
+| **from**  | `Date`   | Time series range start (inclusive).<br>Default: minimum date value. |
+| **to**    | `Date`   | Time series range end (inclusive).<br>Default: maximum date value.   |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -554,20 +554,18 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 #endregion
 
                 #region timeseries_region_Query-Document-And-Include-TimeSeries
-                // Query for a document and include a whole time-series
                 using (var session = store.OpenSession())
                 {
-                    var baseline = DateTime.Today;
-
-                    IRavenQueryable<User> query = session.Query<User>()
+                    // Query for a document and include a whole time-series
+                    User user = session.Query<User>()
                         .Where(u => u.Name == "John")
-                        .Include(includeBuilder => includeBuilder.IncludeTimeSeries(
-                            "HeartRates", DateTime.MinValue, DateTime.MaxValue));
+                        .Include(includeBuilder => includeBuilder.IncludeTimeSeries("HeartRates"))
+                        .FirstOrDefault();
 
-                    var result = query.ToList();
-
-                    IEnumerable<TimeSeriesEntry> val = session.TimeSeriesFor(result[0], "HeartRates")
-                        .Get(DateTime.MinValue, DateTime.MaxValue);
+                    // The following call to 'Get' will Not trigger a server request,  
+                    // the entries will be retrieved from the session's cache.  
+                    IEnumerable<TimeSeriesEntry> entries = session.TimeSeriesFor(user, "HeartRates")
+                        .Get();
                 }
                 #endregion
 

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/includeWithQuery.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/includeWithQuery.js
@@ -1,0 +1,64 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+
+async function includeWithQueyr() {
+
+    const session = documentStore.openSession();
+    await session.store(new User("John"), "users/john");
+
+    const optionalTag = "watches/fitbit";
+    const baseTime = new Date();
+    baseTime.setUTCHours(0);
+
+    const tsf = session.timeSeriesFor("users/john", "HeartRates");
+    for (let i = 0; i < 10; i++)
+    {
+        const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+        const nextMeasurement = 65 + i;
+        tsf.append(nextMinute, nextMeasurement, optionalTag);
+    }
+
+    await session.saveChanges();
+
+    {        
+        //region include_1
+        // Query for a document and include a whole time-series
+        const user = await session.query({ collection: "users" })
+            .whereEquals("name", "John")
+             // Call 'includeTimeSeries' to include the time series entries in the response
+             // Pass the time series name
+             // (find more include builder overloads under the Syntax section)
+            .include(includeBuilder => includeBuilder.includeTimeSeries("HeartRates"))
+            .first();
+
+        const numberOfRequests1 = session.advanced.numberOfRequests;
+
+        // The following call to 'get' will Not trigger a server request,
+        // the entries will be retrieved from the session's cache.
+        const entries = await session.timeSeriesFor(user, "HeartRates")
+            .get();
+
+        const entryValue = entries[0].value;
+
+        const numberOfRequests2 = session.advanced.numberOfRequests;
+        assert.equal(numberOfRequests1, numberOfRequests2);
+        //endregion
+    }
+}
+
+//region syntax
+includeTimeSeries(name);
+includeTimeSeries(name, from, to);
+//endregion
+
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -554,20 +554,18 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 #endregion
 
                 #region timeseries_region_Query-Document-And-Include-TimeSeries
-                // Query for a document and include a whole time-series
                 using (var session = store.OpenSession())
                 {
-                    var baseline = DateTime.Today;
-
-                    IRavenQueryable<User> query = session.Query<User>()
+                    // Query for a document and include a whole time-series
+                    User user = session.Query<User>()
                         .Where(u => u.Name == "John")
-                        .Include(includeBuilder => includeBuilder.IncludeTimeSeries(
-                            "HeartRates", DateTime.MinValue, DateTime.MaxValue));
+                        .Include(includeBuilder => includeBuilder.IncludeTimeSeries("HeartRates"))
+                        .FirstOrDefault();
 
-                    var result = query.ToList();
-
-                    IEnumerable<TimeSeriesEntry> val = session.TimeSeriesFor(result[0], "HeartRates")
-                        .Get(DateTime.MinValue, DateTime.MaxValue);
+                    // The following call to 'Get' will Not trigger a server request,  
+                    // the entries will be retrieved from the session's cache.  
+                    IEnumerable<TimeSeriesEntry> val = session.TimeSeriesFor(user, "HeartRates")
+                        .Get();
                 }
                 #endregion
 


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2809/Node.js-Document-extensions-Time-series-Client-API-Session-Include-With-query-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
https://issues.hibernatingrhinos.com/issue/RDoc-2812/Document-extensions-Time-series-Client-API-Session-Include-With-query-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/includeWithQuery.js
```

