### PR TITLE
[Python] Operations pages batch 3 [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/.docs.json
@@ -1,0 +1,14 @@
+[
+    {
+        "Path": "switch-operations-to-a-different-database.markdown",
+        "Name": "Switch operations to different database",
+        "DiscussionId": "9e232ccc-1683-4e5c-993d-c6948a2a5f51",
+        "Mappings": []
+    },
+    {
+        "Path": "switch-operations-to-a-different-node.markdown",
+        "Name": "Switch operations to different node",
+        "DiscussionId": "9e232ccc-1683-4e5c-993d-c6948a2a5f51",
+        "Mappings": []
+    }
+]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.dotnet.markdown
@@ -1,0 +1,63 @@
+# Switch Operations to a Different Database
+
+---
+
+{NOTE: }
+
+* By default, all operations work on the default database defined in the [Document Store](../../../client-api/creating-document-store).
+
+* **To operate on a different database**, use the `ForDatabase` method.  
+  (An exception is thrown if that database doesn't exist on the server).
+
+* In this page:
+    * [Common operations - ForDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operations---fordatabase)
+    * [Maintenance operations - ForDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operations---fordatabase)
+{NOTE/}
+
+---
+
+{PANEL: Common operations - ForDatabase}
+
+* For reference, all common operations are listed [here](../../../client-api/operations/what-are-operations#common-operations).
+
+{CODE for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+**Syntax**:
+
+{CODE syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | `string` | Name of the database to operate on |
+
+| Return Value | Description |
+| - | - |
+| `OperationExecutor` | New instance of Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+{PANEL: Maintenance operations - ForDatabase}
+
+* For reference, all maintenance operations are listed [here](../../../client-api/operations/what-are-operations#maintenance-operations).
+
+{CODE for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+**Syntax**:
+
+{CODE syntax_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | `string` | Name of the database to operate on |
+
+| Return Value | Description |
+| - | - |
+| `MaintenanceOperationExecutor` | New instance of Maintenance Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.java.markdown
@@ -1,0 +1,49 @@
+# Switch Operations to a Different Database
+
+By default, the operations available directly in store are working on a default database that was setup for that store. To switch operations to a different database that is available on that server use the **forDatabase** method.
+
+{PANEL:Operations.forDatabase}
+
+{CODE:java for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **databaseName** | String | Name of a database for which you want to get new Operations |
+
+| Return Value | |
+| ------------- | ----- |
+| OperationExecutor | New instance of Operations that is scoped to the requested database |
+
+### Example
+
+{CODE:java for_database_3@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+{PANEL/}
+
+## How to Switch Maintenance Operations to a Different Database
+
+As with `operations`, by default the `maintenance` operations available directly in store are working on a default database that was setup for that store. To switch maintenance operations to a different database use the **forDatabase** method.
+
+{PANEL:Maintenance.forDatabase}
+
+{CODE:java for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **databaseName** | String | Name of a database for which you want to get new maintenance operations |
+
+| Return Value | |
+| ------------- | ----- |
+| MaintenanceOperationExecutor | New instance of maintenance that is scoped to the requested database |
+
+### Example
+
+{CODE:java for_database_4@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.java /}
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
@@ -1,0 +1,63 @@
+# Switch Operations to a Different Database
+
+---
+
+{NOTE: }
+
+* By default, all operations work on the default database defined in the [document store](../../../client-api/creating-document-store).
+
+* **To operate on a different database**, use the `forDatabase` method.  
+  (An exception is thrown if that database doesn't exist on the server).
+
+* In this page:
+    * [Common operations - forDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operations---fordatabase)
+    * [Maintenance operations - forDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operations---fordatabase)
+{NOTE/}
+
+---
+
+{PANEL: Common operations - forDatabase}
+
+* For reference, all common operations are listed [here](../../../client-api/operations/what-are-operations#common-operations).
+
+{CODE:nodejs for_database_1@client-api\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+**Syntax**:
+
+{CODE:nodejs syntax_1@client-api\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | `string` | Name of the database to operate on |
+
+| Return Value | Description |
+| - | - |
+| `OperationExecutor` | New instance of Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+{PANEL: Maintenance operations - forDatabase}
+
+* For reference, all maintenance operations are listed [here](../../../client-api/operations/what-are-operations#maintenance-operations).
+
+{CODE:nodejs for_database_2@client-api\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+**Syntax**:
+
+{CODE:nodejs syntax_2@client-api\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | `string` | Name of the database to operate on |
+
+| Return Value | Description |
+| - | - |
+| `MaintenanceOperationExecutor` | New instance of Maintenance Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.js.markdown
@@ -7,20 +7,22 @@
 * By default, all operations work on the default database defined in the [document store](../../../client-api/creating-document-store).
 
 * **To operate on a different database**, use the `forDatabase` method.  
-  (An exception is thrown if that database doesn't exist on the server).
+  If the requested database doesn't exist on the server, an exception will be thrown.
 
 * In this page:
-    * [Common operations - forDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operations---fordatabase)
-    * [Maintenance operations - forDatabase](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operations---fordatabase)
+    * [Common operation: `operations.forDatabase`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operation:-operations.fordatabase)
+    * [Maintenance operation: `maintenance.forDatabase`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operation:-maintenance.fordatabase)
 {NOTE/}
 
 ---
 
-{PANEL: Common operations - forDatabase}
+{PANEL: Common operation: `operations.forDatabase`}
 
 * For reference, all common operations are listed [here](../../../client-api/operations/what-are-operations#common-operations).
 
 {CODE:nodejs for_database_1@client-api\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+---
 
 **Syntax**:
 
@@ -36,11 +38,13 @@
 
 {PANEL/}
 
-{PANEL: Maintenance operations - forDatabase}
+{PANEL: Maintenance operation: `maintenance.forDatabase`}
 
 * For reference, all maintenance operations are listed [here](../../../client-api/operations/what-are-operations#maintenance-operations).
 
 {CODE:nodejs for_database_2@client-api\Operations\HowTo\switchOperationsToDifferentDatabase.js /}
+
+---
 
 **Syntax**:
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.python.markdown
@@ -6,31 +6,31 @@
 
 * By default, all operations work on the default database defined in the [Document Store](../../../client-api/creating-document-store).
 
-* **To operate on a different database**, use the `ForDatabase` method.  
+* **To operate on a different database**, use the `for_database` method.  
   If the requested database doesn't exist on the server, an exception will be thrown.
 
 * In this page:
-    * [Common operation: `Operations.ForDatabase`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operation:-operations.fordatabase)
-    * [Maintenance operation: `Maintenance.ForDatabase`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operation:-maintenance.fordatabase)
+    * [Common operation: `operations.for_database`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operation:-operations.for_database)
+    * [Maintenance operation: `maintenance.for_database`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operation:-maintenance.for_database)
 {NOTE/}
 
 ---
 
-{PANEL: Common operation: `Operations.ForDatabase`}
+{PANEL: Common operation: `operations.for_database`}
 
 * For reference, all common operations are listed [here](../../../client-api/operations/what-are-operations#common-operations).
 
-{CODE for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+{CODE:python for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.py /}
 
 ---
 
 **Syntax**:
 
-{CODE syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+{CODE:python syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.py /}
 
 | Parameters | Type | Description |
 | - | - | - |
-| **databaseName** | `string` | Name of the database to operate on |
+| **database_name** | `str` | Name of the database to operate on |
 
 | Return Value | Description |
 | - | - |
@@ -38,21 +38,21 @@
 
 {PANEL/}
 
-{PANEL: Maintenance operation: `Maintenance.ForDatabase`}
+{PANEL: Maintenance operation: `maintenance.for_database`}
 
 * For reference, all maintenance operations are listed [here](../../../client-api/operations/what-are-operations#maintenance-operations).
 
-{CODE for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+{CODE:python for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.py /}
 
 ---
 
 **Syntax**:
 
-{CODE syntax_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.cs /}
+{CODE:python syntax_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.py /}
 
 | Parameters | Type | Description |
 | - | - | - |
-| **databaseName** | `string` | Name of the database to operate on |
+| **database_name** | `str` | Name of the database to operate on |
 
 | Return Value | Description |
 | - | - |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.dotnet.markdown
@@ -8,7 +8,7 @@
 
 * The index errors will be retrieved only from the server node defined by the current [client-configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
 
-* To clear index errors see [delete index errors](../../../../client-api/operations/maintenance/indexes/delete-index-errors). 
+* To learn about clearing index errors, see [delete index errors](../../../../client-api/operations/maintenance/indexes/delete-index-errors). 
 
 * In this page:
     * [Get errors for all indexes](../../../../client-api/operations/maintenance/indexes/get-index-errors#get-errors-for-all-indexes)
@@ -43,11 +43,11 @@
 
 | Parameters | Type | Description |
 | - | - | - |
-| **indexNames** | `string[]` | List of index names for which to get errors |
+| **indexNames** | `string[]` | List of index names to get errors for |
 
-| Return value of `store.Maintenance.Send(getIndexErrorsOp)`| Description |
+| Return value of<br>`store.Maintenance.Send(getIndexErrorsOp)`| Description |
 | - | - |
-| `IndexErrors[]` |  List of `IndexErrors` class.<br>An exception is thrown if any of the specified indexes do not exist. |
+| `IndexErrors[]` | List of `IndexErrors` classes - see definition below.<br>An exception is thrown if any of the specified indexes doesn't exist. |
 
 {CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.dotnet.markdown
@@ -1,0 +1,70 @@
+# Get Index Errors Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexErrorsOperation` to get errors encountered during indexing.
+
+* The index errors will be retrieved only from the server node defined by the current [client-configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+
+* To clear index errors see [delete index errors](../../../../client-api/operations/maintenance/indexes/delete-index-errors). 
+
+* In this page:
+    * [Get errors for all indexes](../../../../client-api/operations/maintenance/indexes/get-index-errors#get-errors-for-all-indexes)
+    * [Get errors for specific indexes](../../../../client-api/operations/maintenance/indexes/get-index-errors#get-errors-for-specific-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index-errors#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get errors for all indexes}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_errors_all@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
+{CODE-TAB:csharp:Async get_errors_all_async@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Get errors for specific indexes}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_errors_specific@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
+{CODE-TAB:csharp:Async get_errors_specific_async@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexNames** | `string[]` | List of index names for which to get errors |
+
+| Return value of `store.Maintenance.Send(getIndexErrorsOp)`| Description |
+| - | - |
+| `IndexErrors[]` |  List of `IndexErrors` class.<br>An exception is thrown if any of the specified indexes do not exist. |
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
+
+{CODE syntax_3@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Reset Index](../../../../client-api/operations/maintenance/indexes/reset-index)
+- [Delete index errors](../../../../client-api/operations/maintenance/indexes/delete-index-errors)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.java.markdown
@@ -1,0 +1,37 @@
+# Get Index Errors Operation
+
+**GetIndexErrorsOperation** is used to return errors encountered during document indexing. 
+
+## Syntax
+
+{CODE:java errors_1@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.java /}
+
+{CODE:java errors_2@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.java /}
+
+{CODE:java errors_3@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.java /}
+
+| Return Value | | |
+| ------------- | ----- | ---- |
+| **Name** | String | Index name |
+| **Errors** | IndexingError\[\] | List of indexing errors |
+
+## Example I
+
+{CODE:java errors_4@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.java /}
+
+## Example II
+
+{CODE:java errors_5@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Reset Index](../../../../client-api/operations/maintenance/indexes/reset-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.js.markdown
@@ -1,0 +1,65 @@
+# Get Index Errors Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexErrorsOperation` to get errors encountered during indexing.
+
+* The index errors will be retrieved only from the server node defined by the current [client-configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+
+* To clear index errors see [delete index errors](../../../../client-api/operations/maintenance/indexes/delete-index-errors).
+
+* In this page:
+    * [Get errors for all indexes](../../../../client-api/operations/maintenance/indexes/get-index-errors#get-errors-for-all-indexes)
+    * [Get errors for specific indexes](../../../../client-api/operations/maintenance/indexes/get-index-errors#get-errors-for-specific-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index-errors#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get errors for all indexes}
+
+{CODE:nodejs get_errors_all@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+
+{PANEL/}
+
+{PANEL: Get errors for specific indexes}
+
+{CODE:nodejs get_errors_specific@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexNames** | `string[]` | List of index names for which to get errors |
+
+| Return value of `store.maintenance.send(getIndexErrorsOp)`| Description |
+| - | - |
+| `object[]` |  List of 'index errors' objects - see definition below.<br>An exception is thrown if any of the specified indexes do not exist. |
+
+{NOTE: }
+{CODE:nodejs syntax_2@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+{CODE:nodejs syntax_3@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+{NOTE/}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Debugging Index Errors](../../../../indexes/troubleshooting/debugging-index-errors)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Reset Index](../../../../client-api/operations/maintenance/indexes/reset-index)
+- [Delete index errors](../../../../client-api/operations/maintenance/indexes/delete-index-errors)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.python.markdown
@@ -37,7 +37,7 @@
 
 | Parameters | Type | Description |
 | - | - | - |
-| **index_names** | `str` | List of index names to get errors for |
+| **\*index_names** | `str` | List of index names to get errors for |
 
 | Return value of<br>`store.maintenance.send(GetIndexErrorsOperation)` | Description |
 | - | - |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-errors.python.markdown
@@ -21,32 +21,33 @@
 
 {PANEL: Get errors for all indexes}
 
-{CODE:nodejs get_errors_all@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+{CODE:python get_errors_all@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.py /}
 
 {PANEL/}
 
 {PANEL: Get errors for specific indexes}
 
-{CODE:nodejs get_errors_specific@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+{CODE:python get_errors_specific@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE:nodejs syntax_1@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
+{CODE:python syntax_1@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.py /}
 
 | Parameters | Type | Description |
 | - | - | - |
-| **indexNames** | `string[]` | List of index names to get errors for |
+| **index_names** | `str` | List of index names to get errors for |
 
-| Return value of<br>`store.maintenance.send(getIndexErrorsOp)`| Description |
+| Return value of<br>`store.maintenance.send(GetIndexErrorsOperation)` | Description |
 | - | - |
-| `object[]` | List of 'index errors' objects - see definition below.<br>An exception is thrown if any of the specified indexes doesn't exist. |
+| `List[IndexErrors]` | List of `IndexErrors` classes - see definition below.<br>An exception is thrown if any of the specified indexes doesn't exist. |
 
-{NOTE: }
-{CODE:nodejs syntax_2@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
-{CODE:nodejs syntax_3@client-api\Operations\Maintenance\Indexes\getIndexErrors.js /}
-{NOTE/}
+
+
+{CODE:python syntax_2@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.py /}
+
+{CODE:python syntax_3@ClientApi\Operations\Maintenance\Indexes\GetIndexErrors.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.dotnet.markdown
@@ -1,0 +1,53 @@
+# Get Index Names Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexNamesOperation` to retrieve multiple **index names** from the database.
+
+* In this page:
+    * [Get index names example](../../../../client-api/operations/maintenance/indexes/get-index-names#get-index-names-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index-names#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index names example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_index_names@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
+{CODE-TAB:csharp:Async get_index_names_async@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_index_names_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
+
+| Parameters | Type | Description |
+| - |- | - |
+| **start** | `int` | Number of index names to skip |
+| **pageSize** | `int`   | Number of index names to retrieve |
+
+| Return Value of `store.Maintenance.Send(getIndexNamesOp)` | Description |
+| - | - |
+| `string[]` | A list of index names alphabetically ordered |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.java.markdown
@@ -1,0 +1,35 @@
+# Get Index Names Operation
+
+**GetIndexNamesOperation** is used to retrieve multiple index names from a database.
+
+### Syntax
+
+{CODE:java get_3_0@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **start** | int | Number of index names that should be skipped |
+| **pageSize** | int | Maximum number of index names that will be retrieved |
+
+| Return Value | |
+| ------------- | ----- |
+| String[] | This method returns an array of index **name** as a result. |
+
+### Example
+
+{CODE:java get_3_1@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
@@ -1,0 +1,50 @@
+# Get Index Names Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexNamesOperation` to retrieve multiple **index names** from the database.
+
+* In this page:
+    * [Get index names example](../../../../client-api/operations/maintenance/indexes/get-index-names#get-index-names-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index-names#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index names example}
+
+{CODE:nodejs get_index_names@client-api\Operations\Maintenance\Indexes\getIndexNames.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs get_index_names_syntax@client-api\Operations\Maintenance\Indexes\getIndexNames.js /}
+
+| Parameters | Type | Description |
+| - |- | - |
+| **start** | `number` | Number of index names to skip |
+| **pageSize** | `number` | Number of index names to retrieve |
+
+| Return Value of `store.maintenance.send(getIndexNamesOp)` | Description |
+| - | - |
+| `string[]` | A list of index names alphabetically ordered |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.js.markdown
@@ -29,9 +29,9 @@
 | **start** | `number` | Number of index names to skip |
 | **pageSize** | `number` | Number of index names to retrieve |
 
-| Return Value of `store.maintenance.send(getIndexNamesOp)` | Description |
+| Return Value of<br>`store.maintenance.send(getIndexNamesOp)` | Description |
 | - | - |
-| `string[]` | A list of index names alphabetically ordered |
+| `string[]` | A list of index names.<br>Alphabetically ordered. |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index-names.python.markdown
@@ -16,25 +16,22 @@
 
 {PANEL: Get index names example}
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync get_index_names@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
-{CODE-TAB:csharp:Async get_index_names_async@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
-{CODE-TABS/}
+{CODE:python get_index_names@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE get_index_names_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.cs /}
+{CODE:python get_index_names_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndexNames.py /}
 
 | Parameters | Type | Description |
 | - |- | - |
 | **start** | `int` | Number of index names to skip |
-| **pageSize** | `int`   | Number of index names to retrieve |
+| **page_size** | `int`   | Number of index names to retrieve |
 
-| Return Value of<br>`store.Maintenance.Send(getIndexNamesOp)` | Description |
+| Return Value of<br>`store.maintenance.send(GetIndexNamesOperation)` | Description |
 | - | - |
-| `string[]` | A list of index names.<br>Alphabetically ordered. |
+| `str[]` | A list of index names.<br> Alphabetically ordered. |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
@@ -1,0 +1,59 @@
+# Get Index Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexOperation` to retrieve an index definition from the database.
+
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definition returned is taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.
+
+* To get the index state on the local node use `GetIndexStatisticsOperation`.
+
+* In this page:
+    * [Get index example](../../../../client-api/operations/maintenance/indexes/get-index#get-index-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_index@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TAB:csharp:Async get_index_async@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_index_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | `string` | Name of index to get |
+
+| Return value of `store.Maintenance.Send(getIndexOp)` | Description |
+|- | - |
+| `IndexDefinition` | An instance of class [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.dotnet.markdown
@@ -14,14 +14,14 @@
 * To get the index state on the local node use `GetIndexStatisticsOperation`.
 
 * In this page:
-    * [Get index example](../../../../client-api/operations/maintenance/indexes/get-index#get-index-example)
+    * [Get Index example](../../../../client-api/operations/maintenance/indexes/get-index#get-index-example)
     * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: Get index example}
+{PANEL: Get Index example}
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync get_index@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.java.markdown
@@ -1,0 +1,33 @@
+# Get Index Operation
+
+**GetIndexOperation** is used to retrieve an index definition from a database.
+
+### Syntax
+
+{CODE:java get_1_0@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | name of an index |
+
+| Return Value | |
+| ------------- | ----- |
+| `IndexDefinition` | Instance of IndexDefinition representing index. |
+
+### Example
+
+{CODE:java get_1_1@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.js.markdown
@@ -1,0 +1,56 @@
+# Get Index Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexOperation` to retrieve the **index definition** from the database.
+
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definition returned is taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.  
+
+* To get the index state on the local node use `GetIndexStatisticsOperation`.
+
+* In this page:
+    * [Get index example](../../../../client-api/operations/maintenance/indexes/get-index#get-index-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-index#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index example}
+
+{CODE:nodejs get_index@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs get_index_syntax@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | `string` | Name of index to get |
+
+| Return value of `store.maintenance.send(getIndexOp)` | Description |
+|- | - |
+| `IndexDefinition` | An instance of class [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-index.python.markdown
@@ -4,12 +4,12 @@
 
 {NOTE: }
 
-* Use `GetIndexOperation` to retrieve the **index definition** from the database.
+* Use `GetIndexOperation` to retrieve an index definition from the database.
 
 * The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
   However, the index definition returned is taken from the database record,  
   which is common to all the database-group nodes.  
-  i.e., an index state change done only on a local node is not reflected.  
+  i.e., an index state change done only on a local node is not reflected.
 
 * To get the index state on the local node use `GetIndexStatisticsOperation`.
 
@@ -23,19 +23,19 @@
 
 {PANEL: Get Index example}
 
-{CODE:nodejs get_index@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+{CODE:python get_index@ClientApi\Operations\Maintenance\Indexes\GetIndex.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE:nodejs get_index_syntax@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+{CODE:python get_index_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.py /}
 
 | Parameters | Type | Description |
 | - | - | - |
-| **indexName** | `string` | Name of index to get |
+| **index_name** | `str` | Name of index to get |
 
-| Return value of `store.maintenance.send(getIndexOp)` | Description |
+| Return value of `store.maintenance.send(GetIndexOperation)` | Description |
 |- | - |
 | `IndexDefinition` | An instance of class [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) |
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
@@ -14,14 +14,14 @@
 * To get a specific index state on a local node use `GetIndexStatisticsOperation`.  
 
 * In this page:
-    * [Get indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
+    * [Get Indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
     * [Syntax](../../../../client-api/operations/maintenance/indexes/get-indexes#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: Get indexes example}
+{PANEL: Get Indexes example}
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync get_indexes@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
@@ -41,7 +41,7 @@
 
 | Return value of `store.Maintenance.Send(getIndexesOp)` | Description |
 | - | - |
-| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition), <br> ordered alphabetically by index name. |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) classes,<br> ordered alphabetically by index name. |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.dotnet.markdown
@@ -1,0 +1,60 @@
+# Get Indexes Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexesOperation` to retrieve multiple **index definitions** from the database.
+
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definitions returned are taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.
+
+* To get a specific index state on a local node use `GetIndexStatisticsOperation`.  
+
+* In this page:
+    * [Get indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-indexes#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get indexes example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_indexes@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TAB:csharp:Async get_indexes_async@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_indexes_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **start** | `int` | Number of indexes to skip |
+| **pageSize** | `int` | Number of indexes to retrieve |
+
+| Return value of `store.Maintenance.Send(getIndexesOp)` | Description |
+| - | - |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition), <br> ordered alphabetically by index name. |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.java.markdown
@@ -1,0 +1,34 @@
+# Get Indexes Operation
+
+**GetIndexesOperation** is used to retrieve multiple index definitions from a database.
+
+### Syntax
+
+{CODE:java get_2_0@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **start** | int | Number of indexes that should be skipped |
+| **pageSize** | int | Maximum number of indexes that will be retrieved  |
+
+| Return Value | |
+| ------------- | ----- |
+| `IndexDefinition` | Instance of IndexDefinition representing index. |
+
+### Example
+
+{CODE:java get_2_1@ClientApi\Operations\Maintenance\Indexes\Get.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.js.markdown
@@ -1,0 +1,57 @@
+# Get Indexes Operation
+
+---
+
+{NOTE: }
+
+* Use `GetIndexesOperation` to retrieve multiple **index definitions** from the database.
+
+* The operation will execute on the node defined by the [client configuration](../../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  However, the index definitions returned are taken from the database record,  
+  which is common to all the database-group nodes.  
+  i.e., an index state change done only on a local node is not reflected.
+
+* To get a specific index state on a local node use `GetIndexStatisticsOperation`.
+
+* In this page:
+    * [Get indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-indexes#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get indexes example}
+
+{CODE:nodejs get_indexes@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs get_indexes_syntax@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **start** | `number` | Number of indexes to skip |
+| **pageSize** | `number` | Number of indexes to retrieve |
+
+| Return value of `store.maintenance.send(getIndexesOp)` | Description |
+| - | - |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition), <br>ordered alphabetically by index name. |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Index](../../../../client-api/operations/maintenance/indexes/get-index)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-indexes.python.markdown
@@ -11,7 +11,7 @@
   which is common to all the database-group nodes.  
   i.e., an index state change done only on a local node is not reflected.
 
-* To get a specific index state on a local node use `GetIndexStatisticsOperation`.
+* To get a specific index state on a local node use `GetIndexStatisticsOperation`.  
 
 * In this page:
     * [Get Indexes example](../../../../client-api/operations/maintenance/indexes/get-indexes#get-indexes-example)
@@ -23,22 +23,22 @@
 
 {PANEL: Get Indexes example}
 
-{CODE:nodejs get_indexes@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+{CODE:python get_indexes@ClientApi\Operations\Maintenance\Indexes\GetIndex.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE:nodejs get_indexes_syntax@client-api\Operations\Maintenance\Indexes\getIndex.js /}
+{CODE:python get_indexes_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndex.py /}
 
 | Parameters | Type | Description |
 | - | - | - |
-| **start** | `number` | Number of indexes to skip |
-| **pageSize** | `number` | Number of indexes to retrieve |
+| **start** | `int` | Number of indexes to skip |
+| **page_size** | `int` | Number of indexes to retrieve |
 
-| Return value of `store.maintenance.send(getIndexesOp)` | Description |
+| Return value of `store.Maintenance.Send(getIndexesOp)` | Description |
 | - | - |
-| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition), <br>ordered alphabetically by index name. |
+| `IndexDefinition[]` | A list of [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) classes, <br> ordered alphabetically by index name. |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
@@ -1,0 +1,49 @@
+# Get Index Terms Operation
+
+---
+
+{NOTE: }
+
+* Use `GetTermsOperation` to retrieve the **terms of an index-field**.  
+
+* In this page:
+    * [Get index terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-index-terms-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-terms#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index terms example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync get_index_terms@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.cs /}
+{CODE-TAB:csharp:Async get_index_terms_async@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE get_index_terms_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | `string` | Name of an index to get terms for |
+| **field** | `string` | Name of index-field to get terms for |
+| **fromValue** | `string` | The starting term from which to return results.<br>This term is not included in the results.<br>`null` - start from first term. |
+| **pageSize** | `int?` | Number of terms to get.<br>`null` - return all terms.  |
+
+| Return value of `store.Maintenance.Send(getTermsOp)` | Description |
+| - |- |
+| string[] | List of terms for the requested index-field. <br> Alphabetically ordered. |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.dotnet.markdown
@@ -7,14 +7,14 @@
 * Use `GetTermsOperation` to retrieve the **terms of an index-field**.  
 
 * In this page:
-    * [Get index terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-index-terms-example)
+    * [Get Terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-terms-example)
     * [Syntax](../../../../client-api/operations/maintenance/indexes/get-terms#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: Get index terms example}
+{PANEL: Get Terms example}
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync get_index_terms@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.cs /}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.java.markdown
@@ -1,0 +1,31 @@
+# Get Index Terms Operation
+
+The **GetTermsOperation** will retrieve stored terms for a field of an index.
+
+## Syntax
+
+{CODE:java get_terms1@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.java /}
+
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexName** | String | Name of an index to get terms for |
+| **field** | String | Name of field to get terms for |
+| **fromValue** | String | The starting term from which to return results |
+| **pageSize** | Integer | Number of terms to get |
+
+| Return Value | |
+| ------------- | ----- |
+| String[] | List of terms for the requested index-field. <br> Alphabetically ordered. |
+
+## Example
+
+{CODE:java get_terms2@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
@@ -1,0 +1,46 @@
+# Get Index Terms Operation
+
+---
+
+{NOTE: }
+
+* Use `GetTermsOperation` to retrieve the **terms of an index-field**.
+
+* In this page:
+    * [Get index terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-index-terms-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-terms#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get index terms example}
+
+{CODE:nodejs get_index_terms@client-api\Operations\Maintenance\Indexes\getIndexTerms.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs get_index_terms_syntax@client-api\Operations\Maintenance\Indexes\getIndexTerms.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | `string` | Name of an index to get terms for |
+| **field** | `string` | Name of index-field to get terms for |
+| **fromValue** | `string` | The starting term from which to return results.<br>This term is not included in the results.<br>`null` - start from first term. |
+| **pageSize** | `number` | Number of terms to get.<br>`undefined/null` - return all terms.  |
+
+| Return value of `store.maintenance.send(getTermsOp)` | Description |
+| - |- |
+| `string[]` | List of terms for the requested index-field. <br> Alphabetically ordered. |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.js.markdown
@@ -7,14 +7,14 @@
 * Use `GetTermsOperation` to retrieve the **terms of an index-field**.
 
 * In this page:
-    * [Get index terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-index-terms-example)
+    * [Get Terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-terms-example)
     * [Syntax](../../../../client-api/operations/maintenance/indexes/get-terms#syntax)
 
 {NOTE/}
 
 ---
 
-{PANEL: Get index terms example}
+{PANEL: Get Terms example}
 
 {CODE:nodejs get_index_terms@client-api\Operations\Maintenance\Indexes\getIndexTerms.js /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.python.markdown
@@ -28,8 +28,8 @@
 | - | - | - |
 | **index_name** | `str` | Name of an index to get terms for |
 | **field** | `str` | Name of index-field to get terms for |
-| **from_value** | `str` (optional) | The starting term from which to return results.<br>This term is not included in the results.<br>`null` - start from first term. |
-| **page_size** | `int` | Number of terms to get.<br>`null` - return all terms.  |
+| **from_value** | `str` (optional) | The starting term from which to return results.<br>This term is not included in the results.<br>`None` - start from first term. |
+| **page_size** | `int` | Number of terms to get.<br>`None` - return all terms.  |
 
 | Return value of `store.maintenance.send(GetTermsOperation)` | Description |
 | - |- |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/get-terms.python.markdown
@@ -1,0 +1,46 @@
+# Get Index Terms Operation
+
+---
+
+{NOTE: }
+
+* Use `GetTermsOperation` to retrieve the **terms of an index-field**.  
+
+* In this page:
+    * [Get Terms example](../../../../client-api/operations/maintenance/indexes/get-terms#get-terms-example)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/get-terms#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Get Terms example}
+
+{CODE:python get_index_terms@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.py /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:python get_index_terms_syntax@ClientApi\Operations\Maintenance\Indexes\GetIndexTerms.py /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **index_name** | `str` | Name of an index to get terms for |
+| **field** | `str` | Name of index-field to get terms for |
+| **from_value** | `str` (optional) | The starting term from which to return results.<br>This term is not included in the results.<br>`null` - start from first term. |
+| **page_size** | `int` | Number of terms to get.<br>`null` - return all terms.  |
+
+| Return value of `store.maintenance.send(GetTermsOperation)` | Description |
+| - |- |
+| `List[str]` | List of terms for the requested index-field. <br> Alphabetically ordered. |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.dotnet.markdown
@@ -5,9 +5,9 @@
 {NOTE: }
 
 * **When deploying an index**:  
-  * If the new index definition is **different** than the current index definition on the server,  
+  * If the new index definition is **different** from the current index definition on the server,  
     the current index will be overwritten and data will be re-indexed according to the new index definition.
-  * If the new index definition is the **same** as the one on the server,  
+  * If the new index definition is the **same** as the one currently deployed on the server,  
     it will not be overwritten and re-indexing will not occur upon deploying the index.
 
 * **Prior to deploying an index:**,  
@@ -42,7 +42,7 @@
 
 | Return Value | Description |
 | - | - |
-| `true` | When the index **does not exist** on the server<br>or - <br>When the index definition **is different** than the one deployed on the server  |
+| `true` | When the index **does not exist** on the server<br>or -<br>When the index definition **is different** from the one deployed on the server  |
 | `false` | When the index definition is **the same** as the one deployed on the server |
 
 {PANEL/}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.dotnet.markdown
@@ -1,0 +1,62 @@
+# Index has Changed Operation
+
+ ---
+
+{NOTE: }
+
+* **When deploying an index**:  
+  * If the new index definition is **different** than the current index definition on the server,  
+    the current index will be overwritten and data will be re-indexed according to the new index definition.
+  * If the new index definition is the **same** as the one on the server,  
+    it will not be overwritten and re-indexing will not occur upon deploying the index.
+
+* **Prior to deploying an index:**,  
+  * Use `IndexHasChangedOperation` to check if the new index definition differs from the one  
+    on the server to avoid any unwanted changes to the existing indexed data.  
+
+* In this page:
+    * [Check if index has changed](../../../../client-api/operations/maintenance/indexes/index-has-changed#check-if-index-has-changed)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/index-has-changed#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Check if index has changed}
+
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync index_has_changed@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.cs /}
+{CODE-TAB:csharp:Async index_has_changed_async@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **definition** | [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) | The index definition to check |
+
+| Return Value | Description |
+| - | - |
+| `true` | When the index **does not exist** on the server<br>or - <br>When the index definition **is different** than the one deployed on the server  |
+| `false` | When the index definition is **the same** as the one deployed on the server |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.java.markdown
@@ -1,0 +1,35 @@
+# Index has Changed Operation
+
+**IndexHasChangedOperation** will let you check if the given index definition differs from the one on a server. This might be useful when you want to check the prior index deployment, if the index will be overwritten, and if indexing data will be lost.
+
+## Syntax
+
+{CODE:java index_has_changed_1@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **indexDef** | `IndexDefinition` | index definition |
+
+| Return Value | |
+| ------------- | ----- |
+| true | if an index **does not exist** on a server |
+| true | if an index definition **does not match** the one from the **indexDef** parameter |
+| false | if there are no differences between an index definition on the server and the one from the **indexDef** parameter |
+
+## Example
+
+{CODE:java index_has_changed_2@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.js.markdown
@@ -1,0 +1,58 @@
+# Index has Changed Operation
+
+ ---
+
+{NOTE: }
+
+* **When deploying an index**:  
+  * If the new index definition is **different** than the current index definition on the server,  
+    the current index will be overwritten and data will be re-indexed according to the new index definition.
+  * If the new index definition is the **same** as the one on the server,  
+    it will not be overwritten and re-indexing will not occur upon deploying the index.
+
+* **Prior to deploying an index:**,  
+  * Use `IndexHasChangedOperation` to check if the new index definition differs from the one  
+    on the server to avoid any unwanted changes to the existing indexed data.  
+
+* In this page:
+    * [Check if index has changed](../../../../client-api/operations/maintenance/indexes/index-has-changed#check-if-index-has-changed)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/index-has-changed#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Check if index has changed}
+
+{CODE:nodejs index_has_changed@client-api\Operations\Maintenance\Indexes\indexHasChanged.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\Operations\Maintenance\Indexes\indexHasChanged.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **definition** | [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) | The index definition to check |
+
+| Return Value | Description |
+| - | - |
+| `true` | When the index **does not exist** on the server<br>or - <br>When the index definition **is different** than the one deployed on the server  |
+| `false` | When the index definition is **the same** as the one deployed on the server |
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Get Indexes](../../../../client-api/operations/maintenance/indexes/get-indexes)
+- [How to Put Indexes](../../../../client-api/operations/maintenance/indexes/put-indexes)
+- [How to Delete Index](../../../../client-api/operations/maintenance/indexes/delete-index)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/index-has-changed.python.markdown
@@ -24,22 +24,22 @@
 
 {PANEL: Check if index has changed}
 
-{CODE:nodejs index_has_changed@client-api\Operations\Maintenance\Indexes\indexHasChanged.js /}
+{CODE:python index_has_changed@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE:nodejs syntax@client-api\Operations\Maintenance\Indexes\indexHasChanged.js /}
+{CODE:python syntax@ClientApi\Operations\Maintenance\Indexes\IndexHasChanged.py /}
 
 | Parameters | Type | Description |
 | - | - | - |
-| **definition** | [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) | The index definition to check |
+| **index** | [IndexDefinition](../../../../client-api/operations/maintenance/indexes/put-indexes#indexDefinition) | The index definition to check |
 
 | Return Value | Description |
 | - | - |
-| `true` | When the index **does not exist** on the server<br>or -<br>When the index definition **is different** from the one deployed on the server  |
-| `false` | When the index definition is **the same** as the one deployed on the server |
+| `True` | When the index **does not exist** on the server<br>or -<br>When the index definition **is different** from the one deployed on the server  |
+| `False` | When the index definition is **the same** as the one deployed on the server |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
@@ -8,7 +8,7 @@
   By default, RavenDB prioritizes processing requests over indexing,  
   so indexing threads start with a lower priority than request-processing threads.  
 
-* Use `SetIndexesPriorityOperation` to increase or lower the index thread priority.  
+* Use `SetIndexesPriorityOperation` to raise or lower the index thread priority.  
 
 * **Indexes scope**:  
   Index priority can be set for both static and auto indexes.  
@@ -66,7 +66,7 @@ Setting the priority will affect the indexing thread priority at the operating s
 | - | - | - |
 | **indexName** | `string` | Index name for which to change priority |
 | **priority** | `IndexingPriority` | Priority to set |
-| **parameters** | `SetIndexesPriorityOperation.Parameters` | List of indexes + Priority to set.<br>An exception is thrown if any of the specified indexes do not exist. |
+| **parameters** | `SetIndexesPriorityOperation.Parameters` | List of indexes + Priority to set.<br>An exception is thrown if any of the specified indexes doesn't exist. |
 
 {CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.dotnet.markdown
@@ -1,0 +1,90 @@
+# Set Index Priority Operation
+
+---
+
+{NOTE: }
+
+* In RavenDB, each index has its own dedicated thread for all indexing work.  
+  By default, RavenDB prioritizes processing requests over indexing,  
+  so indexing threads start with a lower priority than request-processing threads.  
+
+* Use `SetIndexesPriorityOperation` to increase or lower the index thread priority.  
+
+* **Indexes scope**:  
+  Index priority can be set for both static and auto indexes.  
+
+* **Nodes scope**:  
+  The priority will be updated on all nodes in the database group.
+
+* Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
+
+* In this page:
+    * [Index priority](../../../../client-api/operations/maintenance/indexes/set-index-priority#index-priority)
+    * [Set priority - single index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
+    * [Set priority - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---multiple-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Index priority}
+
+Setting the priority will affect the indexing thread priority at the operating system level:  
+
+| Priority value | Indexing thread priority<br> at OS level | |
+| - | - | - |
+| **Low** | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
+| **Normal** (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
+| **High** | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
+
+{PANEL/}
+
+{PANEL: Set priority - single index}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync set_priority_single@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TAB:csharp:Async set_priority_single_async@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Set priority - multiple indexes}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync set_priority_multiple@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TAB:csharp:Async set_priority_multiple_async@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+
+| Parameters | | |
+| - | - | - |
+| **indexName** | `string` | Index name for which to change priority |
+| **priority** | `IndexingPriority` | Priority to set |
+| **parameters** | `SetIndexesPriorityOperation.Parameters` | List of indexes + Priority to set.<br>An exception is thrown if any of the specified indexes do not exist. |
+
+{CODE syntax_2@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+
+{CODE syntax_3@ClientApi\Operations\Maintenance\Indexes\SetPriority.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Change Index Lock Mode](../../../../client-api/operations/maintenance/indexes/set-index-lock)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.java.markdown
@@ -1,0 +1,48 @@
+# Set Index Priority Operation
+
+**SetIndexesPriorityOperation**  allows you to change an index priority for a given index or indexes.  
+
+Setting the priority will affect the indexing thread priority at the operating system level:  
+
+| Priority value | Indexing thread priority<br> at OS level | |
+| - | - | - |
+| **Low** | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
+| **Normal** (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
+| **High** | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
+
+## Syntax
+
+{CODE:java set_priority_1@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+{CODE:java set_priority_2@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+{CODE:java set_priority_3@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **name** | String | name of an index to change priority for |
+| **priority** | IndexingPriority | new index priority |
+| **parameters** | SetIndexesPriorityOperation.Parameters | list of indexes + new index priority |
+
+## Example I
+
+{CODE:java set_priority_4@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+## Example II
+
+{CODE:java set_priority_5@ClientApi\Operations\Maintenance\Indexes\SetPriority.java /}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Change Index Lock Mode](../../../../client-api/operations/maintenance/indexes/set-index-lock)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.js.markdown
@@ -1,0 +1,82 @@
+# Set Index Priority Operation
+
+---
+
+{NOTE: }
+
+* In RavenDB, each index has its own dedicated thread for all indexing work.  
+  By default, RavenDB prioritizes processing requests over indexing,  
+  so indexing threads start with a lower priority than request-processing threads.  
+
+* Use `SetIndexesPriorityOperation` to increase or lower the index thread priority.  
+
+* **Indexes scope**:  
+  Index priority can be set for both static and auto indexes.  
+
+* **Nodes scope**:  
+  The priority will be updated on all nodes in the database group.
+
+* Setting the priority can also be done from the [indexes list view](../../../../studio/database/indexes/indexes-list-view#indexes-list-view---actions) in the Studio.  
+
+* In this page:
+    * [Index priority](../../../../client-api/operations/maintenance/indexes/set-index-priority#index-priority)
+    * [Set priority - single index](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---single-index)
+    * [Set priority - multiple indexes](../../../../client-api/operations/maintenance/indexes/set-index-priority#set-priority---multiple-indexes)
+    * [Syntax](../../../../client-api/operations/maintenance/indexes/set-index-priority#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Index priority}
+
+Setting the priority will affect the indexing thread priority at the operating system level:  
+
+| Priority value | Indexing thread priority<br> at OS level | |
+| - | - | - |
+| **Low** | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
+| **Normal** (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
+| **High** | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
+
+{PANEL/}
+
+{PANEL: Set priority - single index}
+
+{CODE:nodejs set_priority_single@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+
+{PANEL/}
+
+{PANEL: Set priority - multiple indexes}
+
+{CODE:nodejs set_priority_multiple@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax_1@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **indexName** | `string` | Index name for which to change priority |
+| **priority** | `"Low"` /<br> `"Normal"` /<br> `"High"` | Priority to set |
+| **parameters** | parameters object | List of indexes + Priority to set.<br>An exception is thrown if any of the specified indexes do not exist. |
+
+{CODE:nodejs syntax_2@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Indexes
+
+- [What are Indexes](../../../../indexes/what-are-indexes)
+- [Creating and Deploying Indexes](../../../../indexes/creating-and-deploying)
+
+### Server
+
+- [Index Administration](../../../../indexes/index-administration)
+
+### Operations
+
+- [How to Change Index Lock Mode](../../../../client-api/operations/maintenance/indexes/set-index-lock)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/maintenance/indexes/set-index-priority.python.markdown
@@ -34,35 +34,34 @@ Setting the priority will affect the indexing thread priority at the operating s
 
 | Priority value | Indexing thread priority<br> at OS level | |
 | - | - | - |
-| **Low** | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
-| **Normal** (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
-| **High** | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
+| **LOW** | Lowest | <ul><li>Having the `Lowest` priority at the OS level, indexes will run only when there's a capacity for them, when the system is not occupied with higher-priority tasks.</li><li>Requests to the database will complete faster.<br>Use when querying the server is more important to you than indexing.</li></ul> |
+| **NORMAL** (default) | Below normal | <ul><li>Requests to the database are still preferred over the indexing process.</li><li>The indexing thread priority at the OS level is `Below normal`<br>while Requests processes have a `Normal` priority.</li></ul> |
+| **HIGH** | Normal | <ul><li>Requests and Indexing will have the same priority at the OS level.</li></ul> |
 
 {PANEL/}
 
 {PANEL: Set priority - single index}
 
-{CODE:nodejs set_priority_single@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+{CODE:python set_priority_single@ClientApi\Operations\Maintenance\Indexes\SetPriority.py /}
 
 {PANEL/}
 
 {PANEL: Set priority - multiple indexes}
 
-{CODE:nodejs set_priority_multiple@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+{CODE:python set_priority_multiple@ClientApi\Operations\Maintenance\Indexes\SetPriority.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE:nodejs syntax_1@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+{CODE:python syntax_1@ClientApi\Operations\Maintenance\Indexes\SetPriority.py /}
 
-| Parameters | Type | Description |
+| Parameters | | |
 | - | - | - |
-| **indexName** | `string` | Index name for which to change priority |
-| **priority** | `"Low"` /<br> `"Normal"` /<br> `"High"` | Priority to set |
-| **parameters** | parameters object | List of indexes + Priority to set.<br>An exception is thrown if any of the specified indexes doesn't exist. |
+| **\*index_names** | `str` | Index name for which to change priority |
+| **priority** | `IndexingPriority` | Priority to set |
 
-{CODE:nodejs syntax_2@client-api\Operations\Maintenance\Indexes\setPriority.js /}
+{CODE:python syntax_2@ClientApi\Operations\Maintenance\Indexes\SetPriority.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.dotnet.markdown
@@ -1,0 +1,67 @@
+# Adding a Database Node
+
+---
+
+{NOTE: }
+
+* When creating a database, you can specify the number of replicas for that database.  
+  This determines the number of database instances in the database-group.
+
+* **The number of replicas can be dynamically increased** even after the database is up and running,  
+  by adding more nodes to the database-group.  
+
+* The nodes added must already exist in the [cluster topology](../../../server/clustering/rachis/cluster-topology).
+
+* Once a new node is added to the database-group,  
+  the cluster assigns a mentor node (from the existing database-group nodes) to update the new node.
+
+* In this page:
+    * [Add database node - random](../../../client-api/operations/server-wide/add-database-node#add-database-node---random)
+    * [Add database node - specific](../../../client-api/operations/server-wide/add-database-node#add-database-node---specific)
+    * [Syntax](../../../client-api/operations/server-wide/add-database-node#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Add database node - random}
+
+* Use `AddDatabaseNodeOperation` to add another database-instance to the database-group.
+* The node added will be a random node from the existing cluster nodes.   
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync add_1@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+{CODE-TAB:csharp:Async add_1_async@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Add database node - specific}
+
+* You can specify the node tag to add.  
+* This node must already exist in the cluster topology.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync add_2@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+{CODE-TAB:csharp:Async add_2_async@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | `string` | Name of a database for which to add the node. |
+| **nodeTag** | `string` | Tag of node to add.<br>Default: a random node from the existing cluster topology will be added. |
+
+| Object returned by Send operation:<br>`DatabasePutResult` | Type | Description |
+| - | - | - |
+| RaftCommandIndex | `long` | Index of raft command that was executed |
+| Name | `string` | Database name |
+| Topology | `DatabaseTopology` | The database topology |
+| NodesAddedTo | `List<string>` | New nodes added to the cluster topology.<br>Will be 0 for this operation. |
+
+{PANEL/}
+

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.js.markdown
@@ -1,0 +1,65 @@
+# Adding a Database Node
+
+---
+
+{NOTE: }
+
+* When creating a database, you can specify the number of replicas for that database.  
+  This determines the number of database instances in the database-group.
+
+* **The number of replicas can be dynamically increased** even after the database is up and running,  
+  by adding more nodes to the database-group.  
+
+* The nodes added must already exist in the [cluster topology](../../../server/clustering/rachis/cluster-topology).
+
+* Once a new node is added to the database-group,  
+  the cluster assigns a mentor node (from the existing database-group nodes) to update the new node.
+
+* In this page:
+    * [Add database node - random](../../../client-api/operations/server-wide/add-database-node#add-database-node---random)
+    * [Add database node - specific](../../../client-api/operations/server-wide/add-database-node#add-database-node---specific)
+    * [Syntax](../../../client-api/operations/server-wide/add-database-node#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Add database node - random}
+
+* Use `AddDatabaseNodeOperation` to add another database-instance to the database-group.
+* The node added will be a random node from the existing cluster nodes.   
+
+{CODE:nodejs add_1@client-api\Operations\Server\addDatabaseNode.js /}
+
+{PANEL/}
+
+{PANEL: Add database node - specific}
+
+* You can specify the node tag to add.  
+* This node must already exist in the cluster topology.
+
+{CODE:nodejs add_2@client-api\Operations\Server\addDatabaseNode.js /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\Operations\Server\addDatabaseNode.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **databaseName** | `string` | Name of a database for which to add the node. |
+| **nodeTag** | `string` | Tag of node to add.<br>Default: If not passed then a random node from the existing cluster topology will be added. |
+
+| Object returned by send operation has: | Type | Description |
+| - | - | - |
+| raftCommandIndex | `number` | Index of raft command that was executed |
+| name | `string` | Database name |
+| topology | `DatabaseTopology` | The database topology |
+| nodesAddedTo | `string[]` | New nodes added to the cluster topology.<br>Will be 0 for this operation. |
+
+{PANEL/}
+
+
+
+
+

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.js.markdown
@@ -52,7 +52,7 @@
 
 | Object returned by send operation has: | Type | Description |
 | - | - | - |
-| raftCommandIndex | `number` | Index of raft command that was executed |
+| raftCommandIndex | `number` | Index of the raft command that was executed |
 | name | `string` | Database name |
 | topology | `DatabaseTopology` | The database topology |
 | nodesAddedTo | `string[]` | New nodes added to the cluster topology.<br>Will be 0 for this operation. |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.python.markdown
@@ -28,10 +28,7 @@
 * Use `AddDatabaseNodeOperation` to add another database-instance to the database-group.
 * The node added will be a random node from the existing cluster nodes.   
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync add_1@ClientApi\Operations\Server\AddDatabaseNode.cs /}
-{CODE-TAB:csharp:Async add_1_async@ClientApi\Operations\Server\AddDatabaseNode.cs /}
-{CODE-TABS/}
+{CODE:python add_1@ClientApi\Operations\Server\AddDatabaseNode.py /}
 
 {PANEL/}
 
@@ -40,28 +37,25 @@
 * You can specify the node tag to add.  
 * This node must already exist in the cluster topology.
 
-{CODE-TABS}
-{CODE-TAB:csharp:Sync add_2@ClientApi\Operations\Server\AddDatabaseNode.cs /}
-{CODE-TAB:csharp:Async add_2_async@ClientApi\Operations\Server\AddDatabaseNode.cs /}
-{CODE-TABS/}
+{CODE:python add_2@ClientApi\Operations\Server\AddDatabaseNode.py /}
 
 {PANEL/}
 
 {PANEL: Syntax}
 
-{CODE syntax@ClientApi\Operations\Server\AddDatabaseNode.cs /}
+{CODE:python syntax@ClientApi\Operations\Server\AddDatabaseNode.py /}
 
 | Parameters | Type | Description |
 | - | - | - |
-| **databaseName** | `string` | Name of a database for which to add the node. |
-| **nodeTag** | `string` | Tag of node to add.<br>Default: a random node from the existing cluster topology will be added. |
+| **database_name** | `str` | Name of a database for which to add the node. |
+| **node_tag** | `str` | Tag of node to add.<br>Default: a random node from the existing cluster topology will be added. |
 
 | Object returned by Send operation:<br>`DatabasePutResult` | Type | Description |
 | - | - | - |
-| RaftCommandIndex | `long` | Index of the raft command that was executed |
-| Name | `string` | Database name |
-| Topology | `DatabaseTopology` | The database topology |
-| NodesAddedTo | `List<string>` | New nodes added to the cluster topology.<br>Will be 0 for this operation. |
+| raft_command_index | `int` | Index of the raft command that was executed |
+| name | `str` | Database name |
+| topology | `DatabaseTopology` | The database topology |
+| nodes_added_to | `list<str>` | New nodes added to the cluster topology.<br>Will be 0 for this operation. |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.dotnet.markdown
@@ -1,0 +1,142 @@
+# Compact Database Operation
+
+ ---
+
+{NOTE: }
+
+* The compaction operation **removes empty gaps on disk** that still occupy space after deletes.  
+  You can choose what should be compacted: documents and/or selected indexes.  
+
+* **During compaction the database will be offline**.  
+  The operation is a executed asynchronously as a background operation and can be awaited.  
+
+* The operation will **compact the database on one node**.  
+  To compact all database-group nodes, the command must be sent to each node separately.  
+
+* **Target node**:  
+  By default, the operation will be executed on the server node that is defined by the [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  The operation can be executed on a specific node by using the [ForNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
+
+* **Target database**:  
+  The database to compact is specified in `CompactSettings` (see examples below).  
+  An exception is thrown if the specified database doesn't exist on the server node.  
+
+* In this page:  
+  * [Examples](../../../client-api/operations/server-wide/compact-database#examples):  
+      * [Compact documents](../../../client-api/operations/server-wide/compact-database#examples)  
+      * [Compact specific indexes](../../../client-api/operations/server-wide/compact-database#compact-specific-indexes)  
+      * [Compact all indexes](../../../client-api/operations/server-wide/compact-database#compact-all-indexes)  
+      * [Compact on other nodes](../../../client-api/operations/server-wide/compact-database#compact-on-other-nodes)  
+  * [Compaction triggers compression](../../../client-api/operations/server-wide/compact-database#compaction-triggers-compression)  
+  * [Compact from Studio](../../../client-api/operations/server-wide/compact-database#compact-from-studio)  
+  * [Syntax](../../../client-api/operations/server-wide/compact-database#syntax)  
+
+{NOTE/}
+
+---
+
+{PANEL: Examples}
+
+#### Compact documents:
+
+The following example will compact only documents for the specified database.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync compact_0@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TAB:csharp:Async compact_0_async@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TABS/}
+
+---
+
+#### Compact specific indexes:
+
+The following example will compact only specific indexes.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync compact_1@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TAB:csharp:Async compact_1_async@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TABS/}
+
+---
+
+#### Compact all indexes:
+
+The following example will compact all indexes and documents.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync compact_2@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TAB:csharp:Async compact_2_async@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TABS/}
+
+---
+
+#### Compact on other nodes:
+
+* By default, an operation executes on the server node that is defined by the [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+* The following example will compact the database on all [member](../../../server/clustering/rachis/cluster-topology#nodes-states-and-types) nodes from its database-group topology.  
+  `ForNode` is used to execute the operation on a specific node.   
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync compact_3@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TAB:csharp:Async compact_3_async@ClientApi\Operations\Server\Compact.cs /}
+{CODE-TABS/}
+ 
+{PANEL/}
+
+{PANEL: Compaction triggers compression}
+
+* When document [compression](../../../server/storage/documents-compression) is turned on, compression is applied to the documents when:
+  * **New** documents that are created and saved.  
+  * **Existing** documents that are modified and saved.  
+
+* You can use the [compaction](../../../client-api/operations/server-wide/compact-database) operation to **compress existing documents without having to modify and save** them.  
+  Executing compaction triggers compression on ALL existing documents for the collections that are configured for compression.
+
+* Learn more about Compression -vs- Compaction [here](../../../server/storage/documents-compression#compression--vs--compaction).
+
+{PANEL/}
+
+{PANEL: Compact from Studio}
+
+* Compaction can be triggered from the [Storage Report](../../../studio/database/stats/storage-report) view in the Studio.  
+  The operation will compact the database only on the node being viewed (node info is in the Studio footer).
+ 
+* To compact the database on another node,  
+  simply trigger compaction from the Storage Report view in a browser tab opened for that other node.
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:csharp syntax@ClientApi\Operations\Server\Compact.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **compactSettings** | `CompactSettings`  | Settings for the compact operation |
+
+| `CompactSettings` | Type | Description |
+| - | - | - |
+| **DatabaseName** | `string` | Name of database to compact. Mandatory param. |
+| **Documents** | `bool` | Indicates if documents should be compacted. Optional param. |
+| **Indexes** | `string[]` | List of index names to compact. Optional param. |
+| **SkipOptimizeIndexes** | `bool` | `true` - Skip Lucene's index optimization while compacting<br>`false` - Lucene's index optimization will take place while compacting |
+| | | **Note**: Either _Documents_ or _Indexes_ (or both) must be specified |
+
+{PANEL/}
+
+## Related Articles
+
+**Database**
+
+- [How to create database?](../../../client-api/operations/server-wide/create-database) 
+- [How to get database statistics](../../../client-api/operations/maintenance/get-stats)
+- [How to restore a database from backup](../../../client-api/operations/server-wide/restore-backup)
+- [Switch operation to different node](../../../client-api/operations/how-to/switch-operations-to-a-different-node)
+
+**Compression**
+
+- [Documents Compression](../../../server/storage/documents-compression)
+
+**Studio**
+
+- [Storage Report](../../../studio/database/stats/storage-report)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.dotnet.markdown
@@ -4,8 +4,9 @@
 
 {NOTE: }
 
-* The compaction operation **removes empty gaps on disk** that still occupy space after deletes.  
-  You can choose what should be compacted: documents and/or selected indexes.  
+* Use The `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
+  that still occupy space after deletes.  
+  You can choose whether to compact _documents_ and/or _selected indexes_.  
 
 * **During compaction the database will be offline**.  
   The operation is a executed asynchronously as a background operation and can be awaited.  
@@ -14,8 +15,10 @@
   To compact all database-group nodes, the command must be sent to each node separately.  
 
 * **Target node**:  
-  By default, the operation will be executed on the server node that is defined by the [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
-  The operation can be executed on a specific node by using the [ForNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
+  By default, the operation will be executed on the server node that is defined by the 
+  [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  The operation can be executed on a specific node by using the 
+  [ForNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
 
 * **Target database**:  
   The database to compact is specified in `CompactSettings` (see examples below).  
@@ -39,7 +42,7 @@
 
 #### Compact documents:
 
-The following example will compact only documents for the specified database.  
+The following example will compact only **documents** for the specified database.  
 
 {CODE-TABS}
 {CODE-TAB:csharp:Sync compact_0@ClientApi\Operations\Server\Compact.cs /}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.js.markdown
@@ -1,0 +1,138 @@
+# Compact Database Operation
+
+ ---
+
+{NOTE: }
+
+* The compaction operation **removes empty gaps on disk** that still occupy space after deletes.  
+  You can choose what should be compacted: documents and/or selected indexes.  
+
+* **During compaction the database will be offline**.  
+  The operation is a executed asynchronously as a background operation and can be awaited.  
+
+* The operation will **compact the database on one node**.  
+  To compact all database-group nodes, the command must be sent to each node separately.  
+
+* **Target node**:  
+  By default, the operation will be executed on the server node that is defined by the [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  The operation can be executed on a specific node by using the [forNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
+
+* **Target database**:  
+  The database to compact is specified in `CompactSettings` (see examples below).  
+  An exception is thrown if the specified database doesn't exist on the server node.  
+
+* In this page:  
+  * [Examples](../../../client-api/operations/server-wide/compact-database#examples):  
+      * [Compact documents](../../../client-api/operations/server-wide/compact-database#examples)  
+      * [Compact specific indexes](../../../client-api/operations/server-wide/compact-database#compact-specific-indexes)  
+      * [Compact all indexes](../../../client-api/operations/server-wide/compact-database#compact-all-indexes)  
+      * [Compact on other nodes](../../../client-api/operations/server-wide/compact-database#compact-on-other-nodes)  
+  * [Compaction triggers compression](../../../client-api/operations/server-wide/compact-database#compaction-triggers-compression)  
+  * [Compact from Studio](../../../client-api/operations/server-wide/compact-database#compact-from-studio)  
+  * [Syntax](../../../client-api/operations/server-wide/compact-database#syntax)  
+
+{NOTE/}
+
+---
+
+{PANEL: Examples}
+
+{NOTE: }
+
+#### Compact documents
+
+* The following example will compact only documents for the specified database.  
+
+{CODE:nodejs compact_0@client-api\Operations\Server\compact.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### Compact specific indexes
+
+* The following example will compact only specific indexes.
+
+{CODE:nodejs compact_1@client-api\Operations\Server\compact.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### Compact all indexes
+
+* The following example will compact all indexes and documents.  
+
+{CODE:nodejs compact_2@client-api\Operations\Server\compact.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### Compact on other nodes
+
+* By default, an operation executes on the server node that is defined by the [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+* The following example will compact the database on all [member](../../../server/clustering/rachis/cluster-topology#nodes-states-and-types) nodes from its database-group topology.  
+  `forNode` is used to execute the operation on a specific node.   
+
+{CODE:nodejs compact_3@client-api\Operations\Server\compact.js /}
+ 
+{NOTE/}
+{PANEL/}
+
+{PANEL: Compaction triggers compression}
+
+* When document [compression](../../../server/storage/documents-compression) is turned on, compression is applied to the documents when:
+    * **New** documents that are created and saved.
+    * **Existing** documents that are modified and saved.
+
+* You can use the [compaction](../../../client-api/operations/server-wide/compact-database) operation to **compress existing documents without having to modify and save** them.  
+  Executing compaction triggers compression on ALL existing documents for the collections that are configured for compression.
+
+* Learn more about Compression -vs- Compaction [here](../../../server/storage/documents-compression#compression--vs--compaction).
+
+{PANEL/}
+
+{PANEL: Compact from Studio}
+
+* Compaction can be triggered from the [Storage Report](../../../studio/database/stats/storage-report) view in the Studio.  
+  The operation will compact the database only on the node being viewed (node info is in the Studio footer).
+ 
+* To compact the database on another node,  
+  simply trigger compaction from the Storage Report view in a browser tab opened for that other node.
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@client-api\Operations\Server\compact.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **compactSettings** | `object` | Settings for the compact operation.<br>See object fields below. |
+
+| compactSettings field | Type | Description |
+| - | - | - |
+| **databaseName** | `string` | Name of database to compact. Mandatory param. |
+| **documents** | `boolean` | Indicates if documents should be compacted. Optional param. |
+| **indexes** | `string[]` | List of index names to compact. Optional param. |
+| | | **Note**: Either _Documents_ or _Indexes_ (or both) must be specified |
+
+{PANEL/}
+
+## Related Articles
+
+**Database**
+
+- [How to create database?](../../../client-api/operations/server-wide/create-database) 
+- [How to get database statistics](../../../client-api/operations/maintenance/get-stats)
+- [How to restore a database from backup](../../../client-api/operations/server-wide/restore-backup)
+- [Switch operation to different node](../../../client-api/operations/how-to/switch-operations-to-a-different-node)
+
+**Compression**
+
+- [Documents Compression](../../../server/storage/documents-compression)
+
+**Studio**
+
+- [Storage Report](../../../studio/database/stats/storage-report)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.python.markdown
@@ -9,7 +9,8 @@
   You can choose whether to compact _documents_ and/or _selected indexes_.  
 
 * **During compaction the database will be offline**.  
-  The operation is a executed asynchronously as a background operation and can be awaited.  
+  The operation is a executed asynchronously as a background operation and can be waited for 
+  using `wait_for_completion`.  
 
 * The operation will **compact the database on one node**.  
   To compact all database-group nodes, the command must be sent to each node separately.  
@@ -17,8 +18,6 @@
 * **Target node**:  
   By default, the operation will be executed on the server node that is defined by the 
   [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
-  The operation can be executed on a specific node by using the 
-  [forNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node) method.  
 
 * **Target database**:  
   The database to compact is specified in `CompactSettings` (see examples below).  
@@ -29,7 +28,6 @@
       * [Compact documents](../../../client-api/operations/server-wide/compact-database#examples)  
       * [Compact specific indexes](../../../client-api/operations/server-wide/compact-database#compact-specific-indexes)  
       * [Compact all indexes](../../../client-api/operations/server-wide/compact-database#compact-all-indexes)  
-      * [Compact on other nodes](../../../client-api/operations/server-wide/compact-database#compact-on-other-nodes)  
   * [Compaction triggers compression](../../../client-api/operations/server-wide/compact-database#compaction-triggers-compression)  
   * [Compact from Studio](../../../client-api/operations/server-wide/compact-database#compact-from-studio)  
   * [Syntax](../../../client-api/operations/server-wide/compact-database#syntax)  
@@ -40,56 +38,38 @@
 
 {PANEL: Examples}
 
-{NOTE: }
+#### Compact documents:
 
-#### Compact documents
+The following example will compact only **documents** for the specified database.  
 
-* The following example will compact only **documents** for the specified database.  
+{CODE:python compact_0@ClientApi\Operations\Server\Compact.py /}
 
-{CODE:nodejs compact_0@client-api\Operations\Server\compact.js /}
+---
 
-{NOTE/}
+#### Compact specific indexes:
 
-{NOTE: }
+The following example will compact only specific indexes.
 
-#### Compact specific indexes
+{CODE:python compact_1@ClientApi\Operations\Server\Compact.py /}
 
-* The following example will compact only specific indexes.
+---
 
-{CODE:nodejs compact_1@client-api\Operations\Server\compact.js /}
+#### Compact all indexes:
 
-{NOTE/}
+The following example will compact all indexes and documents.  
 
-{NOTE: }
+{CODE:python compact_2@ClientApi\Operations\Server\Compact.py /}
 
-#### Compact all indexes
-
-* The following example will compact all indexes and documents.  
-
-{CODE:nodejs compact_2@client-api\Operations\Server\compact.js /}
-
-{NOTE/}
-
-{NOTE: }
-
-#### Compact on other nodes
-
-* By default, an operation executes on the server node that is defined by the [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
-* The following example will compact the database on all [member](../../../server/clustering/rachis/cluster-topology#nodes-states-and-types) nodes from its database-group topology.  
-  `forNode` is used to execute the operation on a specific node.   
-
-{CODE:nodejs compact_3@client-api\Operations\Server\compact.js /}
- 
-{NOTE/}
 {PANEL/}
 
 {PANEL: Compaction triggers compression}
 
 * When document [compression](../../../server/storage/documents-compression) is turned on, compression is applied to the documents when:
-    * **New** documents that are created and saved.
-    * **Existing** documents that are modified and saved.
+  * **New** documents that are created and saved.  
+  * **Existing** documents that are modified and saved.  
 
-* You can use the [compaction](../../../client-api/operations/server-wide/compact-database) operation to **compress existing documents without having to modify and save** them.  
+* You can use the [compaction](../../../client-api/operations/server-wide/compact-database) operation 
+  to **compress existing documents without having to modify and save** them.  
   Executing compaction triggers compression on ALL existing documents for the collections that are configured for compression.
 
 * Learn more about Compression -vs- Compaction [here](../../../server/storage/documents-compression#compression--vs--compaction).
@@ -106,22 +86,7 @@
 
 {PANEL/}
 
-{PANEL: Syntax}
 
-{CODE:nodejs syntax@client-api\Operations\Server\compact.js /}
-
-| Parameters | Type | Description |
-| - | - | - |
-| **compactSettings** | `object` | Settings for the compact operation.<br>See object fields below. |
-
-| compactSettings field | Type | Description |
-| - | - | - |
-| **databaseName** | `string` | Name of database to compact. Mandatory param. |
-| **documents** | `boolean` | Indicates if documents should be compacted. Optional param. |
-| **indexes** | `string[]` | List of index names to compact. Optional param. |
-| | | **Note**: Either _Documents_ or _Indexes_ (or both) must be specified |
-
-{PANEL/}
 
 ## Related Articles
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.dotnet.markdown
@@ -1,0 +1,85 @@
+# Toggle Databases State Operation <br> (Enable / Disable)
+---
+
+{NOTE: }
+
+* Use `ToggleDatabasesStateOperation` to enable/disable a single database or multiple databases.
+
+* The database will be enabled/disabled on all nodes in the [database-group](../../../studio/database/settings/manage-database-group).
+
+* In this page:
+
+  * [Enable/Disable database from the Client API](../../../client-api/operations/server-wide/toggle-databases-state#enable/disable-database-from-the-client-api)  
+      * [Enable database](../../../client-api/operations/server-wide/toggle-databases-state#enable-database)
+      * [Disable database](../../../client-api/operations/server-wide/toggle-databases-state#disable-database)
+      * [Syntax](../../../client-api/operations/server-wide/toggle-databases-state#syntax)     
+  * [Disable database via the file system](../../../client-api/operations/server-wide/toggle-databases-state#disable-database-via-the-file-system)
+
+{NOTE/}
+
+---
+
+{PANEL: Enable/Disable database from the Client API}
+
+#### Enable database:  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync enable@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TAB:csharp:Async enable_async@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TABS/}
+
+---
+
+#### Disable database: 
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TAB:csharp:Async disable_async@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+{CODE-TABS/}
+
+---
+
+#### Syntax: 
+
+{CODE syntax_1@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+
+| Parameter         | Type       | Description                                                                               |
+|-------------------|------------|-------------------------------------------------------------------------------------------|
+| **databaseName**  | `string`   | Name of database for which to toggle state                                                |
+| **databaseNames** | `string[]` | List of database names for which to toggle state                                          |
+| **disable**       | `bool`     | `true` - request to disable the database(s)<br>`false`- request to enable the database(s) |
+
+{CODE syntax_2@ClientApi\Operations\Server\ToggleDatabasesState.cs /}
+
+{PANEL/}
+
+{PANEL: Disable database via the file system}
+
+It may sometimes be useful to disable a database manually, through the file system.  
+
+* To **manually disable** a database:  
+ 
+  * Place a file named `disable.marker` in the [database directory](../../../server/storage/directory-structure).  
+  * The `disable.marker` file can be empty,  
+    and can be created by any available method, e.g. using the File Explorer, a terminal, or code.
+  
+* Attempting to use a manually disabled database will generate the following exception:  
+
+         Unable to open database: '{DatabaseName}', 
+         it has been manually disabled via the file: '{disableMarkerPath}'. 
+         To re-enable, remove the disable.marker and reload the database.
+  
+* To **enable** a manually disabled database:
+  
+  * First, remove the `disable.marker` file from the database directory. 
+  * Then, [reload the database](../../../studio/database/settings/database-settings#how-to-reload-the-database).
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+- [Database settings operations](../../../client-api/operations/maintenance/configuration/database-settings-operation)  
+
+### Studio
+- [Database-group](../../../studio/database/settings/manage-database-group)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.js.markdown
@@ -1,0 +1,85 @@
+# Toggle Databases State Operation <br> (Enable / Disable)
+---
+
+{NOTE: }
+
+* Use `ToggleDatabasesStateOperation` to enable/disable a single database or multiple databases.
+
+* The database will be enabled/disabled on all nodes in the [database-group](../../../studio/database/settings/manage-database-group).
+
+* In this page:
+
+    * [Enable/Disable database from the Client API](../../../client-api/operations/server-wide/toggle-databases-state#enable/disable-database-from-the-client-api)
+        * [Enable database](../../../client-api/operations/server-wide/toggle-databases-state#enable-database)
+        * [Disable database](../../../client-api/operations/server-wide/toggle-databases-state#disable-database)
+        * [Syntax](../../../client-api/operations/server-wide/toggle-databases-state#syntax)
+    * [Disable database via the file system](../../../client-api/operations/server-wide/toggle-databases-state#disable-database-via-the-file-system)
+
+{NOTE/}
+
+---
+
+
+{PANEL: Enable/Disable database from the Client API}
+
+{NOTE: }
+
+<a id="enable-database" /> **Enable database**:  
+
+{CODE:nodejs enable@client-api\Operations\Server\toggleDatabasesState.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="disable-database" /> **Disable database**: 
+
+{CODE:nodejs disable@client-api\Operations\Server\toggleDatabasesState.js /}
+
+{NOTE/}
+{NOTE: }
+
+<a id="syntax" /> **Syntax**: 
+
+{CODE:nodejs syntax_1@client-api\Operations\Server\toggleDatabasesState.js /}
+
+| Parameter         | Type     | Description                                                                                 |
+|-------------------|----------|---------------------------------------------------------------------------------------------|
+| **databaseName**  | `string`   | Name of database for which to toggle state                                                |
+| **databaseNames** | `string[]` | List of database names for which to toggle state                                          |
+| **disable**       | `boolean`  | `true` - request to disable the database(s)<br>`false`- request to enable the database(s) |
+
+{CODE:nodejs syntax_2@client-api\Operations\Server\toggleDatabasesState.js /}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Disable database via the file system}
+
+It may sometimes be useful to disable a database manually, through the file system.
+
+* To **manually disable** a database:
+
+    * Place a file named `disable.marker` in the [database directory](../../../server/storage/directory-structure).
+    * The `disable.marker` file can be empty,  
+      and can be created by any available method, e.g. using the File Explorer, a terminal, or code.
+
+* Attempting to use a manually disabled database will generate the following exception:
+
+         Unable to open database: '{DatabaseName}', 
+         it has been manually disabled via the file: '{disableMarkerPath}'. 
+         To re-enable, remove the disable.marker and reload the database.
+
+* To **enable** a manually disabled database:
+
+    * First, remove the `disable.marker` file from the database directory.
+    * Then, [reload the database](../../../studio/database/settings/database-settings#how-to-reload-the-database).
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+- [Database settings operations](../../../client-api/operations/maintenance/configuration/database-settings-operation)  
+
+### Studio
+- [Database-group](../../../studio/database/settings/manage-database-group)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.python.markdown
@@ -1,0 +1,79 @@
+# Toggle Databases State Operation <br> (Enable / Disable)
+---
+
+{NOTE: }
+
+* Use `ToggleDatabasesStateOperation` to enable/disable a single database or multiple databases.
+
+* The database will be enabled/disabled on all nodes in the [database-group](../../../studio/database/settings/manage-database-group).
+
+* In this page:
+
+  * [Enable/Disable database from the Client API](../../../client-api/operations/server-wide/toggle-databases-state#enable/disable-database-from-the-client-api)  
+      * [Enable database](../../../client-api/operations/server-wide/toggle-databases-state#enable-database)
+      * [Disable database](../../../client-api/operations/server-wide/toggle-databases-state#disable-database)
+      * [Syntax](../../../client-api/operations/server-wide/toggle-databases-state#syntax)     
+  * [Disable database via the file system](../../../client-api/operations/server-wide/toggle-databases-state#disable-database-via-the-file-system)
+
+{NOTE/}
+
+---
+
+{PANEL: Enable/Disable database from the Client API}
+
+#### Enable database:  
+
+{CODE:python enable@ClientApi\Operations\Server\ToggleDatabasesState.py /}
+
+---
+
+#### Disable database: 
+
+{CODE:python disable@ClientApi\Operations\Server\ToggleDatabasesState.py /}
+
+---
+
+#### Syntax: 
+
+{CODE:python syntax_1@ClientApi\Operations\Server\ToggleDatabasesState.py /}
+
+| Parameter          | Type    | Description                                                                               |
+|--------------------|---------|-------------------------------------------------------------------------------------------|
+| **database_name**  | `str`  | Name of database for which to toggle state                                                |
+| **database_names** | `str[]` | List of database names for which to toggle state                                          |
+| **disable**        | `bool`  | `True` - request to disable the database(s)<br>`False`- request to enable the database(s) |
+
+{CODE:python syntax_2@ClientApi\Operations\Server\ToggleDatabasesState.py /}
+
+{PANEL/}
+
+{PANEL: Disable database via the file system}
+
+It may sometimes be useful to disable a database manually, through the file system.  
+
+* To **manually disable** a database:  
+ 
+  * Place a file named `disable.marker` in the [database directory](../../../server/storage/directory-structure).  
+  * The `disable.marker` file can be empty,  
+    and can be created by any available method, e.g. using the File Explorer, a terminal, or code.
+  
+* Attempting to use a manually disabled database will generate the following exception:  
+
+         Unable to open database: '{DatabaseName}', 
+         it has been manually disabled via the file: '{disableMarkerPath}'. 
+         To re-enable, remove the disable.marker and reload the database.
+  
+* To **enable** a manually disabled database:
+  
+  * First, remove the `disable.marker` file from the database directory. 
+  * Then, [reload the database](../../../studio/database/settings/database-settings#how-to-reload-the-database).
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+- [Database settings operations](../../../client-api/operations/maintenance/configuration/database-settings-operation)  
+
+### Studio
+- [Database-group](../../../studio/database/settings/manage-database-group)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.cs
@@ -1,0 +1,76 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.HowTo
+{
+    public class SwitchOperationsToDifferentDatabase
+    {
+        private interface OperationsForDatabaseSyntax
+        {
+            #region syntax_1
+            OperationExecutor ForDatabase(string databaseName);
+            #endregion
+        }
+        
+        private interface MaintenanceForDatabaseSyntax
+        {
+            #region syntax_2
+            MaintenanceOperationExecutor ForDatabase(string databaseName);
+            #endregion
+        }
+
+        public void SwitchOperationToDifferentDatabase()
+        {
+            #region for_database_1
+            // Define default database on the store
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "yourServerURL" },
+                Database = "DefaultDB"
+            }.Initialize();
+            
+            using (documentStore)
+            {
+                // Use 'ForDatabase', get operation executor for another database
+                OperationExecutor opExecutor = documentStore.Operations.ForDatabase("AnotherDB");
+                
+                // Send the operation, e.g. 'GetRevisionsOperation' will be executed on "AnotherDB"
+                var revisionsInAnotherDB = 
+                    opExecutor.Send(new GetRevisionsOperation<Order>("Orders/1-A"));
+             
+                // Without 'ForDatabase', the operation is executed "DefaultDB"
+                var revisionsInDefaultDB =
+                    documentStore.Operations.Send(new GetRevisionsOperation<Company>("Company/1-A"));
+            }
+            #endregion
+        }
+        
+        public void SwitchMaintenanceOperationToDifferentDatabase()
+        {
+            #region for_database_2
+            // Define default database on the store
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "yourServerURL" },
+                Database = "DefaultDB"
+            }.Initialize();
+            
+            using (documentStore = new DocumentStore())
+            {
+                // Use 'ForDatabase', get maintenance operation executor for another database
+                MaintenanceOperationExecutor opExecutor = documentStore.Maintenance.ForDatabase("AnotherDB");
+                
+                // Send the maintenance operation, e.g. get database stats for "AnotherDB"
+                var statsForAnotherDB =
+                    opExecutor.Send(new GetStatisticsOperation());
+                
+                // Without 'ForDatabase', the stats are retrieved for "DefaultDB"
+                var statsForDefaultDB =
+                    documentStore.Maintenance.Send(new GetStatisticsOperation());
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndex.cs
@@ -1,0 +1,107 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class GetIndex
+    {
+        public GetIndex()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index
+
+                // Define the get index operation, pass the index name
+                var getIndexOp = new GetIndexOperation("Orders/Totals");
+
+                // Execute the operation by passing it to Maintenance.Send
+                IndexDefinition index = store.Maintenance.Send(getIndexOp);
+
+                // Access the index definition
+                var state = index.State;
+                var lockMode = index.LockMode;
+                var deploymentMode = index.DeploymentMode;
+                // etc.
+
+                #endregion
+            }
+            
+            using (var store = new DocumentStore()) 
+            {
+                #region get_indexes
+                // Define the get indexes operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexesOp = new GetIndexesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                IndexDefinition[] indexes = store.Maintenance.Send(getIndexesOp);
+                
+                // indexes will contain the first 10 indexes, alphabetically ordered by index name
+                // Access an index definition from the resulting list:
+                var name = indexes[0].Name;
+                var state = indexes[0].State;
+                var lockMode = indexes[0].LockMode;
+                var deploymentMode = indexes[0].DeploymentMode;
+                // etc.
+                #endregion
+            }
+        }
+        
+        public async Task GetIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_async
+                // Define the get index operation, pass the index name
+                var getIndexOp = new GetIndexOperation("Orders/Totals");
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                IndexDefinition index = await store.Maintenance.SendAsync(getIndexOp);
+
+                // Access the index definition
+                var state = index.State;
+                var lockMode = index.LockMode;
+                var deploymentMode = index.DeploymentMode;
+                // etc.
+                #endregion
+            }
+            
+            using (var store = new DocumentStore()) 
+            {
+                #region get_indexes_async
+                // Define the get indexes operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexesOp = new GetIndexesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                IndexDefinition[] indexes = await store.Maintenance.SendAsync(getIndexesOp);
+                
+                // indexes will contain the first 10 indexes, alphabetically ordered by index name
+                // Access an index definition from the resulting list:
+                var name = indexes[0].Name;
+                var state = indexes[0].State;
+                var lockMode = indexes[0].LockMode;
+                var deploymentMode = indexes[0].DeploymentMode;
+                // etc.
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region get_index_syntax
+            public GetIndexOperation(string indexName)
+            #endregion
+            */
+
+            /*
+            #region get_indexes_syntax
+            public GetIndexesOperation(int start, int pageSize)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexErrors.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexErrors.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class GetIndexErrors
+    {
+        public GetIndexErrors()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region get_errors_all
+                    // Define the get index errors operation
+                    var getIndexErrorsOp = new GetIndexErrorsOperation();
+                    
+                    // Execute the operation by passing it to Maintenance.Send
+                    IndexErrors[] indexErrors = store.Maintenance.Send(getIndexErrorsOp);
+                    
+                    // indexErrors will contain errors for ALL indexes
+                    #endregion
+                }
+
+                {
+                    #region get_errors_specific
+                    // Define the get index errors operation for specific indexes
+                    var getIndexErrorsOp = new GetIndexErrorsOperation(new[] { "Orders/Totals" });
+                    
+                    // Execute the operation by passing it to Maintenance.Send
+                    // An exception will be thrown if any of the specified indexes do not exist
+                    IndexErrors[] indexErrors = store.Maintenance.Send(getIndexErrorsOp);
+
+                    // indexErrors will contain errors only for index "Orders/Totals"
+                    #endregion
+                }
+            }
+        }
+        
+        public async Task GetIndexErrorsAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region get_errors_all_async
+                    // Define the get index errors operation
+                    var getIndexErrorsOp = new GetIndexErrorsOperation();
+
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    IndexErrors[] indexErrors = await store.Maintenance.SendAsync(getIndexErrorsOp);
+
+                    // indexErrors will contain errors for ALL indexes
+                    #endregion
+                }
+
+                {
+                    #region get_errors_specific_async
+                    // Define the get index errors operation for specific indexes
+                    var getIndexErrorsOp = new GetIndexErrorsOperation(new[] { "Orders/Totals" });
+                    
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    // An exception will be thrown if any of the specified indexes do not exist
+                    IndexErrors[] indexErrors = await store.Maintenance.SendAsync(getIndexErrorsOp);
+                    
+                    // indexErrors will contain errors only for index "Orders/Totals"
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            // Available overloads:
+            public GetIndexErrorsOperation()                    // Get errors for all indexes
+            public GetIndexErrorsOperation(string[] indexNames) // Get errors for specific indexes
+            #endregion
+            */
+        }
+
+        private class Foo
+        {
+            #region syntax_2
+            public class IndexErrors
+            {
+                public string Name { get; set; }            // Index name
+                public IndexingError[] Errors { get; set; } // List of errors for this index
+            }
+            #endregion
+
+            #region syntax_3
+            public class IndexingError
+            {
+                // The error message
+                public string Error { get; set; }
+                
+                // Time of error
+                public DateTime Timestamp { get; set; }
+                
+                // If Action is 'Map'    - field will contain the document ID
+                // If Action is 'Reduce' - field will contain the Reduce key value
+                // For all other Actions - field will be null 
+                public string Document { get; set; }
+                
+                // Area where error has occurred, e.g. Map/Reduce/Analyzer/Memory/etc.
+                public string Action { get; set; }      
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.cs
@@ -1,0 +1,52 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class GetIndexNames
+    {
+        public GetIndexNames()
+        {
+            using (var store = new DocumentStore()) 
+            {
+                #region get_index_names
+                // Define the get index names operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexNamesOp = new GetIndexNamesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                string[] indexNames = store.Maintenance.Send(getIndexNamesOp);
+                
+                // indexNames will contain the first 10 indexes, alphabetically ordered
+                #endregion
+            }
+        }
+        
+        public async Task GetIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_names_async
+                // Define the get index names operation
+                // Pass number of indexes to skip & number of indexes to retrieve
+                var getIndexNamesOp = new GetIndexNamesOperation(0, 10);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                string[] indexNames = await store.Maintenance.SendAsync(getIndexNamesOp);
+                
+                // indexNames will contain the first 10 indexes, alphabetically ordered
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region get_index_names_syntax
+            public GetIndexNamesOperation(int start, int pageSize)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.cs
@@ -1,0 +1,52 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class GetIndexTerms
+    {
+        public GetIndexTerms()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_terms
+                // Define the get terms operation
+                // Pass the requested index-name, index-field, start value & page size
+                var getTermsOp = new GetTermsOperation("Orders/Totals", "Employee", "employees/5-a", 10);
+
+                // Execute the operation by passing it to Maintenance.Send
+                string[] fieldTerms = store.Maintenance.Send(getTermsOp);
+
+                // fieldTerms will contain the all terms that come after term 'employees/5-a' for index-field 'Employee'
+                #endregion
+            }
+        }
+        
+        public async Task GetIndexAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region get_index_terms_async
+                // Define the get terms operation
+                // Pass the requested index-name, index-field, start value & page size
+                var getTermsOp = new GetTermsOperation("Orders/Totals", "Employee", "employees/5-a", 10);
+
+                // Execute the operation by passing it to Maintenance.SendAsync
+                string[] fieldTerms = await store.Maintenance.SendAsync(getTermsOp);
+
+                // fieldTerms will contain the all terms that come after term 'employees/5-a' for index-field 'Employee'
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region get_index_terms_syntax
+            public GetTermsOperation(string indexName, string field, string fromValue, int? pageSize = null)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.cs
@@ -1,0 +1,71 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class IndexHasChanged
+    {
+        public IndexHasChanged()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region index_has_changed
+                // Some index definition
+                var indexDefinition = new IndexDefinition
+                {
+                    Name = "UsersByName",
+                    Maps = { "from user in docs.Users select new { user.Name }"}
+                };
+                
+                // Define the has-changed operation, pass the index definition
+                var indexHasChangedOp = new IndexHasChangedOperation(indexDefinition);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                bool indexHasChanged = store.Maintenance.Send(indexHasChangedOp);
+                
+                // Return values:
+                // false: The definition of the index passed is the SAME as the one deployed on the server  
+                // true:  The definition of the index passed is DIFFERENT than the one deployed on the server
+                //        Or - index does not exist
+                #endregion
+            }
+        }
+        
+        public async Task IndexHasChangedAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region index_has_changed_async
+                // Some index definition
+                var indexDefinition = new IndexDefinition
+                {
+                    Name = "UsersByName",
+                    Maps = { "from user in docs.Users select new { user.Name }"}
+                };
+                
+                // Define the has-changed operation, pass the index definition
+                var indexHasChangedOp = new IndexHasChangedOperation(indexDefinition);
+                
+                // Execute the operation by passing it to Maintenance.SendAsync
+                bool indexHasChanged = await store.Maintenance.SendAsync(indexHasChangedOp);
+                
+                // Return values:
+                // false: The definition of the index passed is the SAME as the one deployed on the server  
+                // true:  The definition of the index passed is DIFFERENT than the one deployed on the server
+                //        Or - index does not exist
+                #endregion
+            }
+        }
+
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public IndexHasChangedOperation(IndexDefinition definition)
+            #endregion
+            */
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Maintenance/Indexes/SetPriority.cs
@@ -1,0 +1,111 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes
+{
+    public class SetPriority
+    {
+        public SetPriority()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region set_priority_single
+                    // Define the set priority operation
+                    // Pass index name & priority
+                    var setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.High);
+
+                    // Execute the operation by passing it to Maintenance.Send
+                    // An exception will be thrown if index does not exist
+                    store.Maintenance.Send(setPriorityOp);
+                    #endregion
+                }
+                {
+                    #region set_priority_multiple
+                    // Define the index list and the new priority:
+                    var parameters = new SetIndexesPriorityOperation.Parameters
+                    {
+                        IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"},
+                        Priority = IndexPriority.Low
+                    };
+
+                    // Define the set priority operation, pass the parameters
+                    var setPriorityOp = new SetIndexesPriorityOperation(parameters);
+
+                    // Execute the operation by passing it to Maintenance.Send
+                    // An exception will be thrown if any of the specified indexes do not exist
+                    store.Maintenance.Send(setPriorityOp);
+                    #endregion
+                }
+            }
+        }
+        
+        public async Task SetPriorityAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region set_priority_single_async
+                    // Define the set priority operation
+                    // Pass index name & priority
+                    var setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.High);
+                
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    // An exception will be thrown if index does not exist
+                    await store.Maintenance.SendAsync(setPriorityOp);
+                    #endregion
+                }
+                {
+                    #region set_priority_multiple_async
+                    // Define the index list and the new priority:
+                    var parameters = new SetIndexesPriorityOperation.Parameters 
+                    {
+                        IndexNames = new[] {"Orders/Totals", "Orders/ByCompany"}, 
+                        Priority = IndexPriority.Low
+                    };
+                
+                    // Define the set priority operation, pass the parameters
+                    var setPriorityOp = new SetIndexesPriorityOperation(parameters);
+
+                    // Execute the operation by passing it to Maintenance.SendAsync
+                    // An exception will be thrown if any of the specified indexes do not exist
+                    await store.Maintenance.SendAsync(setPriorityOp);
+                    #endregion
+                }
+            }
+        }
+        
+        private interface IFoo
+        {
+            /*
+            #region syntax_1
+            // Available overloads:
+            public SetIndexesPriorityOperation(string indexName, IndexPriority priority);
+            public SetIndexesPriorityOperation(Parameters parameters);
+            #endregion
+            */
+        }
+
+        private class Priority
+        {
+            #region syntax_2
+            public enum IndexPriority
+            {
+                Low,
+                Normal,
+                High
+            }
+            #endregion
+        }
+        
+        #region syntax_3
+        public class Parameters
+        {
+            public string[] IndexNames { get; set; }
+            public IndexPriority Priority { get; set; }
+        }
+        #endregion
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/AddDatabaseNode.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/AddDatabaseNode.cs
@@ -1,0 +1,79 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+    public class AddDatabaseNode
+    {
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public AddDatabaseNodeOperation(string databaseName, string nodeTag = null)
+            #endregion
+            */
+        }
+
+        public AddDatabaseNode()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region add_1
+                // Create the AddDatabaseNodeOperation
+                // Add a random node to 'Northwind' database-group
+                var addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind");
+                
+                // Execute the operation by passing it to Maintenance.Server.Send
+                DatabasePutResult result = store.Maintenance.Server.Send(addDatabaseNodeOp);
+                
+                // Can access the new topology
+                var numberOfReplicas = result.Topology.AllNodes.Count();
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region add_2
+                // Create the AddDatabaseNodeOperation
+                // Add node C to 'Northwind' database-group
+                var addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind", "C");
+                
+                // Execute the operation by passing it to Maintenance.Server.Send
+                DatabasePutResult result = store.Maintenance.Server.Send(addDatabaseNodeOp);
+                #endregion
+            }
+        }
+        
+        public async Task AddDatabaseNodeAsync()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region add_1_async
+                // Create the AddDatabaseNodeOperation
+                // Add a random node to 'Northwind' database-group
+                var addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind");
+                
+                // Execute the operation by passing it to Maintenance.Server.SendAsync
+                DatabasePutResult result = await store.Maintenance.Server.SendAsync(addDatabaseNodeOp);
+                
+                // Can access the new topology
+                var numberOfReplicas = result.Topology.AllNodes.Count();
+                #endregion
+            }
+            
+            using (var store = new DocumentStore())
+            {
+                #region add_2_async
+                // Create the AddDatabaseNodeOperation
+                // Add node C to 'Northwind' database-group
+                var addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind", "C");
+                
+                // Execute the operation by passing it to Maintenance.Server.SendAsync
+                DatabasePutResult result = await store.Maintenance.Server.SendAsync(addDatabaseNodeOp);
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/Compact.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/Compact.cs
@@ -1,0 +1,266 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+    public class Compact
+    {
+        private interface IFoo
+        {
+            /*
+            #region syntax
+            public CompactDatabaseOperation(CompactSettings compactSettings)
+            #endregion
+            */
+        }
+
+        public Compact()
+        {
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_0
+                // Define the compact settings
+                CompactSettings settings = new CompactSettings
+                {
+                    // Database to compact
+                    DatabaseName = "Northwind",
+
+                    // Set 'Documents' to true to compact all documents in database
+                    // Indexes are not set and will not be compacted
+                    Documents = true
+                };
+                
+                // Define the compact operation, pass the settings
+                IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+                
+                // Execute compaction by passing the operation to Maintenance.Server.Send
+                Operation operation = documentStore.Maintenance.Server.Send(compactOp);
+                
+                // Wait for operation to complete, during compaction the database is offline
+                operation.WaitForCompletion();
+                #endregion
+            }
+            
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_1
+                // Define the compact settings
+                CompactSettings settings = new CompactSettings
+                {
+                    // Database to compact
+                    DatabaseName = "Northwind",
+                    
+                    // Setting 'Documents' to false will compact only the specified indexes
+                    Documents = false,
+                    
+                    // Specify which indexes to compact
+                    Indexes = new[] { "Orders/Totals", "Orders/ByCompany" }, 
+                    
+                    // Optimize indexes is Lucene's feature to gain disk space and efficiency
+                    // Set whether to skip this optimization when compacting the indexes
+                    SkipOptimizeIndexes = false
+                };
+                
+                // Define the compact operation, pass the settings
+                IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+
+                // Execute compaction by passing the operation to Maintenance.Server.Send
+                Operation operation = documentStore.Maintenance.Server.Send(compactOp);
+                // Wait for operation to complete
+                operation.WaitForCompletion();
+                #endregion
+            }
+            
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_2
+                // Get all indexes names in the database using the 'GetIndexNamesOperation' operation
+                // Use 'ForDatabase' if the target database is different than the default database defined on the store
+                string[] allIndexNames =
+                    documentStore.Maintenance.ForDatabase("Northwind")
+                        .Send(new GetIndexNamesOperation(0, int.MaxValue));
+                
+                // Define the compact settings
+                CompactSettings settings = new CompactSettings
+                {
+                    DatabaseName = "Northwind", // Database to compact
+                    
+                    Documents = true,           // Compact all documents
+
+                    Indexes = allIndexNames,    // All indexes will be compacted
+                    
+                    SkipOptimizeIndexes = true  // Skip Lucene's indexes optimization
+                };
+                
+                // Define the compact operation, pass the settings
+                IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+                
+                // Execute compaction by passing the operation to Maintenance.Server.Send
+                Operation operation = documentStore.Maintenance.Server.Send(compactOp);
+                // Wait for operation to complete
+                operation.WaitForCompletion();
+                #endregion
+            }
+            
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_3
+                // Get all member nodes in the database-group using the 'GetDatabaseRecordOperation' operation
+                List<string> allMemberNodes =
+                    documentStore.Maintenance.Server.Send(new GetDatabaseRecordOperation("Northwind"))
+                        .Topology.Members;
+
+                // Define the compact settings as needed
+                CompactSettings settings = new CompactSettings
+                {
+                    // Database to compact
+                    DatabaseName = "Northwind",
+                    
+                    //Compact all documents in database
+                    Documents = true
+                };
+
+                // Execute the compact operation on each member node
+                foreach (string nodeTag in allMemberNodes)
+                {
+                    // Define the compact operation, pass the settings
+                    IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+                    
+                    // Execute the operation on a specific node
+                    // Use `ForNode` to specify the node to operate on
+                    Operation operation = documentStore.Maintenance.Server.ForNode(nodeTag).Send(compactOp);
+                    // Wait for operation to complete
+                    operation.WaitForCompletion();
+                }
+                #endregion
+            }
+        }
+
+        public async Task CompactAsync()
+        {
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_0_async
+                // Define the compact settings
+                CompactSettings settings = new CompactSettings
+                {
+                    // Database to compact
+                    DatabaseName = "Northwind",
+
+                    // Set 'Documents' to true to compact all documents in database
+                    // Indexes are not set and will not be compacted
+                    Documents = true
+                };
+                
+                // Define the compact operation, pass the settings
+                IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+                
+                // Execute compaction by passing the operation to Maintenance.Server.SendAsync
+                Operation operation = await documentStore.Maintenance.Server.SendAsync(compactOp);
+                
+                // Wait for operation to complete, during compaction the database is offline
+                await operation.WaitForCompletionAsync().ConfigureAwait(false);
+                #endregion
+            }
+            
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_1_async
+                // Define the compact settings
+                CompactSettings settings = new CompactSettings
+                {
+                    // Database to compact
+                    DatabaseName = "Northwind",
+                    
+                    // Setting 'Documents' to false will compact only the specified indexes
+                    Documents = false,
+                    
+                    // Specify which indexes to compact
+                    Indexes = new[] { "Orders/Totals", "Orders/ByCompany" }, 
+                    
+                    // Optimize indexes is Lucene's feature to gain disk space and efficiency
+                    // Set whether to skip this optimization when compacting the indexes
+                    SkipOptimizeIndexes = false
+                };
+                
+                // Define the compact operation, pass the settings
+                IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+
+                // Execute compaction by passing the operation to Maintenance.Server.SendAsync
+                Operation operation = await documentStore.Maintenance.Server.SendAsync(compactOp);
+                // Wait for operation to complete
+                await operation.WaitForCompletionAsync().ConfigureAwait(false);
+                #endregion
+            }
+            
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_2_async
+                // Get all indexes names in the database using the 'GetIndexNamesOperation' operation
+                // Use 'ForDatabase' if the target database is different than the default database defined on the store
+                string[] allIndexNames =
+                    documentStore.Maintenance.ForDatabase("Northwind")
+                        .Send(new GetIndexNamesOperation(0, int.MaxValue));
+                
+                // Define the compact settings
+                CompactSettings settings = new CompactSettings
+                {
+                    DatabaseName = "Northwind", // Database to compact
+                    
+                    Documents = true,           // Compact all documents
+
+                    Indexes = allIndexNames,    // All indexes will be compacted
+                    
+                    SkipOptimizeIndexes = true  // Skip Lucene's indexes optimization
+                };
+                
+                // Define the compact operation, pass the settings
+                IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+                
+                // Execute compaction by passing the operation to Maintenance.Server.SendAsync
+                Operation operation = await documentStore.Maintenance.Server.SendAsync(compactOp);
+                // Wait for operation to complete
+                await operation.WaitForCompletionAsync();
+                #endregion
+            }
+            
+            using (var documentStore = new DocumentStore())
+            {
+                #region compact_3_async
+                // Get all member nodes in the database-group using the 'GetDatabaseRecordOperation' operation
+                List<string> allMemberNodes =
+                    documentStore.Maintenance.Server.Send(new GetDatabaseRecordOperation("Northwind"))
+                        .Topology.Members;
+
+                // Define the compact settings as needed
+                CompactSettings settings = new CompactSettings
+                {
+                    // Database to compact
+                    DatabaseName = "Northwind",
+                    
+                    //Compact all documents in database
+                    Documents = true
+                };
+
+                // Execute the compact operation on each member node
+                foreach (string nodeTag in allMemberNodes)
+                {
+                    // Define the compact operation, pass the settings
+                    IServerOperation<OperationIdResult> compactOp = new CompactDatabaseOperation(settings);
+                    
+                    // Execute the operation on a specific node
+                    // Use `ForNode` to specify the node to operate on
+                    Operation operation = await documentStore.Maintenance.Server.ForNode(nodeTag).SendAsync(compactOp);
+                    // Wait for operation to complete
+                    await operation.WaitForCompletionAsync();
+                }
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ToggleDatabasesState.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ToggleDatabasesState.cs
@@ -1,0 +1,114 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+using static Raven.Documentation.Samples.ClientApi.Operations.Maintenance.Indexes.DisableIndex;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.Server
+{
+    public class ToggleDatabasesState
+    {
+        public ToggleDatabasesState()
+        {
+            using (var documentStore = new DocumentStore())
+            {
+                {
+                    #region enable
+                    // Define the toggle state operation
+                    // specify the database name & pass 'false' to enable
+                    var enableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: false);
+                    
+                    // To enable multiple databases use:
+                    // var enableDatabaseOp =
+                    //     new ToggleDatabasesStateOperation(new [] { "DB1", "DB2", ... }, disable: false);
+                    
+                    // Execute the operation by passing it to Maintenance.Server.Send
+                    var toggleResult = documentStore.Maintenance.Server.Send(enableDatabaseOp);
+                    #endregion
+                }
+                { 
+                    #region disable
+                    // Define the toggle state operation
+                    // specify the database name(s) & pass 'true' to disable
+                    var disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: true);
+                    
+                    // To disable multiple databases use:
+                    // var disableDatabaseOp =
+                    //     new ToggleDatabasesStateOperation(new [] { "DB1", "DB2", ... }, disable: true);
+                    
+                    // Execute the operation by passing it to Maintenance.Server.Send
+                    var toggleResult = documentStore.Maintenance.Server.Send(disableDatabaseOp);
+                    #endregion
+                }
+            }
+        }
+        
+        public async Task ToggleDatabasesStateAsync()
+        {
+            using (var documentStore = new DocumentStore())
+            {
+                {
+                    #region enable_async
+                    // Define the toggle state operation
+                    // specify the database name(s) & pass 'false' to enable
+                    var enableDatabaseOp = new ToggleDatabasesStateOperation(new [] { "Foo", "Bar" }, disable: false);
+                    
+                    // Execute the operation by passing it to Maintenance.Server.SendAsync
+                    var toggleResult = await documentStore.Maintenance.Server.SendAsync(enableDatabaseOp);
+                    #endregion
+                }
+                { 
+                    #region disable_async
+                    // Define the toggle state operation
+                    // specify the database name(s) & pass 'true' to disable
+                    var disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", disable: true);
+                    
+                    // Execute the operation by passing it to Maintenance.Server.SendAsync
+                    var toggleResult = await documentStore.Maintenance.Server.SendAsync(disableDatabaseOp);
+                    #endregion
+                }
+            }
+        }
+
+
+        void DisableDatabaseViaFileSystem()
+        {
+            using (var store = new DocumentStore())
+            {
+                string databasePath = new string("dbPath");
+                #region disable-database-via-file-system
+                // Prevent database access by creating disable.marker in its path
+                var disableMarkerPath = Path.Combine(databasePath, "disable.marker");
+                File.Create(disableMarkerPath).Dispose();
+                #endregion
+            }
+        }
+
+        private class Foo
+        {
+            public class ToggleDatabasesStateOperation
+            {
+                /*
+                #region syntax_1
+                // Available overloads:
+                public ToggleDatabasesStateOperation(string databaseName, bool disable)
+                public ToggleDatabasesStateOperation(string[] databaseNames, bool disable)
+                #endregion
+                */
+                
+                /*
+                #region syntax_2
+                // Executing the operation returns the following object:
+                public class DisableDatabaseToggleResult
+                {
+                    public bool Disabled; // Is database disabled
+                    public string Name;   // Name of the database
+                    public bool Success;  // Has request succeeded
+                    public string Reason; // Reason for success or failure
+                }
+                #endregion
+                */
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.java
@@ -1,0 +1,32 @@
+package net.ravendb.ClientApi.Operations.HowTo;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.MaintenanceOperationExecutor;
+import net.ravendb.client.documents.operations.OperationExecutor;
+
+public class SwitchOperationsToDifferentDatabase {
+    private interface ForDatabase1 {
+        //region for_database_1
+        OperationExecutor forDatabase(String databaseName);
+        //endregion
+    }
+
+    private interface ForDatabase2 {
+        //region for_database_2
+        MaintenanceOperationExecutor forDatabase(String databaseName);
+        //endregion
+    }
+
+    public SwitchOperationsToDifferentDatabase() {
+        try (IDocumentStore documentStore = new DocumentStore()) {
+            //region for_database_3
+            OperationExecutor operations = documentStore.operations().forDatabase("otherDatabase");
+            //endregion
+
+            //region for_database_4
+            MaintenanceOperationExecutor maintenanceOperations = documentStore.maintenance().forDatabase("otherDatabase");
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/Get.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/Get.java
@@ -1,0 +1,50 @@
+package net.ravendb.ClientApi.Operations.Indexes;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexDefinition;
+import net.ravendb.client.documents.operations.indexes.GetIndexNamesOperation;
+import net.ravendb.client.documents.operations.indexes.GetIndexOperation;
+import net.ravendb.client.documents.operations.indexes.GetIndexesOperation;
+
+public class Get {
+
+    private interface IFoo {
+        /*
+        //region get_1_0
+        public GetIndexOperation(String indexName)
+        //endregion
+
+        //region get_2_0
+        public GetIndexesOperation(int start, int pageSize)
+        //endregion
+
+        //region get_3_0
+        public GetIndexNamesOperation(int start, int pageSize)
+        //endregion
+        */
+    }
+
+    public Get() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region get_1_1
+            IndexDefinition index
+                = store.maintenance()
+                    .send(new GetIndexOperation("Orders/Totals"));
+
+            //endregion
+
+            //region get_2_1
+            IndexDefinition[] indexes
+                = store.maintenance()
+                    .send(new GetIndexesOperation(0, 10));
+            //endregion
+
+            //region get_3_1
+            String[] indexNames
+                = store.maintenance()
+                    .send(new GetIndexNamesOperation(0, 10));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/GetIndexErrors.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/GetIndexErrors.java
@@ -1,0 +1,115 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexErrors;
+import net.ravendb.client.documents.indexes.IndexingError;
+import net.ravendb.client.documents.operations.indexes.GetIndexErrorsOperation;
+
+import java.util.Date;
+
+public class IndexError {
+
+    private interface IFoo {
+        /*
+        //region errors_1
+        public GetIndexErrorsOperation()
+
+        public GetIndexErrorsOperation(String[] indexNames)
+        //endregion
+        */
+    }
+
+    private class Foo {
+        //region errors_2
+        public class IndexErrors {
+            private String name;
+            private IndexingError[] errors;
+
+            public IndexErrors() {
+                errors = new IndexingError[0];
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public IndexingError[] getErrors() {
+                return errors;
+            }
+
+            public void setErrors(IndexingError[] errors) {
+                this.errors = errors;
+            }
+        }
+        //endregion
+
+        //region errors_3
+
+        public class IndexingError {
+
+            private String error;
+            private Date timestamp;
+            private String document;
+            private String action;
+
+            public String getError() {
+                return error;
+            }
+
+            public void setError(String error) {
+                this.error = error;
+            }
+
+            public Date getTimestamp() {
+                return timestamp;
+            }
+
+            public void setTimestamp(Date timestamp) {
+                this.timestamp = timestamp;
+            }
+
+            public String getDocument() {
+                return document;
+            }
+
+            public void setDocument(String document) {
+                this.document = document;
+            }
+
+            public String getAction() {
+                return action;
+            }
+
+            public void setAction(String action) {
+                this.action = action;
+            }
+        }
+        //endregion
+    }
+
+    public IndexError() {
+        try (IDocumentStore store = new DocumentStore()) {
+            {
+                //region errors_4
+                // gets errors for all indexes
+                IndexErrors[] indexErrors
+                    = store.maintenance().send(new GetIndexErrorsOperation());
+                //endregion
+            }
+
+            {
+                //region errors_5
+                // gets errors only for 'Orders/Totals' index
+                IndexErrors[] indexErrors
+                    = store.maintenance()
+                        .send(new GetIndexErrorsOperation(new String[]{"Orders/Totals"}));
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.java
@@ -1,0 +1,29 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.operations.indexes.GetTermsOperation;
+
+public class GetIndexTerms {
+
+    private interface IFoo {
+        /*
+        //region get_terms1
+        public GetTermsOperation(String indexName, String field, String fromValue)
+
+        public GetTermsOperation(String indexName, String field, String fromValue, Integer pageSize)
+        //endregion
+        */
+    }
+
+    public GetIndexTerms() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region get_terms2
+            String[] terms = store
+                .maintenance()
+                .send(
+                    new GetTermsOperation("Orders/Totals", "Employee", null));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.java
@@ -1,0 +1,28 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexDefinition;
+import net.ravendb.client.documents.operations.indexes.IndexHasChangedOperation;
+
+public class IndexHasChanged {
+
+
+    private interface IFoo {
+        /*
+        //region index_has_changed_1
+        public IndexHasChangedOperation(IndexDefinition definition)
+        //endregion
+        */
+    }
+
+    public IndexHasChanged() {
+        try (IDocumentStore store = new DocumentStore()) {
+            IndexDefinition ordersIndexDefinition = null;
+            //region index_has_changed_2
+            Boolean ordersIndexHasChanged =
+                store.maintenance().send(new IndexHasChangedOperation(ordersIndexDefinition));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/SetPriority.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Maintenance/Indexes/SetPriority.java
@@ -1,0 +1,68 @@
+package net.ravendb.ClientApi.Operations;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.IndexPriority;
+import net.ravendb.client.documents.operations.indexes.SetIndexesPriorityOperation;
+
+public class ChangeIndexPriority {
+
+    private interface IFoo {
+        /*
+        //region set_priority_1
+        public SetIndexesPriorityOperation(String indexName, IndexPriority priority) {
+        public SetIndexesPriorityOperation(SetIndexesPriorityOperation.Parameters parameters)
+        //endregion
+        */
+    }
+
+    private static class Foo {
+        //region set_priority_2
+        public enum IndexPriority {
+            LOW,
+            NORMAL,
+            HIGH
+        }
+        //endregion
+
+        //region set_priority_3
+        public static class Parameters {
+            private String[] indexNames;
+            private IndexPriority priority;
+
+            public String[] getIndexNames() {
+                return indexNames;
+            }
+
+            public void setIndexNames(String[] indexNames) {
+                this.indexNames = indexNames;
+            }
+
+            public IndexPriority getPriority() {
+                return priority;
+            }
+
+            public void setPriority(IndexPriority priority) {
+                this.priority = priority;
+            }
+        }
+        //endregion
+    }
+
+    public ChangeIndexPriority() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region set_priority_4
+            store.maintenance().send(
+                new SetIndexesPriorityOperation("Orders/Totals", IndexPriority.HIGH));
+            //endregion
+
+            //region set_priority_5
+            SetIndexesPriorityOperation.Parameters parameters = new SetIndexesPriorityOperation.Parameters();
+            parameters.setIndexNames(new String[]{ "Orders/Totals", "Orders/ByCompany" });
+            parameters.setPriority(IndexPriority.LOW);
+
+            store.maintenance().send(new SetIndexesPriorityOperation(parameters));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/HowTo/switchOperationsToDifferentDatabase.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/HowTo/switchOperationsToDifferentDatabase.js
@@ -1,0 +1,53 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function addDatabaseNode() {
+    {
+        //region for_database_1
+        // Define default database on the store
+        const documentStore = new DocumentStore("yourServerURL", "DefaultDB");
+        documentStore.initialize();
+
+        // Use 'forDatabase', get operation executor for another database
+         const opExecutor = documentStore.operations.forDatabase("AnotherDB");
+
+        // Send the operation, e.g. 'GetRevisionsOperation' will be executed on "AnotherDB"
+        const revisionsInAnotherDB =
+            await opExecutor.send(new GetRevisionsOperation("Orders/1-A"));
+
+        // Without 'forDatabase', the operation is executed "DefaultDB"
+        const revisionsInDefaultDB =
+           await documentStore.operations.send(new GetRevisionsOperation("Company/1-A"));
+        //endregion
+    }
+    {
+        //region for_database_2
+        // Define default database on the store
+        const documentStore = new DocumentStore("yourServerURL", "DefaultDB");
+        documentStore.initialize();
+
+        // Use 'forDatabase', get maintenance operation executor for another database
+        const opExecutor = documentStore.maintenance.forDatabase("AnotherDB");
+
+        // Send the maintenance operation, e.g. get database stats for "AnotherDB"
+        const statsForAnotherDB =
+            await opExecutor.send(new GetStatisticsOperation());
+
+        // Without 'forDatabase', the stats are retrieved for "DefaultDB"
+        const statsForDefaultDB =
+            await documentStore.maintenance.send(new GetStatisticsOperation());
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    store.operations.forDatabase(databaseName);
+    //endregion
+}
+{
+    //region syntax_2
+    store.maintenance.forDatabase(databaseName);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndex.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndex.js
@@ -1,0 +1,49 @@
+﻿import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+
+async function getIndex() {
+    {
+        //region get_index
+        // Define the get index operation, pass the index name
+        const getIndexOp = new GetIndexOperation("Orders/Totals");
+
+        // Execute the operation by passing it to maintenance.send
+        const indexDefinition = await store.maintenance.send(getIndexOp);
+
+        // Access the index definition
+        const state = indexDefinition.state;
+        const lockMode = indexDefinition.lockMode;
+        const deploymentMode = indexDefinition.deploymentMode;
+        // etc.
+        //endregion
+
+        //region get_indexes
+        // Define the get indexes operation
+        // Pass number of indexes to skip & number of indexes to retrieve
+        const getIndexesOp = new GetIndexesOperation(0, 10);
+
+        // Execute the operation by passing it to maintenance.send
+        const indexes = await store.maintenance.send(getIndexesOp);
+
+        // indexes will contain the first 10 indexes, alphabetically ordered by index name
+        // Access an index definition from the resulting list:
+        const name = indexes[0].name;
+        const state = indexes[0].state;
+        const lockMode = indexes[0].lockMode;
+        const deploymentMode = indexes[0].deploymentMode;
+        // etc.
+        //endregion
+    }
+}
+
+{
+    //region get_index_syntax
+    const getIndexOp = new GetIndexOperation(indexName);
+    //endregion
+
+    //region get_indexes_syntax
+    const getIndexesOp = new GetIndexesOperation(start, pageSize);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndexErrors.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndexErrors.js
@@ -1,0 +1,63 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getIndexErrors() {
+    {
+        //region get_errors_all
+        // Define the get index errors operation
+        const getIndexErrorsOp = new GetIndexErrorsOperation();
+
+        // Execute the operation by passing it to maintenance.send
+        const indexErrors = await store.maintenance.send(getIndexErrorsOp);
+
+        // indexErrors will contain errors for ALL indexes
+        //endregion
+
+        //region get_errors_specific
+        // Define the get index errors operation for specific indexes
+        const getIndexErrorsOp = new GetIndexErrorsOperation(["Orders/Totals"]);
+
+        // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if any of the specified indexes do not exist
+        const indexErrors = await store.maintenance.send(getIndexErrorsOp);
+
+        // indexErrors will contain errors only for index "Orders/Totals"
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    // Available overloads:
+    const getIndexErrorsOp = new GetIndexErrorsOperation();           // Get errors for all indexes 
+    const getIndexErrorsOp = new GetIndexErrorsOperation(indexNames); // Get errors for specific indexes
+    //endregion
+
+    //region syntax_2
+    // An 'index errors' object:
+    {
+        name,  // Index name
+        errors // List of 'error objects' for this index
+    }
+    //endregion
+    
+    //region syntax_3
+    // An 'error object':
+    {
+        // The error message
+        error,
+            
+        // Time of error
+        timestamp,
+
+        // If Action is 'Map'    - field will contain the document ID
+        // If Action is 'Reduce' - field will contain the Reduce key value
+        // For all other Actions - field will be null    
+        document,
+
+        // Area where error has occurred, e.g. Map/Reduce/Analyzer/Memory/etc.
+        action
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndexNames.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndexNames.js
@@ -1,0 +1,24 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getIndexNames() {
+    {
+        //region get_index_names
+        // Define the get index names operation
+        // Pass number of indexes to skip & number of indexes to retrieve
+        const getIndexNamesOp = new GetIndexNamesOperation(0, 10);
+
+        // Execute the operation by passing it to maintenance.send
+        const indexNames = await store.maintenance.send(getIndexNamesOp);
+
+        // indexNames will contain the first 10 indexes, alphabetically ordered
+        //endregion
+    }
+}
+
+{
+    //region get_index_names_syntax
+    const getIndexNamesOp = new GetIndexNamesOperation(start, pageSize);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndexTerms.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/getIndexTerms.js
@@ -1,0 +1,26 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getIndexTerms() {
+    {
+        //region get_index_terms
+        // Define the get terms operation
+        // Pass the requested index-name, index-field, start value & page size
+        const getTermsOp = new GetTermsOperation("Orders/Totals", "Employee", "employees/5-a", 10);
+
+        // Execute the operation by passing it to maintenance.send
+        const fieldTerms = await store.maintenance.send(getTermsOp);
+
+        // fieldTerms will contain the all terms that come after term 'employees/5-a' for index-field 'Employee'
+        //endregion
+    }
+}
+
+{
+    //region get_index_terms_syntax
+    // Available overloads:
+    const getTermsOp = new GetTermsOperation(indexName, field, fromValue);
+    const getTermsOp = new GetTermsOperation(indexName, field, fromValue, pageSize);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/indexHasChanged.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/indexHasChanged.js
@@ -1,0 +1,32 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getStats() {
+    {
+        //region index_has_changed
+        // Some index definition
+        const indexDefinition = new IndexDefinition();
+        indexDefinition.name = "UsersByName";
+        indexDefinition.maps = new Set([ `from user in docs.Users select new { user.Name }` ]);
+
+        // Define the has-changed operation, pass the index definition
+        const indexHasChangedOp = new IndexHasChangedOperation(indexDefinition);
+
+        // Execute the operation by passing it to maintenance.send
+        const indexHasChanged = await documentStore.maintenance.send(indexHasChangedOp);
+
+        // Return values:
+        // false: The definition of the index passed is the SAME as the one deployed on the server  
+        // true:  The definition of the index passed is DIFFERENT than the one deployed on the server
+        //        Or - index does not exist
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const indexHasChangedOp = new IndexHasChangedOperation(definition);
+    //endregion
+
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/setPriority.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Maintenance/Indexes/setPriority.js
@@ -1,0 +1,50 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function setPriority() {
+    {
+        //region set_priority_single
+        // Define the set priority operation
+        // Pass index name & priority
+        const setPriorityOp = new SetIndexesPriorityOperation("Orders/Totals", "High");
+
+        // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if index does not exist
+        await store.maintenance.send(setPriorityOp);
+        //endregion
+
+    }
+    {
+        //region set_priority_multiple
+        // Define the index list and the new priority:
+        const parameters = {
+            indexNames: ["Orders/Totals", "Orders/ByCompany"],
+            priority: "Low"
+        }
+
+        // Define the set priority operation, pass the parameters
+        const setPriorityOp = new SetIndexesPriorityOperation(parameters);
+
+        // Execute the operation by passing it to maintenance.send
+        // An exception will be thrown if any of the specified indexes do not exist
+        await store.maintenance.send(setPriorityOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    // Available overloads:
+    const setPriorityOp = new SetIndexesPriorityOperation(indexName, priority);
+    const setPriorityOp = new SetIndexesPriorityOperation(parameters);
+    //endregion
+
+    //region syntax_2
+    // parameters object
+    {
+        indexNames, // string[], list of index names
+        priority    // Priority to set
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Server/addDatabaseNode.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Server/addDatabaseNode.js
@@ -1,0 +1,35 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function addDatabaseNode() {
+    {
+        //region add_1
+        // Create the AddDatabaseNodeOperation
+        // Add a random node to 'Northwind' database-group
+        const addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind");
+
+        // Execute the operation by passing it to maintenance.server.send
+        const result = await documentStore.maintenance.server.send(addDatabaseNodeOp);
+
+        // Can access the new topology
+        const numberOfReplicas = getAllNodesFromTopology(result.topology).length;
+        //endregion    
+    }
+    {
+        //region add_2
+        // Create the AddDatabaseNodeOperation
+        // Add node C to 'Northwind' database-group
+        const addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind", "C"));
+
+        // Execute the operation by passing it to maintenance.server.send
+        const result = await documentStore.maintenance.server.send(addDatabaseNodeOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const addDatabaseNodeOp = new AddDatabaseNodeOperation(databaseName, nodeTag?);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Server/compact.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Server/compact.js
@@ -1,0 +1,113 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function compact() {
+    {
+        //region compact_0
+        // Define the compact settings
+        const compactSettings = {
+            // Database to compact
+            databaseName: "Northwind",
+
+            // Set 'documents' to true to compact all documents in database
+            // Indexes are not set and will not be compacted
+            documents: true
+        };
+
+        // Define the compact operation, pass the settings
+        const compactOp = new CompactDatabaseOperation(compactSettings);
+
+        // Execute compaction by passing the operation to maintenance.server.send
+        const asyncOperation = await documentStore.maintenance.server.send(compactOp);
+        
+        // Wait for operation to complete, during compaction the database is offline
+        await asyncOperation.waitForCompletion();
+        //endregion    
+    }
+    {
+        //region compact_1
+        // Define the compact settings
+        const compactSettings = {
+            // Database to compact
+            databaseName: "Northwind",
+
+            // Setting 'documents' to false will compact only the specified indexes
+            documents: false,
+
+            // Specify which indexes to compact
+            indexes: ["Orders/Totals", "Orders/ByCompany"] 
+        };
+
+        // Define the compact operation, pass the settings
+        const compactOp = new CompactDatabaseOperation(compactSettings);
+
+        // Execute compaction by passing the operation to maintenance.server.send
+        const asyncOperation = await documentStore.maintenance.server.send(compactOp);
+        // Wait for operation to complete
+        await asyncOperation.waitForCompletion();
+        //endregion    
+    }
+    {
+        //region compact_2
+        // Get all indexes names in the database using the 'GetIndexNamesOperation' operation
+        // Use 'forDatabase' if the target database is different than the default database defined on the store
+        const allIndexNames = await documentStore.maintenance.forDatabase("Northwind")
+            .send(new GetIndexNamesOperation(0, 50));
+
+        // Define the compact settings
+        const compactSettings = {
+            databaseName: "Northwind", // Database to compact
+
+            documents: true,           // Compact all documents
+
+            indexes: allIndexNames,    // All indexes will be compacted
+        };
+
+        // Define the compact operation, pass the settings
+        const compactOp = new CompactDatabaseOperation(settings);
+    
+        // Execute compaction by passing the operation to maintenance.server.send
+        const asyncOperation = await documentStore.maintenance.server.send(compactOp);
+        // Wait for operation to complete
+        await asyncOperation.waitForCompletion();
+        //endregion    
+    }
+    {
+        //region compact_3
+        // Get all member nodes in the database-group using the 'GetDatabaseRecordOperation' operation
+        const databaseRecord =
+            await documentStore.maintenance.server.send(new GetDatabaseRecordOperation("Northwind"));
+        const allMemberNodes = databaseRecord.topology.members;
+
+        // Define the compact settings as needed
+        const compactSettings = {
+            // Database to compact
+            databaseName: "Northwind",
+
+            //Compact all documents in database
+            documents: true
+        };
+
+        // Execute the compact operation on each member node
+        for (let i = 0; i < allMemberNodes.length; i++) {
+            // Define the compact operation, pass the settings
+            const compactOp = new CompactDatabaseOperation(compactSettings);
+            
+            // Execute the operation on a specific node
+            // Use `forNode` to specify the node to operate on
+            const serverOpExecutor = await documentStore.maintenance.server.forNode(allMemberNodes[i]);
+            const asyncOperation = await serverOpExecutor.send(compactOp);
+            
+            // Wait for operation to complete
+            await asyncOperation.waitForCompletion();
+        }
+        //endregion
+    }
+}
+
+{
+    //region syntax
+    const compactOperation = new CompactDatabaseOperation(compactSettings);
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/Server/toggleDatabasesState.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/Server/toggleDatabasesState.js
@@ -1,0 +1,52 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function toggleDatabasesState() {
+    {
+        //region enable
+        // Define the toggle state operation
+        // specify the database name & pass 'false' to enable
+        const enableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", false);
+
+        // To enable multiple databases use:
+        // const enableDatabaseOp =
+        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], false);
+
+        // Execute the operation by passing it to maintenance.server.send
+        const toggleResult = await documentStore.maintenance.server.send(enableDatabaseOp);
+        //endregion
+    }
+    {
+        //region disable
+        // Define the toggle state operation
+        // specify the database name(s) & pass 'true' to disable
+        const disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", true);
+
+        // To disable multiple databases use:
+        // const disableDatabaseOp =
+        //     new ToggleDatabasesStateOperation(["DB1", "DB2", ...], true);
+        
+        // Execute the operation by passing it to maintenance.server.send
+        const toggleResult = await documentStore.maintenance.server.send(disableDatabaseOp);
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    // Available overloads:
+    const enableDatabaseOp = new ToggleDatabasesStateOperation(databaseName, disable);
+    const enableDatabaseOp = new ToggleDatabasesStateOperation(databaseNames, disable);
+    //endregion
+
+    //region syntax_2
+    // Executing the operation returns an object with the following properties:
+    {
+        disabled, // Is database disabled
+        name,     // Name of the database
+        success,  // Has request succeeded
+        reason    // Reason for success or failure
+    }
+    //endregion
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.py
@@ -1,0 +1,51 @@
+from ravendb import MaintenanceOperationExecutor, DocumentStore, GetStatisticsOperation
+from ravendb.documents.operations.executor import OperationExecutor
+from ravendb.documents.operations.revisions import GetRevisionsOperation
+
+from examples_base import ExampleBase, Order, Company
+
+
+class SwitchOperationsToDifferentDatabase(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    class Foo:
+        # region syntax_1
+        def for_database(self, database_name: str) -> OperationExecutor: ...
+
+        # endregion
+        # region syntax_2
+        def for_database(self, database_name: str) -> MaintenanceOperationExecutor: ...
+
+        # endregion
+
+    def test_switch_operations_to_different_database(self):
+        # region for_database_1
+        # Define default database on the store
+        document_store = DocumentStore(urls=["yourServerURL"], database="DefaultDB")
+        document_store.initialize()
+
+        with document_store:
+            # Use 'for_database', get operation executor for another database
+            op_executor = document_store.operations.for_database("AnotherDB")
+
+            # Send the operation, e.g. 'GetRevisionsOperation' will be executed on "AnotherDB"
+            revisions_in_another_db = op_executor.send(GetRevisionsOperation("Orders/1-A", Order))
+
+            # Without 'for_database', the operation is executed "DefaultDB"
+            revisions_in_default_db = document_store.operations.send(GetRevisionsOperation("Company/1-A", Company))
+        # endregion
+
+        # region for_database_2
+        # Define default database on the store
+        document_store = DocumentStore(urls=["yourServerURL"], database="DefaultDB")
+        document_store.initialize()
+
+        with DocumentStore() as document_store:
+            # Use 'for_database', get maintenance operation executor for another database
+            op_executor = document_store.maintenance.for_database("AnotherDB")
+            # Send the maintenance operation, e.g. get database stats for "AnotherDB"
+            stats_for_another_db = op_executor.send(GetStatisticsOperation())
+            # Without 'for_database', the stats are retrieved for "DefaultDB"
+            stats_for_default_db = document_store.maintenance.send(GetStatisticsOperation())
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndex.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndex.py
@@ -1,0 +1,58 @@
+from typing import List
+
+from ravendb import GetIndexOperation, GetIndexesOperation, IndexDefinition
+from ravendb.documents.operations.definitions import MaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class GetIndex(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_index(self):
+        with self.embedded_server.get_document_store("GetIndex") as store:
+            # region get_index
+            # Define the get index operation, pass the index name
+            get_index_op = GetIndexOperation("Orders/Totals")
+
+            # Execute the operation by passing it to maintenance.send
+            index = store.maintenance.send(get_index_op)
+
+            # Access the index definition
+            state = index.state
+            lock_mode = index.lock_mode
+            deployment_mode = index.deployment_mode
+            # etc.
+
+            # endregion
+
+            # region get_indexes
+            # Define the get indexes operation
+            # Pass number of indexes to skip & number of indexes to retrieve
+            get_index_op = GetIndexesOperation(0, 10)
+
+            # Execute the operation by passing it to maintenance.send
+            indexes = store.maintenance.send(get_index_op)
+
+            # indexes will contain the first 10 indexes, alphabetically ordered by index name
+            # Access an index definition from the resulting list:
+            name = indexes[0].name
+            state = indexes[0].state
+            lock_mode = indexes[0].lock_mode
+            deployment_mode = indexes[0].deployment_mode
+            # etc.
+            # endregion
+
+    class Foo:
+        # region get_index_syntax
+
+        class GetIndexOperation(MaintenanceOperation[IndexDefinition]):
+            def __init__(self, index_name: str): ...
+
+        # endregion
+        # region get_indexes_syntax
+        class GetIndexesOperation(MaintenanceOperation[List[IndexDefinition]]):
+            def __init__(self, start: int, page_size: int): ...
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndexErrors.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndexErrors.py
@@ -1,0 +1,76 @@
+import datetime
+from typing import Optional, List
+
+from ravendb import GetIndexErrorsOperation
+from ravendb.documents.indexes.definitions import IndexingError, IndexErrors
+from ravendb.documents.operations.definitions import MaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class GetIndexErrors(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_index_errors(self):
+        with self.embedded_server.get_document_store("GetIndexErrors") as store:
+            # region get_errors_all
+            # Define the get index errors operation
+            get_index_errors_op = GetIndexErrorsOperation()
+
+            # Execute the operation by passing it to maintenance.send
+            index_errors = store.maintenance.send(get_index_errors_op)
+
+            # index_errors will contain errors for ALL indexes
+            # endregion
+
+            # region get_errors_specific
+            # Define the get index errors operation for specific indexes
+            get_index_errors_op = GetIndexErrorsOperation("Orders/Totals")
+
+            # Execute the operation by passing it to maintenance.send
+            # An exception will be thrown if any of the specified indexes do not exist
+            index_errors = store.maintenance.send(get_index_errors_op)
+
+            # index_errors will contain errors only for index "Orders/Totals"
+            # endregion
+
+    class Foo:
+        # region syntax_1
+        class GetIndexErrorsOperation(MaintenanceOperation[List[IndexErrors]]):
+            def __init__(self, *index_names: str):  # If no index_names provided, get errors for all indexes
+                ...
+
+        # endregion
+        # region syntax_2
+        class IndexErrors:
+            def __init__(self, name: Optional[str] = None, errors: Optional[List[IndexingError]] = None):
+                self.name = name  # Index name
+                self.errors = errors  # List of errors for this index
+
+        # endregion
+
+        # region syntax_3
+        class IndexingError:
+            def __init__(
+                self,
+                error: Optional[str] = None,
+                timestamp: Optional[datetime.datetime] = None,
+                document: Optional[str] = None,
+                action: Optional[str] = None,
+            ):
+                # Error message
+                self.error = error
+
+                # Time of error
+                self.timestamp = timestamp
+
+                # If action is 'Map'    - field will contain the document ID
+                # If action is 'Reduce' - field will contain the Reduce key value
+                # For all other actions - field will be None
+                self.document = document
+
+                # Area where error has occurred, e.g. Map/Reduce/Analyzer/Memory/etc.
+                self.action = action
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndexNames.py
@@ -1,0 +1,29 @@
+from ravendb import GetIndexNamesOperation
+from ravendb.documents.operations.definitions import MaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class GetIndexNames(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_index_names(self):
+        with self.embedded_server.get_document_store("IndexNames") as store:
+            # region get_index_names
+            # Define the get index names operation
+            # Pass number of indexes to skip & number of indexes to retrieve
+            get_index_names_op = GetIndexNamesOperation(0, 10)
+
+            # Execute the operation by passing it to maintenance.send
+            index_names = store.maintenance.send(get_index_names_op)
+
+            # index_names will contain the first 10 indexes, alphabetically ordered
+            # endregion
+
+    class Foo:
+        # region get_index_names_syntax
+        class GetIndexNamesOperation(MaintenanceOperation):
+            def __init__(self, start: int, page_size: int): ...
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/GetIndexTerms.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+
+from ravendb import GetTermsOperation
+from ravendb.documents.operations.definitions import MaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class GetIndexTerms(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_index_terms(self):
+        with self.embedded_server.get_document_store("GetIndexTerms") as store:
+            # region get_index_terms
+            # Define the get terms operation
+            # Pass the requested index-name, index-filed, start value & page size
+            get_terms_op = GetTermsOperation("Orders/Totals", "Employee", "employees/5-A", 10)
+
+            # Execute the operation by passing it to maintenance.send
+            field_terms = store.maintenance.send(get_terms_op)
+
+            # field_terms will contain alle the terms that come after term 'employees/5-A' for index-field 'Employee'
+            # endregion
+
+    class Foo:
+        # region get_index_terms_syntax
+        class GetTermsOperation(MaintenanceOperation[List[str]]):
+            def __init__(self, index_name: str, field: str, from_value: Optional[str], page_size: int = None): ...
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/IndexHasChanged.py
@@ -1,0 +1,36 @@
+from ravendb import IndexDefinition, IndexHasChangedOperation
+from ravendb.documents.operations.definitions import MaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class IndexHasChanged(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_index_has_changed(self):
+        with self.embedded_server.get_document_store("IndexHasChanged") as store:
+            # region index_has_changed
+            # Some index definition
+            index_definition = IndexDefinition(
+                name="UsersByName", maps={"from user in docs.Users select new { user.Name }"}
+            )
+
+            # Define the has-changed operation, pass the index definition
+            index_has_changed_op = IndexHasChangedOperation(index_definition)
+
+            # Execute the operation by passing it to maintenance.send
+            index_has_changed = store.maintenance.send(index_has_changed_op)
+
+            # Return values:
+            # False: The definition of the index passed is the SAME as the one deployed on the server
+            # True:  The definition of the index passed is DIFFERENT from the one deployed on the server
+            #        Or - index does not exist
+            # endregion
+
+    class Foo:
+        # region syntax
+        class IndexHasChangedOperation(MaintenanceOperation[bool]):
+            def __init__(self, index: IndexDefinition): ...
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/SetPriority.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Maintenance/Indexes/SetPriority.py
@@ -1,0 +1,49 @@
+from enum import Enum
+
+from ravendb import SetIndexesPriorityOperation
+from ravendb.documents.indexes.definitions import IndexPriority
+from ravendb.documents.operations.definitions import VoidMaintenanceOperation
+
+from examples_base import ExampleBase
+
+
+class SetPriority(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_set_priority(self):
+        with self.embedded_server.get_document_store("SetPriority") as store:
+            # region set_priority_single
+            # Define the set priority operation
+            # Pass index name & priority
+            set_priority_op = SetIndexesPriorityOperation(IndexPriority.HIGH, "Orders/Totals")
+
+            # Execute the operation by passing it to maintenance.send
+            # An exception will be thrown if index does not exist
+            store.maintenance.send(set_priority_op)
+            # endregion
+
+            # region set_priority_multiple
+            # Define the set priority operation, pass multiple index names
+            set_priority_op = SetIndexesPriorityOperation(IndexPriority.LOW, "Orders/Totals", "Orders/ByCompany")
+
+            # Execute the operation by passing it to maintenance.send
+            # An exception will be thrown if any of the specified indexes do not exist
+            store.maintenance.send(set_priority_op)
+            # endregion
+
+    class Foo:
+        # region syntax_1
+        class SetIndexesPriorityOperation(VoidMaintenanceOperation):
+            def __init__(self, priority: IndexPriority, *index_names: str): ...
+
+        # endregion
+
+    class Priority:
+        # region syntax_2
+        class IndexPriority(Enum):
+            LOW = "Low"
+            NORMAL = "Normal"
+            HIGH = "High"
+
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Server/AddDatabaseNode.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Server/AddDatabaseNode.py
@@ -1,0 +1,39 @@
+from ravendb.serverwide.operations.common import DatabasePutResult, ServerOperation
+
+from examples_base import ExampleBase
+
+
+class Foo:
+    # region syntax
+    class AddDatabaseNodeOperation(ServerOperation[DatabasePutResult]):
+        def __init__(self, database_name: str, node_tag: str = None): ...
+
+    # endregion
+
+
+class AddDatabaseNode(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_add_database_node(self):
+        with self.embedded_server.get_document_store("AddDatabaseNode") as store:
+            # region add_1
+            # Create the AddDatabaseNodeOperation
+            # Add a random node to 'Northwind' database-group
+            add_database_node_op = AddDatabaseNodeOperation("Northwind")
+
+            # Execute the operation by passing it to maintenance.server.send
+            result = store.maintenance.server.send(add_database_node_op)
+
+            # Can access the new topology
+            number_of_replicas = len(result.topology.all_nodes)
+            # endregion
+
+            # region add_2
+            # Create the AddDatabaseNodeOperation
+            # Add node C to 'Northwind
+            add_database_node_op = AddDatabaseNodeOperation("Northwind", "C")
+
+            # Execute the operation by passing it to maintenance.server.send
+            result = store.maintenance.server.send(add_database_node_op)
+            # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Server/Compact.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Server/Compact.py
@@ -1,0 +1,111 @@
+from ravendb import GetIndexNamesOperation, GetDatabaseRecordOperation
+from ravendb.documents.operations.compact import CompactDatabaseOperation
+from ravendb.documents.operations.definitions import OperationIdResult
+from ravendb.primitives.constants import int_max
+from ravendb.serverwide.misc import CompactSettings
+from ravendb.serverwide.operations.common import ServerOperation
+
+from examples_base import ExampleBase
+
+
+class Foo:
+    class CompactDatabaseOperation(ServerOperation[OperationIdResult]):
+        def __init__(self, compact_settings: CompactSettings) -> None: ...
+
+
+class Compact(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_compact(self):
+        with self.embedded_server.get_document_store("Compact") as store:
+            # region compact_0
+            # Define the compact settings
+            settings = CompactSettings(
+                # Database to compact
+                "Northwind",
+                # Set 'documents' to True to compact all documents in database
+                # Indexes are not set and will not be compacted
+                documents=True,
+            )
+
+            # Define the compact operation, pass the settings
+            compact_op = CompactDatabaseOperation(settings)
+
+            # Execute compaction by passing the operation to maintenance.server.send
+            operation = store.maintenance.server.send_async(compact_op)
+
+            # Wait for operation to complete, during compaction the database is offline
+            operation.wait_for_completion()
+            # endregion
+
+            # region compact_1
+            # Define the compact settings
+            settings = CompactSettings(
+                # Database to compact
+                database_name="Northwind",
+                # Setting 'documents' to False will compact only the specified indexes
+                documents=False,
+                # Specify which indexes to compact
+                indexes=["Orders/Totals", "Orders/ByCompany"],
+                # Optimize indexes is Lucene's feature to gain disk space and efficiency
+                # Set whether to skip this optimization when compacting the indexes
+                skip_optimize_indexes=False,
+            )
+            # Define the compact operation, pass the settings
+            compact_op = CompactDatabaseOperation(settings)
+
+            # Execute compaction by passing the operation to maintenance.server.send
+            operation = store.maintenance.server.send_async(compact_op)
+            # Wait for operation to complete
+            operation.wait_for_completion()
+            # endregion
+
+            # region compact_2
+            #  Get all indexes names in the database using the 'GetIndexNamesOperation' operation
+            #  Use 'ForDatabase' if the target database is different from the default database defined on the store
+            all_indexes_names = store.maintenance.for_database("Northwind").send(GetIndexNamesOperation(0, int_max))
+
+            # Define the compact settings
+            settings = CompactSettings(
+                database_name="Northwind",  # Database to compact
+                documents=True,  # Compact all documents
+                indexes=all_indexes_names,  # All indexes will be compacted
+                skip_optimize_indexes=True,  # Skip Lucene's indexes optimization
+            )
+
+            # Define the compact operation, pass the settings
+            compact_op = CompactDatabaseOperation(settings)
+
+            # Execute compaction by passing the operation to maintenance.server.send
+            operation = store.maintenance.server.send(compact_op)
+            # Wait for operation to complete
+            operation.wait_for_completion()
+            # endregion
+
+            # region compact_3
+            # Get all member nodes in the database-group using the 'GetDatabaseRecordOperation' operation
+            all_member_nodes = store.maintenance.server.send(GetDatabaseRecordOperation("Northwind")).topology.members
+
+            # Define the compact settings as needed
+            settings = CompactSettings(
+                # Database to compact
+                database_name="Northwind",
+                # Compact all documents in database
+                documents=True,
+            )
+
+            # Execute the compact operation on each member node
+            for node_tag in all_member_nodes:
+                # Define the compact operation, pass the settings
+                compact_op = CompactDatabaseOperation(settings)
+
+                # Execute the operation on a specific node
+                # Use 'for_node' to specify the node to operate on
+                # todo: https://issues.hibernatingrhinos.com/issue/RDBC-847/Implement-documentStore.Maintenance.Server.ForNode
+                operation = store.maintenance.server.for_node(node_tag).send_async(compact_op)
+
+                # Wait for operation to complete
+                operation.wait_for_completion()
+
+            # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Operations/Server/ToggleDatabasesState.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Operations/Server/ToggleDatabasesState.py
@@ -1,0 +1,66 @@
+import pathlib
+from typing import List
+
+from ravendb.documents.operations.server_misc import ToggleDatabasesStateOperation, DisableDatabaseToggleResult
+from ravendb.serverwide.operations.common import ServerOperation
+
+from examples_base import ExampleBase
+
+
+class ToggleDatabasesState(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_toggle_databases_state(self):
+        with self.embedded_server.get_document_store("ToggleDatabasesState") as store:
+            # region enable
+            # Define the toggle state operation
+            # specify the database name & pass 'False' to enable
+            enable_database_op = ToggleDatabasesStateOperation("Northwind", disable=False)
+
+            # To enable multiple databases use:
+            # enable_database_op = ToggleDatabasesStateOperation.from_multiple_names(["DB1", "DB2", ...], disable=False)
+
+            # Execute the operation by passing it to maintenance.server.send
+            toggle_result = store.maintenance.server.send(enable_database_op)
+            # endregion
+
+            # region disable
+            # Define the toggle state operation
+            # specify the database name(s) & pass 'True' to disable
+            disable_database_op = ToggleDatabasesStateOperation("Northwind", disable=True)
+
+            # To disable multiple databases use:
+            # enable_database_op = ToggleDatabasesStateOperation.from_multiple_names(["DB1", "DB2", ...], disable=True)
+
+            # Execute the operation by passing it to maintenance.server.send
+            toggle_result = store.maintenance.server.send(disable_database_op)
+            # endregion
+
+            database_path = "db_path"
+            # region disable-database-via-file-system
+            # Prevent database access by creating disable.marker in its path
+            disable_marker_path = pathlib.Path(database_path, "disable.marker")
+            disable_marker_path.touch()
+            # endregion
+
+    class Foo:
+        class ToggleDatabasesStateOperation:
+            # region syntax_1
+            class ToggleDatabasesStateOperation(ServerOperation[DisableDatabaseToggleResult]):
+                def __init__(self, database_name: str, disable: bool): ...
+                @classmethod
+                def from_multiple_names(cls, database_names: List[str], disable: bool): ...
+
+            # endregion
+            # region syntax_2
+            class DisableDatabaseToggleResult:
+                def __init__(
+                    self, disabled: bool = None, name: str = None, success: bool = None, reason: str = None
+                ) -> None:
+                    self.disabled = disabled  # Is database disabled
+                    self.name = name  # Name of the database
+                    self.success = success  # Has request succeeded
+                    self.reason = reason  # Reason for success or failure
+
+            # endregion


### PR DESCRIPTION
related issues:
[RDoc-2816](https://issues.hibernatingrhinos.com/issue/RDoc-2816/Python-Client-API-Operations-Maintenance-Indexes-Set-index-priority-Replace-C-samples) Set index priority
[RDoc-2817](https://issues.hibernatingrhinos.com/issue/RDoc-2817/Python-Client-API-Operations-Maintenance-Indexes-Get-index-errors-Replace-C-samples) Get index errors
[RDoc-2818](https://issues.hibernatingrhinos.com/issue/RDoc-2818/Python-Client-API-Operations-Maintenance-Indexes-Get-index-names-Replace-C-samples) Get index names
[RDoc-2819](https://issues.hibernatingrhinos.com/issue/RDoc-2819/Python-Client-API-Operations-Maintenance-Indexes-Get-index-Replace-C-samples) Get index
[RDoc-2820](https://issues.hibernatingrhinos.com/issue/RDoc-2820/Python-Client-API-Operations-Maintenance-Indexes-Get-indexes-Replace-C-samples) Get indexes
[RDoc-2821](https://issues.hibernatingrhinos.com/issue/RDoc-2821/Python-Client-API-Operations-Maintenance-Indexes-Get-terms-Replace-C-samples) Get terms
[RDoc-2822](https://issues.hibernatingrhinos.com/issue/RDoc-2822/Python-Client-API-Operations-Maintenance-Indexes-Index-has-changed-Replace-C-samples) Index has changed
[RDoc-2799](https://issues.hibernatingrhinos.com/issue/RDoc-2799/Python-Client-API-Operations-Server-Wide-Add-database-node-Replace-C-samples) Add database node
[RDoc-2800](https://issues.hibernatingrhinos.com/issue/RDoc-2800/Python-Client-API-Operations-Server-Wide-Compact-database-Replace-C-samples) Compact database
[RDoc-2801](https://issues.hibernatingrhinos.com/issue/RDoc-2801/Python-Client-API-Operations-Server-Wide-Toggle-database-state-Replace-C-samples) Toggle database state
[RDoc-2802](https://issues.hibernatingrhinos.com/issue/RDoc-2802/Python-Client-API-Operations-How-to-Switch-operation-to-diff-database-Replace-C-samples) Switch operation to diff database