### PR TITLE
RDoc-2810 [Node.js] Document extensions > Time series > Client API > Session > Include > With raw queries [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-raw-queries.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-raw-queries.dotnet.markdown
@@ -1,0 +1,54 @@
+﻿# Include Time Series with Raw Queries
+---
+
+{NOTE: }
+
+* Use `include timeseries` in your RQL expression in order to include time series data when making  
+  a raw query via [session.Advanced.RawQuery](../../../../../client-api/session/querying/how-to-query#session.advanced.rawquery).
+
+* The included time series data is stored within the session and can be provided instantly when requested  
+  without any additional server calls.
+
+* In this page:
+   * [Include time series when making a raw query](../../../../../document-extensions/timeseries/client-api/session/include/with-raw-queries#include-time-series-when-making-a-raw-query)
+   * [Syntax](../../../../../document-extensions/timeseries/client-api/session/include/with-raw-queries#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Include time series when making a raw query}
+
+In this example, we use a raw query to retrieve a document   
+and _include_ entries from the document's "HeartRates" time series.  
+
+{CODE timeseries_region_Raw-Query-Document-And-Include-TimeSeries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+**`Advanced.RawQuery`**
+
+{CODE RawQuery-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter | Type     | Description       |
+|-----------|----------|-------------------|
+| **query** | `string` | The raw RQL query |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-raw-queries.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-raw-queries.js.markdown
@@ -1,0 +1,55 @@
+﻿# Include Time Series with Raw Queries
+---
+
+{NOTE: }
+
+* Use `include timeseries` in your RQL expression in order to include time series data when making  
+  a raw query via [session.advanced.rawQuery](../../../../../client-api/session/querying/how-to-query#session.advanced.rawquery).
+
+* The included time series data is stored within the session and can be provided instantly when requested  
+  without any additional server calls.
+
+* In this page:
+   * [Include time series when making a raw query](../../../../../document-extensions/timeseries/client-api/session/include/with-raw-queries#include-time-series-when-making-a-raw-query)
+   * [Syntax](../../../../../document-extensions/timeseries/client-api/session/include/with-raw-queries#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Include time series when making a raw query}
+
+In this example, we use a raw query to retrieve a document   
+and _include_ entries from the document's "HeartRates" time series.  
+
+{CODE:nodejs include_1@documentExtensions\timeSeries\client-api\includeWithRawQuery.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+**`advanced.rawQuery`**
+
+{CODE:nodejs syntax@documentExtensions\timeSeries\client-api\includeWithRawQuery.js /}
+
+| Parameter          | Type     | Description                                  |
+|--------------------|----------|----------------------------------------------|
+| **query**          | `string` | The raw RQL query.                           |
+| **documentType**   | `object` | The document class type (an optional param). |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.dotnet.markdown
@@ -19,8 +19,8 @@
 
 {PANEL: Include time series when making a query}
 
-In this example, we retrieve a document using `session.Query`   
-and _include_ its time series entries from time series "HeartRates".  
+In this example, we retrieve a document using `session.Query`  
+and _include_ entries from the document's "HeartRates" time series.
 
 {CODE timeseries_region_Query-Document-And-Include-TimeSeries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-session-query.js.markdown
@@ -19,8 +19,8 @@
 
 {PANEL: Include time series when making a query}
 
-In this example, we retrieve a document using `session.query`   
-and _include_ its time series entries from time series "HeartRates".  
+In this example, we retrieve a document using `session.query`  
+and _include_ entries from the document's "HeartRates" time series.
 
 {CODE-TABS}
 {CODE-TAB:nodejs:Query include_1@documentExtensions\timeSeries\client-api\includeWithQuery.js /}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -574,29 +574,34 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 #endregion
 
                 #region timeseries_region_Raw-Query-Document-And-Include-TimeSeries
-                // Include a Time Series in a Raw Query
                 using (var session = store.OpenSession())
                 {
-                    var baseline = DateTime.Today;
+                    var baseTime = DateTime.Today;
 
-                    var start = baseline;
-                    var end = baseline.AddHours(1);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(5);
 
+                    // Define the Raw Query:
                     IRawDocumentQuery<User> query = session.Advanced.RawQuery<User>
-                              ("from Users include timeseries('HeartRates', $start, $end)")
-                        .AddParameter("start", start)
-                        .AddParameter("end", end);
+                               // Use 'include timeseries' in the RQL
+                              ("from Users include timeseries('HeartRates', $from, $to)")
+                               // Pass optional parameters
+                              .AddParameter("from", from)
+                              .AddParameter("to", to);
 
-                    var result = query.ToList();
+                    // Execute the query:
+                    // For each document in the query results,
+                    // the time series entries will be 'loaded' to the session along with the document
+                    var users = query.ToList();
 
-                    IEnumerable<TimeSeriesEntry> val = session.TimeSeriesFor(result[0], "HeartRates")
-                        .Get(start, end);
+                    // The following call to 'Get' will Not trigger a server request,
+                    // the entries will be retrieved from the session's cache.
+                    IEnumerable<TimeSeriesEntry> entries = session.TimeSeriesFor(users[0], "HeartRates")
+                        .Get(from, to);
                 }
                 #endregion
-
             }
         }
-
 
         [Fact]
         public void AppendWithIEnumerable()

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/what-is-rql.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/querying/what-is-rql.markdown
@@ -394,7 +394,10 @@ Learn more in [dynamic group by queries](../../../client-api/session/querying/ho
 
 The keyword `include` has been introduced to support:
 
-- [including related documents](../../../client-api/how-to/handle-document-relationships#includes) or counters in the query response
+- [including related documents](../../../client-api/how-to/handle-document-relationships#includes) in the query response
+- [including counters](../../../document-extensions/counters/counters-and-other-features#including-counters),
+  [time series](../../../document-extensions/timeseries/client-api/session/include/with-raw-queries),
+  or [revisions](../../../document-extensions/revisions/client-api/session/including#include-revisions-when-making-a-raw-query) in the query response
 - [including compare-exchange items](../../../client-api/operations/compare-exchange/include-compare-exchange#include-cmpxchg-items-when-querying) in the query response
 - [highlighting](../../../client-api/session/querying/text-search/highlight-query-results) results
 - [get query timings](../../../client-api/session/querying/debugging/query-timings)

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -574,29 +574,34 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 #endregion
 
                 #region timeseries_region_Raw-Query-Document-And-Include-TimeSeries
-                // Include a Time Series in a Raw Query
                 using (var session = store.OpenSession())
                 {
-                    var baseline = DateTime.Today;
+                    var baseTime = DateTime.Today;
 
-                    var start = baseline;
-                    var end = baseline.AddHours(1);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(5);
 
+                    // Define the Raw Query:
                     IRawDocumentQuery<User> query = session.Advanced.RawQuery<User>
-                              ("from Users include timeseries('HeartRates', $start, $end)")
-                        .AddParameter("start", start)
-                        .AddParameter("end", end);
+                             // Use 'include timeseries' in the RQL
+                            ("from Users include timeseries('HeartRates', $from, $to)")
+                             // Pass optional parameters
+                            .AddParameter("from", from)
+                            .AddParameter("to", to);
 
-                    var result = query.ToList();
+                    // Execute the query:
+                    // For each document in the query results,
+                    // the time series entries will be 'loaded' to the session along with the document
+                    var users = query.ToList();
 
-                    IEnumerable<TimeSeriesEntry> val = session.TimeSeriesFor(result[0], "HeartRates")
-                        .Get(start, end);
+                    // The following call to 'Get' will Not trigger a server request,
+                    // the entries will be retrieved from the session's cache.
+                    IEnumerable<TimeSeriesEntry> entries = session.TimeSeriesFor(users[0], "HeartRates")
+                        .Get(from, to);
                 }
                 #endregion
-
             }
         }
-
 
         [Fact]
         public void AppendWithIEnumerable()


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2810/Node.js-Document-extensions-Time-series-Client-API-Session-Include-With-raw-queries-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
TBD..

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/include/with-raw-queries.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/includeWithRawQuery.js
```
