### PR TITLE
[Python] Configuration and Commands pages batch [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.dotnet.markdown
@@ -1,19 +1,35 @@
-# Commands: Documents: Delete
+# Commands: Delete Document
 
-**Delete** is used to remove a document from a database.
+{NOTE: }
 
-## Syntax
+* Use `DeleteDocumentCommand` to remove a document from the database.
+
+* In this page:
+
+    * [Example](../../../client-api/commands/documents/delete#example)
+    * [Syntax](../../../client-api/commands/documents/delete#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Example}
+
+{CODE delete_sample@ClientApi\Commands\Documents\Delete.cs /}
+
+{PANEL/}
+
+
+{PANEL: Syntax}
 
 {CODE delete_interface@ClientApi\Commands\Documents\Delete.cs /}
 
-| Parameters       |        |                                                                          |
-|------------------|--------|--------------------------------------------------------------------------|
-| **id**           | string | ID of a document to be deleted                                           |
-| **changeVector** | string | Entity Change Vector, used for concurrency checks (`null` to skip check) |
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **id**           | `string` | ID of a document to be deleted |
+| **changeVector** | `string` | Entity Change Vector, used for concurrency checks (`null` to skip check) |
 
-## Example
-
-{CODE delete_sample@ClientApi\Commands\Documents\Delete.cs /}
+{PANEL/}
 
 ## Related Articles
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.java.markdown
@@ -8,8 +8,8 @@
 
 | Parameters | | |
 | ------------- | ------------- | ----- |
-| **id** | String | ID of a document to be deleted |
-| **changeVector** | String | Entity Change Vector, used for concurrency checks (`null` to skip check) |
+| **id** | `String` | ID of a document to be deleted |
+| **changeVector** | `String` | Entity Change Vector, used for concurrency checks (`null` to skip check) |
 
 ## Example
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.js.markdown
@@ -1,8 +1,8 @@
-# Delete Document Command
+# Commands: Delete Document
 
 {NOTE: }
 
-* Use the `DeleteDocumentCommand` to remove a document from the database.
+* Use `DeleteDocumentCommand` to remove a document from the database.
 
 * In this page:
 
@@ -23,10 +23,10 @@
 
 {CODE:nodejs syntax@client-api\commands\documents\delete.js /}
 
-| Parameter        | Type   | Description                                                             |
-|------------------|--------|-------------------------------------------------------------------------|
-| __id__           | string | ID of a document to be deleted                                          |
-| __changeVector__ | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| Parameter        | Type     | Description                                                             |
+|------------------|----------|-------------------------------------------------------------------------|
+| **id**           | `string` | ID of a document to be deleted                                          |
+| **changeVector** | `string` | Entity changeVector, used for concurrency checks (`null` to skip check) |
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/delete.python.markdown
@@ -1,0 +1,40 @@
+# Commands: Delete Document
+
+{NOTE: }
+
+* Use `DeleteDocumentCommand` to remove a document from the database.
+
+* In this page:
+
+    * [Example](../../../client-api/commands/documents/delete#example)
+    * [Syntax](../../../client-api/commands/documents/delete#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Example}
+
+{CODE:python delete_sample@ClientApi\Commands\Documents\Delete.py /}
+
+{PANEL/}
+
+
+{PANEL: Syntax}
+
+{CODE:python delete_interface@ClientApi\Commands\Documents\Delete.py /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **key**           | `str` | ID of a document to be deleted |
+| **change_vector** | `str` (optional) | Entity Change Vector, used for concurrency checks (`None` to skip check) |
+
+{PANEL/}
+
+## Related Articles
+
+### Commands 
+
+- [Get](../../../client-api/commands/documents/get)  
+- [Put](../../../client-api/commands/documents/put)  
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.dotnet.markdown
@@ -99,8 +99,8 @@
 |------------|------|-------------|
 | **startsWith** | `string` | prefix for which documents should be returned |
 | **startAfter** | `string` | skip 'document fetching' until the given ID is found, and return documents after that ID (default: null) |
-| **matches** | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should be matched ('?' any single character, '*' any characters) |
-| **exclude** | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should **not** be matched ('?' any single character, '*' any characters) |
+| **matches** | `string` | pipe ('&#124;') separated values for which document IDs (after `startsWith`) should be matched ('?' any single character, '*' any characters) |
+| **exclude** | `string` | pipe ('&#124;') separated values for which document IDs (after `startsWith`) should **not** be matched ('?' any single character, '*' any characters) |
 | **start** | `int` | number of documents that should be skipped |
 | **pageSize** | `int` | maximum number of documents that will be retrieved |
 | **metadataOnly** | `bool` | specifies whether or not only document metadata should be returned |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.dotnet.markdown
@@ -1,0 +1,130 @@
+# Commands: Get Documents
+
+{NOTE: }
+
+* Use `GetDocumentsCommand` to retrieve documents from the database.
+
+* In this page:
+   - [Get single document](../../../client-api/commands/documents/get#get-single-document)   
+   - [Get multiple documents](../../../client-api/commands/documents/get#get-multiple-documents)   
+   - [Get paged documents](../../../client-api/commands/documents/get#get-paged-documents)   
+   - [Get documents by ID prefix](../../../client-api/commands/documents/get#get-documents-by-id-prefix)  
+
+{NOTE/}
+
+---
+
+{PANEL: Get single document}
+
+**GetDocumentsCommand** can be used to retrieve a single document
+
+#### Syntax:
+
+{CODE get_interface_single@ClientApi\Commands\Documents\Get.cs /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **id** | `string` | ID of the documents to get |
+| **includes** | `string[]` | Related documents to fetch along with the document |
+| **metadataOnly** | `boolean` | Whether to fetch the whole document or just the metadata. |
+
+---
+
+#### Example:
+
+{CODE get_sample_single@ClientApi\Commands\Documents\Get.cs /}
+
+{PANEL/}
+
+{PANEL: Get multiple documents}
+
+**GetDocumentsCommand** can also be used to retrieve a list of documents.
+
+#### Syntax:
+
+{CODE get_interface_multiple@ClientApi\Commands\Documents\Get.cs /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **ids** | `string[]` | IDs of the documents to get |
+| **includes** | `string` | Related documents to fetch along with the documents |
+| **metadataOnly** | `boolean` | Whether to fetch whole documents or just the metadata |
+
+---
+
+#### Example I
+
+{CODE get_sample_multiple@ClientApi\Commands\Documents\Get.cs /}
+
+#### Example II - Using Includes
+
+{CODE get_sample_includes@ClientApi\Commands\Documents\Get.cs /}
+
+#### Example III - Missing Documents
+
+{CODE get_sample_missing@ClientApi\Commands\Documents\Get.cs /}
+
+{PANEL/}
+
+{PANEL: Get paged documents}
+
+**GetDocumentsCommand** can also be used to retrieve a paged set of documents.
+
+#### Syntax:
+
+{CODE get_interface_paged@ClientApi\Commands\Documents\Get.cs /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **start** | `int` | number of documents that should be skipped  |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+
+---
+
+#### Example:
+
+{CODE get_sample_paged@ClientApi\Commands\Documents\Get.cs /}
+
+{PANEL/}
+
+{PANEL: Get documents by ID prefix}
+
+**GetDocumentsCommand** can be used to retrieve multiple documents for a specified ID prefix.
+
+#### Syntax:
+
+{CODE get_interface_startswith@ClientApi\Commands\Documents\Get.cs /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **startsWith** | `string` | prefix for which documents should be returned |
+| **startAfter** | `string` | skip 'document fetching' until the given ID is found, and return documents after that ID (default: null) |
+| **matches** | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should be matched ('?' any single character, '*' any characters) |
+| **exclude** | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should **not** be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped |
+| **pageSize** | `int` | maximum number of documents that will be retrieved |
+| **metadataOnly** | `bool` | specifies whether or not only document metadata should be returned |
+
+---
+
+#### Example I
+
+{CODE get_sample_startswith@ClientApi\Commands\Documents\Get.cs /}
+
+#### Example II
+
+{CODE get_sample_startswith_matches@ClientApi\Commands\Documents\Get.cs /}
+
+#### Example III
+
+{CODE get_sample_startswith_matches_end@ClientApi\Commands\Documents\Get.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+### Commands 
+
+- [Put](../../../client-api/commands/documents/put)  
+- [Delete](../../../client-api/commands/documents/delete)
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.java.markdown
@@ -1,0 +1,115 @@
+# Commands: Documents: Get
+
+There are a few methods that allow you to retrieve documents from a database:   
+
+- [Get single document](../../../client-api/commands/documents/get#get-single-document)   
+- [Get multiple documents](../../../client-api/commands/documents/get#get-multiple-documents)   
+- [Get paged documents](../../../client-api/commands/documents/get#get-paged-documents)   
+- [Get documents by starts with](../../../client-api/commands/documents/get#get-by-starts-with)  
+
+{PANEL:Get single document}
+
+**GetDocumentsCommand** can be used to retrieve a single document
+
+### Syntax
+
+{CODE:java get_interface_single@ClientApi\Commands\Documents\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **id** | String | ID of the documents to get |
+| **includes** | String[] | Related documents to fetch along with the document |
+| **metadataOnly** | boolean | Whether to fetch the whole document or just the metadata. |
+
+### Example
+
+{CODE:java get_sample_single@ClientApi\Commands\Documents\Get.java /}
+
+{PANEL/}
+
+{PANEL:Get multiple documents}
+
+**GetDocumentsCommand** can also be used to retrieve a list of documents.
+
+### Syntax
+
+{CODE:java get_interface_multiple@ClientApi\Commands\Documents\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **ids** | String[] | IDs of the documents to get |
+| **includes** | String | Related documents to fetch along with the documents |
+| **metadataOnly** | boolean | Whether to fetch whole documents or just the metadata |
+
+### Example I
+
+{CODE:java get_sample_multiple@ClientApi\Commands\Documents\Get.java /}
+
+### Example II - Using Includes
+
+{CODE:java get_sample_includes@ClientApi\Commands\Documents\Get.java /}
+
+### Example III - Missing Documents
+
+{CODE:java get_sample_missing@ClientApi\Commands\Documents\Get.java /}
+
+{PANEL/}
+
+{PANEL:Get paged documents}
+
+**GetDocumentsCommand** can also be used to retrieve a paged set of documents.
+
+### Syntax
+
+{CODE:java get_interface_paged@ClientApi\Commands\Documents\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **start** | int | number of documents that should be skipped  |
+| **pageSize** | int | maximum number of documents that will be retrieved |
+
+### Example
+
+{CODE:java get_sample_paged@ClientApi\Commands\Documents\Get.java /}
+
+{PANEL/}
+
+{PANEL:Get by starts with}
+
+**GetDocumentsCommand** can be used to retrieve multiple documents for a specified ID prefix.
+
+### Syntax
+
+{CODE:java get_interface_startswith@ClientApi\Commands\Documents\Get.java /}
+
+| Parameters | | |
+| ------------- | ------------- | ----- |
+| **startsWith** | String | prefix for which documents should be returned |
+| **startAfter** | String | skip 'document fetching' until the given ID is found, and return documents after that ID (default: null) |
+| **matches** | String | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should be matched ('?' any single character, '*' any characters) |
+| **exclude** | String | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should **not** be matched ('?' any single character, '*' any characters) |
+| **start** | int | number of documents that should be skipped |
+| **pageSize** | int | maximum number of documents that will be retrieved |
+| **metadataOnly** | boolean | specifies whether or not only document metadata should be returned |
+
+### Example I
+
+{CODE:java get_sample_startswith@ClientApi\Commands\Documents\Get.java /}
+
+### Example II
+
+{CODE:java get_sample_startswith_matches@ClientApi\Commands\Documents\Get.java /}
+
+### Example III
+
+{CODE:java get_sample_startswith_matches_end@ClientApi\Commands\Documents\Get.java /}
+
+{PANEL/}
+
+## Related Articles
+
+### Commands 
+
+- [Put](../../../client-api/commands/documents/put)  
+- [Delete](../../../client-api/commands/documents/delete)
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.js.markdown
@@ -106,8 +106,8 @@
 | **options** | `object` | |
 | &nbsp;&nbsp;*startsWith* | `string` | prefix for which documents should be returned |
 | &nbsp;&nbsp;*startAfter* | `string` | skip 'document fetching' until the given ID is found, and return documents after that ID (default: null) |
-| &nbsp;&nbsp;*matches* | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should be matched ('?' any single character, '*' any characters) |
-| &nbsp;&nbsp;*exclude* | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should **not** be matched ('?' any single character, '*' any characters) |
+| &nbsp;&nbsp;*matches* | `string` | pipe ('&#124;') separated values for which document IDs (after `startsWith`) should be matched ('?' any single character, '*' any characters) |
+| &nbsp;&nbsp;*exclude* | `string` | pipe ('&#124;') separated values for which document IDs (after `startsWith`) should **not** be matched ('?' any single character, '*' any characters) |
 | &nbsp;&nbsp;*start* | `number` | number of documents that should be skipped |
 | &nbsp;&nbsp;*pageSize* | `number` | maximum number of documents that will be retrieved |
 | &nbsp;&nbsp;*metadataOnly* | `boolean` | specifies whether or not only document metadata should be returned |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.js.markdown
@@ -1,0 +1,138 @@
+# Commands: Get Documents
+
+{NOTE: }
+
+* Use `GetDocumentsCommand` to retrieve documents from the database.
+
+* In this page:
+   - [Get single document](../../../client-api/commands/documents/get#get-single-document)   
+   - [Get multiple documents](../../../client-api/commands/documents/get#get-multiple-documents)   
+   - [Get paged documents](../../../client-api/commands/documents/get#get-paged-documents)   
+   - [Get documents by ID prefix](../../../client-api/commands/documents/get#get-documents-by-id-prefix)  
+
+{NOTE/}
+
+---
+
+{PANEL:Get single document}
+
+**GetDocumentsCommand** can be used to retrieve a single document
+
+#### Syntax:
+
+{CODE:nodejs get_interface_single@client-api\commands\documents\get\get.js /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **options** | `object` | |
+| &nbsp;&nbsp;*id* | `string` | ID of the document to get |
+| &nbsp;&nbsp;*includes* | `string[]` | Related documents to fetch along with the document |
+| &nbsp;&nbsp;*metadataOnly* | `boolean` | Whether to fetch the whole document or just the metadata. |
+| &nbsp;&nbsp;*conventions* | D`ocumentConventions` | Document conventions |
+
+---
+
+#### Example:
+
+{CODE:nodejs get_sample_single@client-api\commands\documents\get\get.js /}
+
+{PANEL/}
+
+{PANEL:Get multiple documents}
+
+**GetDocumentsCommand** can also be used to retrieve a list of documents.
+
+#### Syntax:
+
+{CODE:nodejs get_interface_multiple@client-api\commands\documents\get\get.js /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **options** | `object` | |
+| &nbsp;&nbsp;*ids* | `string[]` | IDs of the documents to get |
+| &nbsp;&nbsp;*includes* | `string[]` | Related documents to fetch along with the documents |
+| &nbsp;&nbsp;*metadataOnly* | `boolean` | Whether to fetch whole documents or just the metadata |
+| &nbsp;&nbsp;*conventions* | `DocumentConventions` | Document conventions |
+
+---
+
+#### Example I
+
+{CODE:nodejs get_sample_multiple@client-api\commands\documents\get\get.js /}
+
+#### Example II - Using Includes
+
+{CODE:nodejs get_sample_includes@client-api\commands\documents\get\get.js /}
+
+#### Example III - Missing Documents
+
+{CODE:nodejs get_sample_missing@client-api\commands\documents\get\get.js /}
+
+{PANEL/}
+
+{PANEL:Get paged documents}
+
+**GetDocumentsCommand** can also be used to retrieve a paged set of documents.
+
+#### Syntax:
+
+{CODE:nodejs get_interface_paged@client-api\commands\documents\get\get.js /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **options** | `object` | |
+| &nbsp;&nbsp;*start* | `number` | number of documents that should be skipped  |
+| &nbsp;&nbsp;*pageSize* | `number` | maximum number of documents that will be retrieved |
+| &nbsp;&nbsp;*conventions* | `DocumentConventions` | Document conventions |
+
+---
+
+#### Example:
+
+{CODE:nodejs get_sample_paged@client-api\commands\documents\get\get.js /}
+
+{PANEL/}
+
+{PANEL: Get documents by ID prefix}
+
+**GetDocumentsCommand** can be used to retrieve multiple documents for a specified ID prefix.
+
+#### Syntax:
+
+{CODE:nodejs get_interface_startswith@client-api\commands\documents\get\get.js /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **options** | `object` | |
+| &nbsp;&nbsp;*startsWith* | `string` | prefix for which documents should be returned |
+| &nbsp;&nbsp;*startAfter* | `string` | skip 'document fetching' until the given ID is found, and return documents after that ID (default: null) |
+| &nbsp;&nbsp;*matches* | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should be matched ('?' any single character, '*' any characters) |
+| &nbsp;&nbsp;*exclude* | `string` | pipe ('&#124;') separated values for which document IDs (after 'startsWith') should **not** be matched ('?' any single character, '*' any characters) |
+| &nbsp;&nbsp;*start* | `number` | number of documents that should be skipped |
+| &nbsp;&nbsp;*pageSize* | `number` | maximum number of documents that will be retrieved |
+| &nbsp;&nbsp;*metadataOnly* | `boolean` | specifies whether or not only document metadata should be returned |
+| &nbsp;&nbsp;*conventions* | `DocumentConventions` | Document conventions |
+
+---
+
+#### Example I
+
+{CODE:nodejs get_sample_startswith@client-api\commands\documents\get\get.js /}
+
+#### Example II
+
+{CODE:nodejs get_sample_startswith_matches@client-api\commands\documents\get\get.js /}
+
+#### Example III
+
+{CODE:nodejs get_sample_startswith_matches_end@client-api\commands\documents\get\get.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Commands 
+
+- [Put](../../../client-api/commands/documents/put)  
+- [Delete](../../../client-api/commands/documents/delete)
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/get.python.markdown
@@ -1,0 +1,130 @@
+# Commands: Get Documents
+
+{NOTE: }
+
+* Use `GetDocumentsCommand` to retrieve documents from the database.
+
+* In this page:
+   - [Get single document](../../../client-api/commands/documents/get#get-single-document)   
+   - [Get multiple documents](../../../client-api/commands/documents/get#get-multiple-documents)   
+   - [Get paged documents](../../../client-api/commands/documents/get#get-paged-documents)   
+   - [Get documents by ID prefix](../../../client-api/commands/documents/get#get-documents-by-id-prefix)  
+
+{NOTE/}
+
+---
+
+{PANEL: Get single document}
+
+**GetDocumentsCommand** can be used to retrieve a single document
+
+#### Syntax:
+
+{CODE:python get_interface_single@ClientApi\Commands\Documents\Get.py /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **key** | `str` | ID of the documents to get |
+| **includes** | `List[str]` | Related documents to fetch along with the document |
+| **metadata_only** | `bool` | Whether to fetch the whole document or just the metadata. |
+
+---
+
+#### Example:
+
+{CODE:python get_sample_single@ClientApi\Commands\Documents\Get.py /}
+
+{PANEL/}
+
+{PANEL: Get multiple documents}
+
+**GetDocumentsCommand** can also be used to retrieve a list of documents.
+
+#### Syntax:
+
+{CODE:python get_interface_multiple@ClientApi\Commands\Documents\Get.py /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **keys** | `List[str]` | IDs of the documents to get |
+| **includes** | `List[str]` | Related documents to fetch along with the documents |
+| **metadata_only** | `bool` | Whether to fetch whole documents or just the metadata |
+
+---
+
+#### Example I
+
+{CODE:python get_sample_multiple@ClientApi\Commands\Documents\Get.py /}
+
+#### Example II - Using Includes
+
+{CODE:python get_sample_includes@ClientApi\Commands\Documents\Get.py /}
+
+#### Example III - Missing Documents
+
+{CODE:python get_sample_missing@ClientApi\Commands\Documents\Get.py /}
+
+{PANEL/}
+
+{PANEL: Get paged documents}
+
+**GetDocumentsCommand** can also be used to retrieve a paged set of documents.
+
+#### Syntax:
+
+{CODE:python get_interface_paged@ClientApi\Commands\Documents\Get.py /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **start** | `int` | number of documents that should be skipped  |
+| **page_size** | `int` | maximum number of documents that will be retrieved |
+
+---
+
+#### Example:
+
+{CODE:python get_sample_paged@ClientApi\Commands\Documents\Get.py /}
+
+{PANEL/}
+
+{PANEL: Get documents by ID prefix}
+
+**GetDocumentsCommand** can be used to retrieve multiple documents for a specified ID prefix.
+
+#### Syntax:
+
+{CODE:python get_interface_startswith@ClientApi\Commands\Documents\Get.py /}
+
+| Parameters | Type | Description |
+|------------|------|-------------|
+| **start_with** | `str` | prefix for which documents should be returned |
+| **start_after** | `str` | skip 'document fetching' until the given ID is found, and return documents after that ID (default: None) |
+| **matches** | `str` | pipe ('&#124;') separated values for which document IDs (after `start_with`) should be matched ('?' any single character, '*' any characters) |
+| **exclude** | `str` | pipe ('&#124;') separated values for which document IDs (after `start_with`) should **not** be matched ('?' any single character, '*' any characters) |
+| **start** | `int` | number of documents that should be skipped |
+| **page_size** | `int` | maximum number of documents that will be retrieved |
+| **metadata_only** | `bool` | specifies whether or not only document metadata should be returned |
+
+---
+
+#### Example I
+
+{CODE:python get_sample_startswith@ClientApi\Commands\Documents\Get.py /}
+
+#### Example II
+
+{CODE:python get_sample_startswith_matches@ClientApi\Commands\Documents\Get.py /}
+
+#### Example III
+
+{CODE:python get_sample_startswith_matches_end@ClientApi\Commands\Documents\Get.py /}
+
+{PANEL/}
+
+## Related Articles
+
+### Commands 
+
+- [Put](../../../client-api/commands/documents/put)  
+- [Delete](../../../client-api/commands/documents/delete)
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.dotnet.markdown
@@ -1,30 +1,36 @@
-# Commands: Documents: Put
+# Commands: Put Document
 ---
 
 {NOTE: }
-**Put** is used to insert or update a document in a database.
 
-In this page:
+* Use `PutDocumentCommand` to insert a document to the database or update an existing document.
 
-* [Syntax](../../../client-api/commands/documents/put#syntax)
-* [Example](../../../client-api/commands/documents/put#example)
+* In this page:
+
+   * [Example](../../../client-api/commands/documents/put#example)
+   * [Syntax](../../../client-api/commands/documents/put#syntax)
 
 {NOTE/}
 
-## Syntax
+---
+
+{PANEL: Example}
+
+{CODE put_sample@ClientApi\Commands\Documents\Put.cs /}
+
+{PANEL/}
+
+{PANEL: Syntax}
 
 {CODE put_interface@ClientApi\Commands\Documents\Put.cs /}
 
 | Parameters | Type | Description |
 | ------------- | ------------- | ----- |
-| **conventions** | DocumentConventions | Document conventions |
-| **id** | string | Unique ID under which document will be stored |
-| **changeVector** | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
-| **document** | BlittableJsonReaderObject | The document to store. You may use `session.Advanced.JsonConverter.ToBlittable(doc, docInfo);` to convert your entity to a `BlittableJsonReaderObject`. |
+| **id** | `string` | Unique ID under which document will be stored |
+| **changeVector** | `string` | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **document** | `BlittableJsonReaderObject` | The document to store. You may use `session.Advanced.JsonConverter.ToBlittable(doc, docInfo);` to convert your entity to a `BlittableJsonReaderObject`. |
 
-## Example
-
-{CODE put_sample@ClientApi\Commands\Documents\Put.cs /}
+{PANEL/}
 
 ## Related Articles
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.js.markdown
@@ -1,9 +1,9 @@
-# Put Document Command
+# Commands: Put Document
 ---
 
 {NOTE: }
 
-* Use the `PutDocumentCommand` to insert or update a document in the database.
+* Use `PutDocumentCommand` to insert a document to the database or update an existing document.
 
 * In this page:
 
@@ -24,11 +24,11 @@
 
 {CODE:nodejs syntax_1@client-api\commands\documents\put.js /}
 
-| Parameter        | Type   | Description                                                             |
-|------------------|--------|-------------------------------------------------------------------------|
-| __id__           | string | Unique ID under which document will be stored                           |
-| __changeVector__ | string | Entity changeVector, used for concurrency checks (`null` to skip check) |
-| __document__     | object | The document to store.                                                  |
+| Parameter        | Type     | Description                                                             |
+|------------------|----------|-------------------------------------------------------------------------|
+| **id**           | `string` | Unique ID under which document will be stored                           |
+| **changeVector** | `string` | Entity changeVector, used for concurrency checks (`null` to skip check) |
+| **document**     | `object` | The document to store.                                                  |
 
 {CODE:nodejs syntax_2@client-api\commands\documents\put.js /}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/commands/documents/put.python.markdown
@@ -1,0 +1,41 @@
+# Commands: Put Document
+---
+
+{NOTE: }
+
+* Use `PutDocumentCommand` to insert a document to the database or update an existing document.
+
+* In this page:
+
+   * [Example](../../../client-api/commands/documents/put#example)
+   * [Syntax](../../../client-api/commands/documents/put#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Example}
+
+{CODE:python put_sample@ClientApi\Commands\Documents\Put.py /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:python put_interface@ClientApi\Commands\Documents\Put.py /}
+
+| Parameters | Type | Description |
+| ------------- | ------------- | ----- |
+| **key** | `str` | Unique ID under which document will be stored |
+| **change_vector** | `str` (optional) | Entity changeVector, used for concurrency checks (`None` to skip check) |
+| **document** | `dict` | The document to store |
+
+{PANEL/}
+
+## Related Articles
+
+### Commands
+
+- [Get](../../../client-api/commands/documents/get)
+- [Delete](../../../client-api/commands/documents/delete)
+- [How to Send Multiple Commands Using a Batch](../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/.docs.json
@@ -1,0 +1,35 @@
+[
+    {
+        "Path": "overview.markdown",
+        "Name": "Overview",
+        "DiscussionId": "b0d33f30-29ae-4972-8342-e6ce5ac9a4d1",
+        "Mappings": [
+            {
+                "Version": 4.0,
+                "Key": "client-api/configuration/load-balance-and-failover"
+            }
+        ]
+    },
+    {
+        "Path": "read-balance-behavior.markdown",
+        "Name": "Read balance behavior",
+        "DiscussionId": "b0d33f30-29ae-4972-8342-e6ce5ac9a4d1",
+        "Mappings": [
+            {
+                "Version": 4.0,
+                "Key": "client-api/configuration/load-balance-and-failover"
+            }
+        ]
+    },
+    {
+        "Path": "load-balance-behavior.markdown",
+        "Name": "Load balance behavior",
+        "DiscussionId": "b0d33f30-29ae-4972-8342-e6ce5ac9a4d1",
+        "Mappings": [
+            {
+                "Version": 5.0,
+                "Key": "client-api/session/configuration/use-session-context-for-load-balancing"
+            }
+        ]
+    }
+]

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.dotnet.markdown
@@ -1,0 +1,164 @@
+# Load balance behavior
+
+---
+
+{NOTE: }
+
+* The `loadBalanceBehavior` configuration allows you to specify which sessions should 
+  communicate with the same node.  
+ 
+* Sessions that are assigned the **same context** will have all their _Read_ & _Write_ 
+  requests routed to the **same node**. Gain load balancing by assigning **different contexts** 
+  to **different sessions**.  
+
+---
+
+* In this page:
+    * [LoadBalanceBehavior options](../../../client-api/configuration/load-balance/load-balance-behavior#loadbalancebehavior-options)
+    * [Initialize LoadBalanceBehavior on the client](../../../client-api/configuration/load-balance/load-balance-behavior#initialize-loadbalancebehavior-on-the-client)
+    * [Set LoadBalanceBehavior on the server:](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server)
+        * [By operation](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---by-operation)
+        * [From Studio](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---from-studio)
+    * [When to use](../../../client-api/configuration/load-balance/load-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: LoadBalanceBehavior options }
+
+### `None` (default option)
+
+* Requests will be handled based on the `ReadBalanceBehavior` configuration.  
+  See the conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+   * **_Read_** requests:  
+     The client will calculate the target node from the configured [ReadBalanceBehavior Option](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options).  
+   * **_Write_** requests:  
+     Will be sent to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).  
+     The data will then be replicated to all the other nodes in the database group.
+ 
+---
+
+### `UseSessionContext`
+
+* **Load-balance**
+
+  * When this option is enabled, the client will calculate the target node from the session-id.  
+    The session-id is hashed from a **context string** and an optional **seed** given by the user.  
+    The context string together with the seed are referred to as **"The session context"**.
+  
+  * Per session, the client will select a node from the topology list based on this session-context.  
+    So sessions that use the **same** context will target the **same** node.
+  
+  * All **_Read & Write_** requests made on the session (i.e a query or a load request, etc.)  
+    will address this calculated node.  
+    _Read & Write_ requests that are made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))  
+    will go to the preferred node.
+
+  * All _Write_ requests will be replicated to all the other nodes in the database group as usual.
+
+* **Failover**  
+
+  * In case of a failure, the client will try to access the next node from the topology nodes list.
+
+{PANEL/}
+
+{PANEL: Initialize LoadBalanceBehavior on the client }
+
+* The `LoadBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the load balance behavior for the default database that is set on the store.
+
+* This setting can be **overriden** by setting 'LoadBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server).
+
+---
+
+**Initialize conventions**:
+
+{CODE LoadBalance_1@ClientApi\Configuration\LoadBalance\LoadBalance.cs /}
+{CODE LoadBalance_6@ClientApi\Configuration\LoadBalance\LoadBalance.cs /}
+
+---
+
+**Session usage**:
+
+{CODE LoadBalance_2@ClientApi\Configuration\LoadBalance\LoadBalance.cs /}
+{CODE LoadBalance_3@ClientApi\Configuration\LoadBalance\LoadBalance.cs /}
+
+{PANEL/}
+
+{PANEL: Set LoadBalanceBehavior on the server }
+
+{NOTE: }
+
+**Note**:  
+
+* Setting the load balance behavior on the server, either by an **Operation** or from the **Studio**,  
+  only 'enables the feature' and sets the seed.
+
+* For the feature to be in effect, you still need to define the context string itself:  
+  * either per session, call `session.Advanced.SessionInfo.SetContext`  
+  * or, on the document store, set a default value for - `LoadBalancerPerSessionContextSelector`  
+
+{NOTE/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - by operation:
+
+* The `LoadBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).
+
+* The operation can modify the default database only, or all databases - see examples below.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{CODE-TABS}
+{CODE-TAB:csharp:Operation_For_Default_Database LoadBalance_4@ClientApi\Configuration\LoadBalance\LoadBalance.cs /}
+{CODE-TAB:csharp:Operation_For_All_Databases LoadBalance_5@ClientApi\Configuration\LoadBalance\LoadBalance.cs /}
+{CODE-TABS/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - from Studio:
+
+* The `LoadBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Distributing _Read & Write_ requests among the cluster nodes can be beneficial  
+  when a set of sessions handle a specific set of documents or similar data.  
+  Load balancing can be achieved by routing requests from the sessions that handle similar topics to the same node, while routing other sessions to other nodes.  
+ 
+* Another usage example can be setting the session's context to be the current user.  
+  Thus spreading the _Read & Write_ requests per user that logs into the application.  
+
+* Once setting the load balance to be per session-context,  
+  in the case when detecting that many or all sessions send requests to the same node,  
+  a further level of node randomization can be added by changing the seed.  
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Read balance behavior](../../../client-api/configuration/load-balance/read-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.js.markdown
@@ -1,0 +1,164 @@
+# Load balance behavior
+
+ ---
+
+{NOTE: }
+
+* The `loadBalanceBehavior` configuration allows you to specify which sessions should 
+  communicate with the same node.  
+ 
+* Sessions that are assigned the **same context** will have all their _Read_ & _Write_ 
+  requests routed to the **same node**. Gain load balancing by assigning **different contexts** 
+  to **different sessions**.  
+
+---
+
+* In this page:
+    * [LoadBalanceBehavior options](../../../client-api/configuration/load-balance/load-balance-behavior#loadbalancebehavior-options)
+    * [Initialize LoadBalanceBehavior on the client](../../../client-api/configuration/load-balance/load-balance-behavior#initialize-loadbalancebehavior-on-the-client)
+    * [Set LoadBalanceBehavior on the server:](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server)
+        * [By operation](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---by-operation)
+        * [From Studio](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---from-studio)
+    * [When to use](../../../client-api/configuration/load-balance/load-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: LoadBalanceBehavior options }
+
+### `None` (default option)
+
+* Requests will be handled based on the `readBalanceBehavior` configuration.  
+  See the conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+  * **_Read_** requests:  
+    The client will calculate the target node from the configured [readBalanceBehavior Option](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options).  
+  * **_Write_** requests:  
+    Will be sent to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).  
+    The data will then be replicated to all the other nodes in the database group.
+ 
+---
+
+### `UseSessionContext`
+
+* **Load-balance**
+
+  * When this option is enabled, the client will calculate the target node from the session-id.  
+    The session-id is hashed from a **context string** and an optional **seed** given by the user.  
+    The context string together with the seed are referred to as **"The session context"**.
+  
+  * Per session, the client will select a node from the topology list based on this session-context.  
+    So sessions that use the **same** context will target the **same** node.
+  
+  * All **_Read & Write_** requests made on the session (i.e a query or a load request, etc.)  
+    will address this calculated node.  
+    _Read & Write_ requests that are made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))  
+    will go to the preferred node.
+
+  * All _Write_ requests will be replicated to all the other nodes in the database group as usual.
+
+* **Failover**  
+
+  * In case of a failure, the client will try to access the next node from the topology nodes list.
+
+{PANEL/}
+
+{PANEL: Initialize loadBalanceBehavior on the client }
+
+* The `loadBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the load balance behavior for the default database that is set on the store.
+
+* This setting can be **overriden** by setting 'loadBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server).
+
+---
+
+**Initialize conventions**:
+
+{CODE:nodejs loadBalance_1@client-api\Configuration\LoadBalance\loadBalance.js /}
+{CODE:nodejs loadBalance_6@client-api\Configuration\LoadBalance\loadBalance.js /}
+
+---
+
+**Session usage**:
+
+{CODE:nodejs loadBalance_2@client-api\Configuration\LoadBalance\loadBalance.js /}
+{CODE:nodejs loadBalance_3@client-api\Configuration\LoadBalance\loadBalance.js /}
+
+{PANEL/}
+
+{PANEL: Set loadBalanceBehavior on the server }
+
+{NOTE: }
+
+**Note**:  
+
+* Setting the load balance behavior on the server, either by an **Operation** or from the **Studio**,  
+  only 'enables the feature' and sets the seed.
+
+* For the feature to be in effect, you still need to define the context string itself:  
+  * either per session, call `session.advanced.sessionInfo.setContext`  
+  * or, on the document store, set a default value for - `loadBalancerPerSessionContextSelector`  
+
+{NOTE/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - by operation:
+
+* The `loadBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).
+
+* The operation can modify the default database only, or all databases - see examples below.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Operation_For_Default_Database loadBalance_4@client-api\Configuration\LoadBalance\loadBalance.js /}
+{CODE-TAB:nodejs:Operation_For_All_Databases loadBalance_5@client-api\Configuration\LoadBalance\loadBalance.js /}
+{CODE-TABS/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - from Studio:
+
+* The `loadBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Distributing _Read & Write_ requests among the cluster nodes can be beneficial  
+  when a set of sessions handle a specific set of documents or similar data.  
+  Load balancing can be achieved by routing requests from the sessions that handle similar topics to the same node, while routing other sessions to other nodes.  
+ 
+* Another usage example can be setting the session's context to be the current user.  
+  Thus spreading the _Read & Write_ requests per user that logs into the application.  
+
+* Once setting the load balance to be per session-context,  
+  in the case when detecting that many or all sessions send requests to the same node,  
+  a further level of node randomization can be added by changing the seed.  
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Read balance behavior](../../../client-api/configuration/load-balance/read-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.python.markdown
@@ -96,7 +96,7 @@
   only 'enables the feature' and sets the seed.
 
 * For the feature to be in effect, you still need to define the context string itself:  
-  * either per session, call `session.advanced.session_info.set_context`  
+  * either per session, call `session.advanced.session_info.context`  
   * or, on the document store, set a default value for - `load_balancer_per_session_context_selector`  
 
 {NOTE/}

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.python.markdown
@@ -1,0 +1,164 @@
+# Load balance behavior
+
+---
+
+{NOTE: }
+
+* The `loadBalanceBehavior` configuration allows you to specify which sessions should 
+  communicate with the same node.  
+ 
+* Sessions that are assigned the **same context** will have all their _Read_ & _Write_ 
+  requests routed to the **same node**. Gain load balancing by assigning **different contexts** 
+  to **different sessions**.  
+
+---
+
+* In this page:
+    * [LoadBalanceBehavior options](../../../client-api/configuration/load-balance/load-balance-behavior#loadbalancebehavior-options)
+    * [Initialize LoadBalanceBehavior on the client](../../../client-api/configuration/load-balance/load-balance-behavior#initialize-loadbalancebehavior-on-the-client)
+    * [Set LoadBalanceBehavior on the server:](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server)
+        * [By operation](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---by-operation)
+        * [From Studio](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---from-studio)
+    * [When to use](../../../client-api/configuration/load-balance/load-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: LoadBalanceBehavior options }
+
+### `None` (default option)
+
+* Requests will be handled based on the `ReadBalanceBehavior` configuration.  
+  See the conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+   * **_Read_** requests:  
+     The client will calculate the target node from the configured [ReadBalanceBehavior Option](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options).  
+   * **_Write_** requests:  
+     Will be sent to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).  
+     The data will then be replicated to all the other nodes in the database group.
+ 
+---
+
+### `UseSessionContext`
+
+* **Load-balance**
+
+  * When this option is enabled, the client will calculate the target node from the session-id.  
+    The session-id is hashed from a **context string** and an optional **seed** given by the user.  
+    The context string together with the seed are referred to as **"The session context"**.
+  
+  * Per session, the client will select a node from the topology list based on this session-context.  
+    So sessions that use the **same** context will target the **same** node.
+  
+  * All **_Read & Write_** requests made on the session (i.e a query or a load request, etc.)  
+    will address this calculated node.  
+    _Read & Write_ requests that are made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))  
+    will go to the preferred node.
+
+  * All _Write_ requests will be replicated to all the other nodes in the database group as usual.
+
+* **Failover**  
+
+  * In case of a failure, the client will try to access the next node from the topology nodes list.
+
+{PANEL/}
+
+{PANEL: Initialize LoadBalanceBehavior on the client }
+
+* The `LoadBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the load balance behavior for the default database that is set on the store.
+
+* This setting can be **overriden** by setting 'LoadBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server).
+
+---
+
+**Initialize conventions**:
+
+{CODE:python LoadBalance_1@ClientApi\Configuration\LoadBalance\LoadBalance.py /}
+{CODE:python LoadBalance_6@ClientApi\Configuration\LoadBalance\LoadBalance.py /}
+
+---
+
+**Session usage**:
+
+{CODE:python LoadBalance_2@ClientApi\Configuration\LoadBalance\LoadBalance.py /}
+{CODE:python LoadBalance_3@ClientApi\Configuration\LoadBalance\LoadBalance.py /}
+
+{PANEL/}
+
+{PANEL: Set LoadBalanceBehavior on the server }
+
+{NOTE: }
+
+**Note**:  
+
+* Setting the load balance behavior on the server, either by an **Operation** or from the **Studio**,  
+  only 'enables the feature' and sets the seed.
+
+* For the feature to be in effect, you still need to define the context string itself:  
+  * either per session, call `session.advanced.session_info.set_context`  
+  * or, on the document store, set a default value for - `load_balancer_per_session_context_selector`  
+
+{NOTE/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - by operation:
+
+* The `LoadBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).
+
+* The operation can modify the default database only, or all databases - see examples below.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{CODE-TABS}
+{CODE-TAB:python:Operation_For_Default_Database LoadBalance_4@ClientApi\Configuration\LoadBalance\LoadBalance.py /}
+{CODE-TAB:python:Operation_For_All_Databases LoadBalance_5@ClientApi\Configuration\LoadBalance\LoadBalance.py /}
+{CODE-TABS/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - from Studio:
+
+* The `LoadBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Distributing _Read & Write_ requests among the cluster nodes can be beneficial  
+  when a set of sessions handle a specific set of documents or similar data.  
+  Load balancing can be achieved by routing requests from the sessions that handle similar topics to the same node, while routing other sessions to other nodes.  
+ 
+* Another usage example can be setting the session's context to be the current user.  
+  Thus spreading the _Read & Write_ requests per user that logs into the application.  
+
+* Once setting the load balance to be per session-context,  
+  in the case when detecting that many or all sessions send requests to the same node,  
+  a further level of node randomization can be added by changing the seed.  
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Read balance behavior](../../../client-api/configuration/load-balance/read-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.dotnet.markdown
@@ -1,0 +1,129 @@
+# Read balance behavior
+
+ ---
+
+{NOTE: }
+
+* When set, the `ReadBalanceBehavior` configuration will be in effect according to the   
+  conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+
+* Once configuration is in effect then:  
+  * **_Read_** requests - will be sent to the node determined by the configured option - see below.
+  * **_Write_** requests - are always sent to the preferred node.  
+    The data will then be replicated to all the other nodes in the database group. 
+  * Upon a node failure, the node to failover to is also determined by the defined option.  
+
+* In this page:
+    * [ReadBalanceBehavior options](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options)  
+    * [Initialize ReadBalanceBehavior on the client](../../../client-api/configuration/load-balance/read-balance-behavior#initialize-readbalancebehavior-on-the-client)  
+    * [Set ReadBalanceBehavior on the server:](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server)  
+        * [By operation](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---by-operation)  
+        * [From Studio](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---from-studio)  
+    * [When to use](../../../client-api/configuration/load-balance/read-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: readBalanceBehavior options }
+
+### `None` (default option)
+
+  * **Read-balance**  
+    No read balancing will occur.  
+    The client will always send _Read_ requests to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).
+  * **Failover**  
+    The client will failover nodes in the order they appear in the [topology nodes list](../../../studio/database/settings/manage-database-group#database-group-topology---actions).
+
+---
+
+### `RoundRobin`
+
+* **Read-balance**
+  * Each session opened is assigned an incremental session-id number.  
+    **Per session**, the client will select the next node from the topology list based on this internal session-id.  
+  * All _Read_ requests made on the session (i.e a query or a load request, etc.)  
+    will address the calculated node.  
+  * A _Read_ request that is made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))   
+    will go to the preferred node.  
+* **Failover**  
+  In case of a failure, the client will try the next node from the topology nodes list.  
+
+---
+
+### `FastestNode`
+
+  * **Read-balance**  
+    All _Read_ requests will go to the fastest node.  
+    The fastest node is determined by a [Speed Test](../../../client-api/cluster/speed-test).
+  * **Failover**  
+    In case of a failure, a speed test will be triggered again,  
+    and in the meantime the client will use the preferred node.
+
+{PANEL/}
+
+{PANEL: Initialize ReadBalanceBehavior on the client }
+
+* The `ReadBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the read balance behavior for the default database that is set on the store.  
+
+* This setting can be **overriden** by setting 'ReadBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server).   
+
+{CODE ReadBalance_1@ClientApi\Configuration\LoadBalance\ReadBalance.cs /}
+
+{PANEL/}
+
+{PANEL: Set ReadBalanceBehavior on the server }
+
+#### Set ReadBalanceBehavior on the server - by operation:
+
+* The `ReadBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).  
+
+* The operation can modify the default database only, or all databases - see examples below.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Operation_For_Default_Database ReadBalance_2@ClientApi\Configuration\LoadBalance\ReadBalance.cs /}
+{CODE-TAB:csharp:Operation_For_All_Databases ReadBalance_3@ClientApi\Configuration\LoadBalance\ReadBalance.cs /}
+{CODE-TABS/}
+
+#### Set ReadBalanceBehavior on the server - from Studio:
+
+* The `ReadBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Setting the read balance behavior is beneficial when you only care about distributing the _Read_ requests among the cluster nodes,
+  and when all _Write_ requests can go to the same node.
+
+* Using the 'FastestNode' option is beneficial when some nodes in the system are known to be faster than others,
+  thus letting the fastest node serve each read request.
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Load balance behavior](../../../client-api/configuration/load-balance/load-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.js.markdown
@@ -1,0 +1,131 @@
+# Read balance behavior
+
+ ---
+
+{NOTE: }
+
+* When set, the `readBalanceBehavior` configuration will be in effect according to the   
+  conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+
+* Once configuration is in effect then:  
+  * **_Read_** requests - will be sent to the node determined by the configured option - see below.
+  * **_Write_** requests - are always sent to the preferred node.  
+    The data will then be replicated to all the other nodes in the database group. 
+  * Upon a node failure, the node to failover to is also determined by the defined option.  
+
+* In this page:
+    * [readBalanceBehavior options](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options)  
+    * [Initialize readBalanceBehavior on the client](../../../client-api/configuration/load-balance/read-balance-behavior#initialize-readbalancebehavior-on-the-client)  
+    * [Set readBalanceBehavior on the server:](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server)  
+        * [By operation](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---by-operation)  
+        * [From Studio](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---from-studio)  
+    * [When to use](../../../client-api/configuration/load-balance/read-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: readBalanceBehavior options }
+
+### `None` (default option)
+
+  * **Read-balance**  
+    No read balancing will occur.  
+    The client will always send _Read_ requests to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).
+  * **Failover**  
+    The client will failover nodes in the order they appear in the [topology nodes list](../../../studio/database/settings/manage-database-group#database-group-topology---actions).
+
+---
+
+### `RoundRobin`
+
+* **Read-balance**
+  * Each session opened is assigned an incremental session-id number.  
+    **Per session**, the client will select the next node from the topology list based on this internal session-id.  
+  * All _Read_ requests made on the session (i.e a query or a load request, etc.)  
+    will address the calculated node.  
+  * A _Read_ request that is made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))   
+    will go to the preferred node.  
+* **Failover**  
+  In case of a failure, the client will try the next node from the topology nodes list.  
+
+---
+
+### `FastestNode`
+
+  * **Read-balance**  
+    All _Read_ requests will go to the fastest node.  
+    The fastest node is determined by a [Speed Test](../../../client-api/cluster/speed-test).
+  * **Failover**  
+    In case of a failure, a speed test will be triggered again,  
+    and in the meantime the client will use the preferred node.
+
+{PANEL/}
+
+{PANEL: Initialize readBalanceBehavior on the client }
+
+* The `readBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the read balance behavior for the default database that is set on the store.  
+
+* This setting can be **overriden** by setting 'readBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server).   
+
+{CODE:nodejs readBalance_1@client-api\Configuration\LoadBalance\readBalance.js /}
+
+{PANEL/}
+
+{PANEL: Set readBalanceBehavior on the server }
+
+#### Set readBalanceBehavior on the server - by operation:
+
+* The `readBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).  
+
+* The operation can modify the default database only, or all databases - see examples below.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Operation_For_Default_Database readBalance_2@client-api\Configuration\LoadBalance\readBalance.js /}
+{CODE-TAB:nodejs:Operation_For_All_Databases readBalance_3@client-api\Configuration\LoadBalance\readBalance.js /}
+{CODE-TABS/}
+
+---
+
+#### Set readBalanceBehavior on the server - from Studio:
+
+* The `readBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Setting the read balance behavior is beneficial when you only care about distributing the _Read_ requests among the cluster nodes,
+  and when all _Write_ requests can go to the same node.
+
+* Using the 'FastestNode' option is beneficial when some nodes in the system are known to be faster than others,
+  thus letting the fastest node serve each read request.
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Load balance behavior](../../../client-api/configuration/load-balance/load-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.python.markdown
@@ -1,0 +1,129 @@
+# Read balance behavior
+
+ ---
+
+{NOTE: }
+
+* When set, the `ReadBalanceBehavior` configuration will be in effect according to the   
+  conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+
+* Once configuration is in effect then:  
+  * **_Read_** requests - will be sent to the node determined by the configured option - see below.
+  * **_Write_** requests - are always sent to the preferred node.  
+    The data will then be replicated to all the other nodes in the database group. 
+  * Upon a node failure, the node to failover to is also determined by the defined option.  
+
+* In this page:
+    * [ReadBalanceBehavior options](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options)  
+    * [Initialize ReadBalanceBehavior on the client](../../../client-api/configuration/load-balance/read-balance-behavior#initialize-readbalancebehavior-on-the-client)  
+    * [Set ReadBalanceBehavior on the server:](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server)  
+        * [By operation](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---by-operation)  
+        * [From Studio](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---from-studio)  
+    * [When to use](../../../client-api/configuration/load-balance/read-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: readBalanceBehavior options }
+
+### `None` (default option)
+
+  * **Read-balance**  
+    No read balancing will occur.  
+    The client will always send _Read_ requests to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).
+  * **Failover**  
+    The client will failover nodes in the order they appear in the [topology nodes list](../../../studio/database/settings/manage-database-group#database-group-topology---actions).
+
+---
+
+### `RoundRobin`
+
+* **Read-balance**
+  * Each session opened is assigned an incremental session-id number.  
+    **Per session**, the client will select the next node from the topology list based on this internal session-id.  
+  * All _Read_ requests made on the session (i.e a query or a load request, etc.)  
+    will address the calculated node.  
+  * A _Read_ request that is made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))   
+    will go to the preferred node.  
+* **Failover**  
+  In case of a failure, the client will try the next node from the topology nodes list.  
+
+---
+
+### `FastestNode`
+
+  * **Read-balance**  
+    All _Read_ requests will go to the fastest node.  
+    The fastest node is determined by a [Speed Test](../../../client-api/cluster/speed-test).
+  * **Failover**  
+    In case of a failure, a speed test will be triggered again,  
+    and in the meantime the client will use the preferred node.
+
+{PANEL/}
+
+{PANEL: Initialize ReadBalanceBehavior on the client }
+
+* The `ReadBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the read balance behavior for the default database that is set on the store.  
+
+* This setting can be **overriden** by setting 'ReadBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server).   
+
+{CODE:python ReadBalance_1@ClientApi\Configuration\LoadBalance\ReadBalance.py /}
+
+{PANEL/}
+
+{PANEL: Set ReadBalanceBehavior on the server }
+
+#### Set ReadBalanceBehavior on the server - by operation:
+
+* The `ReadBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).  
+
+* The operation can modify the default database only, or all databases - see examples below.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{CODE-TABS}
+{CODE-TAB:python:Operation_For_Default_Database ReadBalance_2@ClientApi\Configuration\LoadBalance\ReadBalance.py /}
+{CODE-TAB:python:Operation_For_All_Databases ReadBalance_3@ClientApi\Configuration\LoadBalance\ReadBalance.py /}
+{CODE-TABS/}
+
+#### Set ReadBalanceBehavior on the server - from Studio:
+
+* The `ReadBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Setting the read balance behavior is beneficial when you only care about distributing the _Read_ requests among the cluster nodes,
+  and when all _Write_ requests can go to the same node.
+
+* Using the 'FastestNode' option is beneficial when some nodes in the system are known to be faster than others,
+  thus letting the fastest node serve each read request.
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Load balance behavior](../../../client-api/configuration/load-balance/load-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Documents/Get.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Commands/Documents/Get.cs
@@ -1,0 +1,184 @@
+﻿using System.Collections.Generic;
+
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Sparrow.Json;
+
+namespace Raven.Documentation.Samples.ClientApi.Commands.Documents
+{
+    public class GetInterfaces
+    {
+        public class GetDocumentsCommand
+        {
+            #region get_interface_single
+            public GetDocumentsCommand(string id, string[] includes, bool metadataOnly)
+            #endregion
+            {
+
+            }
+
+            #region get_interface_multiple
+            public GetDocumentsCommand(string[] ids, string[] includes, bool metadataOnly)
+            #endregion
+            {
+
+            }
+
+            #region get_interface_paged
+            public GetDocumentsCommand(int start, int pageSize)
+            #endregion
+            {
+
+            }
+
+            #region get_interface_startswith
+            public GetDocumentsCommand(string startWith, string startAfter, string matches, string exclude, int start, int pageSize, bool metadataOnly)
+            #endregion
+            {
+
+            }
+        }
+    }
+
+    public class GetSamples
+    {
+        public void Single()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_single
+                var command = new GetDocumentsCommand("orders/1-A", null, false);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var order = (BlittableJsonReaderObject)command.Result.Results[0];
+                #endregion
+            }
+        }
+
+        public void Multiple()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_multiple
+                var command = new GetDocumentsCommand(new[] { "orders/1-A", "employees/3-A" }, null, false);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var order = (BlittableJsonReaderObject)command.Result.Results[0];
+                var employee = (BlittableJsonReaderObject)command.Result.Results[1];
+                #endregion
+            }
+        }
+
+        public void Includes()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_includes
+                // Fetch employees/5-A and his boss.
+                var command = new GetDocumentsCommand("employees/5-A", includes: new[] { "ReportsTo" }, metadataOnly: false);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var employee = (BlittableJsonReaderObject)command.Result.Results[0];
+                if (employee.TryGet<string>("ReportsTo", out var bossId))
+                {
+                    var boss = command.Result.Includes[bossId];
+                }
+                #endregion
+            }
+        }
+
+        public void Missing()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_missing
+                // Assuming that products/9999-A doesn't exist.
+                var command = new GetDocumentsCommand(new[] { "products/1-A", "products/9999-A", "products/3-A" }, null, false);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var products = command.Result.Results; // products/1-A, null, products/3-A
+                #endregion
+            }
+        }
+
+        public void Paged()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_paged
+                var command = new GetDocumentsCommand(start: 0, pageSize: 128);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var first10Docs = command.Result.Results;
+                #endregion
+            }
+        }
+
+        public void StartsWith()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_startswith
+                // return up to 128 documents with key that starts with 'products'
+                var command = new GetDocumentsCommand(
+                    startWith: "products",
+                    startAfter: null,
+                    matches: null,
+                    exclude: null,
+                    start: 0,
+                    pageSize: 128,
+                    metadataOnly: false);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var products = command.Result.Results;
+                #endregion
+            }
+        }
+
+        public void StartsWithMatches()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_startswith_matches
+                // return up to 128 documents with key that starts with 'products/' 
+                // and rest of the key begins with "1" or "2" e.g. products/10, products/25
+                var command = new GetDocumentsCommand(
+                    startWith: "products",
+                    startAfter: null,
+                    matches: "1*|2*",
+                    exclude: null,
+                    start: 0,
+                    pageSize: 128,
+                    metadataOnly: false);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var products = command.Result.Results;
+                #endregion
+            }
+        }
+
+        public void StartsWithMatchesEnd()
+        {
+            using (var store = new DocumentStore())
+            using (var session = store.OpenSession())
+            {
+                #region get_sample_startswith_matches_end
+                // return up to 128 documents with key that starts with 'products/' 
+                // and rest of the key have length of 3, begins and ends with "1" 
+                // and contains any character at 2nd position e.g. products/101, products/1B1
+                var command = new GetDocumentsCommand(
+                    startWith: "products",
+                    startAfter: null,
+                    matches: "1?1",
+                    exclude: null,
+                    start: 0,
+                    pageSize: 128,
+                    metadataOnly: false);
+                session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                var products = command.Result.Results;
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/LoadBalance/LoadBalance.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/LoadBalance/LoadBalance.cs
@@ -1,0 +1,148 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.ClientApi.Configuration.LoadBalance
+{
+    public class LoadBalanceExamples
+    {
+        public LoadBalanceExamples()
+        {
+            #region LoadBalance_1
+            // Initialize 'LoadBalanceBehavior' on the client:
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] {"ServerURL_1", "ServerURL_2", "..."},
+                Database = "DefaultDB",
+                Conventions = new DocumentConventions
+                {
+                    // Enable the session-context feature
+                    // If this is not enabled then a context string set in a session will be ignored 
+                    LoadBalanceBehavior = LoadBalanceBehavior.UseSessionContext,
+                    
+                    // Assign a method that sets the default context string
+                    // This string will be used for sessions that do Not provide a context string
+                    // A sample GetDefaultContext method is defined below
+                    LoadBalancerPerSessionContextSelector = GetDefaultContext,
+                    
+                    // Set a seed
+                    // The seed is 0 by default, provide any number to override
+                    LoadBalancerContextSeed = 5 
+                }
+            }.Initialize();
+            #endregion
+            
+            #region LoadBalance_2
+            // Open a session that will use the DEFAULT store values:
+            using (var session = documentStore.OpenSession())
+            {
+                // For all Read & Write requests made in this session,
+                // node to access is calculated from string & seed values defined on the store
+                var employee = session.Load<Employee>("employees/1-A"); 
+            }
+            #endregion
+            
+            #region LoadBalance_3
+            // Open a session that will use a UNIQUE context string:
+            using (var session = documentStore.OpenSession())
+            {
+                // Call SetContext, pass a unique context string for this session
+                session.Advanced.SessionInfo.SetContext("SomeOtherContext");
+                
+                // For all Read & Write requests made in this session,
+                // node to access is calculated from the unique string & the seed defined on the store
+                var employee = session.Load<Employee>("employees/1-A");
+            }
+            #endregion
+            
+            #region LoadBalance_4
+            // Setting 'LoadBalanceBehavior' on the server by sending an operation:
+            using (documentStore)
+            {
+                // Define the client configuration to put on the server
+                var configurationToSave = new ClientConfiguration
+                {
+                    // Enable the session-context feature
+                    // If this is not enabled then a context string set in a session will be ignored 
+                    LoadBalanceBehavior = LoadBalanceBehavior.UseSessionContext,
+                    
+                    // Set a seed
+                    // The seed is 0 by default, provide any number to override
+                    LoadBalancerContextSeed = 10,
+                    
+                    // NOTE:
+                    // The session's context string is Not set on the server
+                    // You still need to set it on the client:
+                    //   * either as a convention on the document store
+                    //   * or pass it to 'SetContext' method on the session
+                    
+                    // Configuration will be in effect when Disabled is set to false
+                    Disabled = false
+                };
+                
+                // Define the put configuration operation for the DEFAULT database
+                var putConfigurationOp = new PutClientConfigurationOperation(configurationToSave);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                documentStore.Maintenance.Send(putConfigurationOp);
+                
+                // After the operation has executed:
+                // all Read & Write requests, per session, will address the node calculated from:
+                //   * the seed set on the server &
+                //   * the session's context string set on the client
+            }
+            #endregion
+            
+            #region LoadBalance_5
+            // Setting 'LoadBalanceBehavior' on the server by sending an operation:
+            using (documentStore)
+            {
+                // Define the client configuration to put on the server
+                var configurationToSave = new ClientConfiguration
+                {
+                    // Enable the session-context feature
+                    // If this is not enabled then a context string set in a session will be ignored 
+                    LoadBalanceBehavior = LoadBalanceBehavior.UseSessionContext,
+                    
+                    // Set a seed
+                    // The seed is 0 by default, provide any number to override
+                    LoadBalancerContextSeed = 10,
+                    
+                    // NOTE:
+                    // The session's context string is Not set on the server
+                    // You still need to set it on the client:
+                    //   * either as a convention on the document store
+                    //   * or pass it to 'SetContext' method on the session
+                    
+                    // Configuration will be in effect when Disabled is set to false
+                    Disabled = false
+                };
+                
+                // Define the put configuration operation for ALL databases
+                var putConfigurationOp = new PutServerWideClientConfigurationOperation(configurationToSave);
+                
+                // Execute the operation by passing it to Maintenance.Server.Send
+                documentStore.Maintenance.Server.Send(putConfigurationOp);
+                
+                // After the operation has executed:
+                // all Read & Write requests, per session, will address the node calculated from:
+                //   * the seed set on the server &
+                //   * the session's context string set on the client
+            }
+            #endregion
+        }
+
+        #region LoadBalance_6
+        // A customized method for getting a default context string 
+        private string GetDefaultContext(string dbName)
+        {
+            // Method is invoked by RavenDB with the database name
+            // Use that name - or return any string of your choice
+            return "DefaultContextString";
+        }
+        #endregion
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/LoadBalance/ReadBalance.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Configuration/LoadBalance/ReadBalance.cs
@@ -1,0 +1,76 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations.Configuration;
+
+namespace Raven.Documentation.Samples.ClientApi.Configuration.LoadBalance
+{
+    public class ReadBalanceExamples
+    {
+        public ReadBalanceExamples()
+        {
+            #region ReadBalance_1
+            // Initialize 'ReadBalanceBehavior' on the client:
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "ServerURL_1", "ServerURL_2", "..." },
+                Database = "DefaultDB",
+                Conventions = new DocumentConventions
+                {
+                    // With ReadBalanceBehavior set to: 'FastestNode':
+                    // Client READ requests will address the fastest node
+                    // Client WRITE requests will address the preferred node
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                }
+            }.Initialize();
+            #endregion
+            
+            #region ReadBalance_2
+            // Setting 'ReadBalanceBehavior' on the server by sending an operation:
+            using (documentStore)
+            {
+                // Define the client configuration to put on the server
+                var clientConfiguration = new ClientConfiguration
+                {
+                    // Replace 'FastestNode' (from example above) with 'RoundRobin'
+                    ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin
+                };
+                
+                // Define the put configuration operation for the DEFAULT database
+                var putConfigurationOp = new PutClientConfigurationOperation(clientConfiguration);
+                
+                // Execute the operation by passing it to Maintenance.Send
+                documentStore.Maintenance.Send(putConfigurationOp);
+                
+                // After the operation has executed:
+                // All WRITE requests will continue to address the preferred node 
+                // READ requests, per session, will address a different node based on the RoundRobin logic
+            }
+            #endregion
+            
+            #region ReadBalance_3
+            // Setting 'ReadBalanceBehavior' on the server by sending an operation:
+            using (documentStore)
+            {
+                // Define the client configuration to put on the server
+                var clientConfiguration = new ClientConfiguration
+                {
+                    // Replace 'FastestNode' (from example above) with 'RoundRobin'
+                    ReadBalanceBehavior = ReadBalanceBehavior.RoundRobin
+                };
+                
+                // Define the put configuration operation for the ALL databases
+                var putConfigurationOp = new PutServerWideClientConfigurationOperation(clientConfiguration);
+                
+                // Execute the operation by passing it to Maintenance.Server.Send
+                documentStore.Maintenance.Server.Send(putConfigurationOp);
+                
+                // After the operation has executed:
+                // All WRITE requests will continue to address the preferred node 
+                // READ requests, per session, will address a different node based on the RoundRobin logic
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Commands/Documents/Get.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Commands/Documents/Get.java
@@ -1,0 +1,184 @@
+package net.ravendb.ClientApi.Commands.Documents;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.commands.GetDocumentsCommand;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+public class Get {
+
+    public static class GetInterfaces {
+        public static class GetDocumentsCommand {
+            //region get_interface_single
+            public GetDocumentsCommand(String id, String[] includes, boolean metadataOnly)
+            //endregion
+            {
+
+            }
+
+            //region get_interface_multiple
+            public GetDocumentsCommand(String[] ids, String[] includes, boolean metadataOnly)
+            //endregion
+            {
+
+            }
+
+            //region get_interface_paged
+            public GetDocumentsCommand(int start, int pageSize)
+            //endregion
+            {
+
+            }
+
+            //region get_interface_startswith
+            public GetDocumentsCommand(
+                String startWith,
+                String startAfter,
+                String matches,
+                String exclude,
+                int start,
+                int pageSize,
+                boolean metadataOnly)
+            //endregion
+            {
+
+            }
+        }
+    }
+
+    public static class GetSamples{
+        public void single() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_single
+                    GetDocumentsCommand command = new GetDocumentsCommand(
+                        "orders/1-A", null, false);
+                    session.advanced().getRequestExecutor().execute(command);
+                    ObjectNode order = (ObjectNode) command.getResult().getResults().get(0);
+                    //endregion
+                }
+            }
+        }
+
+        public void multiple() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_multiple
+                    GetDocumentsCommand command = new GetDocumentsCommand(
+                        new String[]{"orders/1-A", "employees/3-A"}, null, false);
+                    session.advanced().getRequestExecutor().execute(command);
+                    ObjectNode order = (ObjectNode) command.getResult().getResults().get(0);
+                    ObjectNode employee = (ObjectNode) command.getResult().getResults().get(1);
+                    //endregion
+                }
+            }
+        }
+
+        public void includes() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_includes
+                    // Fetch emploees/5-A and his boss.
+                    GetDocumentsCommand command = new GetDocumentsCommand(
+                        "employees/5-A", new String[]{"ReportsTo"}, false);
+                    session.advanced().getRequestExecutor().execute(command);
+
+                    ObjectNode employee = (ObjectNode) command.getResult().getResults().get(0);
+                    String bossId = employee.get("ReportsTo").asText();
+                    ObjectNode boss = (ObjectNode) command.getResult().getIncludes().get(bossId);
+                    //endregion
+                }
+            }
+        }
+
+        public void missing() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_missing
+                    // Assuming that products/9999-A doesn't exist.
+                    GetDocumentsCommand command = new GetDocumentsCommand(
+                        new String[]{"products/1-A", "products/9999-A", "products/3-A"}, null, false);
+                    session.advanced().getRequestExecutor().execute(command);
+                    ArrayNode products = command.getResult().getResults(); // products/1-A, null, products/3-A
+                    //endregion
+                }
+            }
+        }
+
+        public void paged() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_paged
+                    GetDocumentsCommand command = new GetDocumentsCommand(0, 128);
+                    session.advanced().getRequestExecutor().execute(command);
+                    ArrayNode firstDocs = command.getResult().getResults();
+                    //endregion
+                }
+            }
+        }
+
+        public void startsWith() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_startswith
+                    GetDocumentsCommand command = new GetDocumentsCommand(
+                        "products",  //startWith
+                        null, //startAfter
+                        null, // matches
+                        null, //exclude
+                        0, // start
+                        128, // pageSize
+                        false //metadataOnly
+                    );
+
+                    session.advanced().getRequestExecutor().execute(command);
+                    ArrayNode products = command.getResult().getResults();
+                    //endregion
+                }
+            }
+        }
+
+        public void startsWithMatches() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_startswith_matches
+                    // return up to 128 documents  with key that starts with 'products/'
+                    // and rest of the key begins with "1" or "2", eg. products/10, products/25
+                    GetDocumentsCommand command = new GetDocumentsCommand(
+                        "products", //startWith
+                        null, // startAfter
+                        "1*|2*", // matches
+                        null, // exclude
+                        0, //start
+                        128, //pageSize
+                        false); //metadataOnly
+                    //endregion
+                }
+            }
+        }
+
+        public void startsWithMatchesEnd() {
+            try (IDocumentStore store = new DocumentStore()) {
+                try (IDocumentSession session = store.openSession()) {
+                    //region get_sample_startswith_matches_end
+                    // return up to 128 documents with key that starts with 'products/'
+                    // and rest of the key have length of 3, begins and ends with "1"
+                    // and contains any character at 2nd position e.g. products/101, products/1B1
+                    GetDocumentsCommand command = new GetDocumentsCommand(
+                        "products", //startWith
+                        null, // startAfter
+                        "1?1", // matches
+                        null, // exclude
+                        0, //start
+                        128, //pageSize
+                        false); //metadataOnly
+                    session.advanced().getRequestExecutor().execute(command);
+                    ArrayNode products = command.getResult().getResults();
+                    //endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/commands/documents/get/get.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/commands/documents/get/get.js
@@ -1,0 +1,166 @@
+import { GetDocumentsCommand, DocumentStore } from "ravendb";
+
+let start,
+    pageSize,
+    startsWith,
+    startsAfter,
+    matches,
+    exclude,
+    metadataOnly,
+    conventions,
+    id,
+    ids;
+
+//region get_interface_single
+new GetDocumentsCommand({
+    id,
+    includes,
+    metadataOnly,
+    conventions
+});
+//endregion
+
+//region get_interface_multiple
+new GetDocumentsCommand({
+    ids,
+    includes,
+    metadataOnly,
+    conventions
+});
+//endregion
+
+//region get_interface_paged
+new GetDocumentsCommand({
+    start,
+    pageSize,
+    conventions
+});
+//endregion
+
+//region get_interface_startswith
+new GetDocumentsCommand({
+    start,
+    pageSize,
+    startsWith,
+    startsAfter,
+    matches,
+    exclude,
+    metadataOnly,
+    conventions
+});
+//endregion
+
+
+async function single() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_single
+    const command = new GetDocumentsCommand({ id: "orders/1-A" });
+    await session.advanced.getRequestExecutor().execute(command);
+    const order = command.result.results[0];
+    //endregion
+}
+
+async function multiple() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_multiple
+    const command = new GetDocumentsCommand({
+        ids: [ "orders/1-A", "employees/3-A" ]
+    });
+    await session.advanced.getRequestExecutor().execute(command);
+    const order = command.result.results[0];
+    const employee = command.result.results[1];
+    //endregion
+}
+
+async function includes() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_includes
+    // Fetch emploees/5-A and his boss.
+    const command = new GetDocumentsCommand({
+        id: "employees/5-A", 
+        includes: [ "ReportsTo" ]
+    });
+    await session.advanced.getRequestExecutor().execute(command);
+
+    const employee = command.result.results[0];
+    const bossId = employee.ReportsTo;
+    const boss = command.result.includes[bossId];
+    //endregion
+}
+
+async function missing() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_missing
+    // Assuming that products/9999-A doesn't exist.
+    const command = new GetDocumentsCommand({
+        ids: [ "products/1-A", "products/9999-A", "products/3-A" ]
+    });
+    await session.advanced.getRequestExecutor().execute(command);
+    const products = command.result.results; // products/1-A, null, products/3-A
+    //endregion
+}
+
+async function paged() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_paged
+    const command = new GetDocumentsCommand({
+        start: 0, 
+        pageSize: 128
+    });
+    await session.advanced.getRequestExecutor().execute(command);
+    const firstDocs = command.result.results;
+    //endregion
+}
+
+async function startsWithExample() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_startswith
+    const command = new GetDocumentsCommand({
+        startsWith: "products",  
+        start: 0, 
+        pageSize: 128
+    });
+
+    await session.advanced.getRequestExecutor().execute(command);
+    const products = command.result.results;
+    //endregion
+}
+
+async function startsWithMatches() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_startswith_matches
+    // return up to 128 documents  with key that starts with 'products/'
+    // and rest of the key begins with "1" or "2", eg. products/10, products/25
+    const command = new GetDocumentsCommand({
+        startsWith: "products", 
+        matches: "1*|2*", 
+        start: 0, 
+        pageSize: 128
+    });
+    //endregion
+}
+
+async function startsWithMatchesEnd() {
+    const store = new DocumentStore();
+    const session = store.openSession();
+    //region get_sample_startswith_matches_end
+    // return up to 128 documents with key that starts with 'products/'
+    // and rest of the key have length of 3, begins and ends with "1"
+    // and contains any character at 2nd position e.g. products/101, products/1B1
+    const command = new GetDocumentsCommand({
+        startsWith: "products",
+        matches: "1?1",
+        start: 0,
+        pageSize: 128
+    });
+    await session.advanced.getRequestExecutor().execute(command);
+    const products = command.result.results;
+    //endregion
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/configuration/LoadBalance/loadBalance.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/configuration/LoadBalance/loadBalance.js
@@ -1,0 +1,136 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function loadBalance() {
+    {
+        //region loadBalance_1
+        // Initialize 'loadBalanceBehavior' on the client: 
+        // ===============================================
+
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+
+        // Enable the session-context feature
+        // If this is not enabled then a context string set in a session will be ignored 
+        documentStore.conventions.loadBalanceBehavior = "UseSessionContext";
+
+        // Assign a method that sets the default context string
+        // This string will be used for sessions that do Not provide a context string
+        // A sample getDefaultContext method is defined below
+        documentStore.conventions.loadBalancerPerSessionContextSelector = getDefaultContext;
+        
+        // Set a seed
+        // The seed is 0 by default, provide any number to override
+        documentStore.conventions.loadBalancerContextSeed = 5
+        
+        documentStore.initialize();
+        //endregion
+    }
+    {
+        //region loadBalance_2
+        // Open a session that will use the DEFAULT store values:
+        const session = documentStore.openSession();
+        
+        // For all Read & Write requests made in this session,
+        // node to access is calculated from string & seed values defined on the store
+        const employee = await session.load("employees/1-A");
+        //endregion    
+    }
+    {
+        //region loadBalance_3
+        // Open a session that will use a UNIQUE context string:
+        const session = documentStore.openSession();
+        
+        // Call setContext, pass a unique context string for this session
+        session.advanced.sessionInfo.setContext("SomeOtherContext");
+
+        // For all Read & Write requests made in this session,
+        // node to access is calculated from the unique string & the seed defined on the store
+        const employee = await session.load("employees/1-A");
+        //endregion    
+    }
+    {
+        //region loadBalance_4
+        // Setting 'loadBalanceBehavior' on the server by sending an operation:
+        // ====================================================================
+
+        // Define the client configuration to put on the server
+        const configurationToSave = {
+            // Enable the session-context feature
+            // If this is not enabled then a context string set in a session will be ignored 
+            loadBalanceBehavior: "UseSessionContext",
+
+            // Set a seed
+            // The seed is 0 by default, provide any number to override
+            loadBalancerContextSeed: 10,
+
+            // NOTE:
+            // The session's context string is Not set on the server
+            // You still need to set it on the client:
+            //   * either as a convention on the document store
+            //   * or pass it to 'setContext' method on the session
+
+            // Configuration will be in effect when 'disabled' is set to false
+            disabled: false
+        };
+
+        // Define the put configuration operation for the DEFAULT database
+        const putConfigurationOp = new PutClientConfigurationOperation(configurationToSave);
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(putConfigurationOp);
+
+        // After the operation has executed:
+        // all Read & Write requests, per session, will address the node calculated from:
+        //   * the seed set on the server &
+        //   * the session's context string set on the client
+        //endregion
+    }
+    {
+        //region loadBalance_5
+        // Setting 'loadBalanceBehavior' on the server by sending an operation:
+        // ====================================================================
+
+        // Define the client configuration to put on the server
+        const configurationToSave = {
+            // Enable the session-context feature
+            // If this is not enabled then a context string set in a session will be ignored 
+            loadBalanceBehavior: "UseSessionContext",
+
+            // Set a seed
+            // The seed is 0 by default, provide any number to override
+            loadBalancerContextSeed: 10,
+
+            // NOTE:
+            // The session's context string is Not set on the server
+            // You still need to set it on the client:
+            //   * either as a convention on the document store
+            //   * or pass it to 'setContext' method on the session
+
+            // Configuration will be in effect when 'disabled' is set to false
+            disabled: false
+        };
+
+        // Define the put configuration operation for ALL databases
+        const putConfigurationOp = new PutServerWideClientConfigurationOperation(configurationToSave);
+
+        // Execute the operation by passing it to maintenance.server.send
+        await documentStore.maintenance.server.send(putConfigurationOp);
+
+        // After the operation has executed:
+        // all Read & Write requests, per session, will address the node calculated from:
+        //   * the seed set on the server &
+        //   * the session's context string set on the client
+        //endregion
+    }
+    {
+        //region loadBalance_6
+        // A customized method for getting a default context string 
+        const getDefaultContext = (dbName) => {
+            // Method is invoked by RavenDB with the database name
+            // Use that name - or return any string of your choice
+            return "defaultContextString";
+        }
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/configuration/LoadBalance/readBalance.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/configuration/LoadBalance/readBalance.js
@@ -1,0 +1,66 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function readBalance() {
+    {
+        //region readBalance_1
+        // Initialize 'readBalanceBehavior' on the client: 
+        // ===============================================
+        
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+
+        // For example:
+        // With readBalanceBehavior set to: 'FastestNode':
+        // Client READ requests will address the fastest node
+        // Client WRITE requests will address the preferred node
+        documentStore.conventions.readBalanceBehavior = "FastestNode";
+        
+        documentStore.initialize();
+        //endregion    
+    }
+    {
+        //region readBalance_2
+        // Setting 'readBalanceBehavior' on the server by sending an operation:
+        // ====================================================================
+        
+        // Define the client configuration to put on the server
+        const configurationToSave = {
+            // Replace 'FastestNode' (from example above) with 'RoundRobin'
+            readBalanceBehavior: "RoundRobin"
+        };
+        
+        // Define the put configuration operation for the DEFAULT database
+        const putConfigurationOp = new PutClientConfigurationOperation(configurationToSave);
+
+        // Execute the operation by passing it to maintenance.send
+        await documentStore.maintenance.send(putConfigurationOp);
+
+        // After the operation has executed:
+        // All WRITE requests will continue to address the preferred node 
+        // READ requests, per session, will address a different node based on the RoundRobin logic
+        //endregion
+    }
+    {
+        //region readBalance_3
+        // Setting 'readBalanceBehavior' on the server by sending an operation:
+        // ====================================================================
+
+        // Define the client configuration to put on the server
+        const configurationToSave = {
+            // Replace 'FastestNode' (from example above) with 'RoundRobin'
+            readBalanceBehavior: "RoundRobin"
+        };
+
+        // Define the put configuration operation for ALL databases
+        const putConfigurationOp = new PutServerWideClientConfigurationOperation(configurationToSave);
+
+        // Execute the operation by passing it to maintenance.server.send
+        await documentStore.maintenance.server.send(putConfigurationOp);
+
+        // After the operation has executed:
+        // All WRITE requests will continue to address the preferred node 
+        // READ requests, per session, will address a different node based on the RoundRobin logic
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/python/ClientApi/Commands/Documents/Delete.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Commands/Documents/Delete.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from ravendb import DeleteDocumentCommand
+from ravendb.http.raven_command import VoidRavenCommand
+
+from examples_base import ExampleBase
+
+
+class Foo:
+    class DeleteDocumentCommand:
+        # region delete_interface
+        class DeleteDocumentCommand(VoidRavenCommand):
+            def __init__(self, key: str, change_vector: Optional[str] = None): ...
+
+        # endregion
+
+
+class DeleteSamples(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_delete(self):
+        with self.embedded_server.get_document_store("DeleteDocumentCommand") as store:
+            with store.open_session() as session:
+                # region delete_sample
+                command = DeleteDocumentCommand("employees/1-A", None)
+                session.advanced.request_executor.execute_command(command)
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Commands/Documents/Get.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Commands/Documents/Get.py
@@ -1,0 +1,121 @@
+from typing import List
+
+from ravendb.documents.commands.crud import GetDocumentsCommand
+
+from examples_base import ExampleBase
+
+
+class Foo:
+    class GetDocumentsCommand:
+        # region get_interface_single
+        # GetDocumentsCommand.from_single_id(...)
+        @classmethod
+        def from_single_id(
+            cls, key: str, includes: List[str] = None, metadata_only: bool = None
+        ) -> GetDocumentsCommand: ...
+
+        # endregion
+
+        # region get_interface_multiple
+        # GetDocumentsCommand.from_multiple_ids(...)
+        @classmethod
+        def from_multiple_ids(
+            cls,
+            keys: List[str],
+            includes: List[str] = None,
+            counter_includes: List[str] = None,
+            time_series_includes: List[str] = None,
+            compare_exchange_value_includes: List[str] = None,
+            metadata_only: bool = False,
+        ) -> GetDocumentsCommand: ...
+
+        # endregion
+
+        # region get_interface_paged
+        # GetDocumentsCommand.from_paging(...)
+        @classmethod
+        def from_paging(cls, start: int, page_size: int) -> GetDocumentsCommand: ...
+
+        # endregion
+
+        # region get_interface_startswith
+        # GetDocumentsCommand.from_starts_with(...)
+        @classmethod
+        def from_starts_with(
+            cls,
+            start_with: str,
+            start_after: str = None,
+            matches: str = None,
+            exclude: str = None,
+            start: int = None,
+            page_size: int = None,
+            metadata_only: bool = None,
+        ) -> GetDocumentsCommand: ...
+
+        # endregion
+
+
+class GetSamples(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_command(self):
+        with self.embedded_server.get_document_store("GetCommand") as store:
+            with store.open_session() as session:
+                # region get_sample_single
+                command = GetDocumentsCommand.from_single_id("orders/1-A", None, False)
+                session.advanced.request_executor.execute_command(command)
+                order = command.result.results[0]
+                # endregion
+
+                # region get_sample_multiple
+                command = GetDocumentsCommand.from_multiple_ids(["orders/1-A", "employees/3-A"])
+                session.advanced.request_executor.execute_command(command)
+                order = command.result.results[0]
+                employee = command.result.results[1]
+                # endregion
+
+                # region get_sample_includes
+                # Fetch employees/5-A and his boss.
+                command = GetDocumentsCommand.from_single_id("employees/5-A", ["ReportsTo"], False)
+                session.advanced.request_executor.execute_command(command)
+                employee = command.result.results[0]
+                boss = command.result.includes.get(employee.get("ReportsTo", None), None)
+                # endregion
+
+                # region get_sample_missing
+                # Assuming that products/9999-A doesn't exist
+                command = GetDocumentsCommand.from_multiple_ids(["products/1-A", "products/9999-A", "products/3-A"])
+                session.advanced.request_executor.execute_command(command)
+                products = command.result.results  # products/1-A, products/3-A
+                # endregion
+
+                # region get_sample_paged
+                command = GetDocumentsCommand.from_paging(0, 128)
+                session.advanced.request_executor.execute_command(command)
+                first_10_docs = command.result.results
+                # endregion
+
+                # region get_sample_startswith
+                # return up to 128 documents with key that starts with 'products'
+                command = GetDocumentsCommand.from_starts_with("products", start=0, page_size=128)
+                session.advanced.request_executor.execute_command(command)
+                products = command.result.results
+                # endregion
+
+                # region get_sample_startswith_matches
+                # return up to 128 documents with key that starts with 'products/'
+                # and rest of the key begins with "1" or "2" e.g. products/10, products/25
+                commands = GetDocumentsCommand.from_starts_with("products", matches="1*2|2*", start=0, page_size=128)
+                session.advanced.request_executor.execute_command(command)
+                products = command.result.results
+                # endregion
+
+                # region get_sample_startswith_matches_end
+                # return up to 128 documents with key that starts with 'products/'
+                # and rest of the key have length of 3, begins and ends with "1"
+                # and contains any character at 2nd position e.g. products/101, products/1B1
+                commands = GetDocumentsCommand.from_starts_with("products", matches="1?1", start=0, page_size=128)
+                session.advanced.request_executor.execute_command(command)
+                products = command.result.results
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Commands/Documents/Put.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Commands/Documents/Put.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+from ravendb import PutDocumentCommand, DocumentInfo
+from ravendb.documents.commands.crud import PutResult
+from ravendb.http.raven_command import VoidRavenCommand, RavenCommand
+
+from examples_base import ExampleBase, Category
+
+
+class Foo:
+    class PutDocumentCommand:
+        # region put_interface
+        class PutDocumentCommand(RavenCommand[PutResult]):
+            def __init__(self, key: str, change_vector: Optional[str], document: dict): ...
+
+        # endregion
+
+
+class PutSamples(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_put(self):
+        with self.embedded_server.get_document_store("PutDocumentCommand") as store:
+            with store.open_session() as session:
+                # region put_sample
+                # Create a new document
+                doc = Category(name="My category", description="My category description")
+
+                # Create metadata on the document
+                doc_info = DocumentInfo(collection="Categories")
+
+                # Convert your entity to a dict
+                dict_doc = session.entity_to_json.convert_entity_to_json_static(doc, session.conventions, doc_info)
+
+                # The put command (parameters are document ID, change vector check is None, the document to store)
+                command = PutDocumentCommand("employees/1-A", None, dict_doc)
+                # Request executor sends the command to the server
+                session.advanced.request_executor.execute_command(command)
+                # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/LoadBalance.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/LoadBalance.py
@@ -1,0 +1,138 @@
+from ravendb import (
+    DocumentStore,
+    LoadBalanceBehavior,
+    ClientConfiguration,
+    PutClientConfigurationOperation,
+    PutServerWideClientConfigurationOperation,
+)
+from ravendb.documents.conventions import DocumentConventions
+
+from examples_base import ExampleBase, Employee
+
+
+class LoadBalance(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    # region LoadBalance_6
+    # A customized method for getting a default context string
+    def get_default_context(self, db_name: str) -> str:
+        # Method is invoked by RavenDB with the database name
+        # Use that name - or return any string of your choice
+        return "DefaultContextString"
+
+    # endregion
+    def test_load_balance(self):
+        get_default_context = self.get_default_context
+        with self.embedded_server.get_document_store("LoadBalance") as store:
+            # region LoadBalance_1
+            # Initialize 'LoadBalanceBehavior' on the client:
+            document_store = DocumentStore(
+                urls=["ServerURL_1", "ServerURL_2", "..."],
+                database="DefaultDB",
+            )
+            conventions = DocumentConventions()
+
+            # Enable the session-context feature
+            # If this is not enabled then a context string set in a session will be ignored
+            conventions.load_balance_behavior = LoadBalanceBehavior.USE_SESSION_CONTEXT
+
+            # Assign a method that sets the default context string
+            # This string will be used for sessions that do Not provide a context string
+            # A sample GetDefaultContext method is defined below
+            conventions.load_balancer_per_session_context_selector = get_default_context
+
+            # Set a seed
+            # The seed is 0 by default, provide any number to override
+            conventions.load_balancer_context_seed = 5
+
+            document_store.conventions = conventions
+            document_store.initialize()
+
+        # endregion
+
+        # region LoadBalance_2
+        # Open a session that will use the DEFAULT store values:
+        with document_store.open_session() as session:
+            # For all Read & Write requests made in this session
+            # node to access is calculated from string & seed values defined on the store
+            employee = session.load("employees/1-A", Employee)
+        # endregion
+
+        # region LoadBalance_3
+        # Open a session that will use a UNIQUE context string:
+        with document_store.open_session() as session:
+            # Call set_context, pass a unique context string for this session
+            session.advanced.session_info.set_context = "SomeOtherContext"
+
+            # For all Read & Write requests made in this session,
+            # node to access is calculated from the unique string & the seed defined on the store
+            employee = session.load("employees/1-A", Employee)
+        # endregion
+
+        # region LoadBalance_4
+        # Setting 'LoadBalanceBehavior' on the server by sending an operation:
+        with document_store:
+            # Define the client configuration to put on the server
+            configuration_to_save = ClientConfiguration()
+            # Enable the session-context feature
+            # If this is not enabled then a context string set in a session will be ignored
+            configuration_to_save.load_balance_behavior = LoadBalanceBehavior.USE_SESSION_CONTEXT
+
+            # Set a seed
+            # The seed is 0 by default, provide any number to override
+            load_balancer_context_seed = 10
+
+            # NOTE:
+            # The session's context string is Not set on the server
+            # You still need to set it on the client:
+            # * either as a convention on the document store
+            # * or pass it to 'SetContext' method on the session
+
+            # Configuration will be in effect when Disabled is set to false
+            configuration_to_save.disabled = False
+
+            # Define the put configuration operation for the DEFAULT database
+            put_configuration_op = PutClientConfigurationOperation(configuration_to_save)
+
+            # Execute the operation by passing it to maintenance.send
+            document_store.maintenance.send(put_configuration_op)
+
+            #  After the operation has executed:
+            #  all Read & Write requests, per session, will address the node calculated from:
+            #    * the seed set on the server &
+            #    * the session's context string set on the client
+        # endregion
+
+        # region LoadBalance_5
+        with document_store:
+            # Define the client configuration to put on the server
+            configuration_to_save = ClientConfiguration()
+            # Enable the session-context feature
+            # If this is not enabled then a context string set in a session will be ignored
+            configuration_to_save.load_balance_behavior = LoadBalanceBehavior.USE_SESSION_CONTEXT
+
+            # Set a seed
+            # The seed is 0 by default, provide any number to override
+            load_balancer_context_seed = 10
+
+            # NOTE:
+            # The session's context string is Not set on the server
+            # You still need to set it on the client:
+            # * either as a convention on the document store
+            # * or pass it to 'SetContext' method on the session
+
+            # Configuration will be in effect when Disabled is set to false
+            configuration_to_save.disabled = False
+
+            # Define the put configuration operation for ALL databases
+            put_configuration_op = PutServerWideClientConfigurationOperation(configuration_to_save)
+
+            # Execute the operation by passing it to maintenance.server.send
+            document_store.maintenance.server.send(put_configuration_op)
+
+            #  After the operation has executed:
+            #  all Read & Write requests, per session, will address the node calculated from:
+            #    * the seed set on the server &
+            #    * the session's context string set on the client
+        # endregion

--- a/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/LoadBalance.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/LoadBalance.py
@@ -87,7 +87,7 @@ class LoadBalance(ExampleBase):
             # The session's context string is Not set on the server
             # You still need to set it on the client:
             # * either as a convention on the document store
-            # * or pass it to 'SetContext' method on the session
+            # * or pass it to the 'context' method on the session
 
             # Configuration will be in effect when Disabled is set to false
             configuration_to_save.disabled = False
@@ -120,7 +120,7 @@ class LoadBalance(ExampleBase):
             # The session's context string is Not set on the server
             # You still need to set it on the client:
             # * either as a convention on the document store
-            # * or pass it to 'SetContext' method on the session
+            # * or pass it to the 'context' method on the session
 
             # Configuration will be in effect when Disabled is set to false
             configuration_to_save.disabled = False

--- a/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/LoadBalance.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/LoadBalance.py
@@ -62,8 +62,8 @@ class LoadBalance(ExampleBase):
         # region LoadBalance_3
         # Open a session that will use a UNIQUE context string:
         with document_store.open_session() as session:
-            # Call set_context, pass a unique context string for this session
-            session.advanced.session_info.set_context = "SomeOtherContext"
+            # Call context, pass a unique context string for this session
+            session.advanced.session_info.context = "SomeOtherContext"
 
             # For all Read & Write requests made in this session,
             # node to access is calculated from the unique string & the seed defined on the store

--- a/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/ReadBalance.py
+++ b/Documentation/5.4/Samples/python/ClientApi/Configuration/LoadBalance/ReadBalance.py
@@ -1,0 +1,71 @@
+from ravendb import (
+    DocumentStore,
+    ReadBalanceBehavior,
+    ClientConfiguration,
+    PutClientConfigurationOperation,
+    PutServerWideClientConfigurationOperation,
+)
+from ravendb.documents.conventions import DocumentConventions
+
+from examples_base import ExampleBase
+
+
+class ReadBalance(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_read_balance(self):
+        with self.embedded_server.get_document_store("ReadBalance") as store:
+            # region ReadBalance_1
+            # Initialize 'ReadBalanceBehavior' on the client:
+            document_store = DocumentStore(
+                urls=["ServerURL_1", "ServerURL_2", "..."],
+                database="DefaultDB",
+            )
+            conventions = DocumentConventions()
+            # With ReadBalanceBehavior set to: 'FastestNode':
+            # Client READ requests will address the fastest node
+            # Client WRITE requests will address the preferred node
+            conventions.read_balance_behavior = ReadBalanceBehavior.FASTEST_NODE
+
+            document_store.conventions = conventions
+            # endregion
+
+            # region ReadBalance_2
+            # Setting 'ReadBalanceBehavior' on the server by sending an operation:
+            with document_store:
+                # Define the client configuration to put on the server
+                client_configuration = ClientConfiguration()
+                # Replace 'FastestNode' (from the example above) with 'RoundRobin'
+                client_configuration.read_balance_behavior = ReadBalanceBehavior.ROUND_ROBIN
+
+                # Define the put configuration operation for the DEFAULT database
+                put_configuration_op = PutClientConfigurationOperation(client_configuration)
+
+                # Execute the operation by passing it to maintenance.send
+                document_store.maintenance.send(put_configuration_op)
+
+                # After the operation has executed:
+                # All WRITE requests will continue to address the preferred node
+                # READ requests, per session, will address a different node based on the RoundRobin logic
+
+            # endregion
+
+            # region ReadBalance_3
+            # Setting 'ReadBalanceBehavior' on the server by sending an operation:
+            with document_store:
+                # Define the client configuration to put on the server
+                client_configuration = ClientConfiguration()
+                # Replace 'FastestNode' (from the example above) with 'RoundRobin'
+                client_configuration.read_balance_behavior = ReadBalanceBehavior.ROUND_ROBIN
+
+                # Define the put configuration operation for the ALL databases
+                put_configuration_op = PutServerWideClientConfigurationOperation(client_configuration)
+
+                # Execute the operation by passing it to maintenance.server.send
+                document_store.maintenance.server.send(put_configuration_op)
+
+                # After the operation has executed:
+                # All WRITE requests will continue to address the preferred node
+                # READ requests, per session, will address a different node based on the RoundRobin logic
+            # endregion


### PR DESCRIPTION
Related issues:
[RDoc-2803](https://issues.hibernatingrhinos.com/issue/RDoc-2803/Python-Client-API-Configuration-Load-balancing-client-requests-Read-balance-behavior-Replace-C-samples) Read balance behavior 
[RDoc-2804](https://issues.hibernatingrhinos.com/issue/RDoc-2804/Python-Client-API-Configuration-Load-balancing-client-requests-Load-balance-behavior-Replace-C-samples) Load balance behavior 
[RDoc-2826](https://issues.hibernatingrhinos.com/issue/RDoc-2826/Python-Client-API-Commands-Documents-Put-Replace-C-samples) Put command
[RDoc-2827](https://issues.hibernatingrhinos.com/issue/RDoc-2827/Python-Client-API-Commands-Documents-Get-Replace-C-samples) Get command
[RDoc-2828](https://issues.hibernatingrhinos.com/issue/RDoc-2828/Python-Client-API-Commands-Documents-Delete-Replace-C-samples) Delete command