### PR TITLE
RDoc-2847 [Node.js] Document extensions > Time series > Client API > Operations > Append & Delete [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/append-and-delete.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/append-and-delete.dotnet.markdown
@@ -1,0 +1,155 @@
+﻿# Append & Delete Time Series Operations
+---
+
+{NOTE: }
+
+* Use `TimeSeriesBatchOperation` to Append and Delete multiple time series entries on a single document.  
+  A list of predefined Append and Delete actions will be executed in this single batch operation.
+
+* To Append and Delete multiple time series entries on multiple documents, see [PatchByQueryOperation](../../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation).
+
+* For a general _Operations_ overview, see [What are Operations](../../../../client-api/operations/what-are-operations).
+
+* In this page:  
+   * [Usage](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#usage)
+   * [Examples](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#examples)
+       * [Append multiple entries](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#append-multiple-entries)
+       * [Delete multiple entries](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#delete-multiple-entries)
+       * [Append & Delete entries in the same batch](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#append--delete-entries-in-the-same-batch)
+   * [Syntax](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Usage}
+
+* Prepare the Append and Delete operations:
+    * Create an instance of `TimeSeriesOperation.AppendOperation` to define an Append action.
+    * Create an instance of ` TimeSeriesOperation.DeleteOperation` fo define a Delete action.
+
+* Create an instance of `TimeSeriesOperation` and pass it the the time series name.
+    * Call `TimeSeriesOperation.Append` to add the Append operation.
+    * Call `TimeSeriesOperation.Delete` to add the Delete operation.
+
+* Create a `TimeSeriesBatchOperation` instance and pass it:  
+   * The document ID
+   * The `TimeSeriesOperation` object
+
+* Execute the `TimeSeriesBatchOperation` operation by calling `store.Operations.Send`
+   * All the added Append and Delete operations will be executed in a single-node transaction.
+   * Delete actions are executed **before** Append actions. As seen in [this example](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#append--delete-entries-in-the-same-batch).
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+#### Append multiple entries
+
+In this example, we append four entries to a time series.
+
+{CODE timeseries_region_Append-Using-TimeSeriesBatchOperation@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### Delete multiple entries
+
+In this example, we delete a range of two entries from a time series.  
+
+{CODE timeseries_region_Delete-Range-Using-TimeSeriesBatchOperation@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### Append & Delete entries in the same batch
+
+* In this example, we append and delete entries in the same batch operation.
+
+* Note: the Delete actions are executed **before** all Append actions.
+
+{CODE timeseries_region-Append-and-Delete-TimeSeriesBatchOperation@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+#### `TimeSeriesBatchOperation`
+
+{CODE TimeSeriesBatchOperation-definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+
+| Parameter      | Type                  | Description                                                                           |
+|----------------|-----------------------|---------------------------------------------------------------------------------------|
+| **documentId** | `string`              | The ID of the document to which you want to Append/Delete time series data.           |
+| **operation**  | `TimeSeriesOperation` | This class defines which Append/Delete actions to perform within the batch operation. |
+
+#### `TimeSeriesOperation`  
+
+{CODE-BLOCK:csharp}
+public class TimeSeriesOperation
+{
+      public string Name;
+      public void Append(AppendOperation appendOperation)
+      public void Delete(DeleteOperation deleteOperation)
+}
+{CODE-BLOCK/}
+
+| Property   | Type     | Description                          |
+|------------|----------|--------------------------------------|
+| **Name**   | `string` | The time series name                 |
+| **Append** | `method` | Add an `AppendOperation` to the list |
+| **Delete** | `method` | Add a `DeleteOperation` to the list  |
+
+#### `AppendOperation`
+    
+{CODE-BLOCK:csharp}
+public class AppendOperation
+{
+      public DateTime Timestamp;
+      public double[] Values;
+      public string Tag;
+}
+{CODE-BLOCK/}
+
+| Property      | Type       | Description                                              |
+|---------------|------------|----------------------------------------------------------|
+| **Timestamp** | `DateTime` | The time series entry will be appended at this timestamp |
+| **Values**    | `double[]` | Entry values                                             |
+| **Tag**       | `string`   | Entry tag (optional)                                     |
+
+#### `DeleteOperation`
+ 
+{CODE-BLOCK:csharp}
+public class DeleteOperation
+{
+     public DateTime? From, To;
+}
+{CODE-BLOCK/}
+
+| Property   | Type        | Description                                                                                    |
+|------------|-------------|------------------------------------------------------------------------------------------------|
+| **From**   | `DateTime?` | Entries will be deleted starting at this timestamp (inclusive)<br>Default: `DateTime.MinValue` |
+| **To**     | `DateTime?` | Entries will be deleted up to this timestamp (inclusive)<br>Default: `DateTime.MaxValue`       |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/append-and-delete.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/append-and-delete.js.markdown
@@ -1,0 +1,135 @@
+﻿# Append & Delete Time Series Operations
+---
+
+{NOTE: }
+
+* Use `TimeSeriesBatchOperation` to Append and Delete multiple time series entries on a single document.  
+  A list of predefined Append and Delete actions will be executed in this single batch operation.
+
+* To Append and Delete multiple time series entries on multiple documents, see [PatchByQueryOperation](../../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation).
+
+* For a general _Operations_ overview, see [What are Operations](../../../../client-api/operations/what-are-operations).
+
+* In this page:  
+   * [Usage](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#usage)
+   * [Examples](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#examples)
+       * [Append multiple entries](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#append-multiple-entries)
+       * [Delete multiple entries](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#delete-multiple-entries)
+       * [Append & delete entries in the same batch](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#append--delete-entries-in-the-same-batch)
+   * [Syntax](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Usage}
+
+* Prepare the Append and Delete operations:
+    * Create an instance of `TimeSeriesOperation.AppendOperation` to define an Append action.
+    * Create an instance of ` TimeSeriesOperation.DeleteOperation` fo define a Delete action.
+
+* Create an instance of `TimeSeriesOperation` and pass it the the time series name.
+    * Call `TimeSeriesOperation.append` to add the Append operation.
+    * Call `TimeSeriesOperation.delete` to add the Delete operation.
+
+* Create a `TimeSeriesBatchOperation` instance and pass it:  
+   * The document ID
+   * The `TimeSeriesOperation` object
+
+* Execute the `TimeSeriesBatchOperation` operation by calling `store.operations.send`
+   * All the added Append and Delete operations will be executed in a single-node transaction.
+   * Delete actions are executed **before** Append actions. As seen in [this example](../../../../document-extensions/timeseries/client-api/operations/append-and-delete#append--delete-entries-in-the-same-batch).
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+#### Append multiple entries
+
+In this example, we append four entries to a time series.
+
+{CODE:nodejs operation_1@documentExtensions\timeSeries\client-api\appendAndDeleteOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### Delete multiple entries
+
+In this example, we delete a range of two entries from a time series.  
+
+{CODE:nodejs operation_2@documentExtensions\timeSeries\client-api\appendAndDeleteOperations.js /}
+
+{NOTE/}
+
+{NOTE: }
+
+#### Append & delete entries in the same batch
+
+* In this example, we append and delete entries in the same batch operation.
+
+* Note: the Delete actions are executed **before** all Append actions.
+
+{CODE:nodejs operation_3@documentExtensions\timeSeries\client-api\appendAndDeleteOperations.js /}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+#### `TimeSeriesBatchOperation`
+
+{CODE:nodejs syntax_1@documentExtensions\timeSeries\client-api\appendAndDeleteOperations.js /}
+
+| Parameter      | Type                  | Description                                                                           |
+|----------------|-----------------------|---------------------------------------------------------------------------------------|
+| **documentId** | `string`              | The ID of the document to which you want to Append/Delete time series data.           |
+| **operation**  | `TimeSeriesOperation` | This class defines which Append/Delete actions to perform within the batch operation. |
+
+#### `TimeSeriesOperation`  
+
+{CODE:nodejs syntax_2@documentExtensions\timeSeries\client-api\appendAndDeleteOperations.js /}
+
+| Property   | Type     | Description                                                          |
+|------------|----------|----------------------------------------------------------------------|
+| **name**   | `string` | The time series name                                                 |
+| **append** | `method` | Pass a `AppendOperation` object to this method to add it to the list |
+| **delete** | `method` | Pass a `DeleteOperation` object to this method to add it to the list |
+
+#### `AppendOperation`
+
+{CODE:nodejs syntax_3@documentExtensions\timeSeries\client-api\appendAndDeleteOperations.js /}
+
+| Property      | Type       | Description                                              |
+|---------------|------------|----------------------------------------------------------|
+| **timestamp** | `Date`     | The time series entry will be appended at this timestamp |
+| **values**    | `number[]` | Entry values                                             |
+| **tag**       | `string`   | Entry tag (optional)                                     |
+
+#### `DeleteOperation`
+
+{CODE:nodejs syntax_4@documentExtensions\timeSeries\client-api\appendAndDeleteOperations.js /}
+
+| Property  | Type   | Description                                                                                       |
+|-----------|--------|---------------------------------------------------------------------------------------------------|
+| **from**  | `Date` | Entries will be deleted starting at this timestamp (inclusive)<br>Default: the minimum date value |
+| **to**    | `Date` | Entries will be deleted up to this timestamp (inclusive)<br>Default: the maximum date value       |
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.dotnet.markdown
@@ -19,9 +19,10 @@
 
 * Each call to `Append` handles a __single__ [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).
 
-* To append __multiple__ entries in a single transaction:  
-  * Call `Append` as many times as needed before calling `session.SaveChanges`, or -
-  * Use patching to update the time series. Learn more in [Patch time series entries](../../../../document-extensions/timeseries/client-api/session/patch).  
+* To append __multiple__ entries in a single transaction you can:  
+  * Call `Append` as many times as needed before calling `session.SaveChanges`, as shown in the examples below.
+  * Use patching to update the time series. Learn more in [Patch time series entries](../../../../document-extensions/timeseries/client-api/session/patch).
+  * Append entries directly on the _Store_ via [Operations](../../../../client-api/operations/what-are-operations). Learn more in [Append time series operations](../../../../document-extensions/timeseries/client-api/operations/append-and-delete). 
 
 ---
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/append.js.markdown
@@ -19,9 +19,10 @@
 
 * Each call to `append` handles a __single__ [time series entry](../../../../document-extensions/timeseries/design#time-series-entries).
 
-* To append __multiple__ entries in a single transaction:
-    * Call `append` as many times as needed before calling `session.saveChanges`, or -
+* To append __multiple__ entries in a single transaction you can:
+    * Call `append` as many times as needed before calling `session.saveChanges`, as shown in the examples below.
     * Use patching to update the time series. Learn more in [Patch time series entries](../../../../document-extensions/timeseries/client-api/session/patch).
+    * Append entries directly on the _Store_ via [Operations](../../../../client-api/operations/what-are-operations). Learn more in [Append time series operations](../../../../document-extensions/timeseries/client-api/operations/append-and-delete).
 
 ---
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.dotnet.markdown
@@ -4,12 +4,12 @@
 
 {NOTE: }
 
-* Patching time series entries (append or delete entries) can be performed via the Session  
+* Patching multiple time series entries (append or delete entries) can be performed via the _Session_  
   using [session.Advanced.Defer](../../../../client-api/operations/patching/single-document#session-api-using-defer), as described below.
   * You can handle a single document at a time.
   * The patching action is defined by the provided [JavaScript script](../../../../document-extensions/timeseries/client-api/javascript-support).
   
-* Patching time series entries can also be done directly on the Store via _Operations_,  
+* Patching time series entries can also be done directly on the _Store_ via [Operations](../../../../client-api/operations/what-are-operations),  
   where multiple documents can be handled at a time. Learn more in [Patching time series operations](../../../../document-extensions/timeseries/client-api/operations/patch).
 
 * In this page:

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/patch.js.markdown
@@ -4,12 +4,12 @@
 
 {NOTE: }
 
-* Patching time series entries (append or delete entries) can be performed via the Session  
+* Patching multiple time series entries (append or delete entries) can be performed via the _Session_  
   using [session.advanced.defer](../../../../client-api/operations/patching/single-document#session-api-using-defer), as described below.
   * You can handle a single document at a time.
   * The patching action is defined by the provided [JavaScript script](../../../../document-extensions/timeseries/client-api/javascript-support).
   
-* Patching time series entries can also be done directly on the Store via _Operations_,  
+* Patching time series entries can also be done directly on the _Store_ via [Operations](../../../../client-api/operations/what-are-operations),  
   where multiple documents can be handled at a time. Learn more in [Patching time series operations](../../../../document-extensions/timeseries/client-api/operations/patch).
 
 * In this page:

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendAndDeleteOperations.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendAndDeleteOperations.js
@@ -1,0 +1,143 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function appendAndDeleteOperations() {
+    {
+        //region operation_1
+        const baseTime = new Date();
+
+        // Define the Append operations:
+        let nextMinute = new Date(baseTime.getTime() + 60_000);
+        const appendOp1 = new AppendOperation(nextMinute, [79], "watches/fitbit");
+
+        nextMinute = new Date(baseTime.getTime() + 60_000 * 2);
+        const appendOp2 = new AppendOperation(nextMinute, [82], "watches/fitbit");
+
+        nextMinute = new Date(baseTime.getTime() + 60_000 * 3);
+        const appendOp3 = new AppendOperation(nextMinute, [80], "watches/fitbit");
+
+        nextMinute = new Date(baseTime.getTime() + 60_000 * 4);
+        const appendOp4 = new AppendOperation(nextMinute, [78], "watches/fitbit");
+
+        // Define the 'TimeSeriesOperation':
+        const timeSeriesOp = new TimeSeriesOperation("HeartRates");
+        
+        // Add the Append operations by calling 'append':
+        timeSeriesOp.append(appendOp1);
+        timeSeriesOp.append(appendOp2);
+        timeSeriesOp.append(appendOp3);
+        timeSeriesOp.append(appendOp4);
+
+        // Define 'TimeSeriesBatchOperation':
+        const timeSeriesBatchOp = new TimeSeriesBatchOperation("users/john", timeSeriesOp);
+
+        // Execute the batch operation:
+        await documentStore.operations.send(timeSeriesBatchOp);
+        //endregion
+    }    
+    {
+        //region operation_2
+        const baseTime = new Date();
+        
+        const from = new Date(baseTime.getTime() + 60_000 * 2);
+        const to = new Date(baseTime.getTime() + 60_000 * 3);
+
+        // Define the Delete operation:
+        const deleteOp = new DeleteOperation(from, to);
+
+        // Define the 'TimeSeriesOperation':
+        const timeSeriesOp = new TimeSeriesOperation("HeartRates");
+
+        // Add the Delete operation by calling 'delete':
+        timeSeriesOp.delete(deleteOp);
+
+        // Define the 'TimeSeriesBatchOperation':
+        const timeSeriesBatchOp = new TimeSeriesBatchOperation("users/john", timeSeriesOp);
+
+        // Execute the batch operation:
+        await documentStore.operations.send(timeSeriesBatchOp);
+        //endregion
+    }
+    {
+        //region operation_3
+        const baseTime = new Date();
+
+        // Define some Append operations:
+        let nextMinute = new Date(baseTime.getTime() + 60_000);
+        const appendOp1 = new AppendOperation(nextMinute, [79], "watches/fitbit");
+
+        nextMinute = new Date(baseTime.getTime() + 60_000 * 2);
+        const appendOp2 = new AppendOperation(nextMinute, [82], "watches/fitbit");
+
+        nextMinute = new Date(baseTime.getTime() + 60_000 * 3);
+        const appendOp3 = new AppendOperation(nextMinute, [80], "watches/fitbit");
+
+        const from = new Date(baseTime.getTime() + 60_000 * 2);
+        const to = new Date(baseTime.getTime() + 60_000 * 3);
+
+        // Define a Delete operation:
+        const deleteOp = new DeleteOperation(from, to);
+
+        // Define the 'TimeSeriesOperation':
+        const timeSeriesOp = new TimeSeriesOperation("HeartRates");
+
+        // Add the Append & Delete operations to the list of actions
+        // Note: the Delete action will be executed BEFORE all the Append actions
+         //      even though it is added last
+        timeSeriesOp.append(appendOp1);
+        timeSeriesOp.append(appendOp2);
+        timeSeriesOp.append(appendOp3);
+        timeSeriesOp.delete(deleteOp);
+
+        // Define the 'TimeSeriesBatchOperation':
+        const timeSeriesBatchOp = new TimeSeriesBatchOperation("users/john", timeSeriesOp);
+
+        // Execute the batch operation:
+        await documentStore.operations.send(timeSeriesBatchOp);
+
+        // Results:
+        // All 3 entries that were appended will exist and are not deleted.
+        // This is because the Delete action occurs first, before all Append actions.
+        //endregion
+    }
+}
+
+//region syntax_1
+TimeSeriesBatchOperation(documentId, operation)
+//endregion
+
+//region syntax_2
+class TimeSeriesOperation {
+    name;
+    append;
+    delete;
+}
+//endregion
+
+//region syntax_3
+class AppendOperation {
+    timestamp;
+    values;
+    tag;
+}
+//endregion
+
+//region syntax_4
+class DeleteOperation {
+    from;
+    to;
+}
+//endregion
+
+//region user_class
+class User {
+    constructor(
+        name = ''
+    ) {
+        Object.assign(this, {
+            name
+        });
+    }
+}
+//endregion

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -798,55 +798,130 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             }
         }
 
-
         [Fact]
         public void UseTimeSeriesBatchOperation()
         {
-            const string documentId = "users/john";
-
             using (var store = getDocumentStore())
             {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User(), documentId);
-                    session.SaveChanges();
-                }
-
                 #region timeseries_region_Append-Using-TimeSeriesBatchOperation
-                var baseline = DateTime.Today;
+                var baseTime = DateTime.Today;
 
-                var timeSeriesExerciseHeartRate = new TimeSeriesOperation
+                // Define the Append operations:
+                // =============================
+                var appendOp1 = new TimeSeriesOperation.AppendOperation
                 {
-                    Name = "RoutineHeartRate"
+                    Timestamp = baseTime.AddMinutes(1), Values = new[] {79d}, Tag = "watches/fitbit"
                 };
 
-                timeSeriesExerciseHeartRate.Append(new TimeSeriesOperation.AppendOperation { Tag = "watches/fitbit", Timestamp = baseline.AddMinutes(1), Values = new[] { 79d } });
-                timeSeriesExerciseHeartRate.Append(new TimeSeriesOperation.AppendOperation { Tag = "watches/fitbit", Timestamp = baseline.AddMinutes(2), Values = new[] { 82d } });
-                timeSeriesExerciseHeartRate.Append(new TimeSeriesOperation.AppendOperation { Tag = "watches/fitbit", Timestamp = baseline.AddMinutes(3), Values = new[] { 80d } });
-                timeSeriesExerciseHeartRate.Append(new TimeSeriesOperation.AppendOperation { Tag = "watches/fitbit", Timestamp = baseline.AddMinutes(4), Values = new[] { 78d } });
+                var appendOp2 = new TimeSeriesOperation.AppendOperation
+                {
+                    Timestamp = baseTime.AddMinutes(2), Values = new[] {82d}, Tag = "watches/fitbit"
+                };
+                
+                var appendOp3 = new TimeSeriesOperation.AppendOperation
+                {
+                    Timestamp = baseTime.AddMinutes(3), Values = new[] {80d}, Tag = "watches/fitbit" 
+                };
+                
+                var appendOp4 = new TimeSeriesOperation.AppendOperation
+                {
+                    Timestamp = baseTime.AddMinutes(4), Values = new[] {78d}, Tag = "watches/fitbit" 
+                };
+                
+                // Define 'TimeSeriesOperation' and add the Append operations:
+                // ===========================================================
+                var timeSeriesOp = new TimeSeriesOperation
+                {
+                    Name = "HeartRates"
+                };
+                
+                timeSeriesOp.Append(appendOp1);
+                timeSeriesOp.Append(appendOp2);
+                timeSeriesOp.Append(appendOp3);
+                timeSeriesOp.Append(appendOp4);
 
-                var timeSeriesBatch = new TimeSeriesBatchOperation(documentId, timeSeriesExerciseHeartRate);
-
-                store.Operations.Send(timeSeriesBatch);
+                
+                // Define 'TimeSeriesBatchOperation' and execute:
+                // ==============================================
+                var timeSeriesBatchOp = new TimeSeriesBatchOperation("users/john", timeSeriesOp);
+                store.Operations.Send(timeSeriesBatchOp);
                 #endregion
-
-
+            }
+            
+            using (var store = getDocumentStore())
+            {
                 #region timeseries_region_Delete-Range-Using-TimeSeriesBatchOperation
-                var removeEntries = new TimeSeriesOperation
+                var baseTime = DateTime.Today;
+
+                var deleteOp = new TimeSeriesOperation.DeleteOperation
                 {
-                    Name = "RoutineHeartRate"
+                    From = baseTime.AddMinutes(2), To = baseTime.AddMinutes(3)
+                };
+                
+                var timeSeriesOp = new TimeSeriesOperation
+                {
+                    Name = "HeartRates"
                 };
 
-                removeEntries.Delete(new TimeSeriesOperation.DeleteOperation { From = baseline.AddMinutes(2), To = baseline.AddMinutes(3) });
+                timeSeriesOp.Delete(deleteOp);
 
-                var removeEntriesBatch = new TimeSeriesBatchOperation(documentId, removeEntries);
+                var timeSeriesBatchOp = new TimeSeriesBatchOperation("users/john", timeSeriesOp);
+                
+                store.Operations.Send(timeSeriesBatchOp);
+                #endregion
+            }
+            
+            using (var store = getDocumentStore())
+            {
+                #region timeseries_region-Append-and-Delete-TimeSeriesBatchOperation
+                var baseTime = DateTime.Today;
 
-                store.Operations.Send(removeEntriesBatch);
+                // Define some Append operations:
+                var appendOp1 = new TimeSeriesOperation.AppendOperation
+                {
+                    Timestamp = baseTime.AddMinutes(1), Values = new[] {79d}, Tag = "watches/fitbit"
+                };
+
+                var appendOp2 = new TimeSeriesOperation.AppendOperation
+                {
+                    Timestamp = baseTime.AddMinutes(2), Values = new[] {82d}, Tag = "watches/fitbit"
+                };
+                
+                var appendOp3 = new TimeSeriesOperation.AppendOperation
+                {
+                    Timestamp = baseTime.AddMinutes(3), Values = new[] {80d}, Tag = "watches/fitbit" 
+                };
+                
+                // Define a Delete operation:
+                var deleteOp = new TimeSeriesOperation.DeleteOperation
+                {
+                    From = baseTime.AddMinutes(2), To = baseTime.AddMinutes(3)
+                };
+                
+                var timeSeriesOp = new TimeSeriesOperation
+                {
+                    Name = "HeartRates"
+                };
+                
+                // Add the Append & Delete operations to the list of actions
+                // Note: the Delete action will be executed BEFORE all the Append actions
+                //       even though it is added last  
+                timeSeriesOp.Append(appendOp1);
+                timeSeriesOp.Append(appendOp2);
+                timeSeriesOp.Append(appendOp3);
+                timeSeriesOp.Delete(deleteOp);
+
+                var timeSeriesBatchOp = new TimeSeriesBatchOperation("users/john", timeSeriesOp);
+                
+                store.Operations.Send(timeSeriesBatchOp);
+                
+                // Results:
+                // All 3 entries that were appended will exist and are not deleted.
+                // This is because the Delete action occurs first, before all Append actions.
                 #endregion
             }
         }
-
-
+        
         // bulk insert
         // Use BulkInsert.TimeSeriesBulkInsert.Append with doubles
         [Fact]


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2847/Node.js-Document-extensions-Time-series-Client-API-Operations-Append-Delete-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2850/Document-extensions-Time-series-Client-API-Operations-Append-Delete-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/append-and-delete.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/appendAndDeleteOperations.js
```
