### PR TITLE
RDoc-2814 [Node.js] Document extensions > Time series > Client API > Session > Patch [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
@@ -17,10 +17,11 @@
     * __Modify an existing time series entry__:  
       Use _Append_ to update the data of an existing entry with the specified timestamp.
 
-* Each call to `Append` handles a single [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).
+* Each call to `Append` handles a __single__ [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).
 
-* To append multiple entries in a single transaction,  
-  call `Append` as many times as needed before calling `session.SaveChanges`.
+* To append __multiple__ entries in a single transaction:  
+  * Call `Append` as many times as needed before calling `session.SaveChanges`, or -
+  * Use patching to update the time series. Learn more in [Patch time series entries](../../../../document-extensions/timeseries/client-api/session/patch).  
 
 ---
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
@@ -17,10 +17,11 @@
   * __Modify an existing time series entry__:  
     Use _append_ to update the data of an existing entry with the specified timestamp.
 
-* Each call to `append` handles a single [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).  
+* Each call to `append` handles a __single__ [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).
 
-* To append multiple entries in a single transaction,  
-  call `append` as many times as needed before calling `session.saveChanges`.
+* To append __multiple__ entries in a single transaction:
+    * Call `append` as many times as needed before calling `session.saveChanges`, or -
+    * Use patching to update the time series. Learn more in [Patch time series entries](../../../../document-extensions/timeseries/client-api/session/patch).
 
 ---
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.dotnet.markdown
@@ -1,0 +1,98 @@
+﻿# Patch Time Series Entries
+
+---
+
+{NOTE: }
+
+* Patching time series entries (append or delete entries) can be performed via the Session  
+  using [session.Advanced.Defer](../../../../client-api/operations/patching/single-document#session-api-using-defer), as described below.
+  * You can handle a single document at a time.
+  * The patching action is defined by the provided [JavaScript script](../../../../document-extensions/timeseries/client-api/javascript-support).
+  
+* Patching time series entries can also be done directly on the Store via _Operations_,  
+  where multiple documents can be handled at a time. Learn more in [Patching time series operations](../../../../document-extensions/timeseries/client-api/operations/patch).
+
+* In this page:
+   * [Usage](../../../../document-extensions/timeseries/client-api/session/patch#usage)  
+   * [Patching examples](../../../../document-extensions/timeseries/client-api/session/patch#patching-examples)
+     * [Append multiple entries](../../../../document-extensions/timeseries/client-api/session/patch#append-multiple-entries) 
+     * [Delete multiple entries](../../../../document-extensions/timeseries/client-api/session/patch#delete-multiple-entries) 
+   * [Syntax](../../../../document-extensions/timeseries/client-api/session/patch#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Usage}
+
+* Open a session
+* Construct a `PatchCommandData` instance and pass it the following:
+    * The document ID that contains the time series
+    * The document change vector (or `null`)
+    * A `PatchRequest` instance with a JavaScript that appends or removes time series entries
+* Call `session.Advanced.Defer` and pass it the `PatchCommandData` command.  
+  Note that you can call _Defer_ multiple times prior to calling _SaveChanges_.
+* Call `session.SaveChanges()`.  
+  All patch requests added via _Defer_ will be sent to the server for execution when _SaveChanges_ is called.
+
+{PANEL/}
+
+{PANEL: Patching examples}
+
+{NOTE: }
+
+<a id="append-multiple-entries" /> __Append multiple entries__:
+
+In this example, we append 100 time series entries with random heart rate values to a document.  
+
+{CODE TS_region-Session_Patch-Append-100-Random-TS-Entries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="delete-multiple-entries" /> __Delete multiple entries__:
+
+In this example, we remove a range of 50 time series entries from a document.  
+
+{CODE TS_region-Session_Patch-Delete-50-TS-Entries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+**`PatchCommandData`**
+
+{CODE PatchCommandData-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+Learn more about `PatchCommandData` [here](../../../../client-api/operations/patching/single-document#session-api-using-defer).
+
+---
+
+**`PatchRequest`**
+
+{CODE PatchRequest-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+Learn more about `PatchRequest` [here](../../../../client-api/operations/patching/single-document#session-api-using-defer).
+
+{PANEL/}
+
+## Related articles
+
+**Time Series and JavaScript**  
+[The Time Series JavaScript API](../../../../document-extensions/timeseries/client-api/javascript-support)  
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.js.markdown
@@ -1,0 +1,87 @@
+﻿# Patch Time Series Entries
+
+---
+
+{NOTE: }
+
+* Patching time series entries (append or delete entries) can be performed via the Session  
+  using [session.advanced.defer](../../../../client-api/operations/patching/single-document#session-api-using-defer), as described below.
+  * You can handle a single document at a time.
+  * The patching action is defined by the provided [JavaScript script](../../../../document-extensions/timeseries/client-api/javascript-support).
+  
+* Patching time series entries can also be done directly on the Store via _Operations_,  
+  where multiple documents can be handled at a time. Learn more in [Patching time series operations](../../../../document-extensions/timeseries/client-api/operations/patch).
+
+* In this page:
+   * [Usage](../../../../document-extensions/timeseries/client-api/session/patch#usage)  
+   * [Patching examples](../../../../document-extensions/timeseries/client-api/session/patch#patching-examples)
+     * [Append multiple entries](../../../../document-extensions/timeseries/client-api/session/patch#append-multiple-entries) 
+     * [Delete multiple entries](../../../../document-extensions/timeseries/client-api/session/patch#delete-multiple-entries) 
+   * [Syntax](../../../../document-extensions/timeseries/client-api/session/patch#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Usage}
+
+* Open a session
+* Construct a `PatchCommandData` instance and pass it the following:
+  * The document ID that contains the time series
+  * The document change vector (or `null`)
+  * A `PatchRequest` instance with a JavaScript that appends or removes time series entries
+* Call `session.advanced.defer` and pass it the `PatchCommandData` command.  
+  Note that you can call _defer_ multiple times prior to calling _saveChanges_.
+* Call `session.saveChanges()`.  
+  All patch requests added via _defer_ will be sent to the server for execution when _saveChanges_ is called.
+
+{PANEL/}
+
+{PANEL: Patching examples}
+
+{NOTE: }
+
+<a id="append-multiple-entries" /> __Append multiple entries__:
+
+In this example, we append 100 time series entries with random heart rate values to a document.  
+
+{CODE:nodejs patch_1@documentExtensions\timeSeries\client-api\patchTimeSeries.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="delete-multiple-entries" /> __Delete multiple entries__:
+
+In this example, we remove a range of 50 time series entries from a document.  
+
+{CODE:nodejs patch_2@documentExtensions\timeSeries\client-api\patchTimeSeries.js /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+A detailed syntax description for `PatchCommandData` & `PatchRequest` can be found in the following section:  
+[Session API using defer syntax](../../../../client-api/operations/patching/single-document#session-api-using-defer-syntax).
+
+{PANEL/}
+
+## Related articles
+
+**Time Series and JavaScript**  
+[The Time Series JavaScript API](../../../../document-extensions/timeseries/client-api/javascript-support)  
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -1136,10 +1136,10 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     List<double> values = new List<double>();
                     List<DateTime> timeStamps = new List<DateTime>();
 
-                    for (var cnt = 0; cnt < 100; cnt++)
+                    for (var i = 0; i < 100; i++)
                     {
                         values.Add(68 + Math.Round(19 * new Random().NextDouble()));
-                        timeStamps.Add(baseline.AddSeconds(cnt));
+                        timeStamps.Add(baseline.AddSeconds(i));
                     }
 
                     session.Advanced.Defer(new PatchCommandData("users/1-A", null,
@@ -1175,7 +1175,7 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                         {
                             Script = @"timeseries(this, $timeseries)
                                      .delete(
-                                        $from, 
+                                        $from,
                                         $to
                                       );",
                             Values =
@@ -1185,14 +1185,12 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                                 { "to", baseline.AddSeconds(49) }
                             }
                         }, null));
+                    
                     session.SaveChanges();
                     #endregion
-
                 }
             }
         }
-
-
 
         // Patching:multiple time-series entries Using session.Advanced.Defer
         [Fact]

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendTimeSeries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendTimeSeries.js
@@ -46,7 +46,8 @@ async function appendTimeSeries() {
         
         // Results:
         // ========
-        // The document will contain a time series named "HeartRates" with 10 entries.
+        // * The document will contain a time series named "HeartRates" with 10 entries.
+        // * The entries' timestamps are saved on the server in UTC.
         //endregion
 
         //region append_2
@@ -75,8 +76,9 @@ async function appendTimeSeries() {
 
         // Results:
         // ========
-        // The document will contain a time series called "StockPrices" with 3 entries.
-        // Each entry will have 5 values.
+        // * The document will contain a time series called "StockPrices" with 3 entries.
+        // * Each entry will have 5 values.
+        // * The entries' timestamps are saved on the server in UTC.
         //endregion
 
         //region append_3
@@ -133,8 +135,9 @@ async function appendTimeSeries() {
 
         // Results:
         // ========
-        // The document will contain a time series called "StockPrices" with 3 entries.
-        // Each entry will have 5 named values.
+        // * The document will contain a time series called "StockPrices" with 3 entries.
+        // * Each entry will have 5 named values.
+        // * The entries' timestamps are saved on the server in UTC.
         //endregion
     }
 }

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/patchTimeSeries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/patchTimeSeries.js
@@ -1,0 +1,133 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function patchTimeSeries() {
+
+    const session = documentStore.openSession();
+    await session.store(new User("John"), "users/john");
+
+    const optionalTag = "watches/fitbit";
+    const baseTime = new Date();
+    baseTime.setUTCHours(0);
+
+    const tsf = session.timeSeriesFor("users/john", "HeartRates");
+    for (let i = 0; i < 10; i++)
+    {
+        const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+        const nextMeasurement = 65 + i;
+        tsf.append(nextMinute, nextMeasurement, optionalTag);
+    }
+
+    await session.saveChanges();
+    
+    {
+        //region patch_1
+        const baseTime = new Date();
+
+        // Prepare random values and timestamps to patch
+        const values = [];
+        const timeStamps = [];
+
+        for (let i = 0; i < 100; i++) {
+            const randomValue = 65 + Math.round(20 * Math.random());
+            values.push(randomValue);
+            
+            // NOTE: the timestamp passed in the patch request script should be in UTC
+            const timeStamp = new Date(baseTime.getTime() + 60_000 * i);
+            const utcDate = new Date(timeStamp.getTime() + timeStamp.getTimezoneOffset() * 60_000);
+            timeStamps.push(utcDate);
+        }
+        
+        // Define the patch request
+        // ========================
+        
+        const patchRequest = new PatchRequest();
+        
+        // Provide a JavaScript script, use the 'append' method
+        // Note: "args." can be replaced with "$". E.g.: "args.tag" => "$tag"
+        patchRequest.script = `
+            for(var i = 0; i < args.values.length; i++)
+            {
+                timeseries(id(this), args.timeseries)
+                .append (
+                    new Date(args.timeStamps[i]),
+                    args.values[i],
+                    args.tag);
+            }`;
+
+        // Provide values for the params used within the script
+        patchRequest.values = {
+            timeseries: "HeartRates",
+            timeStamps: timeStamps,
+            values: values,
+            tag: "watches/fitbit"
+        }
+
+        // Define the patch command
+        const patchCommand = new PatchCommandData("users/john", null, patchRequest, null)
+        
+        // Pass the patch command to 'defer'
+        session.advanced.defer(patchCommand);
+        
+        // Call saveChanges for the patch request to execute on the server
+        await session.saveChanges();
+        //endregion
+
+        //region patch_2
+        // Define the patch request
+        // ========================
+        
+        const patchRequest = new PatchRequest();
+
+        // Provide a JavaScript script, use the 'delete' method
+        // Note: "args." can be replaced with "$". E.g.: "args.to" => "$to"
+        patchRequest.script = `timeseries(this, args.timeseries)
+                 .delete(
+                     args.from,
+                     args.to 
+                 );`;
+       
+        // NOTE: the 'from' & 'to' params in the patch request script should be in UTC
+        const utcDate = new Date(baseTime.getTime() + baseTime.getTimezoneOffset() * 60_000);
+
+        // Provide values for the params used within the script
+        patchRequest.values = {
+            timeseries: "HeartRates",
+            from: utcDate,
+            to: new Date(utcDate.getTime() + 60_000 * 49)
+        }
+
+        // Define the patch command
+        const patchCommand = new PatchCommandData("users/john", null, patchRequest, null)
+
+        // Pass the patch command to 'defer'
+        session.advanced.defer(patchCommand);
+
+        // Call saveChanges for the patch request to execute on the server
+        await session.saveChanges();
+        //endregion
+    }
+}
+
+//region syntax_1
+append(timestamp, value);
+append(timestamp, value, tag);
+//endregion
+
+//region syntax_2
+append(timestamp, values);
+append(timestamp, values, tag); 
+//endregion
+
+//region user_class
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}
+//endregion

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -1137,10 +1137,10 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     List<double> values = new List<double>();
                     List<DateTime> timeStamps = new List<DateTime>();
 
-                    for (var cnt = 0; cnt < 100; cnt++)
+                    for (var i = 0; i < 100; i++)
                     {
                         values.Add(68 + Math.Round(19 * new Random().NextDouble()));
-                        timeStamps.Add(baseline.AddSeconds(cnt));
+                        timeStamps.Add(baseline.AddSeconds(i));
                     }
 
                     session.Advanced.Defer(new PatchCommandData("users/1-A", null,
@@ -1186,14 +1186,12 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                                 { "to", baseline.AddSeconds(49) }
                             }
                         }, null));
+                    
                     session.SaveChanges();
                     #endregion
-
                 }
             }
         }
-
-
 
         // Patching:multiple time-series entries Using session.Advanced.Defer
         [Fact]


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2814/Node.js-Document-extensions-Time-series-Client-API-Session-Patch-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2824/Document-extensions-Time-series-Client-API-Session-Patch-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/patchTimeSeries.js
```
