### PR TITLE
RDoc-2815 [Node.js] Document extensions > Time series > Client API > Session > Querying [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.dotnet.markdown
@@ -18,7 +18,7 @@
 
 * Calling `TimeSeriesFor.Get` will result in a trip to the server unless the series' parent document was loaded  
   (or queried for) with the time series included beforehand.  
-  Learn more in: [Including time series](client-api/session/include/overview).
+  Learn more in: [Including time series](../../../../../document-extensions/timeseries/client-api/session/include/overview).
 
 * In this page:  
   * [`Get` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-usage)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
@@ -18,7 +18,7 @@
 
 * Calling `timeSeriesFor.get` will result in a trip to the server unless the series' parent document was loaded  
   (or queried for) with the time series included beforehand.  
-  Learn more in [Including time series](client-api/session/include/overview).
+  Learn more in [Including time series](../../../../../document-extensions/timeseries/client-api/session/include/overview).
 
 * In this page:  
   * [`get` usage](../../../../../document-extensions/timeseries/client-api/session/get/get-entries#get-usage)

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/querying.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/querying.dotnet.markdown
@@ -1,0 +1,311 @@
+﻿# Time Series Querying 
+---
+
+{NOTE: }
+
+* Time series data can be effectively queried in RavenDB, 
+  allowing users to access and analyze information based on specific time intervals.
+  
+* Time series queries can be made using:  
+  * The high-level `Query` method utilizing LINQ,  
+  * The lower-level API `DocumentQuery`,  
+  * Or directly through [RQL](../../../../client-api/session/querying/what-is-rql),
+    which can be provided to a `RawQuery` or executed from the Studio's [Query view](../../../../studio/database/queries/query-view).
+
+* In this page:  
+    * [Query](../../../../document-extensions/timeseries/client-api/session/querying#query)
+        * [Query usage](../../../../document-extensions/timeseries/client-api/session/querying#query-usage)
+        * [Query examples](../../../../document-extensions/timeseries/client-api/session/querying#query-examples)  
+        * [Query syntax](../../../../document-extensions/timeseries/client-api/session/querying#query-syntax)
+    * [DocumentQuery](../../../../document-extensions/timeseries/client-api/session/querying#document-query)
+        * [DocumentQuery usage](../../../../document-extensions/timeseries/client-api/session/querying#documentquery-usage)
+        * [DocumentQuery examples](../../../../document-extensions/timeseries/client-api/session/querying#documentquery-examples)
+        * [DocumentQuery Syntax](../../../../document-extensions/timeseries/client-api/session/querying#documentquery-examples)
+    * [RawQuery](../../../../document-extensions/timeseries/client-api/session/querying#raw-query)
+        * [RawQuery usage](../../../../document-extensions/timeseries/client-api/session/querying#rawquery-usage)
+        * [RawQuery examples](../../../../document-extensions/timeseries/client-api/session/querying#rawquery-examples)
+        * [RawQuery syntax](../../../../document-extensions/timeseries/client-api/session/querying#rawquery-syntax)
+    
+{NOTE/}
+
+{INFO: }
+Learn more about time series queries in the [section dedicated to this subject](../../../../document-extensions/timeseries/querying/overview-and-syntax).  
+{INFO/}
+
+---
+
+{PANEL: Query}
+
+---
+
+### Query usage
+
+* Open a session  
+* Call `session.Query`:
+  * Extend the query using LINQ expressions
+  * Provide a `Where` query predicate to locate documents whose time series you want to query  
+  * Use `Select` to choose a time series and project time series data
+  * Execute the query
+* Results will be in the form:
+  * `TimeSeriesRawResult` for non-aggregated data, or -  
+  * `TimeSeriesAggregationResult` for aggregated data  
+* Note:  
+  The RavenDB client translates the LINQ query to [RQL](../../../../client-api/session/querying/what-is-rql) before transmitting it to the server for execution.
+
+---
+
+### Query examples
+
+{NOTE: }
+This LINQ query filters users by their age and retrieves their HeartRates time series.  
+The first occurence of `Where` filters the documents.  
+The second `Where` filters the time series entries.
+{CODE-TABS}
+{CODE-TAB:csharp:Query ts_region_LINQ-1-Select-Timeseries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Users" as q
+where q.Age < 30
+select timeseries(from q.HeartRates where (Tag == "watches/fitbit"))
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+{NOTE/}
+
+{NOTE: } 
+In this example, we select a three-day range from the HeartRates time series.  
+{CODE-TABS}
+{CODE-TAB:csharp:Query ts_region_LINQ-3-Range-Selection@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Users" as q
+select timeseries(from q.HeartRates between "2020-05-17T00:00:00.0000000" and "2020-05-17T00:03:00.0000000")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+{NOTE/}
+
+{NOTE: }
+In this example, we retrieve a company's stock trade data.  
+Note the usage of named values, so we may address trade Volume [by name](../../../../document-extensions/timeseries/client-api/named-time-series-values).  
+{CODE-TABS}
+{CODE-TAB:csharp:Native timeseries_region_Unnamed-Values-Query@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TAB:csharp:Named timeseries_region_Named-Values-Query@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TABS/}
+{NOTE/}
+
+{NOTE: }
+In this example, we group heart-rate data of people above the age of 72 into 1-day groups,  
+and retrieve each group's average heart rate and number of measurements.  
+The aggregated results are retrieved as `List<TimeSeriesAggregationResult>`.
+{CODE ts_region_LINQ-6-Aggregation@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{NOTE/}
+
+---
+
+### Query syntax
+
+`session.Query` Definition:
+
+{CODE Query-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+Learn more about `session.Query` [here](../../../../client-api/session/querying/how-to-query#session.query).
+
+{PANEL/}
+
+{PANEL: DocumentQuery}
+
+---
+
+### DocumentQuery usage
+
+* Open a session
+* Call `session.Advanced.DocumentQuery`:
+    * Extend the query using RavenDB's fluent API methods
+    * Provide a `WhereEquals` query predicate to locate documents whose time series you want to query
+    * Use `SelectTimeSeries` to choose a time series and project time series data
+    * Execute the query
+* Results will be in the form:
+    * `TimeSeriesRawResult` for non-aggregated data, or -
+    * `TimeSeriesAggregationResult` for aggregated data
+* Note:  
+  The RavenDB client translates query to [RQL](../../../../client-api/session/querying/what-is-rql) before transmitting it to the server for execution.
+
+---
+
+### DocumentQuery examples
+
+{NOTE: }
+A _DocumentQuery_ using only the `From()` method.  
+{CODE TS_DocQuery_1@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+{NOTE/}
+
+{NOTE: }
+A _DocumentQuery_ using `Between()`.  
+{CODE TS_DocQuery_2@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+{NOTE/}
+
+{NOTE: }
+A _DocumentQuery_ using `FromFirst()`.  
+The query returns the first three days of the 'HeartRates' time series.  
+{CODE TS_DocQuery_3@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+{NOTE/}
+
+{NOTE: }
+A _DocumentQuery_ using `FromLast()`.  
+The query returns the last three days of the 'HeartRates' time series.  
+{CODE TS_DocQuery_4@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+{NOTE/}
+
+{NOTE: }
+A _DocumentQuery_ that loads the related `Monitor` documents that are specified in the time entries tags.  
+The results are then filtered by their content. 
+{CODE-TABS}
+{CODE-TAB:csharp:Query TS_DocQuery_5@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TAB:csharp:Class TS_DocQuery_class@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TABS/}
+{NOTE/}
+
+---
+
+### DocumentQuery syntax
+
+The session [DocumentQuery](../../../../client-api/session/querying/document-query/what-is-document-query),
+which is accessible from `session.Advanced`, can be extended with several useful time series methods.
+To access these methods, begin with method `SelectTimeSeries()`:
+
+{CODE-BLOCK: csharp}
+IDocumentQuery SelectTimeSeries(Func<ITimeSeriesQueryBuilder, TTimeSeries> timeSeriesQuery);
+{CODE-BLOCK/}
+
+`SelectTimeSeries()` takes an `ITimeSeriesQueryBuilder`. The builder has the following methods:
+
+{CODE-BLOCK: csharp}
+From(string name);
+Between(DateTime start, DateTime end);
+FromLast(Action<ITimePeriodBuilder> timePeriod);
+FromFirst(Action<ITimePeriodBuilder> timePeriod);
+LoadByTag<TTag>();
+//LoadByTag is extended by a special version of Where():
+Where(Expression<Func<TimeSeriesEntry, TTag, bool>> predicate);
+{CODE-BLOCK/}
+
+| Parameter                  | Type                                            | Description                                                                                                                                                               |
+|----------------------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **name**                   | `string`                                        | The name of the time series (in one or more documents) to query                                                                                                           |
+| **start**                  | `DateTime`                                      | First parameter for `Between()`.<br>The beginning of the time series range to filter.                                                                                     |
+| **end**                    | `DateTime`                                      | Second parameter for `Between()`.<br>The end of the time series range to filter.                                                                                          |
+| **timePeriod**             | `Action<ITimePeriodBuilder>`                    | Expression returning a number of time units representing a time series range either at the beginning or end of the queried time series.                                   |
+| `LoadByTag` type parameter | `TTag`                                          | Time series entry tags can be just strings, but they can also be document IDs, representing a reference to a related document. `LoadByTag` takes the type of the entity. |
+| **predicate**              | `Expression<Func<TimeSeriesEntry, TTag, bool>>` |
+
+`FromLast()` and `FromFirst()` take an `ITimePeriodBuilder`, which is used to represent a range of time from milliseconds to years:
+
+{CODE-BLOCK: csharp}
+public interface ITimePeriodBuilder
+{
+    Milliseconds(int duration);
+    Seconds(int duration);
+    Minutes(int duration);
+    Hours(int duration);
+    Days(int duration);
+    Months(int duration);
+    Quarters(int duration);
+    Years(int duration);
+}
+{CODE-BLOCK/}
+
+#### Return Value:
+
+* **`List<TimeSeriesAggregationResult>`**  for aggregated data.  
+  When the query [aggregates time series entries](../../../../document-extensions/timeseries/querying/aggregation-and-projections),
+  the results are returned in an aggregated array.
+
+* **`List<TimeSeriesRawResult>`** for non-aggregated data.  
+  When the query doesn't aggregate time series entries, the results are returned in a list of time series results.
+
+{PANEL/}
+
+{PANEL: RawQuery}
+
+---
+
+### RawQuery usage
+
+* Open a session  
+* Call `session.Advanced.RawQuery`, pass it the raw RQL that will be sent to the server 
+* Results will be in the form:  
+    * `TimeSeriesRawResult` for non-aggregated data, or -
+    * `TimeSeriesAggregationResult` for aggregated data
+* Note:  
+  The raw query transmits the provided RQL to the server as is, without checking or altering its content.
+
+---
+
+### RawQuery examples
+
+{NOTE: }
+
+In this example, we retrieve all HearRates time series for all users under 30.
+
+{CODE-TABS}
+{CODE-TAB:csharp:RawQuery ts_region_LINQ-2-RQL-Equivalent@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+* In this example, a raw RQL query retrieves 24 hours of heart rate data from users under the age of 30.  
+* The query does not aggregate data, so results are in the form of a `TimeSeriesRawResult` list.  
+* We define an **offset**, to adjust retrieved results to the client's local time-zone.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Declare-Syntax ts_region_Raw-Query-Non-Aggregated-Declare-Syntax@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TAB:csharp:Select-Syntax ts_region_Raw-Query-Non-Aggregated-Select-Syntax@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+* In this example, the query aggregates 7 days of HeartRates entries into 1-day groups.  
+* From each group, two values are selected and projected to the client:  
+  the **min** and **max** hourly HeartRates values.  
+* The aggregated results are in the form of a `TimeSeriesAggregationResult` list.
+
+{CODE ts_region_Raw-Query-Aggregated@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+---
+
+### RawQuery syntax
+
+{CODE RawQuery-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter  | Type     | Description          |
+|------------|----------|----------------------|
+|  **query** | `string` | The RQL query string |
+
+**Return Value**:
+
+* **`List<TimeSeriesAggregationResult>`**  for aggregated data.  
+  When the query [aggregates time series entries](../../../../document-extensions/timeseries/querying/aggregation-and-projections),
+  the results are returned in an aggregated array.
+
+* **`List<TimeSeriesRawResult>`** for non-aggregated data.  
+  When the query doesn't aggregate time series entries, the results are returned in a list of time series results.
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/querying.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/querying.js.markdown
@@ -1,0 +1,287 @@
+﻿# Time Series Querying 
+---
+
+{NOTE: }
+
+* Time series data can be effectively queried in RavenDB, 
+  allowing users to access and analyze information based on specific time intervals.
+  
+* Time series queries can be made using:  
+  * The `query` method 
+  * Or directly through [RQL](../../../../client-api/session/querying/what-is-rql),
+    which can be provided to a `rawQuery` or executed from the Studio's [Query view](../../../../studio/database/queries/query-view).
+
+* In this page:  
+    * [Query](../../../../document-extensions/timeseries/client-api/session/querying#query)
+        * [Query usage](../../../../document-extensions/timeseries/client-api/session/querying#query-usage)
+        * [Query examples](../../../../document-extensions/timeseries/client-api/session/querying#query-examples)  
+        * [Query syntax](../../../../document-extensions/timeseries/client-api/session/querying#query-syntax)
+    * [RawQuery](../../../../document-extensions/timeseries/client-api/session/querying#raw-query)
+        * [RawQuery usage](../../../../document-extensions/timeseries/client-api/session/querying#rawquery-usage)
+        * [RawQuery examples](../../../../document-extensions/timeseries/client-api/session/querying#rawquery-examples)
+        * [RawQuery syntax](../../../../document-extensions/timeseries/client-api/session/querying#rawquery-syntax)
+    
+{NOTE/}
+
+{INFO: }
+Learn more about time series queries in the [section dedicated to this subject](../../../../document-extensions/timeseries/querying/overview-and-syntax).  
+{INFO/}
+
+---
+
+{PANEL: Query}
+
+---
+
+### Query usage
+
+* Open a session  
+* Call `session.query`:
+  * Provide a query predicate to locate documents whose time series you want to query  
+  * Use `selectTimeSeries` to choose a time series and project time series data
+  * Execute the query
+* Results will be in the form:
+  * `TimeSeriesRawResult` for non-aggregated data, or -  
+  * `TimeSeriesAggregationResult` for aggregated data  
+* Note:  
+  The RavenDB client translates the query to [RQL](../../../../client-api/session/querying/what-is-rql) before transmitting it to the server for execution.
+
+---
+
+### Query examples
+
+{NOTE: }
+
+This query filters users by their age and retrieves their HeartRates time series.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_1@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "users"
+where age < 30
+select timeseries(
+    from "HeartRates"
+    where Tag == "watches/fitbit"
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: } 
+In this example, we select a 5-minute range from the HeartRates time series.  
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_2@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Users"
+select timeseries(
+    from "HeartRates"
+    between "2024-05-19T18:13:17.466Z" and "2024-05-19T18:18:17.466Z"
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+* In this example, we retrieve a company's stock trade data.  
+* Note the usage of named values, so we may address trade Volume [by name](../../../../document-extensions/timeseries/client-api/named-time-series-values).  
+* This example is based on the sample entries that were entered in [this example](../../../../document-extensions/timeseries/client-api/session/append#append-entries-with-multiple-values).
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Native query_3@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB:nodejs:Named query_4@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "companies"
+where address.city == "New York"
+select timeseries(
+    from StockPrices
+    between $start and $end
+    where Tag == "AppleTech"
+)
+{"start":"2024-05-20T07:54:07.259Z","end":"2024-05-23T07:54:07.259Z"}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+* In this example, we group heart-rate data of people above the age of 72 into 1-day groups,
+* For each group, we retrieve the number of measurements, the minimum, maximum, and average heart rate.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Native query_5@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "users"
+where age > 72
+select timeseries(
+    from HeartRates between $start and $end
+    where Tag == "watches/fitbit"
+    group by '1 day'
+    select count(), min(), max(), avg()
+)
+{"start":"2024-05-20T09:32:58.951Z","end":"2024-05-30T09:32:58.951Z"}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+---
+
+### Query syntax
+
+The `session.query` syntax is available [here](../../../../client-api/session/querying/how-to-query#syntax).
+
+Extend the `session.query` method with `selectTimeSeries()`.
+
+{CODE:nodejs syntax_1@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+
+| Parameter             | Type                | Description                                                                     |
+|-----------------------|---------------------|---------------------------------------------------------------------------------|
+| **timeSeriesQuery**   | `(builder) => void` | The time series query builder                                                   |
+| **projectionClass**   | `object`            | The query result type<br>`TimeSeriesRawResult` or `TimeSeriesAggregationResult` |
+
+The time series query builder has one method:
+
+{CODE:nodejs syntax_2@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+
+| Parameter      | Type     | Description                                   |
+|----------------|----------|-----------------------------------------------|
+| **queryText**  | `string` | The time series query part, expressed in RQL. |
+
+| Return value                    | Description                                                                                                               |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `TimeSeriesRawResult[]`         | The returned value for non-aggregated data                                                                                |
+| `TimeSeriesAggregationResult[]` | The returned value for [aggregated data](../../../../document-extensions/timeseries/querying/aggregation-and-projections) |
+
+{CODE:nodejs syntax_3@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+
+{PANEL/}
+
+{PANEL: RawQuery}
+
+---
+
+### RawQuery usage
+
+* Open a session  
+* Call `session.advanced.rawQuery`, pass it the raw RQL that will be sent to the server 
+* Results will be in the form:  
+    * `TimeSeriesRawResult` for non-aggregated data, or -
+    * `TimeSeriesAggregationResult` for aggregated data
+* Note:  
+  The raw query transmits the provided RQL to the server as is, without checking or altering its content.
+
+---
+
+### RawQuery examples
+
+{NOTE: }
+
+In this example, we retrieve all HearRates time series for all users under 30.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:RawQuery query_6@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from users where age < 30
+select timeseries(
+    from HeartRates
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+* In this example, a raw RQL query retrieves 24 hours of heart rate data from users under 30.  
+* The query does not aggregate data, so results are in the form of a `TimeSeriesRawResult` list.  
+* We define an **offset**, to adjust retrieved results to the client's local time-zone.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Declare-Syntax query_7@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB:nodejs:Select-Syntax query_8@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+// declare syntax
+// ==============
+
+declare timeseries getHeartRates(user)
+{
+    from user.HeartRates
+    between $start and $end
+    offset '03:00'
+}
+
+from users as u where age < 30
+select getHeartRates(u)
+{"start":"2024-05-20T11:52:22.316Z","end":"2024-05-21T11:52:22.316Z"}
+
+// select syntax
+// =============
+
+from Users as u where Age < 30
+select timeseries (
+    from HeartRates 
+        between $start and $end
+        offset "03:00"
+)
+{"start":"2024-05-20T11:55:56.701Z","end":"2024-05-21T11:55:56.701Z"}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+* In this example, the query aggregates 7 days of HeartRates entries into 1-day groups.  
+* From each group, two values are selected and projected to the client:  
+  the **min** and **max** hourly HeartRates values.  
+* The aggregated results are in the form of a `TimeSeriesAggregationResult` list.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:RawQuery query_9@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from users as u
+select timeseries(
+    from HeartRates between $start and $end
+    group by '1 day'
+    select min(), max()
+    offset "03:00"
+)
+{"start":"2024-05-20T12:06:40.595Z","end":"2024-05-27T12:06:40.595Z"}
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+---
+
+### RawQuery syntax
+
+{CODE:nodejs syntax_4@documentExtensions\timeSeries\client-api\queryTimeSeries.js /}
+
+| Parameter  | Type     | Description          |
+|------------|----------|----------------------|
+|  **query** | `string` | The RQL query string |
+
+The return value is the same as listed under the [query syntax](../../../../document-extensions/timeseries/client-api/session/querying#query-syntax).
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -311,46 +311,43 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     session.SaveChanges();
                 }
 
-
-                double day1Volume;
-                double day2Volume;
-                double day3Volume;
-
                 #region timeseries_region_Named-Values-Query
                 // Named Values Query
                 using (var session = store.OpenSession())
                 {
-                    IRavenQueryable<TimeSeriesRawResult<StockPrice>> query =
+                    var query =
                         session.Query<Company>()
                         .Where(c => c.Address.City == "New York")
                         .Select(q => RavenQuery.TimeSeries<StockPrice>(q, "StockPrices", baseline, baseline.AddDays(3))
                             .Where(ts => ts.Tag == "companies/kitchenAppliances")
                             .ToList());
 
-                    var result = query.ToList()[0];
+                    List<TimeSeriesRawResult<StockPrice>> queryResults = query.ToList();
+                    
+                    var tsEntries = queryResults[0].Results;
 
-                    day1Volume = result.Results[0].Value.Volume;
-                    day2Volume = result.Results[1].Value.Volume;
-                    day3Volume = result.Results[2].Value.Volume;
+                    double volumeDay1 = tsEntries[0].Value.Volume;
+                    double volumeDay2 = tsEntries[1].Value.Volume;
+                    double volumeDay3 = tsEntries[2].Value.Volume;
                 }
                 #endregion
 
                 #region timeseries_region_Unnamed-Values-Query
-                // Same query, only unnamed
                 using (var session = store.OpenSession())
                 {
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        session.Query<Company>()
+                    var query = session.Query<Company>()
                         .Where(c => c.Address.City == "New York")
                         .Select(q => RavenQuery.TimeSeries(q, "StockPrices", baseline, baseline.AddDays(3))
                             .Where(ts => ts.Tag == "companies/kitchenAppliances")
                             .ToList());
 
-                    var result = query.ToList()[0];
-
-                    day1Volume = result.Results[0].Values[4];
-                    day2Volume = result.Results[1].Values[4];
-                    day3Volume = result.Results[2].Values[4];
+                    List<TimeSeriesRawResult> queryResults = query.ToList();
+                    
+                    TimeSeriesEntry[] tsEntries = queryResults[0].Results;
+                    
+                    double volumeDay1 = tsEntries[0].Values[4];
+                    double volumeDay2 = tsEntries[1].Values[4];
+                    double volumeDay3 = tsEntries[2].Values[4];
                 }
                 #endregion
 
@@ -1377,7 +1374,7 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     var baseline = DateTime.Today;
 
                     #region ts_region_LINQ-6-Aggregation
-                    IRavenQueryable<TimeSeriesAggregationResult> query = session.Query<User>()
+                    var query = session.Query<User>()
                         .Where(u => u.Age > 72)
                         .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseline, baseline.AddDays(10))
                             .Where(ts => ts.Tag == "watches/fitbit")
@@ -1389,7 +1386,7 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                             })
                             .ToList());
 
-                    var result = query.ToList();
+                    List<TimeSeriesAggregationResult> result = query.ToList();
                     #endregion
                 }
 
@@ -1692,18 +1689,16 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     }
 
                     session.SaveChanges();
-
                 }
 
                 // Raw Query
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_Raw-Query-Non-Aggregated-Declare-Syntax
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00); // May 17 2020, 00:00:00
 
                     // Raw query with no aggregation - Declare syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
+                    var query =
                         session.Advanced.RawQuery<TimeSeriesRawResult>(@"
                             declare timeseries getHeartRates(user) 
                             {
@@ -1714,24 +1709,22 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                             from Users as u where Age < 30
                             select getHeartRates(u)
                             ")
-                        .AddParameter("start", baseline)
-                        .AddParameter("end", baseline.AddHours(24));
+                        .AddParameter("start", baseTime)
+                        .AddParameter("end", baseTime.AddHours(24));
 
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
-
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_Raw-Query-Non-Aggregated-Select-Syntax
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00); // May 17 2020, 00:00:00
 
                     // Raw query with no aggregation - Select syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
+                    var query =
                         session.Advanced.RawQuery<TimeSeriesRawResult>(@"
-                            from Users as u where Age < 30                            
+                            from Users as u where Age < 30
                             select timeseries (
                                 from HeartRates 
                                     between $start and $end
@@ -1740,36 +1733,32 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                         .AddParameter("start", baseline)
                         .AddParameter("end", baseline.AddHours(24));
 
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
+                    var results = query.ToList();
                     #endregion
-
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_Raw-Query-Aggregated
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00); // May 17 2020, 00:00:00
 
                     // Raw Query with aggregation
-                    IRawDocumentQuery<TimeSeriesAggregationResult> aggregatedRawQuery =
+                    var query =
                         session.Advanced.RawQuery<TimeSeriesAggregationResult>(@"
                             from Users as u
                             select timeseries(
                                 from HeartRates 
                                     between $start and $end
-                                group by '1 days'
-                                select min(), max())
+                                group by '1 day'
+                                select min(), max()
+                                offset '03:00')
                             ")
                         .AddParameter("start", baseline)
                         .AddParameter("end", baseline.AddDays(7));
 
-                    var aggregatedRawQueryResult = aggregatedRawQuery.ToList();
+                    List<TimeSeriesAggregationResult> results = query.ToList();
                     #endregion
-
                 }
-
-
             }
         }
 
@@ -1816,78 +1805,51 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_LINQ-2-RQL-Equivalent
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
                     // Raw query with no aggregation - Select syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
-                        session.Advanced.RawQuery<TimeSeriesRawResult>(@"
-                            from Users as u where Age < 30                            
+                    var query = session.Advanced.RawQuery<TimeSeriesRawResult>(@"
+                            from Users where Age < 30
                             select timeseries (
                                 from HeartRates
                             )");
 
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
 
                 #region ts_region_LINQ-1-Select-Timeseries
-                // Query - LINQ format
                 using (var session = store.OpenSession())
                 {
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<User>()
+                    // Define the query:
+                    var query = session.Query<User>()
+                             // Filter the user documents
                             .Where(u => u.Age < 30)
+                             // Call 'Select' to project the time series entries
                             .Select(q => RavenQuery.TimeSeries(q, "HeartRates")
-                            .Where(ts => ts.Tag == "watches/fitbit")
-                            .ToList());
-
-                    var result = query.ToList();
+                                 // Filter the time series entries    
+                                .Where(ts => ts.Tag == "watches/fitbit")
+                                 // 'ToList' must be applied here to the inner time series query definition
+                                 // This will not trigger query execution at this point
+                                .ToList());
+                    
+                    // Execute the query:
+                    // The following call to 'ToList' will trigger query execution
+                    List<TimeSeriesRawResult> result = query.ToList();
                 }
                 #endregion
-
 
                 // Query - LINQ format with Range selection 1
                 using (var session = store.OpenSession())
                 {
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
                     #region ts_region_LINQ-3-Range-Selection
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<User>()
-                            .Where(u => u.Age < 30)
-                            .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseline, baseline.AddDays(3))
-                            .ToList());
-
-                    var result = query.ToList();
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    
+                    var query = session.Query<User>()
+                            .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseTime, baseTime.AddDays(3))
+                                .ToList());
+                    
+                    List<TimeSeriesRawResult> result = query.ToList();
                     #endregion
                 }
-
-                // Query - LINQ format with Range selection 2
-                using (var session = store.OpenSession())
-                {
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    #region ts_region_LINQ-4-Where
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<User>()
-
-                            // Choose user profiles of users under the age of 30
-                            .Where(u => u.Age < 30)
-
-                            .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseline, baseline.AddDays(3))
-
-                            // Filter entries by tag.  
-                            .Where(ts => ts.Tag == "watches/fitbit")
-
-                            .ToList());
-
-                    var result = query.ToList();
-                    #endregion
-                }
-
 
                 // Query - LINQ format - LoadByTag to find employee address
                 using (var session = store.OpenSession())
@@ -1909,7 +1871,6 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
 
                     var result = query.ToList();
                 }
-
 
                 using (var session = store.OpenSession())
                 {
@@ -1988,10 +1949,18 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 using (var session = store.OpenSession())
                 {
                     #region TS_DocQuery_1
+                    // Define the query:
                     var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
+                             // 'ToList' must be applied here to the inner time series query definition
+                             // This will not trigger query execution at this point
                             .ToList());
+                    
+    
+                    // Execute the query:
+                    // The following call to 'ToList' will trigger query execution
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
 
@@ -2000,38 +1969,50 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     #region TS_DocQuery_2
                     var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
                             .Between(DateTime.Now, DateTime.Now.AddDays(1))
                             .ToList());
+                    
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region TS_DocQuery_3
-                    var query1 = session.Advanced.DocumentQuery<User>()
+                    var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
                             .FromFirst(x => x.Days(3))
                             .ToList());
 
-                    var query2 = session.Advanced.DocumentQuery<User>()
-                        .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
-                            .FromLast(x => x.Days(3))
-                            .ToList());
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
-
                 using (var session = store.OpenSession())
                 {
                     #region TS_DocQuery_4
                     var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
+                            .FromLast(x => x.Days(3))
+                            .ToList());
+                    
+                    List<TimeSeriesRawResult> results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region TS_DocQuery_5
+                    var query = session.Advanced.DocumentQuery<User>()
+                        .SelectTimeSeries(builder => builder
+                            .From("HeartRates")
                             .LoadByTag<Monitor>()
                             .Where((entry, monitor) => entry.Value <= monitor.Accuracy)
                             .ToList());
+                    
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
             }

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/queryTimeSeries.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/queryTimeSeries.js
@@ -1,0 +1,400 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function queryTimeSeries() {
+    {
+        //region create_data_for_testing_the_article_1
+        const u1 = new User();
+        u1.age = 25; u1.name = "j1";
+        const u2 = new User();
+        u2.age = 35; u2.name = "j2";
+        const u3 = new User();
+        u3.age = 73; u3.name = "j3";
+        
+        await session.store(u1, "users/j1");
+        await session.store(u2, "users/j2");
+        await session.store(u3, "users/j3");
+
+        const timeSeriesName = "HeartRates";
+        const tsf1 = session.timeSeriesFor("users/j1", timeSeriesName);
+        const tsf2 = session.timeSeriesFor("users/j2", timeSeriesName);
+
+        const optionalTag = "watches/fitbit";
+        const baseTime = new Date();
+        
+        tsf1.append(baseTime, 65, optionalTag);
+        tsf2.append(baseTime, 65, optionalTag);
+
+        for (let i = 1; i < 10; i++)
+        {
+            const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+            const nextMeasurement = 65 + i;
+            tsf1.append(nextMinute, nextMeasurement, optionalTag);
+            tsf2.append(nextMinute, nextMeasurement, optionalTag);
+        }
+
+        const tsf3 = session.timeSeriesFor("users/j3", timeSeriesName);        
+        tsf3.append(baseTime, 65, optionalTag);
+        const oneDay = 24 * 60 * 60 * 1000;
+        
+        for (let i = 1; i < 20; i++)
+        {
+            const nextDay = new Date(baseTime.getTime() + oneDay * i);
+            const nextMeasurement = 65 + i;
+            tsf3.append(nextDay, nextMeasurement, optionalTag);
+        }
+        
+        await session.saveChanges();
+        //endregion
+
+        //region create_data_for_testing_the_article_2
+        await documentStore.timeSeries.register("Companies",
+            "StockPrices", ["open", "close", "high", "low", "volume"]);
+        
+        const c1 = new Company();
+        c1.name = "Apple";
+        const a1 = new Address();
+        a1.city = "New York";
+        c1.address = a1;
+        await session.store(c1, "companies/c1");
+
+        const tsf = session.timeSeriesFor("companies/c1", "StockPrices", StockPrice);
+        
+        const optionalTag = "AppleTech";
+        const baseTime = new Date();
+        const oneDay = 24 * 60 * 60 * 1000;
+        
+        const price1 = new StockPrice();
+        price1.open = 52;
+        price1.close = 54;
+        price1.high = 63.5;
+        price1.low = 51.4;
+        price1.volume = 9824;
+
+        let nextDay = new Date(baseTime.getTime() + oneDay);
+        tsf.append(nextDay, price1, optionalTag);
+
+        const price2 = new StockPrice();
+        price2.open = 54;
+        price2.close = 55;
+        price2.high = 61.5;
+        price2.low = 49.4;
+        price2.volume = 8400;
+
+        nextDay = new Date(baseTime.getTime() + oneDay * 2);
+        tsf.append(nextDay, price2, optionalTag);
+
+        const price3 = new StockPrice();
+        price3.open = 55;
+        price3.close = 57;
+        price3.high = 65.5;
+        price3.low = 50;
+        price3.volume = 9020;
+
+        nextDay = new Date(baseTime.getTime() + oneDay * 3);
+        tsf.append(nextDay, price3, optionalTag);
+        
+        await session.saveChanges();
+        //endregion
+
+        //region query_1
+        // Define the time series query part (expressed in RQL):
+        const tsQueryText = `
+            from HeartRates
+            where Tag == "watches/fitbit"`;
+        
+        // Define the high-level query:
+        const query = session.query({ collection: "users" })
+            .whereLessThan("age", 30)
+             // Call 'selectTimeSeries' and pass it:
+             // * the time series query text
+             // * the `TimeSeriesRawResult` return type
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+        
+        // Execute the query:
+        const results = await query.all();
+
+        // Access entries results:
+        rawResults = results[0];
+        assert.equal((rawResults instanceof TimeSeriesRawResult), true);
+
+        const tsEntry = rawResults.results[0];
+        assert.equal((tsEntry instanceof TimeSeriesEntry), true);
+
+        const tsValue = tsEntry.value;
+        //endregion
+        
+        //region query_2
+        const startTime = new Date();
+        const endTime = new Date(startTime.getTime() + 5 * 60_000);
+        
+        // Define the time series query text:
+        const tsQueryText = `
+            from HeartRates
+            between $start and $end`;
+
+        // Define the query:
+        const query = session.query({ collection: "users" })
+             // Call 'selectTimeSeries' and pass it:
+             // * the time series query text
+             // * the `TimeSeriesRawResult` return type
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult)
+             // Add the parameters content
+            .addParameter("start", startTime)
+            .addParameter("end", endTime);
+        
+        // Execute the query:
+        const results = await query.all();
+        //endregion
+        
+        //region query_3
+        const oneDay = 24 * 60 * 60 * 1000;
+        const startTime = new Date();
+        const endTime = new Date(startTime.getTime() + 3 * oneDay);
+        
+        // Note: the 'where' clause must come after the 'between' clause
+        const tsQueryText = `
+            from StockPrices
+            between $start and $end
+            where Tag == "AppleTech"`;
+        
+        const query = session.query({ collection: "companies" })
+            .whereEquals("address.city", "New York")
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult)
+            .addParameter("start", startTime)
+            .addParameter("end", endTime);
+        
+        // Execute the query:
+        const results = await query.all();
+
+        // Access entries results:
+        const tsEntries = results[0].results;
+
+        const volumeDay1 = tsEntries[0].values[4];
+        const volumeDay2 = tsEntries[1].values[4];
+        const volumeDay3 = tsEntries[2].values[4];
+        //endregion
+        
+        //region query_4
+        const oneDay = 24 * 60 * 60 * 1000;
+        const startTime = new Date();
+        const endTime = new Date(startTime.getTime() + 3 * oneDay);
+
+        // Note: the 'where' clause must come after the 'between' clause
+        const tsQueryText = `
+            from StockPrices
+            between $start and $end
+            where Tag == "AppleTech"`;
+
+        const query = session.query({ collection: "companies" })
+            .whereEquals("address.city", "New York")
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult)
+            .addParameter("start", startTime)
+            .addParameter("end", endTime);
+
+        // Execute the query:
+        const results = await query.all();
+
+        // Access entries results:
+        const tsEntries = results[0].results;
+
+        // Call 'asTypedEntry' to be able to access the entry's values by their names
+        // Pass the class type (StockPrice)
+        const volumeDay1 = tsEntries[0].asTypedEntry(StockPrice).value.volume;
+        const volumeDay2 = tsEntries[1].asTypedEntry(StockPrice).value.volume;
+        const volumeDay3 = tsEntries[2].asTypedEntry(StockPrice).value.volume;
+        //endregion
+        
+        //region query_5
+        const oneDay = 24 * 60 * 60 * 1000;
+        const startTime = new Date();
+        const endTime = new Date(startTime.getTime() + 10 * oneDay);
+        
+        const tsQueryText = `from HeartRates between $start and $end
+            where Tag == "watches/fitbit"
+            group by "1 day"
+            select count(), min(), max(), avg()`;
+
+        const query = session.query({ collection: "users" })
+            .whereGreaterThan("age", 72)
+             // Call 'selectTimeSeries' and pass it:
+             // * the time series query text
+             // * the `TimeSeriesAggregationResult` return type
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesAggregationResult)
+            .addParameter("start", startTime)
+            .addParameter("end", endTime);
+        
+        // Execute the query:
+        const results = await query.all();
+        const aggregatedResults = results[0].results;
+
+        const averageForDay1 = aggregatedResults[0].average[0];
+        const averageForDay2 = aggregatedResults[1].average[0];        
+        //endregion
+        
+        //region query_6
+        const rql = `from users where age < 30
+             select timeseries(
+                from HeartRates
+             )`;
+        
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult);
+
+        const result = await query.all();
+        //endregion
+        
+        //region query_7
+        const rql = `
+            declare timeseries getHeartRates(user) 
+            {
+                from user.HeartRates 
+                    between $start and $end
+                    offset "03:00"
+            }
+            
+            from users as u where age < 30
+            select getHeartRates(u)`;
+
+        const startTime = new Date();
+        const endTime = new Date(startTime.getTime() + 24 * 60 * 60 * 1000);
+        
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult)
+            .addParameter("start", startTime)
+            .addParameter("end", endTime);
+
+        const result = await query.all();
+        //endregion
+        
+        //region query_8
+        const rql = `
+            from Users as u where Age < 30
+            select timeseries (
+                from HeartRates 
+                    between $start and $end
+                    offset "03:00"
+            )`;
+
+        const startTime = new Date();
+        const endTime = new Date(startTime.getTime() + 24 * 60 * 60 * 1000);
+
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult)
+            .addParameter("start", startTime)
+            .addParameter("end", endTime);
+
+        const result = await query.all();
+        //endregion
+        
+        //region query_9
+        const rql = `
+            from users as u
+            select timeseries(
+                from HeartRates between $start and $end
+                group by '1 day'
+                select min(), max()
+                offset "03:00"
+            )`;
+
+        const oneDay = 24 * 60 * 60 * 1000;
+        const startTime = new Date();
+        const endTime = new Date(startTime.getTime() + 7 * oneDay);
+
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult)
+            .addParameter("start", startTime)
+            .addParameter("end", endTime);
+
+        const result = await query.all();
+        //endregion
+    }
+}
+
+//region syntax_1
+selectTimeSeries(timeSeriesQuery, projectionClass);
+//endregion
+
+//region syntax_2
+raw(queryText);
+//endregion
+
+//region syntax_3
+class TimeSeriesRawResult {
+    results; // TimeSeriesEntry[]
+    asTypedResult>(clazz);
+}
+
+class TimeSeriesAggregationResult extends TimeSeriesQueryResult {
+    results; // TimeSeriesRangeAggregation[];
+    asTypedEntry(clazz);
+}
+//endregion
+
+//region syntax_4
+session.rawQuery(query);
+//endregion
+
+//region stockPrice_class
+// This class is used in the "Named Values" example
+class StockPrice {
+
+    // Define the names for the entry values
+    static TIME_SERIES_VALUES = ["open", "close", "high", "low", "volume"];
+    
+    constructor(
+        open = 0,
+        close = 0,
+        high = 0,
+        low = 0,
+        volume = 0
+    ) {
+        Object.assign(this, {
+            open,
+            close,
+            high,
+            low,
+            volume
+        });
+    }
+}
+//endregion
+
+//region user_class
+class User {
+    constructor(
+        name = '',
+        age = 0
+    ) {
+        Object.assign(this, {
+            name,
+            age
+        });
+    }
+}
+//endregion
+
+//region company_class
+class Company {
+    constructor(
+        name = '',
+        address = null,
+    ) {
+        Object.assign(this, {
+            name,
+            address
+        });
+    }
+}
+//endregion
+
+//region address_class
+class Address {
+    constructor(
+        city = ''
+    ) {
+        Object.assign(this, {
+            city
+        });
+    }
+}
+//endregion

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -311,46 +311,43 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     session.SaveChanges();
                 }
 
-
-                double day1Volume;
-                double day2Volume;
-                double day3Volume;
-
                 #region timeseries_region_Named-Values-Query
                 // Named Values Query
                 using (var session = store.OpenSession())
                 {
-                    IRavenQueryable<TimeSeriesRawResult<StockPrice>> query =
+                    var query =
                         session.Query<Company>()
-                        .Where(c => c.Address.City == "New York")
-                        .Select(q => RavenQuery.TimeSeries<StockPrice>(q, "StockPrices", baseline, baseline.AddDays(3))
-                            .Where(ts => ts.Tag == "companies/kitchenAppliances")
-                            .ToList());
+                            .Where(c => c.Address.City == "New York")
+                            .Select(q => RavenQuery.TimeSeries<StockPrice>(q, "StockPrices", baseline, baseline.AddDays(3))
+                                .Where(ts => ts.Tag == "companies/kitchenAppliances")
+                                .ToList());
 
-                    var result = query.ToList()[0];
+                    List<TimeSeriesRawResult<StockPrice>> queryResults = query.ToList();
+                    
+                    var tsEntries = queryResults[0].Results;
 
-                    day1Volume = result.Results[0].Value.Volume;
-                    day2Volume = result.Results[1].Value.Volume;
-                    day3Volume = result.Results[2].Value.Volume;
+                    double volumeDay1 = tsEntries[0].Value.Volume;
+                    double volumeDay2 = tsEntries[1].Value.Volume;
+                    double volumeDay3 = tsEntries[2].Value.Volume;
                 }
                 #endregion
 
                 #region timeseries_region_Unnamed-Values-Query
-                // Same query, only unnamed
                 using (var session = store.OpenSession())
                 {
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        session.Query<Company>()
+                    var query = session.Query<Company>()
                         .Where(c => c.Address.City == "New York")
                         .Select(q => RavenQuery.TimeSeries(q, "StockPrices", baseline, baseline.AddDays(3))
                             .Where(ts => ts.Tag == "companies/kitchenAppliances")
                             .ToList());
 
-                    var result = query.ToList()[0];
-
-                    day1Volume = result.Results[0].Values[4];
-                    day2Volume = result.Results[1].Values[4];
-                    day3Volume = result.Results[2].Values[4];
+                    List<TimeSeriesRawResult> queryResults = query.ToList();
+                    
+                    TimeSeriesEntry[] tsEntries = queryResults[0].Results;
+                    
+                    double volumeDay1 = tsEntries[0].Values[4];
+                    double volumeDay2 = tsEntries[1].Values[4];
+                    double volumeDay3 = tsEntries[2].Values[4];
                 }
                 #endregion
 
@@ -1378,7 +1375,7 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     var baseline = DateTime.Today;
 
                     #region ts_region_LINQ-6-Aggregation
-                    IRavenQueryable<TimeSeriesAggregationResult> query = session.Query<User>()
+                    var query = session.Query<User>()
                         .Where(u => u.Age > 72)
                         .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseline, baseline.AddDays(10))
                             .Where(ts => ts.Tag == "watches/fitbit")
@@ -1390,7 +1387,7 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                             })
                             .ToList());
 
-                    var result = query.ToList();
+                    List<TimeSeriesAggregationResult> result = query.ToList();
                     #endregion
                 }
 
@@ -1693,18 +1690,16 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     }
 
                     session.SaveChanges();
-
                 }
 
                 // Raw Query
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_Raw-Query-Non-Aggregated-Declare-Syntax
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00); // May 17 2020, 00:00:00
 
                     // Raw query with no aggregation - Declare syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
+                    var query =
                         session.Advanced.RawQuery<TimeSeriesRawResult>(@"
                             declare timeseries getHeartRates(user) 
                             {
@@ -1715,62 +1710,56 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                             from Users as u where Age < 30
                             select getHeartRates(u)
                             ")
-                        .AddParameter("start", baseline)
-                        .AddParameter("end", baseline.AddHours(24));
+                            .AddParameter("start", baseTime)
+                            .AddParameter("end", baseTime.AddHours(24));
 
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
-
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_Raw-Query-Non-Aggregated-Select-Syntax
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00); // May 17 2020, 00:00:00
 
                     // Raw query with no aggregation - Select syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
+                    var query =
                         session.Advanced.RawQuery<TimeSeriesRawResult>(@"
-                            from Users as u where Age < 30                            
+                            from Users as u where Age < 30
                             select timeseries (
                                 from HeartRates 
                                     between $start and $end
                                     offset '02:00'
                             )")
-                        .AddParameter("start", baseline)
-                        .AddParameter("end", baseline.AddHours(24));
+                            .AddParameter("start", baseline)
+                            .AddParameter("end", baseline.AddHours(24));
 
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
+                    var results = query.ToList();
                     #endregion
-
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_Raw-Query-Aggregated
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00); // May 17 2020, 00:00:00
 
                     // Raw Query with aggregation
-                    IRawDocumentQuery<TimeSeriesAggregationResult> aggregatedRawQuery =
+                    var query =
                         session.Advanced.RawQuery<TimeSeriesAggregationResult>(@"
                             from Users as u
                             select timeseries(
                                 from HeartRates 
                                     between $start and $end
                                 group by '1 days'
-                                select min(), max())
+                                select min(), max()
+                                offset '03:00')
                             ")
-                        .AddParameter("start", baseline)
-                        .AddParameter("end", baseline.AddDays(7));
+                            .AddParameter("start", baseline)
+                            .AddParameter("end", baseline.AddDays(7));
 
-                    var aggregatedRawQueryResult = aggregatedRawQuery.ToList();
+                    List<TimeSeriesAggregationResult> results = query.ToList();
                     #endregion
-
                 }
-
-
             }
         }
 
@@ -1817,38 +1806,37 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 using (var session = store.OpenSession())
                 {
                     #region ts_region_LINQ-2-RQL-Equivalent
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
                     // Raw query with no aggregation - Select syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
-                        session.Advanced.RawQuery<TimeSeriesRawResult>(@"
-                            from Users as u where Age < 30                            
+                    var query = session.Advanced.RawQuery<TimeSeriesRawResult>(@"
+                            from Users where Age < 30
                             select timeseries (
                                 from HeartRates
                             )");
 
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
 
                 #region ts_region_LINQ-1-Select-Timeseries
-                // Query - LINQ format
                 using (var session = store.OpenSession())
                 {
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<User>()
-                            .Where(u => u.Age < 30)
-                            .Select(q => RavenQuery.TimeSeries(q, "HeartRates")
+                    // Define the query:
+                    var query = session.Query<User>()
+                         // Filter the user documents
+                        .Where(u => u.Age < 30)
+                         // Call 'Select' to project the time series entries
+                        .Select(q => RavenQuery.TimeSeries(q, "HeartRates")
+                             // Filter the time series entries    
                             .Where(ts => ts.Tag == "watches/fitbit")
+                             // 'ToList' must be applied here to the inner time series query definition
+                             // This will not trigger query execution at this point
                             .ToList());
-
-                    var result = query.ToList();
+                    
+                    // Execute the query:
+                    // The following call to 'ToList' will trigger query execution
+                    List<TimeSeriesRawResult> result = query.ToList();
                 }
                 #endregion
-
 
                 // Query - LINQ format with Range selection 1
                 using (var session = store.OpenSession())
@@ -1856,39 +1844,15 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
 
                     #region ts_region_LINQ-3-Range-Selection
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<User>()
-                            .Where(u => u.Age < 30)
-                            .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseline, baseline.AddDays(3))
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    
+                    var query = session.Query<User>()
+                        .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseTime, baseTime.AddDays(3))
                             .ToList());
-
-                    var result = query.ToList();
+                    
+                    List<TimeSeriesRawResult> result = query.ToList();
                     #endregion
                 }
-
-                // Query - LINQ format with Range selection 2
-                using (var session = store.OpenSession())
-                {
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    #region ts_region_LINQ-4-Where
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<User>()
-
-                            // Choose user profiles of users under the age of 30
-                            .Where(u => u.Age < 30)
-
-                            .Select(q => RavenQuery.TimeSeries(q, "HeartRates", baseline, baseline.AddDays(3))
-
-                            // Filter entries by tag.  
-                            .Where(ts => ts.Tag == "watches/fitbit")
-
-                            .ToList());
-
-                    var result = query.ToList();
-                    #endregion
-                }
-
 
                 // Query - LINQ format - LoadByTag to find employee address
                 using (var session = store.OpenSession())
@@ -1910,7 +1874,6 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
 
                     var result = query.ToList();
                 }
-
 
                 using (var session = store.OpenSession())
                 {
@@ -1989,10 +1952,18 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 using (var session = store.OpenSession())
                 {
                     #region TS_DocQuery_1
+                    // Define the query:
                     var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
+                             // 'ToList' must be applied here to the inner time series query definition
+                             // This will not trigger query execution at this point
                             .ToList());
+                    
+    
+                    // Execute the query:
+                    // The following call to 'ToList' will trigger query execution
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
 
@@ -2001,38 +1972,50 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     #region TS_DocQuery_2
                     var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
                             .Between(DateTime.Now, DateTime.Now.AddDays(1))
                             .ToList());
+                    
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
 
                 using (var session = store.OpenSession())
                 {
                     #region TS_DocQuery_3
-                    var query1 = session.Advanced.DocumentQuery<User>()
+                    var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
                             .FromFirst(x => x.Days(3))
                             .ToList());
 
-                    var query2 = session.Advanced.DocumentQuery<User>()
-                        .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
-                            .FromLast(x => x.Days(3))
-                            .ToList());
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
-
                 using (var session = store.OpenSession())
                 {
                     #region TS_DocQuery_4
                     var query = session.Advanced.DocumentQuery<User>()
                         .SelectTimeSeries(builder => builder
-                            .From("Heartrate")
+                            .From("HeartRates")
+                            .FromLast(x => x.Days(3))
+                            .ToList());
+                    
+                    List<TimeSeriesRawResult> results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region TS_DocQuery_5
+                    var query = session.Advanced.DocumentQuery<User>()
+                        .SelectTimeSeries(builder => builder
+                            .From("HeartRates")
                             .LoadByTag<Monitor>()
                             .Where((entry, monitor) => entry.Value <= monitor.Accuracy)
                             .ToList());
+                    
+                    List<TimeSeriesRawResult> results = query.ToList();
                     #endregion
                 }
             }


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2815/Node.js-Document-extensions-Time-series-Client-API-Session-Querying-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2846/Document-extensions-Time-series-Client-API-Session-Querying-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/querying.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/queryTimeSeries.js
```
