### PR TITLE
[Python] Operations pages batch 1 [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.dotnet.markdown
@@ -1,0 +1,137 @@
+﻿# Delete by Query Operation
+---
+
+{NOTE: }
+
+* Use `DeleteByQueryOperation` to delete a large number of documents that match the provided query in a single server call.
+
+* **Dynamic behavior**:   
+  The deletion of documents matching the specified query is run in batches of size 1024.  
+  During the deletion process, documents that are added/modified **after** the delete operation has started  
+  may also be deleted if they match the query criteria.
+
+* **Background operation**:  
+  This operation is performed in the background on the server.  
+  If needed, you can **wait** for the operation to complete. See: [Wait for completion](../../../client-api/operations/what-are-operations#wait-for-completion).
+
+* In this page:  
+   * [Delete by dynamic query](../../../client-api/operations/common/delete-by-query#delete-by-dynamic-query)
+   * [Delete by index query](../../../client-api/operations/common/delete-by-query#delete-by-index-query)
+   * [Syntax](../../../client-api/operations/common/delete-by-query#syntax)
+
+{NOTE/}
+
+{PANEL: Delete by dynamic query}
+
+{NOTE: }
+
+**Delete all documents in collection**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:DeleteOperation_Sync delete_by_query_0@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB:csharp:DeleteOperation_Async delete_by_query_0_async@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Orders"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+**Delete with filtering**:  
+
+{CODE-TABS}
+{CODE-TAB:csharp:DeleteOperation_Sync delete_by_query_1@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB:csharp:DeleteOperation_Async delete_by_query_1_async@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Orders" where Freight > 30
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Delete by index query}
+
+* `DeleteByQueryOperation` can only be performed on a **Map-index**.  
+  An exception is thrown when executing the operation on a Map-Reduce index.  
+
+* A few overloads are available, see the following examples:
+
+---
+
+{NOTE: }
+
+**A sample Map-index**:
+
+{CODE the_index@ClientApi\Operations\Common\DeleteByQuery.cs /}
+
+{NOTE/}
+
+{NOTE: }
+
+**Delete documents via an index query**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:DeleteOperation delete_by_query_2@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB:csharp:Overload_1 delete_by_query_3@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB:csharp:Overload_2 delete_by_query_4@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB:csharp:Overload_3 delete_by_query_5@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByPrice" where Price > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+**Delete with options**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:DeleteOperation delete_by_query_6@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB:csharp:DeleteOperation_async delete_by_query_6_async@ClientApi\Operations\Common\DeleteByQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByPrice" where Price > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+* Specifying `QueryOperationOptions` is also supported by the other overload methods, see the Syntax section below.
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Common\DeleteByQuery.cs /}
+<br />
+
+| Parameter         | Type                        | Description                                                |
+|-------------------|-----------------------------|------------------------------------------------------------|
+| **queryToDelete** | string                      | The RQL query to perform                                   |
+| **queryToDelete** | `IndexQuery`                | Holds all the information required to query an index       |
+| **indexName**     | string                      | The name of the index queried                              |
+| **expression**    | `Expression<Func<T, bool>>` | The expression that defines the query criteria             |
+| **options**       | `QueryOperationOptions`     | Object holding different setting options for the operation |
+
+{CODE syntax_2@ClientApi\Operations\Common\DeleteByQuery.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+
+### Client API
+
+- [How to Query](../../../client-api/session/querying/how-to-query)
+
+### Querying
+
+- [What is RQL](../../../client-api/session/querying/what-is-rql)
+- [Querying an index](../../../indexes/querying/query-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.dotnet.markdown
@@ -23,9 +23,7 @@
 
 {PANEL: Delete by dynamic query}
 
-{NOTE: }
-
-**Delete all documents in collection**:
+#### Delete all documents in a collection:
 
 {CODE-TABS}
 {CODE-TAB:csharp:DeleteOperation_Sync delete_by_query_0@ClientApi\Operations\Common\DeleteByQuery.cs /}
@@ -35,11 +33,9 @@ from "Orders"
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 
-{NOTE/}
+---
 
-{NOTE: }
-
-**Delete with filtering**:  
+#### Delete with filtering:  
 
 {CODE-TABS}
 {CODE-TAB:csharp:DeleteOperation_Sync delete_by_query_1@ClientApi\Operations\Common\DeleteByQuery.cs /}
@@ -48,8 +44,6 @@ from "Orders"
 from "Orders" where Freight > 30
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
-
-{NOTE/}
 
 {PANEL/}
 
@@ -62,17 +56,13 @@ from "Orders" where Freight > 30
 
 ---
 
-{NOTE: }
-
-**A sample Map-index**:
+#### A sample Map-index:
 
 {CODE the_index@ClientApi\Operations\Common\DeleteByQuery.cs /}
 
-{NOTE/}
+---
 
-{NOTE: }
-
-**Delete documents via an index query**:
+#### Delete documents via an index query:
 
 {CODE-TABS}
 {CODE-TAB:csharp:DeleteOperation delete_by_query_2@ClientApi\Operations\Common\DeleteByQuery.cs /}
@@ -84,11 +74,9 @@ from index "Products/ByPrice" where Price > 10
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 
-{NOTE/}
+---
 
-{NOTE: }
-
-**Delete with options**:
+#### Delete with options:
 
 {CODE-TABS}
 {CODE-TAB:csharp:DeleteOperation delete_by_query_6@ClientApi\Operations\Common\DeleteByQuery.cs /}
@@ -99,8 +87,6 @@ from index "Products/ByPrice" where Price > 10
 {CODE-TABS/}
 
 * Specifying `QueryOperationOptions` is also supported by the other overload methods, see the Syntax section below.
-
-{NOTE/}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.java.markdown
@@ -1,0 +1,83 @@
+﻿# Delete by Query Operation
+
+`DeleteByQueryOperation` gives you the ability to delete a large number of documents with a single query.
+This operation is performed in the background on the server. 
+
+## Syntax
+
+{CODE:java delete_by_query@ClientApi\Operations\Common\DeleteByQuery.java /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **indexName** | String | Name of an index to perform a query on |
+| **queryToDelete** | IndexQuery | Holds all the information required to query an index |
+| **options** | QueryOperationOptions | Holds different setting options for base operations |
+
+## Example I
+
+{CODE-TABS}
+{CODE-TAB:java:Java delete_by_query1@ClientApi\Operations\Common\DeleteByQuery.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Person/ByName' where Name = 'Bob' 
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+
+## Example II
+
+{CODE-TABS}
+{CODE-TAB:java:Java delete_by_query2@ClientApi\Operations\Common\DeleteByQuery.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Person/ByName' where Age < 35
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Example III
+
+{CODE-TABS}
+{CODE-TAB:java:Java delete_by_query3@ClientApi\Operations\Common\DeleteByQuery.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from People u where id(u) in ('people/1-A', 'people/3-A')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE: WaitForCompletion}
+`DeleteByQueryOperation` is performed in the background on the server.    
+You have the option to **wait** for it using `waitForCompletion`.
+
+{CODE-TABS}
+{CODE-TAB:java:Java delete_by_query_wait_for_completion@ClientApi\Operations\Common\DeleteByQuery.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from People where Name = 'Bob' and Age >= 29
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+{NOTE /}
+
+## Remarks
+
+{WARNING: Map only indexes} 
+`DeleteByQueryOperation` can only be performed on a map index. Executing it on map-reduce index will lead to an exception. 
+{WARNING/}
+
+{WARNING: Batching and Concurrency} 
+
+The deletion of documents matching a specified query is run in batches of size 1024. RavenDB doesn't do concurrency checks during the operation
+so it can happen than a document has been updated or deleted meanwhile.
+
+{WARNING/}
+
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+
+### Client API
+
+- [Querying: Basics](../../../indexes/querying/query-index)
+
+### Querying
+
+- [What is RQL](../../../client-api/session/querying/what-is-rql)
+- [Querying an index](../../../indexes/querying/query-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.js.markdown
@@ -1,0 +1,130 @@
+﻿# Delete by Query Operation
+---
+
+{NOTE: }
+
+* Use `DeleteByQueryOperation` to delete a large number of documents that match the provided query in a single server call.
+
+* __Dynamic behavior__:   
+  The deletion of documents matching the specified query is run in batches of size 1024.  
+  During the deletion process, documents that are added/modified __after__ the delete operation has started  
+  may also be deleted if they match the query criteria.
+
+* __Background operation__:  
+  This operation is performed in the background on the server.  
+  If needed, you can __wait__ for the operation to complete. See: [Wait for completion](../../../client-api/operations/what-are-operations#wait-for-completion).
+
+* In this page:  
+   * [Delete by dynamic query](../../../client-api/operations/common/delete-by-query#delete-by-dynamic-query)
+   * [Delete by index query](../../../client-api/operations/common/delete-by-query#delete-by-index-query)
+   * [Syntax](../../../client-api/operations/common/delete-by-query#syntax)
+
+{NOTE/}
+
+{PANEL: Delete by dynamic query}
+
+{NOTE: }
+
+__Delete all documents in collection__:
+
+{CODE-TABS}
+{CODE-TAB:nodejs:DeleteOperation delete_by_query_0@client-api\Operations\Common\deleteByQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Orders"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Delete with filtering__:  
+
+{CODE-TABS}
+{CODE-TAB:nodejs:DeleteOperation delete_by_query_1@client-api\Operations\Common\deleteByQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Orders" where Freight > 30
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Delete by index query}
+
+* `DeleteByQueryOperation` can only be performed on a __Map-index__.  
+  An exception is thrown when executing the operation on a Map-Reduce index.  
+
+* A few overloads are available, see the following examples:
+
+---
+
+{NOTE: }
+
+__A sample Map-index__:
+
+{CODE:nodejs the_index@client-api\Operations\Common\deleteByQuery.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+__Delete documents via an index query__:
+
+{CODE-TABS}
+{CODE-TAB:nodejs:DeleteOperation delete_by_query_2@client-api\Operations\Common\deleteByQuery.js /}
+{CODE-TAB:nodejs:DeleteOperation_overload delete_by_query_3@client-api\Operations\Common\deleteByQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByPrice" where Price > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+__Delete with options__:
+
+{CODE-TABS}
+{CODE-TAB:nodejs:DeleteOperation delete_by_query_4@client-api\Operations\Common\deleteByQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByPrice" where Price > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+* Specifying `options` is also supported by the other overload methods, see the Syntax section below.
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\Operations\Common\deleteByQuery.js /}
+<br />
+
+| Parameter         | Type                        | Description                                                |
+|-------------------|-----------------------------|------------------------------------------------------------|
+| __queryToDelete__ | string                      | The RQL query to perform                                   |
+| __queryToDelete__ | `IndexQuery`                | Holds all the information required to query an index       |
+| __options__       | `object`                    | Object holding different setting options for the operation |
+
+{CODE:nodejs syntax_2@client-api\Operations\Common\DeleteByQuery.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+
+### Client API
+
+- [How to Query](../../../client-api/session/querying/how-to-query)
+
+### Querying
+
+- [What is RQL](../../../client-api/session/querying/what-is-rql)
+- [Querying an index](../../../indexes/querying/query-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/common/delete-by-query.python.markdown
@@ -1,0 +1,99 @@
+﻿# Delete by Query Operation
+---
+
+{NOTE: }
+
+* Use `DeleteByQueryOperation` to delete a large number of documents that match the provided query in a single server call.
+
+* **Dynamic behavior**:   
+  The deletion of documents matching the specified query is run in batches of size 1024.  
+  During the deletion process, documents that are added/modified **after** the delete operation has started  
+  may also be deleted if they match the query criteria.
+
+* **Background operation**:  
+  This operation is performed in the background on the server.  
+
+* In this page:  
+   * [Delete by dynamic query](../../../client-api/operations/common/delete-by-query#delete-by-dynamic-query)
+   * [Delete by index query](../../../client-api/operations/common/delete-by-query#delete-by-index-query)
+
+{NOTE/}
+
+{PANEL: Delete by dynamic query}
+
+#### Delete all documents in a collection:
+
+{CODE-TABS}
+{CODE-TAB:python:DeleteByQueryOperation delete_by_query_0@ClientApi\Operations\Common\DeleteByQuery.py /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Orders"
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+---
+
+#### Delete with filtering:  
+
+{CODE-TABS}
+{CODE-TAB:python:DeleteByQueryOperation delete_by_query_1@ClientApi\Operations\Common\DeleteByQuery.py /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Orders" where Freight > 30
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Delete by index query}
+
+* `DeleteByQueryOperation` can only be performed on a **Map-index**.  
+  An exception is thrown when executing the operation on a Map-Reduce index.  
+
+* A few overloads are available, see the following examples:
+
+---
+
+#### A sample Map-index:
+
+{CODE:python the_index@ClientApi\Operations\Common\DeleteByQuery.py /}
+
+---
+
+#### Delete documents via an index query:
+
+{CODE-TABS}
+{CODE-TAB:python:RQL delete_by_query_2@ClientApi\Operations\Common\DeleteByQuery.py /}
+{CODE-TAB:python:IndexQuery delete_by_query_3@ClientApi\Operations\Common\DeleteByQuery.py /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByPrice" where Price > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+---
+
+#### Delete with options:
+
+{CODE-TABS}
+{CODE-TAB:python:QueryOperationOptions delete_by_query_6@ClientApi\Operations\Common\DeleteByQuery.py /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByPrice" where Price > 10
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+* Specifying `QueryOperationOptions` is also supported by the other overload methods, see the Syntax section below.
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+
+### Client API
+
+- [How to Query](../../../client-api/session/querying/how-to-query)
+
+### Querying
+
+- [What is RQL](../../../client-api/session/querying/what-is-rql)
+- [Querying an index](../../../indexes/querying/query-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.dotnet.markdown
@@ -1,0 +1,185 @@
+# Compare Exchange Overview 
+---
+
+{NOTE: }
+
+* Compare Exchange items are **key/value pairs** where the key is unique across your database. 
+
+* Compare-exchange operations require cluster consensus to ensure consistency across all nodes.  
+  Once a consensus is reached, the compare-exchange items are distributed through the Raft algorithm to all nodes in the database group.
+
+* Compare-exchange items can be used to coordinate work between sessions that are trying to modify a shared resource (such as a document) at the same time.
+
+* Compare-exchange items are [not replicated externally](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-databases) to other databases.
+
+* In this page:  
+* [What Compare Exchange Items Are](../../../client-api/operations/compare-exchange/overview#what-compare-exchange-items-are)  
+* [Creating and Managing Compare-Exchange Items](../../../client-api/operations/compare-exchange/overview#creating-and-managing-compare-exchange-items)  
+* [Why Compare-Exchange Items are Not Replicated to External Databases](../../../client-api/operations/compare-exchange/overview#why-compare-exchange-items-are-not-replicated-to-external-databases)  
+* [Example I - Email Address Reservation](../../../client-api/operations/compare-exchange/overview#example-i---email-address-reservation)  
+* [Example II - Reserve a Shared Resource](../../../client-api/operations/compare-exchange/overview#example-ii---reserve-a-shared-resource)  
+* [Example III - Ensuring Unique Values without Using Compare Exchange](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange)  
+
+{NOTE/}
+
+---
+
+{PANEL: What Compare Exchange Items Are}
+
+Compare Exchange items are key/value pairs where the key servers a unique value across your database.
+
+* Each compare-exchange item contains: 
+  * **A key** - A unique string identifier in the database scope.
+  * **A value** - Can be any object (a number, string, array, or any valid JSON object). 
+  * **Metadata** - Data that is associated with the compare-exchange item.
+    Must be a valid JSON object.
+     * For example, the metadata can be used to set expiration time for the compare-exchange item.  
+       Learn more in [compare-exchange expiration](../../../client-api/operations/compare-exchange/compare-exchange-expiration).  
+  * **Raft index** - The compare-exchange item's version.  
+    Any change to the value or metadata will increase this number.  
+
+* Creating and modifying a compare-exchange item is an atomic, thread-safe [compare-and-swap](https://en.wikipedia.org/wiki/Compare-and-swap) interlocked 
+  compare-exchange operation.
+
+{PANEL/}
+
+{PANEL: Creating and Managing Compare-Exchange Items}
+  
+Compare exchange items are created and managed with any of the following approaches:
+
+* **Document Store Operations**  
+  You can manage a compare-exchange item as an [Operation on the document store](../../../client-api/operations/compare-exchange/put-compare-exchange-value).  
+  This can be done within or outside of a session (cluster-wide or single-node session).
+   * When inside a session:  
+     If the session fails, the compare-exchange operation can still succeed
+     because store Operations do not rely on the success of the session.  
+     You will need to delete the compare-exchange item explicitly upon session failure if you don't want the compare-exchange item to persist.
+
+* **Cluster-Wide Sessions**  
+  You can manage a compare-exchange item from inside a [Cluster-Wide session](../../../client-api/session/cluster-transaction/compare-exchange).  
+  If the session fails, the compare-exchange item creation also fails.  
+  None of the nodes in the group will have the new compare-exchange item.
+
+
+* **Atomic Guards**  
+  When creating documents using a cluster-wide session RavenDB automatically creates [Atomic Guards](../../../client-api/session/cluster-transaction/atomic-guards),  
+  which are compare-exchange items that guarantee ACID transactions.  
+  See [Cluster-wide vs. Single-node](../../../client-api/session/cluster-transaction/overview#cluster-wide-transaction-vs.-single-node-transaction) for a session comparision overview.
+
+* **Studio**  
+  Compare-exchange items can be created from the [Studio](../../../studio/database/documents/compare-exchange-view#the-compare-exchange-view) as well.
+
+{PANEL/}
+
+{PANEL: Why Compare-Exchange Items are Not Replicated to External Databases }
+
+* Each cluster defines its policies and configurations, and should ideally have sole responsibility for managing its own documents. 
+  Read [Consistency in a Globally Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system) 
+  to learn more about why global database modeling is more efficient this way.
+   
+* When creating a compare-exchange item a Raft consensus is required from the nodes in the database group.
+  Externally replicating such data is problematic as the target database may reside within a cluster that is in an
+  unstable state where Raft decisions cannot be made. In such a state, the compare-exchange item will not be persisted in the target database.
+
+* Conflicts between documents that occur between two databases are solved with the help of the documents
+  Change-Vector. Compare-exchange conflicts cannot be handled properly as they do not have a similar
+  mechanism to resolve conflicts.
+
+* To ensure unique values between two databases without using compare-exchange items see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange).
+
+{PANEL/}
+
+{PANEL: Example I - Email Address Reservation}  
+
+The following example shows how to use compare-exchange to create documents with unique values.  
+The scope is within the database group on a single cluster. 
+
+Compare-exchange items are not externally replicated to other databases.  
+To establish uniqueness without using compare-exchange see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange).
+
+{CODE email@Server\CompareExchange.cs /}  
+
+**Implications**:
+
+* The `User` object is saved as a document, hence it can be indexed, queried, etc.  
+
+* This compare-exchange item was [created as an operation](../../../client-api/operations/compare-exchange/put-compare-exchange-value)
+  rather than with a [cluster-wide session](../../../client-api/session/cluster-transaction/overview).  
+  Thus, if `session.SaveChanges` fails, then the email reservation is _not_ rolled back automatically.  
+  It is your responsibility to do so.  
+
+* The compare-exchange value that was saved can be accessed in a query using `CmpXchg`:  
+    {CODE-TABS}
+    {CODE-TAB:csharp:Query-LINQ query_cmpxchg@Server\CompareExchange.cs /}  
+    {CODE-TAB:csharp:Document-Query document_query_cmpxchg@Server\CompareExchange.cs /}  
+    {CODE-TAB-BLOCK:sql:RQL}
+    from Users as s where id() == cmpxchg("emails/ayende@ayende.com")  
+    {CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+    {PANEL/}
+
+{PANEL: Example II - Reserve a Shared Resource}  
+
+In the following example, we use compare-exchange to reserve a shared resource.  
+The scope is within the database group on a single cluster.
+
+The code also checks for clients who never release resources (i.e. due to failure) by using timeout.  
+
+{CODE shared_resource@Server\CompareExchange.cs /}
+
+{PANEL/}
+
+{PANEL: Example III - Ensuring Unique Values without Using Compare Exchange}  
+
+Unique values can also be ensured without using compare-exchange.
+
+The below example shows how to achieve that by using **reference documents**.  
+The reference documents' IDs will contain the unique values instead of the compare-exchange items.
+
+Using reference documents is especially useful when [External Replication](../../../server/ongoing-tasks/external-replication) 
+is defined between two databases that need to be synced with unique values.  
+The reference documents will replicate to the destination database, 
+as opposed to compare-exchange items, which are not externally replicated.
+
+{NOTE: }
+Sessions which process fields that must be unique should be set to [TransactionMode.ClusterWide](../../../client-api/session/cluster-transaction/overview).  
+{NOTE/}
+
+{CODE create_uniqueness_control_documents@Server\CompareExchange.cs /}
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Get a Compare-Exchange Value](../../../client-api/operations/compare-exchange/get-compare-exchange-value)
+- [Get Compare-Exchange Values](../../../client-api/operations/compare-exchange/get-compare-exchange-values)
+- [Put a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)
+- [Delete a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)
+- [Atomic Guards](../../../client-api/session/cluster-transaction/atomic-guards)
+- [Resolving Document Conflicts](../../../client-api/cluster/document-conflicts-in-client-side)
+
+
+### Studio
+
+- [Compare Exchange View](../../../studio/database/documents/compare-exchange-view)  
+
+### Server
+
+- [Conflict Resolution](../../../server/clustering/replication/replication-conflicts)
+- [Cluster-Wide Transactions](../../../server/clustering/cluster-transactions)
+
+---
+
+### Code Walkthrough
+
+- [Create CmpXchg Item](https://demo.ravendb.net/demos/csharp/compare-exchange/create-compare-exchange)  
+- [Index CmpXchg Values](https://demo.ravendb.net/demos/csharp/compare-exchange/index-compare-exchange)  
+
+---
+
+### Ayende @ Rahien Blog
+
+- [Consistency in a Globally Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system)
+
+

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.java.markdown
@@ -96,7 +96,7 @@ from Users as s where id() == cmpxchg("emails/ayende@ayende.com")
 
 * Use compare exchange for a shared resource reservation.  
 
-* The code also checks for clients who never release resources (i.e. due to failure) by using timeout.  
+* The code also checks for clients which never release resources (i.e. due to failure) by using timeout.  
 
 {CODE:java shared_resource@Server\CompareExchange.java /}
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.java.markdown
@@ -1,0 +1,112 @@
+# Compare Exchange Overview 
+---
+
+{NOTE: }
+
+* The **Compare Exchange** feature allows you to perform cluster-wide _interlocked_ distributed operations.  
+
+* Unique **Keys** can be reserved in the [Database Group](../../../studio/database/settings/manage-database-group) accross the cluster.  
+  Each key has an associated **Value**.  
+
+* Modifying these values is an ***interlocked compare exchange*** operation.  
+
+* Once defined, the Compare Exchange Values can be accessed via [GetCompareExchangeValuesOperation](../../../client-api/operations/compare-exchange/get-compare-exchange-values),  
+  or by using RQL in a query (see example-I below)  
+
+{INFO: }
+Compare exchange key/value pairs can be created and managed explicitly in your code.  
+Starting from RavenDB 5.2, they can also be created and managed automatically by RavenDB.  
+Compare exchange entries that are automatically administered by RavenDB are called 
+**Atomic Guards**, read more about them [here](../../../client-api/session/cluster-transaction/atomic-guards).  
+{INFO/}
+
+
+* In this page:  
+  * [Compare Exchange Transaction Scope](../../../client-api/operations/compare-exchange/overview#compare-exchange-transaction-scope)  
+  * [Creating a Key](../../../client-api/operations/compare-exchange/overview#creating-a-key)  
+  * [Updating a Key](../../../client-api/operations/compare-exchange/overview#updating-a-key)  
+  * [Example I - Email Address Reservation](../../../client-api/operations/compare-exchange/overview#example-i---email-address-reservation)  
+  * [Example II- Reserve a Shared Resource](../../../client-api/operations/compare-exchange/overview#example-ii---reserve-a-shared-resource)  
+{NOTE/}
+
+---
+
+{PANEL: Compare Exchange Transaction Scope}
+
+* Since the compare-exchange operations guarantee atomicity across the entire cluster, 
+  the feature is **not** using the transaction associated with a session object, as a session transaction spans only a single node.  
+
+* So if a compare-exchange operation has failed when used inside a session block, it will **not** be rolled back automatically upon a session transaction failure.  
+{PANEL/}
+
+{PANEL: Creating a Key}
+
+* Provide the following when saving a **key**:
+
+| Parameter | Description |
+| ------------- | ---- |
+| **Key** | A string under which _Value_ is saved, unique in the database scope across the cluster. This string can be up to 512 bytes. |
+| **Value** | The Value that is associated with the _Key_. <br/>Can be a number, string, boolean, array or any JSON formatted object. |
+| **Index** | The _Index_ number is indicating the version of _Value_.<br/>The _Index_ is used for the concurrency control, similar to documents Etags. |
+
+* When creating a _new_ 'Compare Exchange Key', the index should be set to `0`.  
+
+* The [Put](../../../client-api/operations/compare-exchange/put-compare-exchange-value) operation will succeed only if this key doesn't exist yet.  
+
+* Note: Two different keys _can_ have the same values as long as the keys are unique.  
+{PANEL/}
+
+{PANEL: Updating a Key}
+
+* Updating a 'Compare Exchange' key can be divided into 2 phases:
+
+  1. [Get](../../../client-api/operations/compare-exchange/get-compare-exchange-value) the existing _Key_. The associated _Value_ and _Index_ are received.  
+
+  2. The _Index_ obtained from the read operation is provided to the [Put](../../../client-api/operations/compare-exchange/put-compare-exchange-value) operation along with the new _Value_ to be saved.  
+     This save will succeed only if the index that is provided to the 'Put' operation is the **same** as the index that was received from the server in the previous 'Get', 
+     which means that the _Value_ was not modified by someone else between the read and write operations.
+{PANEL/}
+
+{PANEL: Example I - Email Address Reservation}  
+
+* Compare Exchange can be used to maintain uniqueness across users emails accounts.  
+
+* First try to reserve a new user email.  
+  If the email is successfully reserved then save the user account document.  
+
+{CODE:java email@Server\CompareExchange.java /}  
+
+**Implications**:
+
+* The `User` object is saved as a document, hence it can be indexed, queried, etc.  
+
+* If `session.saveChanges` fails, the email reservation is _not_ rolled back automatically. It is your responsibility to do so.  
+
+* The compare exchange value that was saved can be accessed from `RQL` in a query:  
+
+{CODE-TABS}
+{CODE-TAB:java:Sync query_cmpxchg@Server\CompareExchange.java /}  
+{CODE-TAB-BLOCK:sql:RQL}
+from Users as s where id() == cmpxchg("emails/ayende@ayende.com")  
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+{PANEL/}
+
+{PANEL: Example II - Reserve a Shared Resource}  
+
+* Use compare exchange for a shared resource reservation.  
+
+* The code also checks for clients who never release resources (i.e. due to failure) by using timeout.  
+
+{CODE:java shared_resource@Server\CompareExchange.java /}
+{PANEL/}
+
+## Related Articles
+
+### Compare Exchange
+
+- [Get a Compare-Exchange Value](../../../client-api/operations/compare-exchange/get-compare-exchange-value)
+- [Get Compare-Exchange Values](../../../client-api/operations/compare-exchange/get-compare-exchange-values)
+- [Put a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)
+- [Delete a Compare-Exchange Value](../../../client-api/operations/compare-exchange/delete-compare-exchange-value)
+- [Atomic Guards](../../../client-api/session/cluster-transaction/atomic-guards)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/compare-exchange/overview.python.markdown
@@ -97,7 +97,7 @@ The scope is within the database group on a single cluster.
 Compare-exchange items are not externally replicated to other databases.  
 To establish uniqueness without using compare-exchange see [Example III](../../../client-api/operations/compare-exchange/overview#example-iii---ensuring-unique-values-without-using-compare-exchange).
 
-{CODE email@Server\CompareExchange.cs /}  
+{CODE:python email@Server\CompareExchange.py /}  
 
 **Implications**:
 
@@ -105,13 +105,12 @@ To establish uniqueness without using compare-exchange see [Example III](../../.
 
 * This compare-exchange item was [created as an operation](../../../client-api/operations/compare-exchange/put-compare-exchange-value)
   rather than with a [cluster-wide session](../../../client-api/session/cluster-transaction/overview).  
-  Thus, if `session.SaveChanges` fails, then the email reservation is _not_ rolled back automatically.  
+  Thus, if `session.save_changes` fails, then the email reservation is _not_ rolled back automatically.  
   It is your responsibility to do so.  
 
 * The compare-exchange value that was saved can be accessed in a query using `CmpXchg`:  
     {CODE-TABS}
-    {CODE-TAB:csharp:Query-LINQ query_cmpxchg@Server\CompareExchange.cs /}  
-    {CODE-TAB:csharp:Document-Query document_query_cmpxchg@Server\CompareExchange.cs /}  
+    {CODE-TAB:python:Query query_cmpxchg@Server\CompareExchange.py /}  
     {CODE-TAB-BLOCK:sql:RQL}
     from Users as s where id() == cmpxchg("emails/ayende@ayende.com")  
     {CODE-TAB-BLOCK/}
@@ -125,7 +124,7 @@ The scope is within the database group on a single cluster.
 
 The code also checks for clients which never release resources (i.e. due to failure) by using timeout.  
 
-{CODE shared_resource@Server\CompareExchange.cs /}
+{CODE:python shared_resource@Server\CompareExchange.py /}
 
 {PANEL/}
 
@@ -142,10 +141,10 @@ The reference documents will replicate to the destination database,
 as opposed to compare-exchange items, which are not externally replicated.
 
 {NOTE: }
-Sessions which process fields that must be unique should be set to [TransactionMode.ClusterWide](../../../client-api/session/cluster-transaction/overview).  
+Sessions which process fields that must be unique should be set to [TransactionMode.CLUSTER_WIDE](../../../client-api/session/cluster-transaction/overview).  
 {NOTE/}
 
-{CODE create_uniqueness_control_documents@Server\CompareExchange.cs /}
+{CODE:python create_uniqueness_control_documents@Server\CompareExchange.py /}
 {PANEL/}
 
 ## Related Articles
@@ -173,8 +172,8 @@ Sessions which process fields that must be unique should be set to [TransactionM
 
 ### Code Walkthrough
 
-- [Create CmpXchg Item](https://demo.ravendb.net/demos/csharp/compare-exchange/create-compare-exchange)  
-- [Index CmpXchg Values](https://demo.ravendb.net/demos/csharp/compare-exchange/index-compare-exchange)  
+- [Create CmpXchg Item](https://demo.ravendb.net/demos/python/compare-exchange/create-compare-exchange)  
+- [Index CmpXchg Values](https://demo.ravendb.net/demos/python/compare-exchange/index-compare-exchange)  
 
 ---
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/.docs.json
@@ -1,0 +1,20 @@
+[
+    {
+        "Path": "database-settings-operation.markdown",
+        "Name": "Database Settings Operations",
+        "DiscussionId": "43ab588b-0d2c-4604-854e-43e7e1bf44da",
+        "Mappings": []
+    },
+    {
+        "Path": "put-client-configuration.markdown",
+        "Name": "Put Client Configuration",
+        "DiscussionId": "e05cdf82-e3a4-434e-86eb-494449e27bcc",
+        "Mappings": []
+    },
+    {
+        "Path": "get-client-configuration.markdown",
+        "Name": "Get Client Configuration",
+        "DiscussionId": "43ab588b-0d2c-4604-854e-43e7e1bf44da",
+        "Mappings": []
+    }
+]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.dotnet.markdown
@@ -1,0 +1,47 @@
+# Get Client Configuration Operation <br> (for database)
+
+---
+
+{NOTE: }
+
+* It is recommended to first refer to the **client-configuration description** in the [put client-configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration) article.
+  
+* Use `GetClientConfigurationOperation` to get the current client-configuration set on the server for the database.
+
+* In this page:
+    * [Get client-configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration#get-client-configuration)
+    * [Syntax](../../../../client-api/operations/maintenance/configuration/get-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: Get client-configuration}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_config@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+{CODE-TAB:csharp:Async get_config_async@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Put client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+- [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.java.markdown
@@ -1,0 +1,31 @@
+# Get Client Configuration Operation
+
+**GetClientConfigurationOperation** is used to return a client configuration, which is saved on the server and overrides client behavior. 
+
+## Syntax
+
+{CODE:java config_1_0@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+{CODE:java config_1_1@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+| Return Value | | |
+| ------------- | ----- | ---- |
+| **Etag** | String | Etag of configuration |
+| **Configuration** | `ClientConfiguration` | configuration which will be used by the client API |
+
+## Example
+
+{CODE:java config_1_2@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [How to Put Client Configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [How to Get Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [How to Put Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.js.markdown
@@ -1,0 +1,44 @@
+# Get Client Configuration Operation <br> (for database)
+
+---
+
+{NOTE: }
+
+* It is recommended to first refer to the __client-configuration description__ in the [put client-configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration) article.
+
+* Use `GetClientConfigurationOperation` to get the current client-configuration set on the server for the database.
+
+* In this page:
+    * [Get client-configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration#get-client-configuration)
+    * [Syntax](../../../../client-api/operations/maintenance/configuration/get-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: Get client-configuration}
+
+{CODE:nodejs get_config@client-api\Operations\Maintenance\Configuration\getClientConfig.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\Operations\Maintenance\Configuration\getClientConfig.js /}
+
+{CODE:nodejs syntax_2@client-api\Operations\Maintenance\Configuration\getClientConfig.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Put client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+- [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/get-client-configuration.python.markdown
@@ -1,0 +1,44 @@
+# Get Client Configuration Operation <br> (for database)
+
+---
+
+{NOTE: }
+
+* It is recommended to first refer to the **client-configuration description** in the [put client-configuration](../../../../client-api/operations/maintenance/configuration/put-client-configuration) article.
+  
+* Use `GetClientConfigurationOperation` to get the current client-configuration set on the server for the database.
+
+* In this page:
+    * [Get client-configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration#get-client-configuration)
+    * [Syntax](../../../../client-api/operations/maintenance/configuration/get-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: Get client-configuration}
+
+{CODE:python get_config@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.py /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:python syntax_1@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.py /}
+
+{CODE:python syntax_2@ClientApi\Operations\Maintenance\Configuration\GetClientConfig.py /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Put client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration)
+- [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+- [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.dotnet.markdown
@@ -1,0 +1,104 @@
+# Put Client Configuration Operation <br> (for database)
+
+---
+
+{NOTE: }
+
+* **What is the Client-Configuration**:  
+  The Client-Configuration is a set of configuration options that apply to the client when communicating with the database.
+  See [what can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured) below.  
+
+* **Initializing the Client-Configuration** (on the client):  
+  This configuration can be initially customized from the client code when creating the Document Store via the [Conventions](../../../../client-api/configuration/conventions).
+  
+* **Overriding the initial Client-Configuration for the database** (on the server):  
+
+    * From the client code:  
+      Use `PutClientConfigurationOperation` to set the client-configuration options on the server.  
+      See the example below.
+    
+    * From the Studio:  
+      Set the Client-Configuration from the [Client-Configuration view](../../../../studio/database/settings/client-configuration-per-database).
+
+* **Updating the running client**:  
+
+  * Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
+    the next time it makes a request to the database.  
+
+  * Setting the Client-Configuration on the server enables administrators to dynamically control the client behavior after it has started running.  
+    e.g. manage load balancing of client requests on the fly in response to changing system demands.
+
+* The client-configuration set for the database level **overrides** the [server-wide client-configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration).
+
+---
+
+* In this page:
+  * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
+  * [Put client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-(for-database))
+  * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: What can be configured}
+
+The following client-configuration options are available:  
+
+* **Identity parts separator**:  
+  Set the separator used with automatically generated document identity IDs (default separator is `/`).  
+  Learn more about identity IDs creation [here](../../../../server/kb/document-identifier-generation#strategy--3).
+
+* **Maximum number of requests per session**:  
+  Set this number to restrict the number of requests (Reads & Writes) per session in the client API.
+
+* **Read balance behavior**:  
+  Set the Read balance method the client will use when accessing a node with Read requests.  
+  Learn more in [Balancing client requests - overview](../../../../client-api/configuration/load-balance/overview) and [Read balance behavior](../../../../client-api/configuration/load-balance/read-balance-behavior).
+  
+* **Load balance behavior**:  
+  Set the Load balance method for Read & Write requests.  
+  Learn more in [Load balance behavior](../../../../client-api/configuration/load-balance/load-balance-behavior).
+
+{PANEL/}
+
+{PANEL: Put client-configuration (for database)}
+
+{CODE put_config_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync put_config_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE-TAB:csharp:Async put_config_3@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+
+| Parameter         | Type                  | Description                                                            |
+|-------------------|-----------------------|------------------------------------------------------------------------|
+| **configuration** | `ClientConfiguration` | Client configuration that will be set on the server (for the database) |
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration View](../../../../studio/database/settings/client-configuration-per-database)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Get client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+
+
+### Load balancing
+
+- [Load balancing client requests](../../../../client-api/configuration/load-balance/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.java.markdown
@@ -1,0 +1,28 @@
+# Put Client Configuration Operation <br> (for database)
+
+**PutClientConfigurationOperation** is used to save a client configuration on the server. It allows you to override client's settings remotely. 
+
+## Syntax
+
+{CODE:java config_2_0@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+| Return Value | | |
+| ------------- | ----- | ---- |
+| **configuration** | `ClientConfiguration` | configuration which will be used by client API |
+
+## Example
+
+{CODE:java config_2_2@ClientApi\Operations\Maintenance\Configuration\ClientConfig.java /}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration](../../../../studio/server/client-configuration)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [How to Get Client Configuration](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [How to Get Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [How to Put Server-Wide Client Configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
@@ -1,0 +1,101 @@
+# Put Client Configuration Operation <br> (for database)
+
+---
+
+{NOTE: }
+
+* __What is the Client-Configuration__:  
+  The Client-Configuration is a set of configuration options that apply to the client when communicating with the database.
+  See [what can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured) below.
+
+* __Initializing the Client-Configuration__ (on the client):  
+  This configuration can be initially customized from the client code when creating the Document Store via the Conventions.
+  
+* __Overriding the initial Client-Configuration for the database__ (on the server):
+
+    * From the client code:  
+      Use `PutClientConfigurationOperation` to set the client-configuration options on the server.  
+      See the example below.
+
+    * From the Studio:  
+      Set the Client-Configuration from the [Client-Configuration view](../../../../studio/database/settings/client-configuration-per-database).
+
+* __Updating the running client__:
+
+    * Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
+      the next time it makes a request to the database.
+
+    * Setting the Client-Configuration on the server enables administrators to dynamically control the client behavior after it has started running.  
+      e.g. manage load balancing of client requests on the fly in response to changing system demands.
+
+* The client-configuration set for the database level __overrides__ the [server-wide client-configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration).
+
+---
+
+* In this page:
+    * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
+    * [Put client-configuration (for-database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-(for-database))
+    * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
+
+{NOTE /}
+
+---
+
+{PANEL: What can be configured}
+
+The following client-configuration options are available:
+
+* __Identity parts separator__:  
+  Set the separator used with automatically generated document identity IDs (default separator is `/`).  
+  Learn more about identity IDs creation [here](../../../../server/kb/document-identifier-generation#strategy--3).
+
+* __Maximum number of requests per session__:  
+  Set this number to restrict the number of requests (Reads & Writes) per session in the client API.
+
+* __Read balance behavior__:  
+  Set the Read balance method the client will use when accessing a node with Read requests.  
+  Learn more in [Balancing client requests - overview](../../../../client-api/configuration/load-balance/overview) and [Read balance behavior](../../../../client-api/configuration/load-balance/read-balance-behavior).
+
+* __Load balance behavior__:  
+  Set the Load balance method for Read & Write requests.  
+  Learn more in [Load balance behavior](../../../../client-api/configuration/load-balance/load-balance-behavior).
+
+{PANEL/}
+
+{PANEL: Put client-configuration (for-database)}
+
+{CODE:nodejs put_config_1@client-api\Operations\Maintenance\Configuration\putClientConfig.js /}
+
+{CODE:nodejs put_config_2@client-api\Operations\Maintenance\Configuration\putClientConfig.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\Operations\Maintenance\Configuration\putClientConfig.js /}
+
+| Parameter         | Type     | Description                                                            |
+|-------------------|----------|------------------------------------------------------------------------|
+| __configuration__ | `object` | Client configuration that will be set on the server (for the database) |
+
+{CODE:nodejs syntax_2@client-api\Operations\Maintenance\Configuration\putClientConfig.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Studio
+
+- [Client Configuration View](../../../../studio/database/settings/client-configuration-per-database)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Get client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+
+
+### Load balancing
+
+- [Load balancing client requests](../../../../client-api/configuration/load-balance/overview)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.js.markdown
@@ -4,59 +4,75 @@
 
 {NOTE: }
 
-* __What is the Client-Configuration__:  
-  The Client-Configuration is a set of configuration options that apply to the client when communicating with the database.
-  See [what can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured) below.
-
-* __Initializing the Client-Configuration__ (on the client):  
-  This configuration can be initially customized from the client code when creating the Document Store via the Conventions.
-  
-* __Overriding the initial Client-Configuration for the database__ (on the server):
-
-    * From the client code:  
-      Use `PutClientConfigurationOperation` to set the client-configuration options on the server.  
-      See the example below.
-
-    * From the Studio:  
-      Set the Client-Configuration from the [Client-Configuration view](../../../../studio/database/settings/client-configuration-per-database).
-
-* __Updating the running client__:
-
-    * Once the Client-Configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
-      the next time it makes a request to the database.
-
-    * Setting the Client-Configuration on the server enables administrators to dynamically control the client behavior after it has started running.  
-      e.g. manage load balancing of client requests on the fly in response to changing system demands.
-
-* The client-configuration set for the database level __overrides__ the [server-wide client-configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration).
+* The **client configuration** is a set of configuration options applied during 
+  client-server communication.  
+* The initial client configuration can be set by the client when creating the Document Store.  
+* A database administrator can modify the current client configuration on the server using the 
+  `PutClientConfigurationOperation` operation or via Studio, to gain dynamic control over 
+  client-server communication.  
+  The client will be updated with the modified configuration the next time it sends a request to the database.  
 
 ---
 
 * In this page:
-    * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
-    * [Put client-configuration (for-database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-(for-database))
-    * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
+  
+  * [Client configuration overview and modification](../../../../client-api/operations/maintenance/configuration/put-client-configuration#client-configuration-overview-and-modification)
+  * [What can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured)
+  * [Put client configuration (for database)](../../../../client-api/operations/maintenance/configuration/put-client-configuration#put-client-configuration-(for-database))
+  * [Syntax](../../../../client-api/operations/maintenance/configuration/put-client-configuration#syntax)
 
 {NOTE /}
 
 ---
 
+{PANEL: Client configuration overview and modification}
+
+* **What is the client configuration**:  
+  The client configuration is a set of configuration options that apply to the client when communicating with the database.
+  See [what can be configured](../../../../client-api/operations/maintenance/configuration/put-client-configuration#what-can-be-configured) below.  
+
+* **Initializing the client configuration** (on the client):  
+  This configuration can be initially customized from the client code when creating the Document Store via the [Conventions](../../../../client-api/configuration/conventions).
+  
+* **Overriding the initial client configuration for the database** (on the server):  
+
+    * From the client code:  
+      Use `PutClientConfigurationOperation` to set the client configuration options on the server.  
+      See the example below.
+    
+    * From the Studio:  
+      Set the client configuration from the [Client Configuration view](../../../../studio/database/settings/client-configuration-per-database).
+
+* **Updating the running client**:  
+
+  * Once the client configuration is modified on the server, the running client will [receive the updated settings](../../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date)
+    the next time it makes a request to the database.  
+
+  * Setting the client configuration on the server enables administrators to dynamically control 
+    the client behavior after it has started running.  
+    e.g. manage load balancing of client requests on the fly in response to changing system demands.
+
+* The client configuration set for the database level **overrides** the 
+  [server-wide client configuration](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration).
+
+{PANEL/}
+
 {PANEL: What can be configured}
 
-The following client-configuration options are available:
+The following client configuration options are available:  
 
-* __Identity parts separator__:  
+* **Identity parts separator**:  
   Set the separator used with automatically generated document identity IDs (default separator is `/`).  
   Learn more about identity IDs creation [here](../../../../server/kb/document-identifier-generation#strategy--3).
 
-* __Maximum number of requests per session__:  
+* **Maximum number of requests per session**:  
   Set this number to restrict the number of requests (Reads & Writes) per session in the client API.
 
-* __Read balance behavior__:  
+* **Read balance behavior**:  
   Set the Read balance method the client will use when accessing a node with Read requests.  
   Learn more in [Balancing client requests - overview](../../../../client-api/configuration/load-balance/overview) and [Read balance behavior](../../../../client-api/configuration/load-balance/read-balance-behavior).
-
-* __Load balance behavior__:  
+  
+* **Load balance behavior**:  
   Set the Load balance method for Read & Write requests.  
   Learn more in [Load balance behavior](../../../../client-api/configuration/load-balance/load-balance-behavior).
 
@@ -91,9 +107,9 @@ The following client-configuration options are available:
 ### Operations
 
 - [What are Operations](../../../../client-api/operations/what-are-operations)
-- [Get client-configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
-- [Get client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
-- [Put client-configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
+- [Get client configuration (for database)](../../../../client-api/operations/maintenance/configuration/get-client-configuration)
+- [Get client configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)
+- [Put client configuration (server-wide)](../../../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)
 
 
 ### Load balancing

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/configuration/put-client-configuration.python.markdown
@@ -80,21 +80,21 @@ The following client configuration options are available:
 
 {PANEL: Put client configuration (for database)}
 
-{CODE put_config_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE:python put_config_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.py /}
 
-{CODE put_config_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE:python put_config_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE:python syntax_1@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.py /}
 
 | Parameter         | Type                  | Description                                                            |
 |-------------------|-----------------------|------------------------------------------------------------------------|
-| **configuration** | `ClientConfiguration` | Client configuration that will be set on the server (for the database) |
+| **config** | `ClientConfiguration` | Client configuration that will be set on the server (for the database) |
 
-{CODE syntax_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.cs /}
+{CODE:python syntax_2@ClientApi\Operations\Maintenance\Configuration\PutClientConfig.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.dotnet.markdown
@@ -1,0 +1,93 @@
+# Get Statistics
+
+---
+
+{NOTE: }
+
+* Statistics about your database and collections can be retrieved.  
+
+* By default, you get stats for the database defined in your Document Store.   
+  To get database and collection stats for another database use [ForDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).  
+
+* In this page:
+    * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
+    * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+    * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
+    * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+    * [Get stats for another database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database)
+{NOTE/}
+
+---
+
+{PANEL: Get collection stats}
+{NOTE: }
+Use `GetCollectionStatisticsOperation` to get **collection stats**.
+{CODE stats_1@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `CollectionStatistics` object.
+{CODE stats_1_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed collection stats}
+{NOTE: }
+Use `GetDetailedCollectionStatisticsOperation` to get **detailed collection stats**.
+{CODE stats_2@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedCollectionStatistics` object.
+{CODE stats_2_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get database stats}
+{NOTE: }
+Use `GetStatisticsOperation` to get **database stats**.
+{CODE stats_3@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DatabaseStatistics` object.
+{CODE stats_3_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed database stats}
+{NOTE: }
+Use `GetDetailedStatisticsOperation` to get **detailed database stats**.
+{CODE stats_4@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedDatabaseStatistics` object.
+{CODE stats_4_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get stats for another database}
+{NOTE: }
+
+* By default, you get stats for the database defined in your Document Store.  
+* Use `ForDatabase` to get database & collection stats for another database.  
+* 'ForDatabase' can be used with **any** of the above stats options.
+
+{CODE stats_5@ClientApi\Operations\Maintenance\GetStats.cs /}
+
+* Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+- [Switch operation to another database](../../../client-api/operations/how-to/switch-operations-to-a-different-database)
+
+### FAQ
+
+- [What is a Collection](../../../client-api/faq/what-is-a-collection)
+
+### Client API
+
+- [Get Query Statistics](../../../client-api/session/querying/how-to-get-query-statistics)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.java.markdown
@@ -1,0 +1,89 @@
+# Get Statistics
+
+---
+
+{NOTE: }
+
+* Statistics about your database and collections can be retrieved.
+
+* By default, you get stats for the database defined in your Document Store.   
+  To get database and collection stats for another database use [forDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).
+
+* In this page:
+    * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
+    * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+    * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
+    * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+    * [Get stats for another database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database)
+{NOTE/}
+
+---
+
+{PANEL: Get collection stats}
+{NOTE: }
+Use `GetCollectionStatisticsOperation` to get **collection stats**.
+{CODE:java stats_1@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `CollectionStatistics` object.
+{CODE:java stats_1_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed collection stats}
+{NOTE: }
+Use `GetDetailedCollectionStatisticsOperation` to get **detailed collection stats**.
+{CODE:java stats_2@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedCollectionStatistics` object.
+{CODE:java stats_2_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get database stats}
+{NOTE: }
+Use `GetStatisticsOperation` to get **database stats**.
+{CODE:java stats_3@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DatabaseStatistics` object.
+{CODE:java stats_3_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed database stats}
+{NOTE: }
+Use `GetDetailedStatisticsOperation` to get **detailed database stats**.
+{CODE:java stats_4@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{NOTE: }
+Stats are returned in the `DetailedDatabaseStatistics` object.
+{CODE:java stats_4_results@ClientApi\Operations\Maintenance\GetStats.java /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get stats for another database}
+{NOTE: }
+
+* By default, you get stats for the database defined in your Document Store.
+* Use `forDatabase` to get database & collection stats for another database.
+* 'ForDatabase' can be used with **any** of the above stats options.
+ 
+{CODE:java stats_5@ClientApi\Operations\Maintenance\GetStats.java /}
+
+* Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+- [Switch operation to another database](../../../client-api/operations/how-to/switch-operations-to-a-different-database)
+
+### FAQ
+
+- [What is a Collection](../../../client-api/faq/what-is-a-collection)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
@@ -1,0 +1,93 @@
+# Get Statistics
+
+---
+
+{NOTE: }
+
+* Statistics about your database and collections can be retrieved.
+
+* By default, you get stats for the database defined in your Document Store.   
+  To get database and collection stats for another database use [forDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).
+
+* In this page:
+    * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
+    * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
+    * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
+    * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
+    * [Get stats for another database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database)
+{NOTE/}
+
+---
+
+{PANEL: Get collection stats}
+{NOTE: }
+Use `GetCollectionStatisticsOperation` to get __collection stats__.
+{CODE:nodejs stats_1@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Collection stats results:
+{CODE:nodejs stats_1_results@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed collection stats}
+{NOTE: }
+Use `GetDetailedCollectionStatisticsOperation` to get __detailed collection stats__.
+{CODE:nodejs stats_2@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Detailed collection stats results:
+{CODE:nodejs stats_2_results@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get database stats}
+{NOTE: }
+Use `GetStatisticsOperation` to get __database stats__.
+{CODE:nodejs stats_3@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Database stats results:
+{CODE:nodejs stats_3_results@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get detailed database stats}
+{NOTE: }
+Use `GetDetailedStatisticsOperation` to get __detailed database stats__.
+{CODE:nodejs stats_4@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{NOTE: }
+Detailed database stats results:
+{CODE:nodejs stats_4_results@client-api\Operations\Maintenance\getStats.js /}
+{NOTE/}
+{PANEL/}
+
+{PANEL: Get stats for another database}
+{NOTE: }
+
+* By default, you get stats for the database defined in your Document Store.
+* Use `forDatabase` to get database & collection stats for another database.
+* 'forDatabase' can be used with __any__ of the above stats options.
+ 
+{CODE:nodejs stats_5@client-api\Operations\Maintenance\getStats.js /}
+
+* Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
+
+{NOTE/}
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)
+- [Switch operation to another database](../../../client-api/operations/how-to/switch-operations-to-a-different-database)
+
+### FAQ
+
+- [What is a Collection](../../../client-api/faq/what-is-a-collection)
+
+### Client API
+
+- [Get Query Statistics](../../../client-api/session/querying/how-to-get-query-statistics)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.js.markdown
@@ -4,77 +4,79 @@
 
 {NOTE: }
 
-* Statistics about your database and collections can be retrieved.
+* Statistics can be retrieved for the database and for collections.  
 
-* By default, you get stats for the database defined in your Document Store.   
-  To get database and collection stats for another database use [forDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).
+* By default, statistics are retrieved for the database defined in the Document Store.   
+  To get database and collection statistics for another database use [forDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).  
 
 * In this page:
-    * [Get collection stats](../../../client-api/operations/maintenance/get-stats#get-collection-stats)
-    * [Get detailed collection stats](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
-    * [Get database stats](../../../client-api/operations/maintenance/get-stats#get-database-stats)
-    * [Get detailed database stats](../../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)
-    * [Get stats for another database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database)
+    * [Get collection statistics](../../../client-api/operations/maintenance/get-stats#get-collection-statistics)
+    * [Get detailed collection statistics](../../../client-api/operations/maintenance/get-stats#get-detailed-collection-statistics)
+    * [Get database statistics](../../../client-api/operations/maintenance/get-stats#get-database-statistics)
+    * [Get detailed database statistics](../../../client-api/operations/maintenance/get-stats#get-detailed-database-statistics)
+    * [Get statistics for another database](../../../client-api/operations/maintenance/get-stats#get-statistics-for-another-database)
 {NOTE/}
 
 ---
 
-{PANEL: Get collection stats}
-{NOTE: }
-Use `GetCollectionStatisticsOperation` to get __collection stats__.
+{PANEL: Get collection statistics}
+
+To get **collection statistics**, use `GetCollectionStatisticsOperation`:  
 {CODE:nodejs stats_1@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
-{NOTE: }
-Collection stats results:
+
+---
+
+Statistics are returned in the `CollectionStatistics` object.
 {CODE:nodejs stats_1_results@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
+
 {PANEL/}
 
-{PANEL: Get detailed collection stats}
-{NOTE: }
-Use `GetDetailedCollectionStatisticsOperation` to get __detailed collection stats__.
-{CODE:nodejs stats_2@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
-{NOTE: }
-Detailed collection stats results:
+{PANEL: Get detailed collection statistics}
+
+To get **detailed collection statistics**, use `GetDetailedCollectionStatisticsOperation`:  
 {CODE:nodejs stats_2_results@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
+
+---
+
+Statistics are returned in the `DetailedCollectionStatistics` object.
+{CODE:python stats_2_results@ClientApi\Operations\Maintenance\GetStats.py /}
+
 {PANEL/}
 
-{PANEL: Get database stats}
-{NOTE: }
-Use `GetStatisticsOperation` to get __database stats__.
+{PANEL: Get database statistics}
+
+To get **database statistics**, use `GetStatisticsOperation`:  
 {CODE:nodejs stats_3@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
-{NOTE: }
-Database stats results:
+
+---
+
+Statistics are returned in the `DatabaseStatistics` object.
 {CODE:nodejs stats_3_results@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
+
 {PANEL/}
 
-{PANEL: Get detailed database stats}
-{NOTE: }
-Use `GetDetailedStatisticsOperation` to get __detailed database stats__.
+{PANEL: Get detailed database statistics}
+
+To get **detailed database statistics**, use `GetDetailedStatisticsOperation`:  
 {CODE:nodejs stats_4@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
-{NOTE: }
-Detailed database stats results:
+
+---
+
+Statistics are returned in the `DetailedDatabaseStatistics` object.
 {CODE:nodejs stats_4_results@client-api\Operations\Maintenance\getStats.js /}
-{NOTE/}
+
 {PANEL/}
 
-{PANEL: Get stats for another database}
-{NOTE: }
+{PANEL: Get statistics for another database}
 
-* By default, you get stats for the database defined in your Document Store.
-* Use `forDatabase` to get database & collection stats for another database.
-* 'forDatabase' can be used with __any__ of the above stats options.
- 
+* By default, you get statistics for the database defined in your Document Store.  
+* Use `forDatabase` to get database and collection statistics for another database.  
+* `forDatabase` can be used with **any** of the above statistics options.
+
 {CODE:nodejs stats_5@client-api\Operations\Maintenance\getStats.js /}
 
 * Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
 
-{NOTE/}
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/get-stats.python.markdown
@@ -7,7 +7,7 @@
 * Statistics can be retrieved for the database and for collections.  
 
 * By default, statistics are retrieved for the database defined in the Document Store.   
-  To get database and collection statistics for another database use [ForDatabase](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).  
+  To get database and collection statistics for another database use [for_database](../../../client-api/operations/maintenance/get-stats#get-stats-for-another-database).  
 
 * In this page:
     * [Get collection statistics](../../../client-api/operations/maintenance/get-stats#get-collection-statistics)
@@ -22,58 +22,58 @@
 {PANEL: Get collection statistics}
 
 To get **collection statistics**, use `GetCollectionStatisticsOperation`:  
-{CODE stats_1@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_1@ClientApi\Operations\Maintenance\GetStats.py /}
 
 ---
 
 Statistics are returned in the `CollectionStatistics` object.
-{CODE stats_1_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_1_results@ClientApi\Operations\Maintenance\GetStats.py /}
 
 {PANEL/}
 
 {PANEL: Get detailed collection statistics}
 
 To get **detailed collection statistics**, use `GetDetailedCollectionStatisticsOperation`:  
-{CODE stats_2@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_2@ClientApi\Operations\Maintenance\GetStats.py /}
 
 ---
 
 Statistics are returned in the `DetailedCollectionStatistics` object.
-{CODE stats_2_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_2_results@ClientApi\Operations\Maintenance\GetStats.py /}
 
 {PANEL/}
 
 {PANEL: Get database statistics}
 
 To get **database statistics**, use `GetStatisticsOperation`:  
-{CODE stats_3@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_3@ClientApi\Operations\Maintenance\GetStats.py /}
 
 ---
 
 Statistics are returned in the `DatabaseStatistics` object.
-{CODE stats_3_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_3_results@ClientApi\Operations\Maintenance\GetStats.py /}
 
 {PANEL/}
 
 {PANEL: Get detailed database statistics}
 
 To get **detailed database statistics**, use `GetDetailedStatisticsOperation`:  
-{CODE stats_4@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_4@ClientApi\Operations\Maintenance\GetStats.py /}
 
 ---
 
 Statistics are returned in the `DetailedDatabaseStatistics` object.
-{CODE stats_4_results@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_4_results@ClientApi\Operations\Maintenance\GetStats.py /}
 
 {PANEL/}
 
 {PANEL: Get statistics for another database}
 
 * By default, you get statistics for the database defined in your Document Store.  
-* Use `ForDatabase` to get database and collection statistics for another database.  
-* `ForDatabase` can be used with **any** of the above statistics options.
+* Use `for_database` to get database and collection statistics for another database.  
+* `for_database` can be used with **any** of the above statistics options.
 
-{CODE stats_5@ClientApi\Operations\Maintenance\GetStats.cs /}
+{CODE:python stats_5@ClientApi\Operations\Maintenance\GetStats.py /}
 
 * Learn more about switching operations to another database [here](../../../client-api/operations/how-to/switch-operations-to-a-different-database).
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/.docs.json
@@ -1,0 +1,20 @@
+[
+    {
+        "Path": "get-identities.markdown",
+        "Name": "Get Identities",
+        "DiscussionId": "41763cbe-a6ab-4735-aeef-0478ef81ecb1",
+        "Mappings": []
+    },
+    {
+        "Path": "increment-next-identity.markdown",
+        "Name": "Increment Next Identity",
+        "DiscussionId": "41763cbe-a6ab-4735-aeef-0478ef81ecb1",
+        "Mappings": []
+    },
+    {
+        "Path": "seed-identity.markdown",
+        "Name": "Seed Identity",
+        "DiscussionId": "41763cbe-a6ab-4735-aeef-0478ef81ecb1",
+        "Mappings": []
+    }
+]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.dotnet.markdown
@@ -1,0 +1,62 @@
+# Get Identities Operation
+
+---
+
+{NOTE: }
+
+* Upon document creation, providing a collection name with a pipe symbol (`|`)  
+  will cause the server to generate an ID for the new document called an **identity**.
+ 
+* The identity document ID is unique across the entire cluster within the database scope.  
+  It is composed  of the collection name provided and an integer value that is continuously incremented.
+
+* Identity values can also be managed from the Studio [identities view](../../../../studio/database/documents/identities-view).
+
+* Use `GetIdentitiesOperation` to get the dictionary that maps collection names to their corresponding latest identity values.
+
+* Learn more about identities in:
+
+    * [Document identifier generation](../../../../server/kb/document-identifier-generation#strategy--3)
+    * [Working with document identifiers](../../../../client-api/document-identifiers/working-with-document-identifiers#identities)
+
+* In this page:
+
+  * [Get identities operation](../../../../client-api/operations/maintenance/identities/get-identities#get-identities-operation)
+  * [Syntax](../../../../client-api/operations/maintenance/identities/get-identities#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get identities operation }
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_identities@ClientApi\Operations\Maintenance\Identities\GetIdentities.cs /}
+{CODE-TAB:csharp:Async get_identities_async@ClientApi\Operations\Maintenance\Identities\GetIdentities.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax }
+
+{CODE syntax@ClientApi\Operations\Maintenance\Identities\GetIdentities.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation#strategy--3)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Seed identity](../../../../client-api/operations/maintenance/identities/seed-identity)
+- [Increment next identity](../../../../client-api/operations/maintenance/identities/increment-next-identity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.java.markdown
@@ -1,0 +1,27 @@
+# Get Identities Operation
+
+**GetIdentitiesOperation** is used to return a dictionary which maps from the collection name to the identity value.
+
+## Syntax
+
+{CODE:java sample_1@ClientApi\Operations\Maintenance\Identities\Identities.java /}
+
+## Example
+
+{CODE:java sample_2@ClientApi\Operations\Maintenance\Identities\Identities.java /}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.js.markdown
@@ -1,0 +1,57 @@
+# Get Identities Operation
+
+---
+
+{NOTE: }
+
+* Upon document creation, providing a collection name with a pipe symbol (`|`)  
+  will cause the server to generate an ID for the new document called an __identity__.
+ 
+* The identity document ID is unique across the entire cluster within the database scope.  
+  It is composed  of the collection name provided and an integer value that is continuously incremented.
+
+* Identity values can also be managed from the Studio [identities view](../../../../studio/database/documents/identities-view).
+
+* Use `GetIdentitiesOperation` to get the dictionary that maps collection names to their corresponding latest identity values.
+
+* Learn more about identities in:
+
+    * [Document identifier generation](../../../../server/kb/document-identifier-generation#strategy--3)
+
+* In this page:
+
+  * [Get identities operation](../../../../client-api/operations/maintenance/identities/get-identities#get-identities-operation)
+  * [Syntax](../../../../client-api/operations/maintenance/identities/get-identities#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get identities operation }
+
+{CODE:nodejs get_identities@client-api\Operations\Maintenance\Identities\getIdentities.js /}
+
+{PANEL/}
+
+{PANEL: Syntax }
+
+{CODE:nodejs syntax@client-api\Operations\Maintenance\Identities\getIdentities.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation#strategy--3)
+
+### Operations
+
+- [What are Operations](../../../../client-api/operations/what-are-operations)
+- [Seed identity](../../../../client-api/operations/maintenance/identities/seed-identity)
+- [Increment next identity](../../../../client-api/operations/maintenance/identities/increment-next-identity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.js.markdown
@@ -4,13 +4,14 @@
 
 {NOTE: }
 
-* Upon document creation, providing a collection name with a pipe symbol (`|`)  
-  will cause the server to generate an ID for the new document called an __identity__.
+* Upon document creation, providing a collection name with a pipe symbol (`|`) 
+  will cause the server to generate an ID for the new document called an **identity**.  
+  E.g. `companies|`
  
 * The identity document ID is unique across the entire cluster within the database scope.  
-  It is composed  of the collection name provided and an integer value that is continuously incremented.
+  It is composed of the provided collection name and an integer value that is continuously incremented.
 
-* Identity values can also be managed from the Studio [identities view](../../../../studio/database/documents/identities-view).
+* Identity values can also be managed from the Studio [identities](../../../../studio/database/documents/identities-view) view.
 
 * Use `GetIdentitiesOperation` to get the dictionary that maps collection names to their corresponding latest identity values.
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/get-identities.python.markdown
@@ -31,16 +31,13 @@
 
 {PANEL: Get identities operation }
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync get_identities@ClientApi\Operations\Maintenance\Identities\GetIdentities.cs /}
-{CODE-TAB:csharp:Async get_identities_async@ClientApi\Operations\Maintenance\Identities\GetIdentities.cs /}
-{CODE-TABS/}
+{CODE:python get_identities@ClientApi\Operations\Maintenance\Identities\GetIdentities.py /}
 
 {PANEL/}
 
 {PANEL: Syntax }
 
-{CODE syntax@ClientApi\Operations\Maintenance\Identities\GetIdentities.cs /}
+{CODE:python syntax@ClientApi\Operations\Maintenance\Identities\GetIdentities.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/increment-next-identity.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/increment-next-identity.dotnet.markdown
@@ -1,0 +1,55 @@
+# Increment Next Identity Operation
+
+---
+
+{NOTE: }
+
+* Use `NextIdentityForOperation` to increment the latest identity value set on the server for the specified collection in the database.
+
+* The next document that will be created using an identity for the collection will receive the consecutive integer value.
+
+* In this page:
+
+  * [Increment the next identity value](../../../../client-api/operations/maintenance/identities/increment-next-identity#increment-the-next-identity-value)
+  * [Syntax](../../../../client-api/operations/maintenance/identities/increment-next-identity#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Increment the next identity value }
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync increment_identity@ClientApi\Operations\Maintenance\Identities\IncrementIdentity.cs /}
+{CODE-TAB:csharp:Async increment_identity_async@ClientApi\Operations\Maintenance\Identities\IncrementIdentity.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax }
+
+{CODE syntax@ClientApi\Operations\Maintenance\Identities\IncrementIdentity.cs /}
+
+| Parameter | Type   | Description                                                                                                                                    |
+|-----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| **name**  | string | The collection name for which to increment the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
+
+{PANEL/}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [Get identities](../../../../client-api/operations/maintenance/identities/get-identities)
+- [Seed identity](../../../../client-api/operations/maintenance/identities/seed-identity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/increment-next-identity.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/increment-next-identity.js.markdown
@@ -1,0 +1,51 @@
+# Increment Next Identity Operation
+
+---
+
+{NOTE: }
+
+* Use `NextIdentityForOperation` to increment the latest identity value set on the server for the specified collection in the database.
+
+* The next document that will be created using an identity for the collection will receive the consecutive integer value.
+
+* In this page:
+
+  * [Increment the next identity value](../../../../client-api/operations/maintenance/identities/increment-next-identity#increment-the-next-identity-value)
+  * [Syntax](../../../../client-api/operations/maintenance/identities/increment-next-identity#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Increment the next identity value }
+
+{CODE:nodejs increment_identity@client-api\Operations\Maintenance\Identities\incrementIdentity.js /}
+
+{PANEL/}
+
+{PANEL: Syntax }
+
+{CODE:nodejs syntax@client-api\Operations\Maintenance\Identities\incrementIdentity.js /}
+
+| Parameter | Type   | Description                                                                                                                                    |
+|-----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| __name__  | string | The collection name for which to increment the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
+
+{PANEL/}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [Get identities](../../../../client-api/operations/maintenance/identities/get-identities)
+- [Seed identity](../../../../client-api/operations/maintenance/identities/seed-identity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/increment-next-identity.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/increment-next-identity.python.markdown
@@ -1,0 +1,52 @@
+# Increment Next Identity Operation
+
+---
+
+{NOTE: }
+
+* Use `NextIdentityForOperation` to increment the latest identity value set on the server for the specified collection in the database.
+
+* The next document that will be created using an identity for the collection will receive the consecutive integer value.
+
+* In this page:
+
+  * [Increment the next identity value](../../../../client-api/operations/maintenance/identities/increment-next-identity#increment-the-next-identity-value)
+  * [Syntax](../../../../client-api/operations/maintenance/identities/increment-next-identity#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Increment the next identity value }
+
+{CODE:python increment_identity@ClientApi\Operations\Maintenance\Identities\IncrementIdentity.py /}
+
+{PANEL/}
+
+{PANEL: Syntax }
+
+{CODE:python syntax@ClientApi\Operations\Maintenance\Identities\IncrementIdentity.py /}
+
+| Parameter | Type   | Description                                                         |
+|-----------|--------|---------------------------------------------------------------------|
+| **MaintenanceOperation[int]**  | Operation | An operation to increment the next identity |
+
+{PANEL/}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [Get identities](../../../../client-api/operations/maintenance/identities/get-identities)
+- [Seed identity](../../../../client-api/operations/maintenance/identities/seed-identity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.dotnet.markdown
@@ -1,0 +1,75 @@
+# Seed Identity Operation
+
+---
+
+{NOTE: }
+
+* Use `SeedIdentityForOperation` to set the latest identity value for the specified collection.
+  
+* The next document that will be created using an identity for the collection will receive the consecutive integer value.
+
+* Identity values can also be managed from the Studio [identities view](../../../../studio/database/documents/identities-view).
+
+* In this page:
+  * [Set a higher identity value](../../../../client-api/operations/maintenance/identities/seed-identity#set-a-higher-identity-valure)
+  * [Force a smaller identity value](../../../../client-api/operations/maintenance/identities/seed-identity#force-a-smaller-identity-value)
+  * [Syntax](../../../../client-api/operations/maintenance/identities/seed-identity#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Set a higher identity value }
+
+You can replace the latest identity value on the server with a new, **higher** number. 
+ 
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync seed_identity_1@ClientApi\Operations\Maintenance\Identities\SeedIdentity.cs /}
+{CODE-TAB:csharp:Async seed_identity_1_async@ClientApi\Operations\Maintenance\Identities\SeedIdentity.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Force a smaller identity value }
+
+* You can set the latest identity value to a number that is **smaller** than the current latest value.
+
+* Before proceeding, first ensure that documents with an identity value higher than the new number do not exist.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync seed_identity_2@ClientApi\Operations\Maintenance\Identities\SeedIdentity.cs /}
+{CODE-TAB:csharp:Async seed_identity_2_async@ClientApi\Operations\Maintenance\Identities\SeedIdentity.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax }
+
+{CODE syntax@ClientApi\Operations\Maintenance\Identities\SeedIdentity.cs /}
+
+| Parameter       | Type   | Description                                                                                                                               |
+|-----------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| **name**        | string | The collection name for which to seed the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
+| **value**       | long   | The number to set as the latest identity value.                                                                                           |
+| **forceUpdate** | bool   | `true` - force a new value that is smaller than the latest.<br>`false` - only a higher value can be set.                                  |
+
+{PANEL/}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [Get identities](../../../../client-api/operations/maintenance/identities/get-identities)
+- [Increment next identity](../../../../client-api/operations/maintenance/identities/increment-next-identity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.dotnet.markdown
@@ -11,8 +11,8 @@
 * Identity values can also be managed from the Studio [identities view](../../../../studio/database/documents/identities-view).
 
 * In this page:
-  * [Set a higher identity value](../../../../client-api/operations/maintenance/identities/seed-identity#set-a-higher-identity-valure)
-  * [Force a smaller identity value](../../../../client-api/operations/maintenance/identities/seed-identity#force-a-smaller-identity-value)
+  * [Set a higher identity value](../../../../client-api/operations/maintenance/identities/seed-identity#set-a-higher-identity-value)
+  * [Force a lower identity value](../../../../client-api/operations/maintenance/identities/seed-identity#force-a-lower-identity-value)
   * [Syntax](../../../../client-api/operations/maintenance/identities/seed-identity#syntax)
 
 {NOTE/}
@@ -31,9 +31,9 @@ You can replace the latest identity value on the server with a new, **higher** n
 
 {PANEL/}
 
-{PANEL: Force a smaller identity value }
+{PANEL: Force a lower identity value }
 
-* You can set the latest identity value to a number that is **smaller** than the current latest value.
+* You can set the latest identity value to a number that is **lower** than the current latest value.
 
 * Before proceeding, first ensure that documents with an identity value higher than the new number do not exist.
 
@@ -48,11 +48,11 @@ You can replace the latest identity value on the server with a new, **higher** n
 
 {CODE syntax@ClientApi\Operations\Maintenance\Identities\SeedIdentity.cs /}
 
-| Parameter       | Type   | Description                                                                                                                               |
-|-----------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| **name**        | string | The collection name for which to seed the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
-| **value**       | long   | The number to set as the latest identity value.                                                                                           |
-| **forceUpdate** | bool   | `true` - force a new value that is smaller than the latest.<br>`false` - only a higher value can be set.                                  |
+| Parameter       | Type     | Description                                                                                                                               |
+|-----------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| **name**        | `string` | The collection name for which to seed the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
+| **value**       | `long`   | The number to set as the latest identity value.                                                                                           |
+| **forceUpdate** | `bool`   | `true` - force a new value that is lower than the latest.<br>`false` - only a higher value can be set.                                  |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.js.markdown
@@ -1,0 +1,67 @@
+# Seed Identity Operation
+
+---
+
+{NOTE: }
+
+* Use `SeedIdentityForOperation` to set the latest identity value for the specified collection.
+  
+* The next document that will be created using an identity for the collection will receive the consecutive integer value.
+
+* Identity values can also be managed from the Studio [identities view](../../../../studio/database/documents/identities-view).
+
+* In this page:
+  * [Set a higher identity value](../../../../client-api/operations/maintenance/identities/seed-identity#set-a-higher-identity-valure)
+  * [Force a smaller identity value](../../../../client-api/operations/maintenance/identities/seed-identity#force-a-smaller-identity-value)
+  * [Syntax](../../../../client-api/operations/maintenance/identities/seed-identity#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Set a higher identity value }
+
+You can replace the latest identity value on the server with a new, __higher__ number. 
+
+{CODE:nodejs seed_identity_1@client-api\Operations\Maintenance\Identities\seedIdentity.js /}
+
+{PANEL/}
+
+{PANEL: Force a smaller identity value }
+
+* You can set the latest identity value to a number that is __smaller__ than the current latest value.
+
+* Before proceeding, first ensure that documents with an identity value higher than the new number do not exist.
+
+{CODE:nodejs seed_identity_2@client-api\Operations\Maintenance\Identities\seedIdentity.js /}
+
+{PANEL/}
+
+{PANEL: Syntax }
+
+{CODE:nodejs syntax@client-api\Operations\Maintenance\Identities\seedIdentity.js /}
+
+| Parameter       | Type    | Description                                                                                                                               |
+|-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| __name__        | string  | The collection name for which to seed the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
+| __value__       | number  | The number to set as the latest identity value.                                                                                           |
+| __forceUpdate__ | boolean | `true` - force a new value that is smaller than the latest.<br>`false` - only a higher value can be set.                                  |
+
+{PANEL/}
+
+## Related Articles
+
+### Document Identifiers
+
+- [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../../server/kb/document-identifier-generation)
+
+### Operations
+
+- [What are operations](../../../../client-api/operations/what-are-operations)
+- [Get identities](../../../../client-api/operations/maintenance/identities/get-identities)
+- [Increment next identity](../../../../client-api/operations/maintenance/identities/increment-next-identity)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/identities/seed-identity.python.markdown
@@ -21,31 +21,32 @@
 
 {PANEL: Set a higher identity value }
 
-You can replace the latest identity value on the server with a new, __higher__ number. 
+You can replace the latest identity value on the server with a new, **higher** number. 
+ 
 
-{CODE:nodejs seed_identity_1@client-api\Operations\Maintenance\Identities\seedIdentity.js /}
+{CODE:python seed_identity_1@ClientApi\Operations\Maintenance\Identities\SeedIdentity.py /}
 
 {PANEL/}
 
 {PANEL: Force a lower identity value }
 
-* You can set the latest identity value to a number that is __lower__ than the current latest value.
+* You can set the latest identity value to a number that is **lower** than the current latest value.
 
 * Before proceeding, first ensure that documents with an identity value higher than the new number do not exist.
 
-{CODE:nodejs seed_identity_2@client-api\Operations\Maintenance\Identities\seedIdentity.js /}
+{CODE:python seed_identity_2@ClientApi\Operations\Maintenance\Identities\SeedIdentity.py /}
 
 {PANEL/}
 
 {PANEL: Syntax }
 
-{CODE:nodejs syntax@client-api\Operations\Maintenance\Identities\seedIdentity.js /}
+{CODE:python syntax@ClientApi\Operations\Maintenance\Identities\SeedIdentity.py /}
 
-| Parameter       | Type      | Description                                                                                                                               |
-|-----------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| __name__        | `string`  | The collection name for which to seed the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
-| __value__       | `number`  | The number to set as the latest identity value.                                                                                           |
-| __forceUpdate__ | `boolean` | `true` - force a new value that is lower than the latest.<br>`false` - only a higher value can be set.                                  |
+| Parameter        | Type   | Description                                                                                                                               |
+|------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| **name**         | `str`  | The collection name for which to seed the identity value.<br>Can be with or without a pipe in the end (e.g. "companies" or "companies\|". |
+| **value**        | `long` | The number to set as the latest identity value.                                                                                           |
+| **force_update** | `bool` | `True` - force a new value that is lower than the latest.<br>`False` - only a higher value can be set.                                  |
 
 {PANEL/}
 
@@ -53,6 +54,7 @@ You can replace the latest identity value on the server with a new, __higher__ n
 
 ### Document Identifiers
 
+- [Working with Document Identifiers](../../../../client-api/document-identifiers/working-with-document-identifiers)
 - [Global ID Generation Conventions](../../../../client-api/configuration/identifier-generation/global)
 - [Type-specific ID Generation Conventions](../../../../client-api/configuration/identifier-generation/type-specific)
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.dotnet.markdown
@@ -7,22 +7,22 @@
 * The RavenDB Client API is built with the notion of layers.  
   At the top, and what you will usually interact with, are the **[DocumentStore](../../client-api/what-is-a-document-store)**
   and the **[Session](../../client-api/session/what-is-a-session-and-how-does-it-work)**.  
-  They in turn are built on top of the lower-level __Operations__ and __RavenCommands__ API.
+  They in turn are built on top of the lower-level **Operations** and **RavenCommands** API.
 
-* __RavenDB provides access to this lower-level API__, so that instead of using the higher session API,  
+* **RavenDB provides access to this lower-level API**, so that instead of using the higher session API,  
   you can generate requests directly to the server by executing operations on the DocumentStore.
 
 * In this page:  
   * [Why use operations](../../client-api/operations/what-are-operations#why-use-operations)  
   * [How operations work](../../client-api/operations/what-are-operations#how-operations-work)  
   <br>
-  * __Operation types__: 
+  * **Operation types**: 
       * [Common operations](../../client-api/operations/what-are-operations#common-operations)  
       * [Maintenance operations](../../client-api/operations/what-are-operations#maintenance-operations)  
       * [Server-maintenance operations](../../client-api/operations/what-are-operations#server-maintenance-operations)
   * [Manage lengthy operations](../../client-api/operations/what-are-operations#manage-lengthy-operations)
       * [Wait for completion](../../client-api/operations/what-are-operations#wait-for-completion)  
-      * [Kill operation](../../client-api/operations/what-are-operations#killOperation)  
+      * [Kill operation](../../client-api/operations/what-are-operations#kill-operation)  
 
 {NOTE/}
 
@@ -30,7 +30,7 @@
 
 {PANEL: Why use operations}
 
-* Operations provide __management functionality__ that is Not available in the context of the session, for example:
+* Operations provide **management functionality** that is Not available in the context of the session, for example:
     * Create/delete a database
     * Execute administrative tasks
     * Assign permissions
@@ -45,20 +45,20 @@
 
 {PANEL: How operations work}
 
-* __Sending the request__:  
+* **Sending the request**:  
   Each Operation is an encapsulation of a `RavenCommand`.  
   The RavenCommand creates the HTTP request message to be sent to the relevant server endpoint.  
   The DocumentStore `OperationExecutor` sends the request and processes the results.
-* __Target node__:  
+* **Target node**:  
   By default, the operation will be executed on the server node that is defined by the [client configuration](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
   However, server-maintenance operations can be executed on a specific node by using the [ForNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
-* __Target database__:  
+* **Target database**:  
   By default, operations work on the default database defined in the DocumentStore.  
   However, common operations & maintenance operations can operate on a different database by using the [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) method.  
-* __Transaction scope__:  
+* **Transaction scope**:  
   Operations execute as a single-node transaction.  
   If needed, data will then replicate to the other nodes in the database-group.  
-* __Background operations__:  
+* **Background operations**:  
   Some operations may take a long time to complete and can be awaited for completion.   
   Learn more [below](../../client-api/operations/what-are-operations#wait-for-completion).
 
@@ -66,10 +66,8 @@
 
 {PANEL: Common operations}
 
-{NOTE: }
-
 * All common operations implement the `IOperation` interface.  
-  The operation is executed within the __database scope__.  
+  The operation is executed within the **database scope**.  
   Use [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.  
 
 * These operations include set-based operations such as _PatchOperation_, _CounterBatchOperation_,  
@@ -79,58 +77,52 @@
 * To execute a common operation request,  
   use the `Send` method on the `Operations` property in the DocumentStore.
 
-__Example__:
+**Example**:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync operations_ex@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TAB:csharp:Async operations_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-{NOTE/}
-
-{NOTE: }
-
-__Send syntax__:
+#### Send syntax:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync operations_send@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TAB:csharp:Async operations_send_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-{NOTE/}
-
 {NOTE: }
 
-<span id="operations-list"> __The following common operations are available:__ </span>
+<span id="operations-list"> **The following common operations are available:** </span>
 
 ---
 
-* __Attachments__:  
+* **Attachments**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutAttachmentOperation](../../client-api/operations/attachments/put-attachment)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetAttachmentOperation](../../client-api/operations/attachments/get-attachment)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteAttachmentOperation](../../client-api/operations/attachments/delete-attachment)  
 
-* __Counters__:  
+* **Counters**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CounterBatchOperation](../../client-api/operations/counters/counter-batch)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCountersOperation](../../client-api/operations/counters/get-counters)  
 
-* __Time series__:  
+* **Time series**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [TimeSeriesBatchOperation](../../document-extensions/timeseries/client-api/operations/append-and-delete)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetMultipleTimeSeriesOperation](../../document-extensions/timeseries/client-api/operations/get)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetTimeSeriesOperation](../../document-extensions/timeseries/client-api/operations/get)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTimeSeriesStatisticsOperation  
 
-* __Revisions__:  
+* **Revisions**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetRevisionsOperation](../../document-extensions/revisions/client-api/operations/get-revisions)  
 
-* __Patching__:  
+* **Patching**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PatchOperation](../../client-api/operations/patching/single-document)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PatchByQueryOperation](../../client-api/operations/patching/set-based)  
 
-* __Delete by query__:  
+* **Delete by query**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteByQueryOperation](../../client-api/operations/common/delete-by-query)   
 
-* __Compare-exchange__:  
+* **Compare-exchange**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutCompareExchangeValueOperation](../../client-api/operations/compare-exchange/put-compare-exchange-value)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCompareExchangeValueOperation](../../client-api/operations/compare-exchange/get-compare-exchange-value)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCompareExchangeValuesOperation](../../client-api/operations/compare-exchange/get-compare-exchange-values)  
@@ -141,10 +133,8 @@ __Send syntax__:
 
 {PANEL: Maintenance operations}
 
-{NOTE: }
-
 * All maintenance operations implement the `IMaintenanceOperation` interface.  
-  The operation is executed within the __database scope__.  
+  The operation is executed within the **database scope**.  
   Use [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.
 
 * These operations include database management operations such as setting client configuration,  
@@ -154,43 +144,37 @@ __Send syntax__:
 * To execute a maintenance operation request,  
   use the `Send` method on the `Maintenance` property in the DocumentStore.
 
-__Example__:
+**Example**:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync maintenance_ex@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TAB:csharp:Async maintenance_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-{NOTE/}
-
-{NOTE: }
-
-__Send syntax__:
+**Send syntax**:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync maintenance_send@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TAB:csharp:Async maintenance_send_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-{NOTE/}
-
 {NOTE: }
 
-<span id="maintenance-list"> __The following maintenance operations are available:__ </span>
+<span id="maintenance-list"> **The following maintenance operations are available:** </span>
 
 ---
 
-* __Statistics__:  
+* **Statistics**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-database-stats)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDetailedStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-detailed-database-stats)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCollectionStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-collection-stats)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDetailedCollectionStatisticsOperation](../../client-api/operations/maintenance/get-stats#get-detailed-collection-stats)
 
-* __Client Configuration__:  
+* **Client Configuration**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutClientConfigurationOperation](../../client-api/operations/maintenance/configuration/put-client-configuration)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetClientConfigurationOperation](../../client-api/operations/maintenance/configuration/get-client-configuration)  
 
-* __Indexes__:  
+* **Indexes**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutIndexesOperation](../../client-api/operations/maintenance/indexes/put-indexes)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SetIndexesLockOperation](../../client-api/operations/maintenance/indexes/set-index-lock)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SetIndexesPriorityOperation](../../client-api/operations/maintenance/indexes/set-index-priority)   
@@ -215,21 +199,21 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [EnableIndexOperation](../../client-api/operations/maintenance/indexes/enable-index)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [IndexHasChangedOperation](../../client-api/operations/maintenance/indexes/index-has-changed)   
 
-* __Analyzers__:  
+* **Analyzers**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutAnalyzersOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteAnalyzerOperation  
 
-* __Ongoing tasks__:  
+* **Ongoing tasks**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetOngoingTaskInfoOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteOngoingTaskOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ToggleOngoingTaskStateOperation  
 
-* __ETL tasks__:  
+* **ETL tasks**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; AddEtlOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateEtlOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ResetEtlOperation](../../client-api/operations/maintenance/etl/reset-etl)
 
-* __Replication tasks__:  
+* **Replication tasks**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutPullReplicationAsHubOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetPullReplicationTasksInfoOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetReplicationHubAccessOperation  
@@ -239,44 +223,44 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateExternalReplicationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdatePullReplicationAsSinkOperation
 
-* __Backup__:  
+* **Backup**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; BackupOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetPeriodicBackupStatusOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StartBackupOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdatePeriodicBackupOperation  
 
-* __Connection strings__:  
+* **Connection strings**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutConnectionStringOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RemoveConnectionStringOperation  
 
-* __Transaction recording__:  
+* **Transaction recording**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StartTransactionsRecordingOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; StopTransactionsRecordingOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplayTransactionsRecordingOperation  
 
-* __Database settings__:  
+* **Database settings**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#put-database-settings-operation)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetDatabaseSettingsOperation](../../client-api/operations/maintenance/configuration/database-settings-operation#get-database-settings-operation)  
 
-* __Identities__:  
+* **Identities**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetIdentitiesOperation](../../client-api/operations/maintenance/identities/get-identities)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [NextIdentityForOperation](../../client-api/operations/maintenance/identities/increment-next-identity)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [SeedIdentityForOperation](../../client-api/operations/maintenance/identities/seed-identity)
 
-* __Time series__:  
+* **Time series**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesPolicyOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureTimeSeriesValueNamesOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RemoveTimeSeriesPolicyOperation  
 
-* __Revisions__:  
+* **Revisions**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ConfigureRevisionsOperation](../../document-extensions/revisions/client-api/operations/configure-revisions)  
 
-* __Sorters__:   
+* **Sorters**:   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutSortersOperation](../../client-api/operations/maintenance/sorters/put-sorter)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteSorterOperation  
 
-* __Misc__:  
+* **Misc**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureExpirationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ConfigureRefreshOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateDocumentsCompressionConfigurationOperation  
@@ -289,10 +273,8 @@ __Send syntax__:
 
 {PANEL: Server-maintenance operations}
 
-{NOTE: }
-
 * All server-maintenance operations implement the `IServerOperation` interface.  
-  The operation is executed within the __server scope__.   
+  The operation is executed within the **server scope**.   
   Use [ForNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) to operate on a specific node other than the default defined in the client configuration.
 
 * These operations include server management and configuration operations.  
@@ -301,33 +283,27 @@ __Send syntax__:
 * To execute a server-maintenance operation request,  
   use the `Send` method on the `Maintenance.Server` property in the DocumentStore.
 
-__Example__:
+**Example**:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync server_ex@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TAB:csharp:Async server_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-{NOTE/}
-
-{NOTE: }
-
-__Send syntax__:
+**Send syntax**:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync server_send@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TAB:csharp:Async server_send_async@ClientApi\Operations\WhatAreOperations.cs /}
 {CODE-TABS/}
 
-{NOTE/}
-
 {NOTE: }
 
-<span id="server-list"> __The following server-maintenance operations are available:__ </span>
+<span id="server-list"> **The following server-maintenance operations are available:** </span>
 
 ---
 
-* __Client certificates__:  
+* **Client certificates**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutClientCertificateOperation](../../client-api/operations/server-wide/certificates/put-client-certificate)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CreateClientCertificateOperation](../../client-api/operations/server-wide/certificates/create-client-certificate)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetCertificatesOperation](../../client-api/operations/server-wide/certificates/get-certificates)   
@@ -336,11 +312,11 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetCertificateMetadataOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ReplaceClusterCertificateOperation  
 
-* __Server-wide client configuration__:  
+* **Server-wide client configuration**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutServerWideClientConfigurationOperation](../../client-api/operations/server-wide/configuration/put-serverwide-client-configuration)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetServerWideClientConfigurationOperation](../../client-api/operations/server-wide/configuration/get-serverwide-client-configuration)   
 
-* __Database management__:  
+* **Database management**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [CreateDatabaseOperation](../../client-api/operations/server-wide/create-database)   
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [DeleteDatabasesOperation](../../client-api/operations/server-wide/delete-database)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ToggleDatabasesStateOperation](../../client-api/operations/server-wide/toggle-databases-state)  
@@ -357,44 +333,44 @@ __Send syntax__:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateDatabaseOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; UpdateUnusedDatabasesOperation  
 
-* __Server-wide ongoing tasks__:  
+* **Server-wide ongoing tasks**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideTaskOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ToggleServerWideTaskStateOperation  
 
-* __Server-wide replication tasks__:  
+* **Server-wide replication tasks**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideExternalReplicationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideExternalReplicationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideExternalReplicationsOperation  
 
-* __Server-wide backup tasks__:  
+* **Server-wide backup tasks**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideBackupConfigurationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideBackupConfigurationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideBackupConfigurationsOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RestoreBackupOperation  
 
-* __Server-wide analyzers__:  
+* **Server-wide analyzers**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutServerWideAnalyzersOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideAnalyzerOperation  
 
-* __Server-wide sorters__:  
+* **Server-wide sorters**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [PutServerWideSortersOperation](../../client-api/operations/server-wide/sorters/put-sorter-server-wide)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; DeleteServerWideSorterOperation  
 
-* __Logs & debug__:  
+* **Logs & debug**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; SetLogsConfigurationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetLogsConfigurationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetClusterDebugInfoPackageOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [GetBuildNumberOperation](../../client-api/operations/server-wide/get-build-number)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetServerWideOperationStateOperation  
 
-* __Traffic watch__:  
+* **Traffic watch**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; PutTrafficWatchConfigurationOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GetTrafficWatchConfigurationOperation
 
-* __Revisions__:  
+* **Revisions**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [ConfigureRevisionsForConflictsOperation](../../document-extensions/revisions/client-api/operations/conflict-revisions-configuration)  
 
-* __Misc__:  
+* **Misc**:  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ModifyConflictSolverOperation  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OfflineMigrationOperation  
 
@@ -407,13 +383,11 @@ __Send syntax__:
 
 * For Operations that implement an interface with type `OperationIdResult`,  
   executing the operation via the `Send` method will return an `Operation` object,  
-  which can be __awaited for completion__ or __aborted (killed)__.  
+  which can be **awaited for completion** or **aborted (killed)**.  
 
 ---
 
-{NOTE: }
-
-<a id="wait-for-completion" /> __Wait for completion__:
+#### Wait for completion:
 
 {CODE-TABS}
 {CODE-TAB:csharp:With_Timeout wait_timeout_ex@ClientApi\Operations\WhatAreOperations.cs /}
@@ -431,18 +405,14 @@ __Send syntax__:
 
 | Parameter   | Type                | Description                                                                                                                                                                                                                                                                                                                                           |
 |-------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| __timeout__ | `TimeSpan`          | <ul><li> __When timespan is specified__ - <br>The server will throw a `TimeoutException` if operation has Not completed within the specified time frame.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li><li>`null` - <br>WaitForCompletion will wait for operation to complete forever.</li></ul> |
-| __token__   | `CancellationToken` | <ul><li> __When cancellation token is specified__ - <br>The server will throw a `TimeoutException` if operation has Not completed at cancellation time.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li></ul>                                                                                      |
+| **timeout** | `TimeSpan`          | <ul><li> **When timespan is specified** - <br>The server will throw a `TimeoutException` if operation has Not completed within the specified time frame.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li><li>`null` - <br>WaitForCompletion will wait for operation to complete forever.</li></ul> |
+| **token**   | `CancellationToken` | <ul><li> **When cancellation token is specified** - <br>The server will throw a `TimeoutException` if operation has Not completed at cancellation time.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li></ul>                                                                                      |
 
 | Return type        |                               |
 |--------------------|-------------------------------|
 | `IOperationResult` | The operation result content. |
 
-{NOTE/}
-
-{NOTE: }
-
-<a id="killOperation" /> __Kill operation__:
+#### Kill operation:
 
 {CODE-TABS}
 {CODE-TAB:csharp:Kill kill_ex@ClientApi\Operations\WhatAreOperations.cs /}
@@ -455,9 +425,8 @@ __Send syntax__:
 
 | Parameter   | Type                | Description                                                          |
 |-------------|---------------------|----------------------------------------------------------------------|
-| __token__   | `CancellationToken` | Provide a cancellation token if needed to abort the KillAsync method |
+| **token**   | `CancellationToken` | Provide a cancellation token if needed to abort the KillAsync method |
 
-{NOTE/}
 {PANEL/}
 
 ## Related articles

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.js.markdown
@@ -7,10 +7,10 @@
 * The RavenDB Client API is built with the notion of layers.  
   At the top, and what you will usually interact with, are the **[DocumentStore](../../client-api/what-is-a-document-store)**
   and the **[Session](../../client-api/session/what-is-a-session-and-how-does-it-work)**.  
-  They in turn are built on top of the lower-level __Operations__ and __RavenCommands__ API.
+  They in turn are built on top of the lower-level **Operations** and **Commands** API.
 
-* __RavenDB provides access to this lower-level API__, so that instead of using the higher session API,  
-  you can generate requests directly to the server by executing operations on the DocumentStore.
+* **RavenDB provides direct access to this lower-level API**, allowing direct delivery of requests 
+  to the server via document store operations instead of using the higher-level session API.  
 
 * In this page:  
   * [Why use operations](../../client-api/operations/what-are-operations#why-use-operations)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/what-are-operations.python.markdown
@@ -5,12 +5,12 @@
 {NOTE: }
 
 * The RavenDB Client API is built with the notion of layers.  
-  At the top, and what you will usually interact with, are the **[DocumentStore](../../client-api/what-is-a-document-store)**
-  and the **[Session](../../client-api/session/what-is-a-session-and-how-does-it-work)**.  
+  At the top, and what you will usually interact with, are the **[documentStore](../../client-api/what-is-a-document-store)**
+  and the **[session](../../client-api/session/what-is-a-session-and-how-does-it-work)**.  
   They in turn are built on top of the lower-level **Operations** and **Commands** API.
 
 * **RavenDB provides direct access to this lower-level API**, allowing direct delivery of requests 
-  to the server via document store operations instead of using the higher-level Session API.  
+  to the server via document store operations instead of using the higher-level session API.  
 
 * In this page:  
   * [Why use operations](../../client-api/operations/what-are-operations#why-use-operations)  
@@ -38,7 +38,8 @@
 
 * The operations are executed on the DocumentStore and are Not part of the session transaction.
 
-* There are some client tasks, such as patching documents, that can be carried out either via the Session ([session.Advanced.Patch()](../../client-api/operations/patching/single-document#array-manipulation))
+* There are some client tasks, such as patching documents, that can be carried out either via the Session 
+  ([session.advanced.patch()](../../client-api/operations/patching/single-document#array-manipulation))
   or via an Operation on the DocumentStore ([PatchOperation](../../client-api/operations/patching/single-document#operations-api)).
 
 {PANEL/}
@@ -51,10 +52,10 @@
   The DocumentStore `OperationExecutor` sends the request and processes the results.
 * **Target node**:  
   By default, the operation will be executed on the server node that is defined by the [client configuration](../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
-  However, server-maintenance operations can be executed on a specific node by using the [ForNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
+  However, server-maintenance operations can be executed on a specific node by using the [for_node](../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
 * **Target database**:  
   By default, operations work on the default database defined in the DocumentStore.  
-  However, common operations & maintenance operations can operate on a different database by using the [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) method.  
+  However, common operations & maintenance operations can operate on a different database by using the [for_database](../../client-api/operations/how-to/switch-operations-to-a-different-database) method.  
 * **Transaction scope**:  
   Operations execute as a single-node transaction.  
   If needed, data will then replicate to the other nodes in the database-group.  
@@ -68,28 +69,22 @@
 
 * All common operations implement the `IOperation` interface.  
   The operation is executed within the **database scope**.  
-  Use [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.  
+  Use [for_database](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.  
 
 * These operations include set-based operations such as _PatchOperation_, _CounterBatchOperation_,  
   document-extensions related operations such as getting/putting an attachment, and more.  
   See all available operations [below](../../client-api/operations/what-are-operations#operations-list).
 
 * To execute a common operation request,  
-  use the `Send` method on the `Operations` property in the DocumentStore.
+  use the `send` method on the `operations` property in the DocumentStore.
 
 #### Example:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync operations_ex@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async operations_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
+{CODE:python operations_ex@ClientApi\Operations\WhatAreOperations.py /}
 
 ##### Syntax:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync operations_send@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async operations_send_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
+{CODE:python operations_send@ClientApi\Operations\WhatAreOperations.py /}
 
 {NOTE: }
 
@@ -135,28 +130,22 @@
 
 * All maintenance operations implement the `IMaintenanceOperation` interface.  
   The operation is executed within the **database scope**.  
-  Use [ForDatabase](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.
+  Use [for_database](../../client-api/operations/how-to/switch-operations-to-a-different-database) to operate on a specific database other than the default defined in the store.
 
 * These operations include database management operations such as setting client configuration,  
   managing indexes & ongoing-tasks operations, getting stats, and more.  
   See all available maintenance operations [below](../../client-api/operations/what-are-operations#maintenance-list).
  
 * To execute a maintenance operation request,  
-  use the `Send` method on the `Maintenance` property in the DocumentStore.
+  use the `send` method on the `maintenance` property in the DocumentStore.
 
 #### Example:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync maintenance_ex@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async maintenance_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
+{CODE:python maintenance_ex@ClientApi\Operations\WhatAreOperations.py /}
 
 ##### Syntax:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync maintenance_send@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async maintenance_send_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
+{CODE:python maintenance_send@ClientApi\Operations\WhatAreOperations.py /}
 
 {NOTE: }
 
@@ -275,27 +264,21 @@
 
 * All server-maintenance operations implement the `IServerOperation` interface.  
   The operation is executed within the **server scope**.   
-  Use [ForNode](../../client-api/operations/how-to/switch-operations-to-a-different-node) to operate on a specific node other than the default defined in the client configuration.
+  Use [for_node](../../client-api/operations/how-to/switch-operations-to-a-different-node) to operate on a specific node other than the default defined in the client configuration.
 
 * These operations include server management and configuration operations.  
   See all available operations [below](../../client-api/operations/what-are-operations#server-list).
 
 * To execute a server-maintenance operation request,  
-  use the `Send` method on the `Maintenance.Server` property in the DocumentStore.
+  use the `send` method on the `maintenance.server` property in the DocumentStore.
 
 #### Example:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync server_ex@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async server_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
+{CODE:python server_ex@ClientApi\Operations\WhatAreOperations.py /}
 
 ##### Syntax:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync server_send@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async server_send_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
+{CODE:python server_send@ClientApi\Operations\WhatAreOperations.py /}
 
 {NOTE: }
 
@@ -375,58 +358,6 @@
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OfflineMigrationOperation  
 
 {NOTE/}
-{PANEL/}
-
-{PANEL: Manage lengthy operations}
-
-* Some operations that run in the server background may take a long time to complete.  
-
-* For Operations that implement an interface with type `OperationIdResult`,  
-  executing the operation via the `Send` method will return an `Operation` object,  
-  which can be **awaited for completion** or **aborted (killed)**.  
-
----
-
-#### Wait for completion:
-
-{CODE-TABS}
-{CODE-TAB:csharp:With_Timeout wait_timeout_ex@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:With_Timout_async wait_timeout_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:With_CancellationToken wait_token_ex@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:With_CancellationToken_async wait_token_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
-
-##### Syntax:
-
-{CODE-TABS}
-{CODE-TAB:csharp:Sync waitForCompletion_syntax@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Async waitForCompletion_syntax_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
-
-| Parameter   | Type                | Description                                                                                                                                                                                                                                                                                                                                           |
-|-------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **timeout** | `TimeSpan`          | <ul><li> **When timespan is specified** - <br>The server will throw a `TimeoutException` if operation has Not completed within the specified time frame.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li><li>`null` - <br>WaitForCompletion will wait for operation to complete forever.</li></ul> |
-| **token**   | `CancellationToken` | <ul><li> **When cancellation token is specified** - <br>The server will throw a `TimeoutException` if operation has Not completed at cancellation time.<br>The operation itself continues to run in the background,<br>no rollback action takes place.</li></ul>                                                                                      |
-
-| Return type        |                               |
-|--------------------|-------------------------------|
-| `IOperationResult` | The operation result content. |
-
-#### Kill operation:
-
-{CODE-TABS}
-{CODE-TAB:csharp:Kill kill_ex@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TAB:csharp:Kill_async kill_ex_async@ClientApi\Operations\WhatAreOperations.cs /}
-{CODE-TABS/}
-
-##### Syntax:
-
-{CODE kill_syntax@ClientApi\Operations\WhatAreOperations.cs /}
-
-| Parameter   | Type                | Description                                                          |
-|-------------|---------------------|----------------------------------------------------------------------|
-| **token**   | `CancellationToken` | Provide a cancellation token if needed to abort the KillAsync method |
-
 {PANEL/}
 
 ## Related articles

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Common/DeleteByQuery.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Common/DeleteByQuery.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Common
+{
+    #region the_index
+    // The index definition:
+    // =====================
+    
+    public class Products_ByPrice : AbstractIndexCreationTask<Product>
+    {
+        public class IndexEntry
+        {
+            public decimal Price { get; set; }  
+        }
+        
+        public Products_ByPrice()
+        {
+            Map = products => from product in products
+                select new IndexEntry
+                {
+                    Price = product.PricePerUnit 
+                };
+        }
+    }
+    #endregion
+
+    public class DeleteByQuery
+    {
+        public DeleteByQuery()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_0
+                // Define the delete by query operation, pass an RQL querying a collection
+                var deleteByQueryOp = new DeleteByQueryOperation("from 'Orders'");
+                
+                // Execute the operation by passing it to Operations.Send
+                var operation = store.Operations.Send(deleteByQueryOp);
+                
+                // All documents in collection 'Orders' will be deleted from the server.
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_1
+                // Define the delete by query operation, pass an RQL querying a collection
+                var deleteByQueryOp = new DeleteByQueryOperation("from 'Orders' where Freight > 30");
+                
+                // Execute the operation by passing it to Operations.Send
+                var operation = store.Operations.Send(deleteByQueryOp);
+                
+                // * All documents matching the specified RQL will be deleted from the server.
+                
+                // * Since the dynamic query was made with a filtering condition,
+                //   an auto-index is generated (if no other matching auto-index already exists).
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_2
+                // Define the delete by query operation, pass an RQL querying the index
+                var deleteByQueryOp = new DeleteByQueryOperation("from index 'Products/ByPrice' where Price > 10");
+                
+                // Execute the operation by passing it to Operations.Send
+                var operation = store.Operations.Send(deleteByQueryOp);
+
+                // All documents with document-field PricePerUnit > 10 will be deleted from the server.
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_3
+                // Define the delete by query operation
+                var deleteByQueryOp = new DeleteByQueryOperation(new IndexQuery
+                {
+                    // Provide an RQL querying the index
+                    Query = "from index 'Products/ByPrice' where Price > 10"
+                });
+                
+                // Execute the operation by passing it to Operations.Send
+                var operation = store.Operations.Send(deleteByQueryOp);
+
+                // All documents with document-field PricePerUnit > 10 will be deleted from the server.
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_4
+                // Define the delete by query operation
+                var deleteByQueryOp =
+                    // Pass parameters:
+                    // * The index name
+                    // * A filtering expression on the index-field
+                    new DeleteByQueryOperation<Products_ByPrice.IndexEntry>("Products/ByPrice", x => x.Price > 10);
+                
+                // Execute the operation by passing it to Operations.Send
+                var operation = store.Operations.Send(deleteByQueryOp);
+
+                // All documents with document-field PricePerUnit > 10 will be deleted from the server.
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_5
+                // Define the delete by query operation
+                var deleteByQueryOp =
+                    // Pass param:
+                    // * A filtering expression on the index-field
+                    new DeleteByQueryOperation<Products_ByPrice.IndexEntry, Products_ByPrice>(x => x.Price > 10);
+                
+                // Execute the operation by passing it to Operations.Send
+                var operation = store.Operations.Send(deleteByQueryOp);
+
+                // All documents with document-field PricePerUnit > 10 will be deleted from the server.
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_6
+                // Define the delete by query operation
+                var deleteByQueryOp = new DeleteByQueryOperation(
+                    // QUERY: Specify the query
+                    new IndexQuery
+                    {
+                        Query = "from index 'Products/ByPrice' where Price > 10"
+                    },
+                    // OPTIONS: Specify the options for the operation
+                    // (See all other available options in the Syntax section below)
+                    new QueryOperationOptions
+                    {
+                        // Allow the operation to operate even if index is stale
+                        AllowStale = true, 
+                        // Get info in the operation result about documents that were deleted
+                        RetrieveDetails = true 
+                    });
+                
+                // Execute the operation by passing it to Operations.Send
+                Operation operation = store.Operations.Send(deleteByQueryOp);
+                    
+                // Wait for operation to complete
+                var result = operation.WaitForCompletion<BulkOperationResult>(TimeSpan.FromSeconds(15));
+                
+                // * All documents with document-field PricePerUnit > 10 will be deleted from the server.
+                
+                // * Details about deleted documents are available:
+                var details = result.Details;
+                var documentIdThatWasDeleted = details[0].ToJson()["Id"];
+                #endregion
+            }
+        }
+
+        public async Task DeleteByQueryAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_0_async
+                // Define the delete by query operation, pass an RQL querying a collection
+                var deleteByQueryOp = new DeleteByQueryOperation("from 'Orders'");
+                
+                // Execute the operation by passing it to Operations.SendAsync
+                var result = await store.Operations.SendAsync(deleteByQueryOp);
+                
+                // All documents in collection 'Orders' will be deleted from the server.
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_1_async
+                // Define the delete by query operation, pass an RQL querying a collection
+                var deleteByQueryOp = new DeleteByQueryOperation("from 'Orders' where Freight > 30");
+                
+                // Execute the operation by passing it to Operations.SendAsync
+                var result = await store.Operations.SendAsync(deleteByQueryOp);
+                
+                // * All documents matching the provided RQL will be deleted from the server.
+                
+                // * Since a dynamic query was made with a filtering condition,
+                //   an auto-index is generated (if no other matching auto-index already exists).
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region delete_by_query_6_async
+                // Define the delete by query operation
+                var deleteByQueryOp = new DeleteByQueryOperation(
+                    // QUERY: Specify the query
+                    new IndexQuery
+                    {
+                        Query = "from index 'Products/ByPrice' where Price > 10"
+                    },
+                    // OPTIONS: Specify the options for the operation
+                    // (See all other available options in the Syntax section below)
+                    new QueryOperationOptions
+                    {
+                        // Allow the operation to operate even if index is stale
+                        AllowStale = true, 
+                        // Get info in the operation result about documents that were deleted
+                        RetrieveDetails = true 
+                    });
+                
+                // Execute the operation by passing it to Operations.Send
+                Operation operation = await store.Operations.SendAsync(deleteByQueryOp);
+                
+                // Wait for operation to complete
+                BulkOperationResult result = 
+                    await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromSeconds(15))
+                        .ConfigureAwait(false);
+                
+                // * All documents with document-field PricePerUnit > 10 will be deleted from the server.
+                
+                // * Details about deleted documents are available:
+                var details = result.Details;
+                var documentIdThatWasDeleted = details[0].ToJson()["Id"];
+                #endregion
+            }
+        }
+        
+        private interface IFoo
+        {
+            #region syntax_1
+            // Available overload:
+            // ===================
+            
+            DeleteByQueryOperation DeleteByQueryOperation(
+                string queryToDelete);
+            
+            DeleteByQueryOperation DeleteByQueryOperation(
+                IndexQuery queryToDelete, 
+                QueryOperationOptions options = null);
+
+            DeleteByQueryOperation DeleteByQueryOperation<TEntity>(
+                string indexName, 
+                Expression<Func<TEntity, bool>> expression,
+                QueryOperationOptions options = null);
+            
+            DeleteByQueryOperation DeleteByQueryOperation<TEntity, TIndexCreator>(
+                Expression<Func<TEntity, bool>> expression,
+                QueryOperationOptions options = null)
+                where TIndexCreator : AbstractIndexCreationTask, new();
+            #endregion
+            
+            /*
+            #region syntax_2
+            public class QueryOperationOptions
+            {
+                // Indicates whether operations are allowed on stale indexes.
+                // DEFAULT: false
+                public bool AllowStale { get; set; }
+                
+                // If AllowStale is set to false and index is stale, 
+                // then this is the maximum timeout to wait for index to become non-stale. 
+                // If timeout is exceeded then exception is thrown.
+                // DEFAULT: null (if index is stale then exception is thrown immediately) 
+                public TimeSpan? StaleTimeout { get; set; }
+                
+                // Limits the number of base operations per second allowed.
+                // DEFAULT: no limit
+                public int? MaxOpsPerSecond
+                
+                // Determines whether operation details about each document should be returned by server.
+                // DEFAULT: false
+                public bool RetrieveDetails { get; set; }
+                
+                // Ignore the maximum number of statements a script can execute.
+                // Note: this is only relevant for the PatchByQueryOperation. 
+                public bool IgnoreMaxStepsForScript { get; set; }
+            }
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.cs
@@ -1,0 +1,67 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Configuration;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configuration
+{
+    public class GetClientConfig
+    {
+        public GetClientConfig()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_config
+                // Define the get client-configuration operation 
+                var getClientConfigOp = new GetClientConfigurationOperation();
+                    
+                // Execute the operation by passing it to Maintenance.Send
+                GetClientConfigurationOperation.Result result = store.Maintenance.Send(getClientConfigOp);
+                
+                ClientConfiguration clientConfiguration = result.Configuration;
+                #endregion
+            }
+        }
+        
+        public async Task GetClientConfigAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region get_config_async
+                    // Define the get client-configuration operation 
+                    var getClientConfigOp = new GetClientConfigurationOperation();
+                
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    GetClientConfigurationOperation.Result config = 
+                        await store.Maintenance.SendAsync(getClientConfigOp);
+                
+                    ClientConfiguration clientConfiguration = config.Configuration;
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            public GetClientConfigurationOperation()
+            #endregion
+            */
+            
+            /*
+            #region syntax_2
+            // Executing the operation returns the following object: 
+            public class Result
+            {
+                // The configuration Etag
+                public long Etag { get; set; }
+                
+                // The current client-configuration deployed on the server for the database
+                public ClientConfiguration Configuration { get; set; }
+            }
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.cs
@@ -1,0 +1,104 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Http;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Configuration
+{
+    public class PutClientConfig
+    {
+        public PutClientConfig()
+        {
+            #region put_config_1
+            // You can customize the client-configuration options in the client
+            // when creating the Document Store (this is optional):
+            // =================================================================
+            
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "ServerURL_1", "ServerURL_2", "..." },
+                Database = "DefaultDB",
+                Conventions = new DocumentConventions
+                {
+                    // Initialize some client-configuration options:
+                    MaxNumberOfRequestsPerSession = 100,
+                    IdentityPartsSeparator = '$'
+                    // ...
+                }
+            }.Initialize();
+            #endregion
+            
+            #region put_config_2
+            // Override the initial client-configuration in the server using the put operation:
+            // ================================================================================
+            
+            using (documentStore)
+            {
+                // Define the client-configuration object
+                ClientConfiguration clientConfiguration = new ClientConfiguration
+                {
+                    MaxNumberOfRequestsPerSession = 200,
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                    // ...
+                };
+                    
+                // Define the put client-configuration operation, pass the configuration 
+                var putClientConfigOp = new PutClientConfigurationOperation(clientConfiguration);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                documentStore.Maintenance.Send(putClientConfigOp);
+            }
+            #endregion
+        }
+        
+        public async Task PutClientConfigAsync()
+        {
+            var documentStore = new DocumentStore();
+            
+            #region put_config_3
+            // Override the initial client-configuration using the put operation:
+            using (documentStore)
+            {
+                // Define the client-configuration object
+                ClientConfiguration clientConfiguration = new ClientConfiguration
+                {
+                    MaxNumberOfRequestsPerSession = 200,
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                    // ...
+                };
+                    
+                // Define the put client-configuration operation, pass the configuration 
+                var putClientConfigOp = new PutClientConfigurationOperation(clientConfiguration);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                await documentStore.Maintenance.SendAsync(putClientConfigOp);
+            }
+            #endregion
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            public PutClientConfigurationOperation(ClientConfiguration configuration)
+            #endregion
+            */
+            
+            /*
+            #region syntax_2
+            public class ClientConfiguration
+            {
+                public long Etag { get; set; }
+                public bool Disabled { get; set; }
+                public int? MaxNumberOfRequestsPerSession { get; set; }
+                public ReadBalanceBehavior? ReadBalanceBehavior { get; set; }
+                public LoadBalanceBehavior? LoadBalanceBehavior { get; set; }
+                public int? LoadBalancerContextSeed { get; set; }
+                public char? IdentityPartsSeparator;  // can be any character except '|'
+            }
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/GetStats.cs
@@ -1,0 +1,150 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance
+{
+    public class GetStats
+    {
+        public GetStats()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region stats_1
+                // Pass an instance of class `GetCollectionStatisticsOperation` to the store 
+                CollectionStatistics stats =
+                    store.Maintenance.Send(new GetCollectionStatisticsOperation());
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region stats_2
+                // Pass an instance of class `GetDetailedCollectionStatisticsOperation` to the store 
+                DetailedCollectionStatistics stats =
+                    store.Maintenance.Send(new GetDetailedCollectionStatisticsOperation());
+                #endregion
+            }
+
+            using (var store = new DocumentStore())
+            {
+                #region stats_3
+                // Pass an instance of class `GetStatisticsOperation` to the store 
+                DatabaseStatistics stats =
+                    store.Maintenance.Send(new GetStatisticsOperation());
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region stats_4
+                // Pass an instance of class `GetDetailedStatisticsOperation` to the store 
+                DetailedDatabaseStatistics stats =
+                    store.Maintenance.Send(new GetDetailedStatisticsOperation());
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region stats_5
+                // Get stats for 'AnotherDatabase':
+                DatabaseStatistics stats =
+                    store.Maintenance.ForDatabase("AnotherDatabase").Send(new GetStatisticsOperation());
+                #endregion
+            }
+        }
+    }
+  
+    /*
+    #region stats_1_results
+    // Collection stats results:
+    public class CollectionStatistics
+    {
+        // Total # of documents in all collections
+        public int CountOfDocuments { get; set; }
+        // Total # of conflicts
+        public int CountOfConflicts { get; set; }
+        // Total # of documents per collection
+        public Dictionary<string, long> Collections { get; set; }
+    }
+    #endregion
+    */
+    
+    /*
+    #region stats_2_results
+    // Detailed collection stats results:
+    public class DetailedCollectionStatistics
+    {
+        // Total # of documents in all collections
+        public long CountOfDocuments { get; set; }
+        // Total # of conflicts
+        public long CountOfConflicts { get; set; }
+        // Collection details per collection
+        public Dictionary<string, CollectionDetails> Collections { get; set; }
+    }
+    
+    // Details per collection
+    public class CollectionDetails
+    {        
+        public string Name { get; set; }
+        public long CountOfDocuments { get; set; }
+        public Size Size { get; set; }
+        public Size DocumentsSize { get; set; }
+        public Size TombstonesSize { get; set; }
+        public Size RevisionsSize { get; set; }
+    }
+    #endregion
+    */
+    
+    /*
+    #region stats_3_results
+    // Database stats results:
+    public class DatabaseStatistics
+    {
+        public long? LastDocEtag { get; set; }      // Last document etag in database
+        public long? LastDatabaseEtag { get; set; } // Last database etag
+        
+        public int CountOfIndexes { get; set; }     // Total # of indexes in database
+        public long CountOfDocuments { get; set; }  // Total # of documents in database
+        public long CountOfRevisionDocuments { get; set; }  // Total # of revision documents in database
+        public long CountOfDocumentsConflicts { get; set; } // Total # of documents conflicts in database
+        public long CountOfTombstones { get; set; }         // Total # of tombstones in database
+        public long CountOfConflicts { get; set; }          // Total # of conflicts in database
+        public long CountOfAttachments { get; set; }        // Total # of attachments in database
+        public long CountOfUniqueAttachments { get; set; }  // Total # of unique attachments in database
+        public long CountOfCounterEntries { get; set; }     // Total # of counter-group entries in database
+        public long CountOfTimeSeriesSegments { get; set; } // Total # of time-series segments in database
+        
+        // List of stale index names in database
+        public string[] StaleIndexes => Indexes?.Where(x => x.IsStale).Select(x => x.Name).ToArray();
+        // Statistics for each index in database
+        public IndexInformation[] Indexes { get; set; }
+        
+        public string DatabaseChangeVector { get; set; } // Global change vector of the database
+        public string DatabaseId { get; set; }           // Database identifier
+        public bool Is64Bit { get; set; }                // Indicates if process is 64-bit
+        public string Pager { get; set; }                // Component handling the memory-mapped files
+        public DateTime? LastIndexingTime { get; set; }  // Last time of indexing an item
+        public Size SizeOnDisk { get; set; }             // Database size on disk
+        public Size TempBuffersSizeOnDisk { get; set; }  // Temp buffers size on disk
+        public int NumberOfTransactionMergerQueueOperations { get; set; }
+    }
+    #endregion
+    */
+    
+    /*
+    #region stats_4_results
+    // Detailed database stats results:
+    public class DetailedDatabaseStatistics : DatabaseStatistics
+    {
+        // Total # of identities in database
+        public long CountOfIdentities { get; set; }
+        // Total # of compare-exchange items in database
+        public long CountOfCompareExchange { get; set; }
+        // Total # of cmpXchg tombstones in database
+        public long CountOfCompareExchangeTombstones { get; set; }
+        // Total # of TS deleted ranges values in database
+        public long CountOfTimeSeriesDeletedRanges { get; set; }
+    }
+    #endregion
+    */
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Identities/GetIdentities.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Identities/GetIdentities.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Identities;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Identities
+{
+    public class GetIdentities
+    {
+        public GetIdentities()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_identities
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var session = store.OpenSession())
+                {
+                    // Request the server to generate an identity ID for the new document. Pass:
+                    //   * The entity to store
+                    //   * The collection name with a pipe (|) postfix 
+                    session.Store(new Company { Name = "RavenDB" }, "companies|");
+                    
+                    // If this is the first identity created for this collection,
+                    // and if the identity value was not customized
+                    // then a document with an identity ID "companies/1" will be created
+                    session.SaveChanges();
+                }
+                
+                // Get identities information:
+                // ===========================
+                
+                // Define the get identities operation
+                var getIdentitiesOp = new GetIdentitiesOperation();
+                
+                // Execute the operation by passing it to Maintenance.Send
+                Dictionary<string, long> identities = store.Maintenance.Send(getIdentitiesOp);
+                
+                // Results
+                var latestIdentityValue = identities["companies|"]; // => value will be 1
+                #endregion
+            }
+        }
+        
+        public async Task GetIdentitiesAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_identities_async
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    // Request the server to generate an identity ID for the new document. Pass:
+                    //   * The entity to store
+                    //   * The collection name with a pipe (|) postfix 
+                    asyncSession.StoreAsync(new Company { Name = "RavenDB" }, "companies|");
+                    
+                    // If this is the first identity created for this collection,
+                    // and if the identity value was not customized
+                    // then a document with an identity ID "companies/1" will be created
+                    asyncSession.SaveChangesAsync();
+                }
+                
+                // Get identities information:
+                // ===========================
+                
+                // Define the get identities operation
+                var getIdentitiesOp = new GetIdentitiesOperation();
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                Dictionary<string, long> identities = await store.Maintenance.SendAsync(getIdentitiesOp);
+                
+                // Results
+                var latestIdentityValue = identities["companies|"]; // => value will be 1
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public GetIdentitiesOperation();
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Identities/IncrementIdentity.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Identities/IncrementIdentity.cs
@@ -1,0 +1,101 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Identities;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Identities
+{
+    public class IncrementIdentity
+    {
+        public IncrementIdentity()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region increment_identity
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var session = store.OpenSession())
+                { 
+                    // Pass a collection name that ends with a pipe '|' to create an identity ID
+                    session.Store(new Company { Name = "RavenDB" }, "companies|");
+                    session.SaveChanges();
+                    // => Document "companies/1" will be created 
+                }
+                
+                // Increment the identity value on the server:
+                // ===========================================
+                
+                // Define the next identity operation
+                // Pass the collection name (can be with or without a pipe)
+                var nextIdentityOp = new NextIdentityForOperation("companies|");
+                
+                // Execute the operation by passing it to Maintenance.Send
+                // The latest value will be incremented to "2"
+                // and the next document created with an identity will be assigned "3"
+                long incrementedValue = store.Maintenance.Send(nextIdentityOp);
+                
+                // Create another document with an identity ID:
+                // ============================================
+                
+                using (var session = store.OpenSession())
+                { 
+                    session.Store(new Company { Name = "RavenDB" }, "companies|");
+                    session.SaveChanges();
+                    // => Document "companies/3" will be created
+                }
+                #endregion
+            }
+        }
+        
+        public async Task IncrementIdentityAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region increment_identity_async
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                { 
+                    // Pass a collection name that ends with a pipe '|' to create an identity ID
+                    asyncSession.StoreAsync(new Company { Name = "RavenDB" }, "companies|");
+                    asyncSession.SaveChangesAsync(); 
+                    // => Document "companies/1" will be created 
+                }
+                
+                // Increment the identity value on the server:
+                // ===========================================
+                
+                // Define the next identity operation
+                // Pass the collection name (can be with or without a pipe)
+                var nextIdentityOp = new NextIdentityForOperation("companies|");
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                // The latest value will be incremented to "2"
+                // and the next document created with an identity will be assigned "3"
+                long incrementedValue = await store.Maintenance.SendAsync(nextIdentityOp);
+                
+                // Create another document with an identity ID:
+                // ============================================
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                { 
+                    asyncSession.StoreAsync(new Company { Name = "AnotherCompany" }, "companies|");
+                    asyncSession.SaveChangesAsync();
+                    // => Document "companies/3" will be created
+                }
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public NextIdentityForOperation(string name);
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Identities/SeedIdentity.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Identities/SeedIdentity.cs
@@ -1,0 +1,139 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Identities;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Identities
+{
+    public class SeedIdentity
+    {
+        public SeedIdentity()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region seed_identity_1
+                // Seed a higher identity value on the server:
+                // ===========================================
+                
+                // Define the seed identity operation. Pass:
+                //   * The collection name (can be with or without a pipe)
+                //   * The new value to set
+                var seedIdentityOp = new SeedIdentityForOperation("companies|", 23);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                // The latest value on the server will be incremented to "23"
+                // and the next document created with an identity will be assigned "24"
+                long seededValue = store.Maintenance.Send(seedIdentityOp);
+                
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var session = store.OpenSession())
+                { 
+                    session.Store(new Company { Name = "RavenDB" }, "companies|");
+                    session.SaveChanges();
+                    // => Document "companies/24" will be created
+                }
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region seed_identity_2
+                // Force a smaller identity value on the server:
+                // =============================================
+                
+                // Define the seed identity operation. Pass:
+                //   * The collection name (can be with or without a pipe)
+                //   * The new value to set
+                //   * Set 'forceUpdate' to true
+                var seedIdentityOp = new SeedIdentityForOperation("companies|", 5, forceUpdate: true);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                // The latest value on the server will be decremented to "5"
+                // and the next document created with an identity will be assigned "6"
+                long seededValue = store.Maintenance.Send(seedIdentityOp);
+                
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var session = store.OpenSession())
+                { 
+                    session.Store(new Company { Name = "RavenDB" }, "companies|");
+                    session.SaveChanges();
+                    // => Document "companies/6" will be created
+                }
+                #endregion
+            }
+        }
+        
+        public async Task SeedIdentityAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region seed_identity_1_async
+                // Seed the identity value on the server:
+                // ======================================
+                
+                // Define the seed identity operation. Pass:
+                //   * The collection name (can be with or without a pipe)
+                //   * The new value to set
+                var seedIdentityOp = new SeedIdentityForOperation("companies|", 23);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                // The latest value on the server will be incremented to "23"
+                // and the next document created with an identity will be assigned "24"
+                long seededValue = await store.Maintenance.SendAsync(seedIdentityOp);
+                
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                { 
+                    asyncSession.StoreAsync(new Company { Name = "RavenDB" }, "companies|");
+                    asyncSession.SaveChangesAsync();
+                    // => Document "companies/24" will be created
+                }
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region seed_identity_2_async
+                // Force a smaller identity value on the server:
+                // =============================================
+                
+                // Define the seed identity operation. Pass:
+                //   * The collection name (can be with or without a pipe)
+                //   * The new value to set
+                //   * Set 'forceUpdate' to true
+                var seedIdentityOp = new SeedIdentityForOperation("companies|", 5, forceUpdate: true);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                // The latest value on the server will be decremented to "5"
+                // and the next document created with an identity will be assigned "6"
+                long seededValue = await store.Maintenance.SendAsync(seedIdentityOp);
+                
+                // Create a document with an identity ID:
+                // ======================================
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                { 
+                    asyncSession.StoreAsync(new Company { Name = "RavenDB" }, "companies|");
+                    asyncSession.SaveChangesAsync();
+                    // => Document "companies/6" will be created
+                }
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public SeedIdentityForOperation(string name, long value, bool forceUpdate = false);
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/Server/CompareExchange.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Linq;
+using Raven.Documentation.Samples.Orders;
+using Raven.Client.Exceptions;
+
+
+namespace Raven.Documentation.Samples.Server
+{
+    public class CompareExchange
+    {
+        private DocumentStore store;
+
+        private class User
+        {
+            public string Email { get; set; }
+            public string Id { get; set; }
+            public int Age { get; set; }
+        }
+
+        public async Task Sample()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region email
+                string email = "user@example.com";
+
+                User user = new User
+                {
+                    Email = email
+                };
+
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    session.Store(user);
+                    // At this point, the user document has an Id assigned
+
+                    // Try to reserve a new user email 
+                    // Note: This operation takes place outside of the session transaction, 
+                    //       It is a cluster-wide reservation
+                    CompareExchangeResult<string> cmpXchgResult
+                        = store.Operations.Send(
+                            new PutCompareExchangeValueOperation<string>("emails/" + email, user.Id, 0));
+
+                    if (cmpXchgResult.Successful == false)
+                        throw new Exception("Email is already in use");
+
+                    // At this point we managed to reserve/save the user email -
+                    // The document can be saved in SaveChanges
+                    session.SaveChanges();
+                }
+                #endregion
+
+
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    #region query_cmpxchg
+                    var query = from u in session.Query<User>()
+                                where u.Id == RavenQuery.CmpXchg<string>("emails/ayende@ayende.com")
+                                select u;
+                    #endregion
+
+                    #region document_query_cmpxchg
+                    var q = session.Advanced
+                        .DocumentQuery<User>()
+                        .WhereEquals("Id", CmpXchg.Value("emails/ayende@ayende.com"));
+                    #endregion
+                }
+
+            }
+        }
+
+        #region shared_resource
+        private class SharedResource
+        {
+            public DateTime? ReservedUntil { get; set; }
+        }
+
+        public void PrintWork() 
+        {
+            // Try to get hold of the printer resource
+            long reservationIndex = LockResource(store, "Printer/First-Floor", TimeSpan.FromMinutes(20));
+
+            try
+            {
+                // Do some work for the duration that was set.
+                // Don't exceed the duration, otherwise resource is available for someone else.
+            }
+            finally
+            {
+                ReleaseResource(store, "Printer/First-Floor", reservationIndex);
+            }
+        }
+
+        public long LockResource(IDocumentStore store, string resourceName, TimeSpan duration)
+        {
+            while (true)
+            {
+                DateTime now = DateTime.UtcNow;
+
+                SharedResource resource = new SharedResource
+                {
+                    ReservedUntil = now.Add(duration)
+                };
+
+                CompareExchangeResult<SharedResource> saveResult = store.Operations.Send(
+                        new PutCompareExchangeValueOperation<SharedResource>(resourceName, resource, 0));
+
+                if (saveResult.Successful)
+                {
+                    // resourceName wasn't present - we managed to reserve
+                    return saveResult.Index;
+                }
+
+                // At this point, Put operation failed - someone else owns the lock or lock time expired
+                if (saveResult.Value.ReservedUntil < now)
+                {
+                    // Time expired - Update the existing key with the new value
+                    CompareExchangeResult<SharedResource> takeLockWithTimeoutResult = store.Operations.Send(
+                        new PutCompareExchangeValueOperation<SharedResource>(resourceName, resource, saveResult.Index));
+
+                    if (takeLockWithTimeoutResult.Successful)
+                    {
+                        return takeLockWithTimeoutResult.Index;
+                    }
+                }
+
+                // Wait a little bit and retry
+                Thread.Sleep(20);
+            }
+        }
+
+        public void ReleaseResource(IDocumentStore store, string resourceName, long index)
+        {
+            CompareExchangeResult<SharedResource> deleteResult
+                = store.Operations.Send(new DeleteCompareExchangeValueOperation<SharedResource>(resourceName, index));
+
+            // We have 2 options here:
+            // deleteResult.Successful is true - we managed to release resource
+            // deleteResult.Successful is false - someone else took the lock due to timeout 
+        }
+
+        #endregion
+
+        #region create_uniqueness_control_documents
+        // When you create documents that must contain a unique value such as a phone or email, etc.,
+        // you can create reference documents that will have that unique value in their IDs.
+        // To know if a value already exists, all you need to do is check whether a reference document with such ID exists.
+
+        // The reference document class
+        class UniquePhoneReference
+        {
+            public class PhoneReference
+            {
+                public string Id;
+                public string CompanyId;
+            }
+
+            static void Main(string[] args)
+            {
+                // A company document class that must be created with a unique 'Phone' field
+                Company newCompany = new Company
+                {
+                    Name = "companyName",
+                    Phone = "phoneNumber",
+                    Contact = new Contact
+                    {
+                        Name = "contactName",
+                        Title = "contactTitle"
+                    },
+                };
+
+                void CreateCompanyWithUniquePhone(Company newCompany)
+                {
+                    // Open a cluster-wide session in your document store
+                    using var session = DocumentStoreHolder.Store.OpenSession(
+                            new SessionOptions { TransactionMode = TransactionMode.ClusterWide }
+                        );
+
+                    // Check whether the new company phone already exists
+                    // by checking if there is already a reference document that has the new phone in its ID.
+                    var phoneRefDocument = session.Load<PhoneReference>("phones/" + newCompany.Phone);
+                    if (phoneRefDocument != null)
+                    {
+                        var msg = $"Phone '{newCompany.Phone}' already exists in ID: {phoneRefDocument.CompanyId}";
+                        throw new ConcurrencyException(msg);
+                    }
+
+                    // If the new phone number doesn't already exist, store the new entity
+                    session.Store(newCompany);
+                    // Store a new reference document with the new phone value in its ID for future checks.
+                    session.Store(new PhoneReference { CompanyId = newCompany.Id }, "phones/" + newCompany.Phone);
+
+                    // May fail if called concurrently with the same phone number
+                    session.SaveChanges();
+                }
+            }
+        }
+        #endregion
+    }
+
+    public static class DocumentStoreHolder
+    {
+        private static readonly Lazy<IDocumentStore> LazyStore =
+            new Lazy<IDocumentStore>(() =>
+            {
+                var store = new DocumentStore
+                {
+                    Urls = new[] { "https://a.15-8-22-serez.development.run" },
+                    Database = "Northwind",
+                    Certificate = new X509Certificate2(@"C:\Users\shachar\Desktop\CurrentServers\15-8-22\A\Server\cluster.server.certificate.15-8-22-serez.pfx")
+                };
+
+                return store.Initialize();
+            });
+
+        public static IDocumentStore Store =>
+            LazyStore.Value;
+
+
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Common/DeleteByQuery.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Common/DeleteByQuery.java
@@ -1,0 +1,70 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.operations.DeleteByQueryOperation;
+import net.ravendb.client.documents.operations.Operation;
+import net.ravendb.client.documents.operations.OperationIdResult;
+import net.ravendb.client.documents.queries.IndexQuery;
+import net.ravendb.client.documents.queries.QueryOperationOptions;
+
+public class DeleteByQuery {
+
+    private static class Person_ByAge extends AbstractIndexCreationTask {
+
+    }
+
+    private static class Person {
+
+    }
+
+    private interface IFoo {
+            /*
+            //region delete_by_query
+            public DeleteByQueryOperation(IndexQuery queryToDelete)
+
+            public DeleteByQueryOperation(IndexQuery queryToDelete, QueryOperationOptions options)
+            //endregion
+            */
+    }
+
+    public DeleteByQuery() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region delete_by_query1
+            // remove all documents from the server where Name == Bob using Person/ByName index
+            store
+                .operations()
+                .send(new DeleteByQueryOperation(new IndexQuery("from Persons where name = 'Bob'")));
+            //endregion
+
+            //region delete_by_query2
+            // remove all documents from the server where Age > 35 using Person/ByAge index
+            store
+                .operations()
+                .send(new DeleteByQueryOperation(new IndexQuery("from 'Person/ByAge' where age < 35")));
+            //endregion
+
+            //region delete_by_query3
+            // delete multiple docs with specific ids in a single run without loading them into the session
+            Operation operation = store
+                .operations()
+                .sendAsync(new DeleteByQueryOperation(new IndexQuery(
+                    "from People u where id(u) in ('people/1-A', 'people/3-A')"
+                )));
+            //endregion
+        }
+
+        try (IDocumentStore store = new DocumentStore()) {
+            //region delete_by_query_wait_for_completion
+            // remove all document from server where Name == Bob and Age >= 29 using People collection
+            Operation operation = store.operations()
+                .sendAsync(new DeleteByQueryOperation(new IndexQuery(
+                    "from People where Name = 'Bob' and Age >= 29"
+                )));
+
+            operation.waitForCompletion();
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Configuration/ClientConfig.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Configuration/ClientConfig.java
@@ -1,0 +1,72 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.configuration.ClientConfiguration;
+import net.ravendb.client.documents.operations.configuration.GetClientConfigurationOperation;
+import net.ravendb.client.documents.operations.configuration.PutClientConfigurationOperation;
+import net.ravendb.client.http.ReadBalanceBehavior;
+
+public class ClientConfig {
+
+    private interface IFoo {
+        /*
+        //region config_1_0
+        GetClientConfigurationOperation()
+        //endregion
+
+
+        //region config_2_0
+        PutClientConfigurationCommand(ClientConfiguration configuration)
+        //endregion
+        */
+    }
+
+    private static class Foo {
+        //region config_1_1
+        public static class Result {
+            private long etag;
+            private ClientConfiguration configuration;
+
+            public long getEtag() {
+                return etag;
+            }
+
+            public void setEtag(long etag) {
+                this.etag = etag;
+            }
+
+            public ClientConfiguration getConfiguration() {
+                return configuration;
+            }
+
+            public void setConfiguration(ClientConfiguration configuration) {
+                this.configuration = configuration;
+            }
+        }
+        //endregion
+    }
+
+    public ClientConfig() {
+        try (IDocumentStore store = new DocumentStore()) {
+            {
+                //region config_1_2
+                GetClientConfigurationOperation.Result config
+                    = store.maintenance().send(new GetClientConfigurationOperation());
+                ClientConfiguration clientConfiguration = config.getConfiguration();
+                //endregion
+            }
+
+            {
+                //region config_2_2
+                ClientConfiguration clientConfiguration = new ClientConfiguration();
+                clientConfiguration.setMaxNumberOfRequestsPerSession(100);
+                clientConfiguration.setReadBalanceBehavior(ReadBalanceBehavior.FASTEST_NODE);
+
+                store.maintenance().send(
+                    new PutClientConfigurationOperation(clientConfiguration));
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/GetStats.java
@@ -1,0 +1,148 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+
+import net.ravendb.client.documents.operations.CollectionStatistics;
+import net.ravendb.client.documents.operations.GetCollectionStatisticsOperation;
+
+import net.ravendb.client.documents.operations.DetailedCollectionStatistics;
+import net.ravendb.client.documents.operations.GetDetailedCollectionStatisticsOperation;
+
+import net.ravendb.client.documents.operations.DatabaseStatistics;
+import net.ravendb.client.documents.operations.GetStatisticsOperation;
+
+import net.ravendb.client.documents.operations.DetailedDatabaseStatistics;
+import net.ravendb.client.documents.operations.GetDetailedStatisticsOperation;
+
+public class GetStats {
+
+    public DetailedStatistics() {
+    
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_1
+            // Pass an instance of class `GetCollectionStatisticsOperation` to the store 
+            CollectionStatistics stats =
+                store.maintenance().send(new GetCollectionStatisticsOperation());
+            //endregion
+        }
+        
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_2
+            // Pass an instance of class `GetDetailedCollectionStatisticsOperation` to the store 
+            DetailedCollectionStatistics stats =
+                store.maintenance().send(new GetDetailedCollectionStatisticsOperation());
+            //endregion
+        }
+        
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_3
+            // Pass an instance of class `GetStatisticsOperation` to the store 
+            DatabaseStatistics stats =
+                store.maintenance().send(new GetStatisticsOperation());
+            //endregion
+        }
+    
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_4
+            // Pass an instance of class `GetDetailedStatisticsOperation` to the store 
+            DetailedDatabaseStatistics stats =
+                store.maintenance().send(new GetDetailedStatisticsOperation());
+            //endregion
+        }
+        
+        try (IDocumentStore store = new DocumentStore()) {
+            //region stats_5
+            // Get stats for 'AnotherDatabase':
+            DatabaseStatistics stats =
+                store.maintenance().forDatabase("AnotherDatabase").send(new GetStatisticsOperation());
+            //endregion
+        }
+    }
+    
+    /*
+    //region stats_1_results
+    public class CollectionStatistics {
+    // Collection stats results:
+        // Total # of documents in all collections
+        int CountOfDocuments;
+        // Total # of conflicts
+        int CountOfConflicts;
+        // Total # of documents per collection
+        Map<String, Long> Collections;
+    }
+    //endregion
+    */
+    
+    /*
+    //region stats_2_results
+    // Detailed collection stats results:
+    public class DetailedCollectionStatistics  {
+        // Total # of documents in all collections
+        long CountOfDocuments;
+        // Total # of conflicts
+        long CountOfConflicts;
+        // Collection details per collection
+        Map<String, CollectionDetails> Collections;
+    }
+    
+    // Details per collection
+    public class CollectionDetails {
+        String Name;
+        long CountOfDocuments;
+        Size Size;
+        Size DocumentsSize;
+        Size TombstonesSize;
+        Size RevisionsSize;
+    }
+    //endregion
+    */
+    
+    /*
+    //region stats_3_results
+    // Database stats results:
+    public class DatabaseStatistics {
+        Long LastDocEtag;       // Last document etag in database
+        Long LastDatabaseEtag;  // Last database etag
+        
+        int CountOfIndexes;     // Total # of indexes in database
+        long CountOfDocuments;  // Total # of documents in database
+        long CountOfRevisionDocuments;  // Total # of revision documents in database
+        long CountOfDocumentsConflicts; // Total # of documents conflicts in database
+        long CountOfTombstones;         // Total # of tombstones in database
+        long CountOfConflicts;          // Total # of conflicts in database
+        long CountOfAttachments;        // Total # of attachments in database
+        long CountOfUniqueAttachments;  // Total # of unique attachments in database
+        long CountOfCounterEntries;     // Total # of counter-group entries in database
+        long CountOfTimeSeriesSegments; // Total # of time-series segments in database
+    
+        IndexInformation[] Indexes;     // Statistics for each index in database
+    
+        String DatabaseChangeVector;    // Global change vector of the database
+        String DatabaseId;              // Database identifier
+        boolean Is64Bit;                // Indicates if process is 64-bit
+        String Pager;                   // Component handling the memory-mapped files
+        Date LastIndexingTime;          // Last time of indexing an item
+        Size SizeOnDisk;                // Database size on disk
+        Size TempBuffersSizeOnDisk;     // Temp buffers size on disk
+        int NumberOfTransactionMergerQueueOperations;
+    }
+    //endregion
+    */
+    
+    /*
+    //region stats_4_results
+    // Detailed database stats results:
+    public class DetailedDatabaseStatistics extends DatabaseStatistics {
+        // Total # of identities in database
+        long CountOfIdentities;
+        // Total # of compare-exchange items in database
+        long CountOfCompareExchange;
+        // Total # of cmpXchg tombstones in database
+        long CountOfCompareExchangeTombstones;
+        // Total # of TS deleted ranges values in database
+        long CountOfTimeSeriesDeletedRanges;
+    }
+    //endregion
+    */
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Identities/Identities.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Identities/Identities.java
@@ -1,0 +1,27 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.identities.GetIdentitiesOperation;
+
+import java.util.Map;
+
+public class Identities {
+
+    private interface IFoo {
+        /*
+        //region sample_1
+        public GetIdentitiesOperation()
+        //endregion
+         */
+    }
+
+    public Identities() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region sample_2
+            Map<String, Long> identities
+                = store.maintenance().send(new GetIdentitiesOperation());
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Server/CompareExchange.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/Server/CompareExchange.java
@@ -1,0 +1,163 @@
+package net.ravendb.Server;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.compareExchange.CompareExchangeResult;
+import net.ravendb.client.documents.operations.compareExchange.DeleteCompareExchangeValueOperation;
+import net.ravendb.client.documents.operations.compareExchange.PutCompareExchangeValueOperation;
+import net.ravendb.client.documents.session.CmpXchg;
+import net.ravendb.client.documents.session.IDocumentQuery;
+import net.ravendb.client.documents.session.IDocumentSession;
+import net.ravendb.client.documents.session.IRawDocumentQuery;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+
+public class CompareExchange {
+    private DocumentStore store;
+    private static class User {
+        private String email;
+        private String id;
+        private int age;
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+    }
+
+    public void sample() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region email
+            String email = "user@example.com";
+
+            User user = new User();
+            user.setEmail(email);
+
+            try (IDocumentSession session = store.openSession()) {
+                session.store(user);
+
+                // At this point, the user document has an Id assigned
+
+                // Try to reserve a new user email
+                // Note: This operation takes place outside of the session transaction,
+                //       It is a cluster-wide reservation
+                CompareExchangeResult<String> cmpXchgResult = store
+                    .operations().send(
+                        new PutCompareExchangeValueOperation<>(
+                            "emails/" + email, user.getId(), 0));
+
+                if (!cmpXchgResult.isSuccessful()) {
+                    throw new RuntimeException("Email is already in use");
+                }
+
+                // At this point we managed to reserve/save the user email -
+                // The document can be saved in SaveChanges
+                session.saveChanges();
+            }
+            //endregion
+
+            //region query_cmpxchg
+            try (IDocumentSession session = store.openSession()) {
+                List<User> query = session.advanced().rawQuery(User.class,
+                    "from Users as s where id() == cmpxchg(\"emails/ayende@ayende.com\")")
+                    .toList();
+
+                IDocumentQuery<User> q = session.advanced()
+                    .documentQuery(User.class)
+                    .whereEquals("id", CmpXchg.value("emails/ayende@ayende.com"));
+            }
+            //endregion
+        }
+    }
+
+    //region shared_resource
+    private class SharedResource {
+        private LocalDateTime reservedUntil;
+
+        public LocalDateTime getReservedUntil() {
+            return reservedUntil;
+        }
+
+        public void setReservedUntil(LocalDateTime reservedUntil) {
+            this.reservedUntil = reservedUntil;
+        }
+    }
+
+    public void printWork() throws InterruptedException {
+        // Try to get hold of the printer resource
+        long reservationIndex = lockResource(store, "Printer/First-Floor", Duration.ofMinutes(20));
+
+        try {
+            // Do some work for the duration that was set.
+            // Don't exceed the duration, otherwise resource is available for someone else.
+        } finally {
+            releaseResource(store, "Printer/First-Floor", reservationIndex);
+        }
+    }
+
+    public long lockResource(IDocumentStore store, String resourceName, Duration duration) throws InterruptedException {
+        while (true) {
+            LocalDateTime now = LocalDateTime.now();
+
+            SharedResource resource = new SharedResource();
+            resource.setReservedUntil(now.plus(duration));
+
+            CompareExchangeResult<SharedResource> saveResult =
+                store.operations().send(
+                    new PutCompareExchangeValueOperation<SharedResource>(resourceName, resource, 0));
+
+            if (saveResult.isSuccessful()) {
+                // resourceName wasn't present - we managed to reserve
+                return saveResult.getIndex();
+            }
+
+            // At this point, Put operation failed - someone else owns the lock or lock time expired
+            if (saveResult.getValue().reservedUntil.isBefore(now)) {
+                // Time expired - Update the existing key with the new value
+                CompareExchangeResult<SharedResource> takeLockWithTimeoutResult =
+                    store.operations().send(
+                        new PutCompareExchangeValueOperation<>(resourceName, resource, saveResult.getIndex()));
+
+                if (takeLockWithTimeoutResult.isSuccessful()) {
+                    return takeLockWithTimeoutResult.getIndex();
+                }
+            }
+
+            // Wait a little bit and retry
+            Thread.sleep(20);
+        }
+    }
+
+    public void releaseResource(IDocumentStore store, String resourceName, long index) {
+        CompareExchangeResult<SharedResource> deleteResult = store
+            .operations().send(
+                new DeleteCompareExchangeValueOperation<>(SharedResource.class, resourceName, index));
+
+        // We have 2 options here:
+        // deleteResult.Successful is true - we managed to release resource
+        // deleteResult.Successful is false - someone else took the lock due to timeout
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Common/deleteByQuery.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Common/deleteByQuery.js
@@ -1,0 +1,134 @@
+import { DocumentStore, AbstractIndexCreationTask } from "ravendb";
+
+const store = new DocumentStore();
+const session = store.openSession();
+
+{
+    //region the_index
+    // The index definition:
+    // =====================
+    
+    class Products_ByPrice extends AbstractJavaScriptIndexCreationTask {
+        constructor () {
+            super();
+
+            this.map("products", product => {
+                return {
+                    Price: product.PricePerUnit
+                };
+            });
+        }
+    }
+    //endregion
+
+    async function deleteByQuery() {
+        {
+            //region delete_by_query_0
+            // Define the delete by query operation, pass an RQL querying a collection
+            const deleteByQueryOp = new DeleteByQueryOperation("from 'Orders'");
+
+            // Execute the operation by passing it to operations.send
+            const operation = await store.operations.send(deleteByQueryOp);
+            
+            // All documents in collection 'Orders' will be deleted from the server.
+            //endregion
+        }
+
+        {
+            //region delete_by_query_1
+            // Define the delete by query operation, pass an RQL querying a collection
+            const deleteByQueryOp = new DeleteByQueryOperation("from 'Orders' where Freight > 30");
+            
+            // Execute the operation by passing it to operations.send
+            const operation = await store.operations.send(deleteByQueryOp);
+            
+            // * All documents matching the specified RQL will be deleted from the server.
+            
+            // * Since the dynamic query was made with a filtering condition,
+            //   an auto-index is generated (if no other matching auto-index already exists).
+            //endregion
+        }
+
+        {
+            //region delete_by_query_2
+            // Define the delete by query operation, pass an RQL querying the index
+            const deleteByQueryOp = 
+                new DeleteByQueryOperation("from index 'Products/ByPrice' where Price > 10");
+
+            // Execute the operation by passing it to operations.send
+            const operation = await store.operations.send(deleteByQueryOp);
+            
+            // All documents with document-field PricePerUnit > 10 will be deleted from the server.
+            //endregion
+        }
+
+        {
+            //region delete_by_query_3
+            // Define the index query, provide an RQL querying the index
+            const indexQuery = new IndexQuery();
+            indexQuery.query = "from index 'Products/ByPrice' where Price > 10";
+
+            // Define the delete by query operation
+            const deleteByQueryOp = new DeleteByQueryOperation(indexQuery);
+
+            // Execute the operation by passing it to operations.send
+            const operation = await store.operations.send(deleteByQueryOp);
+
+            // All documents with document-field PricePerUnit > 10 will be deleted from the server.
+            //endregion
+        }
+
+        {
+            //region delete_by_query_4
+            // QUERY: Define the index query, provide an RQL querying the index
+            const indexQuery = new IndexQuery();
+            indexQuery.query = "from index 'Products/ByPrice' where Price > 10";
+            
+            // OPTIONS: Define the operations options
+            // (See all available options in the Syntax section below)
+            const options = {
+                // Allow the operation to operate even if index is stale
+                allowStale: true,
+                // Limit the number of base operations per second allowed.
+                maxOpsPerSecond: 500
+            }
+            
+            // Define the delete by query operation
+            const deleteByQueryOp = new DeleteByQueryOperation(indexQuery, options);
+            
+            // Execute the operation by passing it to operations.send
+            const operation = await store.operations.send(deleteByQueryOp);
+
+            // All documents with document-field PricePerUnit > 10 will be deleted from the server.
+            //endregion
+        }
+    }
+}
+
+{
+    //region syntax_1
+    // Available overload:
+    // ===================
+    const deleteByQueryOp = new DeleteByQueryOperation(indexQuery);
+    const deleteByQueryOp = new DeleteByQueryOperation(indexQuery, options);
+    //endregion
+
+    //region syntax_2
+    // options object
+    {
+        // Indicates whether operations are allowed on stale indexes.
+        // DEFAULT: false
+        allowStale, // boolean
+            
+        // If AllowStale is set to false and index is stale,
+        // then this is the maximum timeout to wait for index to become non-stale.
+        // If timeout is exceeded then exception is thrown.
+        // DEFAULT: null (if index is stale then exception is thrown immediately)
+        staleTimeout, // number 
+            
+        // Limits the number of base operations per second allowed.
+        // DEFAULT: null (no limit)
+        maxOpsPerSecond, // number
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Configuration/getClientConfig.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Configuration/getClientConfig.js
@@ -1,0 +1,42 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getClientConfig() {
+    {
+        //region get_config
+        // Define the get client-configuration operation 
+        const getClientConfigOp = new GetClientConfigurationOperation();
+
+        // Execute the operation by passing it to maintenance.send
+        const result = await store.maintenance.send(getClientConfigOp);
+        
+        const configuration = result.configuration;
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    const getClientConfigOp = new GetClientConfigurationOperation();
+    //endregion
+
+    //region syntax_2
+    // Object returned from store.maintenance.send(getClientConfigOp):
+    {
+       etag,
+       configuration // The configution object
+    }
+
+    // The configuration object:
+    {
+        identityPartsSeparator,
+        etag,
+        disabled,
+        maxNumberOfRequestsPerSession,
+        readBalanceBehavior,
+        loadBalanceBehavior,
+        loadBalancerContextSeed
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Configuration/putClientConfig.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Configuration/putClientConfig.js
@@ -1,0 +1,59 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function putClientConfig() {
+    {
+        //region put_config_1
+        // You can customize the client-configuration options in the client
+        // when creating the Document Store (this is optional):
+        // =================================================================
+        
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+        
+        documentStore.conventions.maxNumberOfRequestsPerSession = 100;
+        documentStore.conventions.identityPartsSeparator = '$';
+        // ...
+        
+        documentStore.initialize();
+        //endregion
+    }
+    {
+        //region put_config_2
+        // Override the initial client-configuration in the server using the put operation:
+        // ================================================================================
+
+        // Define the client-configuration object
+        const clientConfiguration = {
+            maxNumberOfRequestsPerSession: 200,
+            readBalanceBehavior: "FastestNode",
+            // ...
+        };
+
+        // Define the put client-configuration operation, pass the configuration 
+        const putClientConfigOp = new PutClientConfigurationOperation(clientConfiguration);
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(putClientConfigOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    const putClientConfigOp = new PutClientConfigurationOperation(configuration);
+    //endregion
+
+    //region syntax_2
+    // The client-configuration object
+    {
+        identityPartsSeparator,
+        etag,
+        disabled,
+        maxNumberOfRequestsPerSession,
+        readBalanceBehavior,
+        loadBalanceBehavior,
+        loadBalancerContextSeed
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Identities/getIdentities.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Identities/getIdentities.js
@@ -1,0 +1,43 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getIdentities() {
+    
+    //region get_identities
+    // Create a document with an identity ID:
+    // ======================================
+
+    const session = documentStore.openSession();
+    const company = new Company();
+    company.name = "RavenDB";
+
+    // Request the server to generate an identity ID for the new document. Pass:
+    //   * The entity to store
+    //   * The collection name with a pipe (|) postfix 
+    await session.store(company, "companies|");
+
+    // If this is the first identity created for this collection,
+    // and if the identity value was not customized
+    // then a document with an identity ID "companies/1" will be created
+    await session.saveChanges();
+
+    // Get identities information:
+    // ===========================
+
+    // Define the get identities operation
+    const getIdentitiesOp = new GetIdentitiesOperation();
+
+    // Execute the operation by passing it to maintenance.send
+    const identities = await store.maintenance.send(getIdentitiesOp);
+
+    // Results
+    const latestIdentityValue = identities["companies|"]; // => value will be 1
+    //endregion
+}
+
+{
+    //region syntax
+    const getIdentitiesOp = new GetIdentitiesOperation();
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Identities/incrementIdentity.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Identities/incrementIdentity.js
@@ -1,0 +1,49 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function incrementIdentity() {
+    
+    //region increment_identity
+    // Create a document with an identity ID:
+    // ======================================
+
+    const session = documentStore.openSession();
+    const company = new Company();
+    company.name = "RavenDB";
+
+    // Pass a collection name that ends with a pipe '|' to create an identity ID
+    await session.store(company, "companies|");
+
+    await session.saveChanges();
+    // => Document "companies/1" will be created 
+
+    // Increment the identity value on the server:
+    // ===========================================
+
+    // Define the next identity operation
+    // Pass the collection name (can be with or without a pipe)
+    const nextIdentityOp = new NextIdentityForOperation("companies|");
+
+    // Execute the operation by passing it to maintenance.send
+    // The latest value will be incremented to "2"
+    // and the next document created with an identity will be assigned "3"
+    const incrementedValue = await store.maintenance.send(nextIdentityOp);
+
+    // Create another document with an identity ID:
+    // ============================================
+
+    const company = new Company();
+    company.name = "AnotherComapany";
+
+    await session.store(company, "companies|");
+    await session.saveChanges();
+    // => Document "companies/3" will be created
+    //endregion
+}
+
+{
+    //region syntax
+    const nextIdentityOp = new NextIdentityForOperation(name);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Identities/seedIdentity.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Identities/seedIdentity.js
@@ -1,0 +1,65 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function seedIdentity() {
+    {
+        //region seed_identity_1
+        // Seed a higher identity value on the server:
+        // ===========================================
+
+        // Define the seed identity operation. Pass:
+        //   * The collection name (can be with or without a pipe)
+        //   * The new value to set
+        const seedIdentityOp = new SeedIdentityForOperation("companies|", 23);
+
+        // Execute the operation by passing it to maintenance.send
+        // The latest value on the server will be incremented to "23"
+        // and the next document created with an identity will be assigned "24"
+        const seededValue = await store.maintenance.send(seedIdentityOp);
+
+        // Create a document with an identity ID:
+        // ======================================
+
+        const company = new Company();
+        company.name = "RavenDB";
+
+        await session.store(company, "companies|");
+        await session.saveChanges();
+        // => Document "companies/24" will be created
+        //endregion
+    }
+    {
+        //region seed_identity_2
+        // Force a smaller identity value on the server:
+        // =============================================
+        
+        // Define the seed identity operation. Pass:
+        //   * The collection name (can be with or without a pipe)
+        //   * The new value to set
+        //   * Pass 'true' to force the update
+        const seedIdentityOp = new SeedIdentityForOperation("companies|", 5, true);
+
+        // Execute the operation by passing it to maintenance.send
+        // The latest value on the server will be decremented to "5"
+        // and the next document created with an identity will be assigned "6"
+        const seededValue = await store.maintenance.send(seedIdentityOp);
+
+        // Create a document with an identity ID:
+        // ======================================
+
+        const company = new Company();
+        company.name = "RavenDB";
+
+        await session.store(company, "companies|");
+        await session.saveChanges();
+        // => Document "companies/6" will be created
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const seedIdentityOp = new SeedIdentityForOperation(name, value, forceUpdate);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/getStats.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/getStats.js
@@ -1,0 +1,116 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function getStats() {
+    {
+        //region stats_1
+        // Pass an instance of class `GetCollectionStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetCollectionStatisticsOperation());
+        //endregion
+    }
+    {
+        //region stats_2
+        // Pass an instance of class `GetDetailedCollectionStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetDetailedCollectionStatisticsOperation());
+        //endregion
+    }
+    {
+        //region stats_3
+        // Pass an instance of class `GetStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetStatisticsOperation());
+        //endregion
+    }
+    {
+        //region stats_4
+        // Pass an instance of class `GetDetailedStatisticsOperation` to the store 
+        const stats = await store.maintenance.send(new GetDetailedStatisticsOperation());
+        //endregion
+    }
+    {
+        //region stats_5
+        // Get stats for 'AnotherDatabase':
+        const stats = 
+            await store.maintenance.forDatabase("AnotherDatabase").send(new GetStatisticsOperation());
+        //endregion
+    }
+}
+
+//region stats_1_results
+// Object with following props is returned:
+{
+    // Total # of documents in all collections
+    countOfDocuments,
+    // Total # of conflicts
+    countOfConflicts,
+    // Dictionary with total # of documents per collection
+    collections
+}
+//endregion
+
+//region stats_2_results
+// Object with following props is returned:
+{
+    // Total # of documents in all collections
+    countOfDocuments,
+    // Total # of conflicts
+    countOfConflicts,
+    // Dictionary with 'collection details per collection'
+    collections,
+}
+
+// 'Collection details per collection' object props:
+{
+    name,
+    countOfDocuments,
+    size,
+    documentsSize,
+    tombstonesSize,
+    revisionsSize
+}
+//endregion
+
+//region stats_3_results
+// Object with following props is returned:
+{
+    lastDocEtag,      // Last document etag in database
+    lastDatabaseEtag, // Last database etag
+    
+    countOfIndexes,            // Total # of indexes in database
+    countOfDocuments,          // Total # of documents in database
+    countOfRevisionDocuments,  // Total # of revision documents in database
+    countOfDocumentsConflicts, // Total # of documents conflicts in database 
+    countOfTombstones,         // Total # of tombstones in database
+    countOfConflicts,          // Total # of conflicts in database
+    countOfAttachments,        // Total # of attachments in database
+    countOfUniqueAttachments,  // Total # of unique attachments in database
+    countOfCounterEntries,     // Total # of counter-group entries in database
+    countOfTimeSeriesSegments, // Total # of time-series segments in database
+    
+    indexes, // Statistics for each index in database (array of IndexInformation) 
+
+    databaseChangeVector,  // Global change vector of the database
+    databaseId,            // Database identifier
+    is64Bit,               // Indicates if process is 64-bit 
+    pager,                 // Component handling the memory-mapped files
+    lastIndexingTime,      // Last time of indexing an item
+    sizeOnDisk,            // Database size on disk
+    tempBuffersSizeOnDisk, // Temp buffers size on disk
+    numberOfTransactionMergerQueueOperations
+}
+//endregion
+
+//region stats_4_results
+// Resulting object contains all database stats props from above and the following in addition:
+{
+    // Total # of identities in database
+    countOfIdentities,
+    // Total # of compare-exchange items in database
+    countOfCompareExchange,
+    // Total # of cmpXchg tombstones in database
+    countOfCompareExchangeTombstones,
+    // Total # of TS deleted ranges values in database
+    countOfTimeSeriesDeletedRanges
+}
+//endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Common/DeleteByQuery.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Common/DeleteByQuery.py
@@ -1,0 +1,96 @@
+from ravendb import DeleteByQueryOperation, AbstractIndexCreationTask, IndexQuery, QueryOperationOptions
+
+from examples_base import ExampleBase
+
+
+# region the_index
+# The index definition:
+# =====================
+class ProductsByPrice(AbstractIndexCreationTask):
+    class IndexEntry:
+        def __init__(self, price: int):
+            self.price = price
+
+    def __init__(self):
+        super().__init__()
+        self.map = "from product in products select new {price = product.PricePerUnit}"
+
+
+# endregion
+
+
+class DeleteByQuery(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_delete_by_query(self):
+        with self.embedded_server.get_document_store() as store:
+            # region delete_by_query_0
+            # Define the delete by query operation, pass an RQL querying a collection
+            delete_by_query_op = DeleteByQueryOperation("from 'Orders'")
+
+            # Execute the operation by passing it to Operation.send_async
+            operation = store.operations.send_async(delete_by_query_op)
+
+            # All documents in collection 'Orders' will be deleted from the server
+            # endregion
+
+            # region delete_by_query_1
+            # Define the delete by query operation, pass an RQL querying a collection
+            delete_by_query_op = DeleteByQueryOperation("from 'Orders' where Freight > 30")
+
+            # Execute the operation by passing it to Operation.send_async
+            operation = store.operations.send_async(delete_by_query_op)
+
+            # * All documents matching the specified RQL will be deleted from the server.
+            #
+            # * Since the dynamic query was made with a filtering condition,
+            #   an auto-index is generated (if no other matching auto-index already exists).
+            # endregion
+            ProductsByPrice().execute(store)
+
+            # region delete_by_query_2
+            # Define the delete by query operation, pass an RQL querying the index
+            delete_by_query_op = DeleteByQueryOperation("from index 'Products/ByPrice' where Price > 10")
+
+            # Execute the operation by passing it to Operation.send_async
+            operation = store.operations.send_async(delete_by_query_op)
+
+            # All documents with document-field PricePerUnit > 10 will be deleted from the server.
+            # endregion
+
+            # region delete_by_query_3
+            # Define the delete by query operation
+            delete_by_query_op = DeleteByQueryOperation(
+                IndexQuery(query="from index 'Products/ByPrice' where Price > 10")
+            )
+
+            # Execute the operation by passing it to Operation.send_async
+            operation = store.operations.send_async(delete_by_query_op)
+
+            # All documents with document-field PricePerUnit > 10 will be deleted from the server.
+            # endregion
+            # region delete_by_query_6
+            # Define the delete by query operation
+            delete_by_query_op = DeleteByQueryOperation(
+                # QUERY: Specify the query
+                IndexQuery(query="from index 'Products/ByPrice' where Price > 10"),
+                # OPTIONS: Specify the options for the operations
+                # (See all other available options in the Syntax section below)
+                QueryOperationOptions(
+                    # Allow the operation to operate even if index is stale
+                    allow_stale=True,
+                    # Get info in the operation result about documents that were deleted
+                    retrieve_details=True,
+                ),
+            )
+
+            # Execute the operation by passing it to Operations.send_async
+            operation = store.operations.send_async(delete_by_query_op)
+
+            # * All documents with document-field PricePerUnit > 10 will be deleted from the server
+
+            # * Details about deleted documents are available:
+            details = result.details
+            document_id_that_was_deleted = details[0]["Id"]
+            # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Configuration/GetClientConfig.py
@@ -1,0 +1,39 @@
+from ravendb import GetClientConfigurationOperation, ClientConfiguration
+from ravendb.documents.operations.definitions import MaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class GetClientConfig(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_client_config(self):
+        with self.embedded_server.get_document_store("GetClientConfig") as store:
+            # region get_config
+            # Define the get client-configuration operation
+            get_client_config_op = GetClientConfigurationOperation()
+
+            # Execute the operation by passing it to maintenance.send
+            result = store.maintenance.send(get_client_config_op)
+
+            client_configuration = result.configuration
+            # endregion
+
+
+class Foo:
+    # region syntax_1
+    class GetClientConfigurationOperation(MaintenanceOperation): ...
+
+    # no __init__ (default)
+    # endregion
+    # region syntax_2
+    # Executing the operation returns the following object:
+    class Result:
+        def __init__(self, etag: int, configuration: ClientConfiguration):
+            # The configuration Etag
+            self.etag = etag
+            # The current client-configuration deployed on the server for the database
+            self.configuration = configuration
+
+    # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Configuration/PutClientConfig.py
@@ -1,0 +1,72 @@
+from typing import Optional, Union
+
+from ravendb import (
+    DocumentStore,
+    ClientConfiguration,
+    ReadBalanceBehavior,
+    PutClientConfigurationOperation,
+    LoadBalanceBehavior,
+)
+from ravendb.documents.conventions import DocumentConventions
+from ravendb.documents.operations.definitions import VoidMaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class PutClientConfig(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_put_client_config(self):
+        with self.embedded_server.get_document_store("PutClientConfig") as store:
+            # region put_config_1
+            # You can customize the client-configuration options in the client
+            # when creating the Document Store (this is optional):
+            # =================================================================
+            document_store = DocumentStore(urls=["ServerURL_1", "ServerURL_2", "..."], database="DefaultDB")
+            document_store.conventions = DocumentConventions()
+
+            # Initialize some client-configuration options:
+            document_store.conventions.max_number_of_requests_per_session = 100
+            document_store.conventions.identity_parts_separator = "$"
+            # ...
+
+            document_store.initialize()
+            # endregion
+
+            # region put_config_2
+            # Override the initial client-configuration in the server using the put operation:
+            # ================================================================================
+            with document_store:
+                # Define the client-configuration object
+                client_configuration = ClientConfiguration()
+                client_configuration.max_number_of_requests_per_session = 200
+                client_configuration.read_balance_behavior = ReadBalanceBehavior.FASTEST_NODE
+                # ...
+
+            # Define the put client-configuration operation, pass the configuration
+            put_client_config_op = PutClientConfigurationOperation(client_configuration)
+
+            # Execute the operation by passing it to maintenance.send
+            document_store.maintenance.send(put_client_config_op)
+            # endregion
+
+
+class Foo:
+    # region syntax_1
+    class PutClientConfigurationOperation(VoidMaintenanceOperation):
+        def __init__(self, config: ClientConfiguration): ...
+
+    # endregion
+    # region syntax_2
+    class ClientConfiguration:
+        def __init__(self):
+            self.__identity_parts_separator: Union[None, str] = None
+            self.etag: int = 0
+            self.disabled: bool = False
+            self.max_number_of_requests_per_session: Optional[int] = None
+            self.read_balance_behavior: Optional[ReadBalanceBehavior] = None
+            self.load_balance_behavior: Optional[LoadBalanceBehavior] = None
+            self.load_balancer_context_seed: Optional[int] = None
+
+    # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/GetStats.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/GetStats.py
@@ -1,0 +1,148 @@
+import datetime
+from typing import List, Optional, Dict
+
+from ravendb import GetCollectionStatisticsOperation
+from ravendb import GetDetailedStatisticsOperation
+from ravendb.tools.utils import Size
+
+from examples_base import ExampleBase
+from ravendb.documents.operations.statistics import (
+    GetDetailedCollectionStatisticsOperation,
+    GetStatisticsOperation,
+    IndexInformation,
+)
+
+
+class GetStats(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_stats(self):
+        with self.embedded_server.get_document_store("GetStats") as store:
+            with store.open_session() as session:
+                # region stats_1
+                # Pass an instance of class 'GetCollectionStatisticsOperation' to the store
+                stats = store.maintenance.send(GetCollectionStatisticsOperation())
+                # endregion
+
+            with store.open_session() as session:
+                # region stats_2
+                # Pass an instance of class 'GetDetailedCollectionStatisticsOperation' to the store
+                stats = store.maintenance.send(GetDetailedCollectionStatisticsOperation())
+                # endregion
+
+            with store.open_session() as session:
+                # region stats_3
+                # Pass an instance of class 'GetStatisticsOperation' to the store
+                stats = store.maintenance.send(GetStatisticsOperation())
+                # endregion
+
+            with store.open_session() as session:
+                # region stats_4
+                # Pass an instance of class 'GetDetailedStatisticsOperation' to the store
+                stats = store.maintenance.send(GetDetailedStatisticsOperation())
+                # endregion
+
+            with store.open_session() as session:
+                # region stats_5
+                # Get stats for 'AnotherDatabase'
+                stats = store.maintenance.for_database("AnotherDatabase").send(GetStatisticsOperation())
+                # endregion
+
+
+class Foo:
+    # region stats_1_results
+    class CollectionStatistics:
+        def __init__(
+            self,
+            count_of_documents: Optional[int] = None,
+            count_of_conflicts: Optional[int] = None,
+            collections: Optional[Dict[str, int]] = None,
+        ): ...
+
+    # endregion
+    # region stats_2_results
+    class Size:
+        def __init__(self, size_in_bytes: int = None, human_size: str = None): ...
+
+    class CollectionDetails:
+        def __init__(
+            self,
+            name: str = None,
+            count_of_documents: int = None,
+            size: Size = None,
+            documents_size: Size = None,
+            tombstones_size: Size = None,
+            revisions_size: Size = None,
+        ): ...
+
+    class DetailedCollectionStatistics:
+        def __init__(
+            self,
+            count_of_documents: int = None,
+            count_of_conflicts: int = None,
+            collections: Dict[str, CollectionDetails] = None,
+        ) -> None: ...
+
+    # endregion
+
+    # region stats_3_results
+    class DatabaseStatistics:
+        def __init__(
+            self,
+            last_doc_etag: int = None,
+            last_database_etag: int = None,
+            count_of_indexes: int = None,
+            count_of_documents: int = None,
+            count_of_revision_documents: int = None,
+            count_of_documents_conflicts: int = None,
+            count_of_tombstones: int = None,
+            count_of_conflicts: int = None,
+            count_of_attachments: int = None,
+            count_of_unique_attachments: int = None,
+            count_of_counter_entries: int = None,
+            count_of_time_series_segments: int = None,
+            indexes: List[IndexInformation] = None,
+            database_change_vector: str = None,
+            database_id: str = None,
+            is_64_bit: bool = None,
+            pager: str = None,
+            last_indexing_time: datetime.datetime = None,
+            size_on_disk: Size = None,
+            temp_buffers_size_on_disk: Size = None,
+            number_of_transaction_merger_queue_operations: int = None,
+        ): ...
+
+    # endregion
+
+    # region stats_4_results
+    class DetailedDatabaseStatistics(DatabaseStatistics):
+        def __init__(
+            self,
+            last_doc_etag: int = None,
+            last_database_etag: int = None,
+            count_of_indexes: int = None,
+            count_of_documents: int = None,
+            count_of_revision_documents: int = None,
+            count_of_documents_conflicts: int = None,
+            count_of_tombstones: int = None,
+            count_of_conflicts: int = None,
+            count_of_attachments: int = None,
+            count_of_unique_attachments: int = None,
+            count_of_counter_entries: int = None,
+            count_of_time_series_segments: int = None,
+            indexes: List[IndexInformation] = None,
+            database_change_vector: str = None,
+            database_id: str = None,
+            is_64_bit: bool = None,
+            pager: str = None,
+            last_indexing_time: datetime.datetime = None,
+            size_on_disk: Size = None,
+            temp_buffers_size_on_disk: Size = None,
+            number_of_transaction_merger_queue_operations: int = None,
+            count_of_identities: int = None,  # Total # of identities in database
+            count_of_compare_exchange: int = None,  # Total # of compare-exchange items in database
+            count_of_compare_exchange_tombstones: int = None,  # Total # of cmpXchg tombstones in database
+        ): ...
+
+    # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Identities/GetIdentities.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Identities/GetIdentities.py
@@ -1,0 +1,48 @@
+from typing import Dict
+
+from ravendb.documents.operations.definitions import MaintenanceOperation
+from ravendb.documents.operations.identities import GetIdentitiesOperation
+
+from examples_base import ExampleBase, Company
+
+
+class GetIdentities(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_identities(self):
+        with self.embedded_server.get_document_store("GetIdentities") as store:
+            # region get_identities
+            # Create a document with an identity ID:
+            # ======================================
+            with store.open_session() as session:
+                # Request the server to generate an identity ID for the new document. Pass:
+                #    * The entity to store
+                #    * The collection name with a pipe (|) postfix
+                session.store(Company(name="RavenDB"), "companies|")
+
+                #  If this is the first identity created for this collection,
+                #  and if the identity value was not customized
+                #  then a document with an identity ID "companies/1" will be created
+                session.save_changes()
+
+            # Get identities information:
+            # ===========================
+
+            # Define the get identities operation
+            get_identities_op = GetIdentitiesOperation()
+
+            # Execute the operation by passing it to maintenance.send
+            identities = store.maintenance.send(get_identities_op)
+
+            # Results
+            latest_identity_value = identities["companies|"]  # => value will be 1
+            # endregion
+
+
+class Foo:
+    # region syntax
+    class GetIdentitiesOperation(MaintenanceOperation[Dict[str, int]]): ...
+
+
+# endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Identities/IncrementIdentity.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Identities/IncrementIdentity.py
@@ -1,0 +1,49 @@
+from ravendb.documents.operations.definitions import MaintenanceOperation
+from ravendb.documents.operations.identities import NextIdentityForOperation
+
+from examples_base import ExampleBase, Company
+
+
+class IncrementIdentity(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_increment_identity(self):
+        with self.embedded_server.get_document_store("IncrementIdentity") as store:
+            # region increment_identity
+            # Create a document with an identity ID:
+            # ======================================
+
+            with store.open_session() as session:
+                # Pass a collection name that ends with a pipe '|' to create an identity ID
+                session.store(Company(name="RavenDB"), "companies|")
+                session.save_changes()
+                # => Document "companies/1" will be created
+
+            # Increment the identity value on the server:
+            # ===========================================
+
+            # Define the next identity operation
+            # Pass the collection name (can be with or without a pipe)
+            next_identity_op = NextIdentityForOperation("companies|")
+
+            #  Execute the operation by passing it to Maintenance.Send
+            #  The latest value will be incremented to "2"
+            #  and the next document created with an identity will be assigned "3"
+            incremented_value = store.maintenance.send(next_identity_op)
+
+            # Create another document with an identity ID:
+            # ============================================
+
+            with store.open_session() as session:
+                session.store(Company(name="RavenDB"), "companies|")
+                session.save_changes()
+                # => Document "companies/3" will be created
+
+            # endregion
+
+    class Foo:
+        # region syntax
+        class NextIdentityForOperation(MaintenanceOperation[int]): ...
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Identities/SeedIdentity.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Identities/SeedIdentity.py
@@ -1,0 +1,66 @@
+from ravendb.documents.operations.definitions import MaintenanceOperation
+from ravendb.documents.operations.identities import SeedIdentityForOperation
+
+from examples_base import ExampleBase, Company
+
+
+class SeedIdentity(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_seed_identity(self):
+        with self.embedded_server.get_document_store("SeedIdentity") as store:
+            # region seed_identity_1
+            # Seed a higher identity value on the server:
+            # ===========================================
+
+            # Define the seed identity operation. Pass:
+            # * The collection name (can be with or without a pipe)
+            # * The new value to set
+            seed_identity_op = SeedIdentityForOperation("companies|", 23)
+
+            # Execute the operation by passing it to maintenance.send
+            # The latest value on the server will be incremented to "23"
+            # and the next document created with an identity will be assigned "24"
+            seeded_value = store.maintenance.send(seed_identity_op)
+
+            # Create a document with an identity ID:
+            # ======================================
+
+            with store.open_session() as session:
+                session.store(Company(name="RavenDB"), "companies|")
+                session.save_changes()
+                # => Document "companies/24" will be created
+
+            # endregion
+            # region seed_identity_2
+            # Force a smaller identity value on the server:
+            # =============================================
+
+            # Define the seed identity operation. Pass:
+            #   * The collection name (can be with or without a pipe)
+            #   * The new value to set
+            #   * Set 'force_update' to True
+            seed_identity_op = SeedIdentityForOperation("companies|", 5, force_update=True)
+
+            # Execute the operation by passing it to maintenance.send
+            # The latest value on the server will be decremented to "5"
+            # and the next document created with an identity will be assigned "6"
+            seeded_value = store.maintenance.send(seed_identity_op)
+
+            # Create a document with an identity ID:
+            # ======================================
+
+            with store.open_session() as session:
+                session.store(Company(name="RavenDB"), "companies|")
+                session.save_changes()
+                # => Document "companies/6" will be created
+
+            # endregion
+
+    class Foo:
+        # region syntax
+        class SeedIdentityForOperation(MaintenanceOperation[int]):
+            def __init__(self, name: str, value: int, force_update: bool = False): ...
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/WhatAreOperations.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/WhatAreOperations.py
@@ -1,0 +1,151 @@
+import datetime
+from typing import TypeVar, Optional, Union, Generic
+
+from ravendb import (
+    PatchOperation,
+    PatchStatus,
+    DocumentStore,
+    StopIndexOperation,
+    GetIndexStatisticsOperation,
+    DeleteByQueryOperation,
+    RavenCommand,
+)
+from ravendb.documents.conventions import DocumentConventions
+from ravendb.documents.operations.counters import GetCountersOperation
+from ravendb.documents.operations.definitions import (
+    IOperation,
+    OperationIdResult,
+    _T,
+    VoidMaintenanceOperation,
+    MaintenanceOperation,
+)
+from ravendb.documents.operations.operation import Operation
+from ravendb.documents.session.misc import SessionInfo
+from ravendb.http.http_cache import HttpCache
+from ravendb.serverwide.operations.common import ServerOperation, GetBuildNumberOperation
+
+from examples_base import ExampleBase
+
+_Operation_T = TypeVar("_Operation_T")
+_T_OperationResult = TypeVar("_T_OperationResult")
+
+
+class WhatAreOperations(ExampleBase):
+    class SendSyntax:
+        # region operations_send
+        # Available overloads:
+        def send(self, operation: IOperation[_Operation_T], session_info: SessionInfo = None) -> _Operation_T: ...
+
+        def send_async(self, operation: IOperation[OperationIdResult]) -> Operation: ...
+
+        def send_patch_operation(self, operation: PatchOperation, session_info: SessionInfo) -> PatchStatus: ...
+
+        def send_patch_operation_with_entity_class(
+            self, entity_class: _T, operation: PatchOperation, session_info: Optional[SessionInfo] = None
+        ) -> PatchOperation.Result[_T]: ...
+
+        # endregion
+
+    class MaintenanceSyntax:
+        # region maintenance_send
+        def send(
+            self, operation: Union[VoidMaintenanceOperation, MaintenanceOperation[_Operation_T]]
+        ) -> Optional[_Operation_T]: ...
+
+        def send_async(self, operation: MaintenanceOperation[OperationIdResult]) -> Operation: ...
+
+        # endregion
+
+        # region ioperation
+
+        # (It's beginning with capital I to mirror the different clients API - and is similar to what is an interface)
+        class IOperation(Generic[_Operation_T]):
+            def get_command(
+                self, store: "DocumentStore", conventions: "DocumentConventions", cache: HttpCache
+            ) -> "RavenCommand[_Operation_T]":
+                pass
+
+        # endregion
+
+    class ServerSend:
+        # region server_send
+        def send(self, operation: ServerOperation[_T_OperationResult]) -> Optional[_T_OperationResult]: ...
+
+        def send_async(self, operation: ServerOperation[OperationIdResult]) -> Operation: ...
+
+    def test_examples(self):
+        with self.embedded_server.get_document_store("WhatAreOperations") as store:
+            # region operations_ex
+            # Define operation, e.g. get all counters info for a document
+            get_counters_op = GetCountersOperation("products/1-A")
+
+            # Execute the operation by passing the operation to operations.send
+            all_counters_result = store.operations.send(get_counters_op)
+
+            # Access the operation result
+            number_of_counters = len(all_counters_result.counters)
+            # endregion
+
+            # region maintenance_ex
+            # Define operation, e.g. stop an index
+            stop_index_op = StopIndexOperation("Orders/ByCompany")
+
+            # Execute the operation by passing the operation to maintenance.send
+            store.maintenance.send(stop_index_op)
+
+            # This specific operation returns void
+            # You can send another operation to verify the index running status
+            index_stats_op = GetIndexStatisticsOperation("Orders/ByCompany")
+            index_stats = store.maintenance.send(index_stats_op)
+            status = index_stats.status  # will be "Paused"
+            # endregion
+
+            # region server_ex
+            # Define operation, e.g. get the server build number
+            get_build_number_op = GetBuildNumberOperation()
+
+            # Execute the operation by passing to maintenance.server.send
+            build_number_result = store.maintenance.server.send(get_build_number_op)
+
+            # Access the operation result
+            version = build_number_result.build_version
+            # endregion
+
+            # region kill_ex
+            # Define operation, e.g. delete all discontinued products
+            # Note: This operation implements class: IOperation[OperationIdResult]
+
+            delete_by_query_op = DeleteByQueryOperation("from Products where Discontinued = true")
+
+            # Execute the operation
+            # Send returns an 'Operation' object that can be 'killed'
+            operation = store.operations.send_async(delete_by_query_op)
+
+            # Call 'kill' to abort operation
+            # todo: skip it - wait for the merge of the ticket linked in the checklist
+            operation.kill()
+            # endregion
+
+        # region wait_timeout_ex
+
+    def wait_for_completion_with_timeout(timeout: datetime.timedelta, document_store: DocumentStore):
+        # Define operation, e.g. delete all discontinued products
+        # Note: This operation implements:'IOperation[OperationIdResult]'
+        delete_by_query_op = DeleteByQueryOperation("from Products where Discontinued = true")
+
+        # Execute the operation
+        # Send returns an 'Operation' object that can be awaited on
+        operation = document_store.operations.send_async(delete_by_query_op)
+
+        try:
+            # Call method 'WaitForCompletion' to wait for the operation to complete.
+            # If a timeout is specified, the method will only wait for the specified time frame.
+            result = operation.wait_for_completion_with_timeout(timeout)  # todo: skip, wait for the merge
+
+            # The operation has finished within the specified timeframe
+            number_of_items_deleted = result.total
+        except TimeoutError:
+            # The operation did not finish within the specified timeframe
+            ...
+
+    # endregion

--- a/Documentation/5.4/Samples/python/Server/CompareExchange.py
+++ b/Documentation/5.4/Samples/python/Server/CompareExchange.py
@@ -1,0 +1,156 @@
+import time
+from datetime import datetime, timedelta
+from typing import Dict, Any
+
+from ravendb import (
+    PutCompareExchangeValueOperation,
+    CmpXchg,
+    DocumentStore,
+    DeleteCompareExchangeValueOperation,
+    SessionOptions,
+    TransactionMode,
+)
+
+from examples_base import ExampleBase, Company, Contact
+
+
+class User:
+    def __init__(self, email: str = None, Id: str = None, age: int = None):
+        self.email = email
+        self.Id = Id
+        self.age = age
+
+    @classmethod
+    def from_json(cls, json_dict: Dict[str, Any]):
+        return cls(json_dict["Email"], json_dict["Id"], json_dict["Age"])
+
+    def to_json(self) -> Dict[str, Any]:
+        return {"Email": self.email, "Id": self.Id, "Age": self.age}
+
+
+class CompareExchange(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_compare_exchange(self):
+        with self.embedded_server.get_document_store("ServerCompareExchange") as store:
+            # region email
+            email = "user@example.com"
+
+            user = User(email=email)
+
+            with store.open_session() as sesion:
+                sesion.store(user)
+                # At this point, the user document has an Id assigned
+
+                # Try to reserve a new user email
+                # Note: This operation takes place outside the session transaction,
+                # It is a cluster-wide reservation
+                cmp_xchg_result = store.operations.send(PutCompareExchangeValueOperation(f"emails/{email}", user.Id, 0))
+
+                if cmp_xchg_result.successful is False:
+                    raise RuntimeError("Email is already in use")
+
+                # At this point we managed to reserve/save the user mail -
+                # The document can be saved in save_changes
+                sesion.save_changes()
+
+                # endregion
+
+                # region query_cmpxchg
+                query = sesion.query(object_type=User).where_equals("Id", CmpXchg.value("emails/ayende@ayende.com"))
+                # endregion
+
+        # region shared_resource
+        class SharedResource:
+            def __init__(self, reserved_until: datetime = None):
+                self.reserved_until = reserved_until
+
+        def print_work() -> None:
+            # Try to get hold of the printer resource
+            reservation_index = lock_resource(store, "Printer/First-Floor", timedelta(minutes=20))
+
+            try:
+                ...
+                # Do some work for the duration that was set
+                # Don't exceed the duration, otherwise resource is available for someone else
+            finally:
+                release_resource(store, "Printer/First-Floor", reservation_index)
+
+        def lock_resource(document_store: DocumentStore, resource_name: str, duration: timedelta):
+            while True:
+                now = datetime.utcnow()
+
+                resource = SharedResource(reserved_until=now + duration)
+                save_result = document_store.operations.send(
+                    PutCompareExchangeValueOperation(resource_name, resource, 0)
+                )
+
+                if save_result.successful:
+                    # resource_name wasn't present - we managed to reserve
+                    return save_result.index
+
+                # At this point, Put operation failed - someone else owns the lock or lock time expired
+                if save_result.value.reserved_until < now:
+                    # Time expired - Update the existing key with new value
+                    take_lock_with_timeout_result = document_store.operations.send(
+                        PutCompareExchangeValueOperation(resource_name, resource, save_result.index)
+                    )
+
+                    if take_lock_with_timeout_result.successful:
+                        return take_lock_with_timeout_result.index
+
+                # Wait a little bit and retry
+                time.sleep(0.02)
+
+        def release_resource(store: DocumentStore, resource_name: str, index: int) -> None:
+            delete_result = store.operations.send(DeleteCompareExchangeValueOperation(resource_name, index))
+
+            # We have 2 options here:
+            # delete_result.successful is True - we managed to release resource
+            # delete_result.successful is False - someone else took the lock due to timeout
+
+        # endregion
+
+        # region create_uniqueness_control_documents
+        # When you create documents that must contain a unique value such as a phone or email, etc.,
+        # you can create reference documents that will have that unique value in their IDs.
+        # To know if a value already exists, all you need to do is check whether a reference document with such ID exists.
+
+        # The reference document class
+        class UniquePhoneReference:
+            class PhoneReference:
+                def __init__(self, Id: str = None, company_id: str = None):
+                    self.Id = Id
+                    self.company_id = company_id
+
+            def main(self):
+                # A company document class that must be created with a unique 'Phone' field
+                new_company = Company(
+                    name="companyName", phone="phoneNumber", contact=Contact(name="contactName", title="contactTitle")
+                )
+
+                def create_company_with_unique_phone(new_company: Company) -> None:
+                    # Open a cluster-wide session in your document store
+                    with store.open_session(
+                        session_options=SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
+                    ) as session:
+                        # Check whether the new company phone already exists
+                        # by checking if there is already a reference document that has the new phone in its ID.
+                        phone_ref_document = session.load(f"phones/{new_company.phone}")
+                        if phone_ref_document is not None:
+                            msg = f"Phone '{new_company.phone}' already exists, store the new entity"
+                            raise RuntimeError(msg)
+
+                        # If the new phone number doesn't already exist, store the new entity
+                        session.store(new_company)
+                        # Store a new reference document with the new phone value in its ID for future checks
+                        session.store(
+                            UniquePhoneReference.PhoneReference(company_id=new_company.Id),
+                            f"phones/{new_company.phone}",
+                        )
+
+                        # May fail if called concurrently with the same phone number
+                        session.save_changes()
+
+                # endregion


### PR DESCRIPTION
Related issues:

[RDoc-2772](https://issues.hibernatingrhinos.com/issue/RDoc-2772/Python-Client-API-Operations-What-are-operations-Replace-C-samples) - What are operations
[RDoc-2773](https://issues.hibernatingrhinos.com/issue/RDoc-2773/Python-Client-API-Operations-Common-Operations-Delete-by-query-Replace-C-samples) - Delete by query
[RDoc-2774](https://issues.hibernatingrhinos.com/issue/RDoc-2774/Python-Client-API-Operations-Compare-Exchange-Overview-Replace-C-samples) - Compare Exchange Overview
[RDoc-2775](https://issues.hibernatingrhinos.com/issue/RDoc-2775/Python-Client-API-Operations-Maintenance-Get-statistics-Replace-C-samples) - Get statistics
[RDoc-2777](https://issues.hibernatingrhinos.com/issue/RDoc-2777/Python-Client-API-Operations-Maintenance-Configuration-Put-client-configuration-Replace-C-samples) - Put client configuration
[RDoc-2778](https://issues.hibernatingrhinos.com/issue/RDoc-2778/Python-Client-API-Operations-Maintenance-Configuration-Get-client-configuration-Replace-C-samples) - Get client configuration
[RDoc-2781](https://issues.hibernatingrhinos.com/issue/RDoc-2781/Python-Client-API-Operations-Maintenance-Identities-Get-identities-Replace-C-samples) - Get identities
[RDoc-2782](https://issues.hibernatingrhinos.com/issue/RDoc-2782/Python-Client-API-Operations-Maintenance-Identities-Increment-next-identity-Replace-C-samples) - Increment next identity
[RDoc-2783](https://issues.hibernatingrhinos.com/issue/RDoc-2783/Python-Client-API-Operations-Maintenance-Identities-Seed-identity-Replace-C-samples) - Seed identity