### PR TITLE
RDoc-2848 [Node.js] Document extensions > Time series > Client API > Operations > Get [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/get.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/get.dotnet.markdown
@@ -1,0 +1,119 @@
+﻿# Get Time Series Operation
+---
+
+{NOTE: }
+
+* Use `GetTimeSeriesOperation` to retrieve entries from a **single** time series.  
+  You can also retrieve entries from a single time series using the Session's [TimesSeriesFor.Get](../../../../document-extensions/timeseries/client-api/session/get/get-entries) method.
+
+* Use `GetMultipleTimeSeriesOperation` to retrieve entries from **multiple** time series.
+
+* For a general _Operations_ overview, see [What are Operations](../../../../client-api/operations/what-are-operations).
+
+* In this page:  
+      * [Get entries - from single time series](../../../../document-extensions/timeseries/client-api/operations/get#get-entries---from-single-time-series)  
+         * [Example](../../../../document-extensions/timeseries/client-api/operations/get#example)  
+         * [Syntax](../../../../document-extensions/timeseries/client-api/operations/get#syntax)  
+      * [Get entries - from multiple time series](../../../../document-extensions/timeseries/client-api/operations/get#get-entries---from-multiple-time-series)  
+         * [Example](../../../../document-extensions/timeseries/client-api/operations/get#example-1)  
+         * [Syntax](../../../../document-extensions/timeseries/client-api/operations/get#syntax-1)  
+
+{NOTE/}
+
+---
+
+{PANEL: Get entries - from single time series}
+
+---
+
+### Example
+
+In this example, we retrieve all entries from a single time series.  
+
+{CODE timeseries_region_Get-Single-Time-Series@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+---
+
+### Syntax
+
+{CODE GetTimeSeriesOperation-Definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter             | Type        | Description                                                                                                                                                           |
+|-----------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **docId**             | `string`    | Document ID                                                                                                                                                           |
+| **timeseries**        | `string`    | Time series name                                                                                                                                                      |
+| **from**              | `DateTime?` | Get time series entries starting from this timestamp (inclusive).<br> Default: `DateTime.MinValue`                                                                    |
+| **to**                | `DateTime?` | Get time series entries ending at this timestamp (inclusive).<br> Default: `DateTime.MaxValue`                                                                        |
+| **start**             | `int`       | The position of the first result to retrieve (for paging)<br>Default: 0                                                                                                                                              |
+| **pageSize**          | `int`       | Number of results per page to retrieve (for paging)<br>Default: `int.MaxValue`                                                                                                                                                  |
+| **returnFullResults** | `bool`      | This param is only relevant when [getting incremental time series data](../../../../document-extensions/timeseries/incremental-time-series/client-api/operations/get) |
+
+**Return Value**: 
+
+{CODE TimeSeriesRangeResult-class@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+
+{INFO: }
+
+* Details of class `TimeSeriesEntry ` are listed in [this syntax section](../../../../document-extensions/timeseries/client-api/session/get/get-entries#syntax).
+* If the requested time series does Not exist, the returned object will be `null`.
+* No exceptions are generated.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Get entries - from multiple time series}
+
+---
+
+### Example
+
+In this example, we retrieve entries from the specified ranges of two time series.
+
+{CODE timeseries_region_Get-Multiple-Time-Series@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+---
+
+### Syntax
+
+{CODE GetMultipleTimeSeriesOperation-Definition@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+| Parameter             | Type                           | Description                                                                                                                                                           |
+|-----------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **docId**             | `string`                       | Document ID                                                                                                                                                           |
+| **ranges**            | `IEnumerable<TimeSeriesRange>` | Provide a `TimeSeriesRange` object for each time series from which you want to retrieve data                                                                          |
+| **start**             | `int`                          | The position of the first result to retrieve (for paging)<br>Default: 0                                                                                               |
+| **pageSize**          | `int`                          | Number of results per page to retrieve (for paging)<br>Default: `int.MaxValue`                                                                                        |
+| **returnFullResults** | `bool`                         | This param is only relevant when [getting incremental time series data](../../../../document-extensions/timeseries/incremental-time-series/client-api/operations/get) |
+ 
+{CODE TimeSeriesRange-class@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+**Return Value**:
+
+{CODE TimeSeriesDetails-class@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{CODE TimeSeriesRangeResult-class@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+* If any of the requested time series do not exist, the returned object will be `null`.
+
+* When an entries range that does not exist are requested,  
+  the return value for the that range is a `TimeSeriesRangeResult` object with an empty `Entries` property.  
+
+* No exceptions are generated.
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/get.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/get.js.markdown
@@ -1,0 +1,117 @@
+﻿# Get Time Series Operation
+---
+
+{NOTE: }
+
+* Use `GetTimeSeriesOperation` to retrieve entries from a **single** time series.  
+  You can also retrieve entries from a single time series using the Session's [timesSeriesFor.get](../../../../document-extensions/timeseries/client-api/session/get/get-entries) method.
+
+* Use `GetMultipleTimeSeriesOperation` to retrieve entries from **multiple** time series.
+
+* For a general _Operations_ overview, see [What are Operations](../../../../client-api/operations/what-are-operations).
+
+* In this page:  
+      * [Get entries - from single time series](../../../../document-extensions/timeseries/client-api/operations/get#get-entries---from-single-time-series)  
+         * [Example](../../../../document-extensions/timeseries/client-api/operations/get#example)  
+         * [Syntax](../../../../document-extensions/timeseries/client-api/operations/get#syntax)  
+      * [Get entries - from multiple time series](../../../../document-extensions/timeseries/client-api/operations/get#get-entries---from-multiple-time-series)  
+         * [Example](../../../../document-extensions/timeseries/client-api/operations/get#example-1)  
+         * [Syntax](../../../../document-extensions/timeseries/client-api/operations/get#syntax-1)  
+
+{NOTE/}
+
+---
+
+{PANEL: Get entries - from single time series}
+
+---
+
+### Example
+
+In this example, we retrieve all entries from a single time series.  
+
+{CODE:nodejs get_1@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+---
+
+### Syntax
+
+{CODE:nodejs syntax_1@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+| Parameter             | Type      | Description                                                                                                                                                           |
+|-----------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **docId**             | `string`  | Document ID                                                                                                                                                           |
+| **timeseries**        | `string`  | Time series name                                                                                                                                                      |
+| **from**              | `Date`    | Get time series entries starting from this timestamp (inclusive).<br> Default: The minimum date value will be used.                                                   |
+| **to**                | `Date`    | Get time series entries ending at this timestamp (inclusive).<br> Default: The maximum date value will be used.                                                       |
+| **start**             | `number`  | The position of the first result to retrieve (for paging).<br>Default: 0                                                                                              |
+| **pageSize**          | `number`  | Number of results per page to retrieve (for paging).<br>Default: `2,147,483,647` (equivalent to  `int.MaxValue` in C#).                                                                             |
+
+**Return Value**: 
+
+{CODE:nodejs syntax_2@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+{INFO: }
+
+* Details of class `TimeSeriesEntry ` are listed in [this syntax section](../../../../document-extensions/timeseries/client-api/session/get/get-entries#syntax).
+* If the requested time series does Not exist, a null object will be returned.
+* No exceptions are generated.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Get entries - from multiple time series}
+
+---
+
+### Example
+
+In this example, we retrieve entries from the specified ranges of two time series.
+
+{CODE:nodejs get_2@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+---
+
+### Syntax
+
+{CODE:nodejs syntax_3@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+| Parameter             | Type                | Description                                                                                                                     |
+|-----------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| **docId**             | `string`            | Document ID                                                                                                                     |
+| **ranges**            | `TimeSeriesRange[]` | Provide a `TimeSeriesRange` object for each time series from which you want to retrieve data                                    |
+| **start**             | `number`            | The position of the first result to retrieve (for paging)<br>Default: 0                                                         |
+| **pageSize**          | `number`            | Number of results per page to retrieve (for paging)<br>Default: Default: `2,147,483,647` (equivalent to  `int.MaxValue` in C#). |
+ 
+{CODE:nodejs syntax_4@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+**Return Value**:
+
+{CODE:nodejs syntax_5@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+{CODE:nodejs syntax_2@documentExtensions\timeSeries\client-api\getOperation.js /}
+
+* If any of the requested time series do not exist, the returned object will be `null`.
+
+* When an entries range that does not exist are requested,  
+  the return value for the that range is a `TimeSeriesRangeResult` object with an empty `entries` property.
+
+* No exceptions are generated.
+
+{PANEL/}
+
+## Related articles
+
+**Client API**  
+[Time Series API Overview](../../../../document-extensions/timeseries/client-api/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../../studio/database/document-extensions/time-series)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/session/get/get-entries.js.markdown
@@ -111,13 +111,13 @@ In this example, we query for a document and get a range of entries from its "He
 
 <br/>
 
-| Parameter        | Type                       | Description                                                                                                                                      |
-|------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| **from**         | `Date`                     | Get the range of time series entries starting from this timestamp (inclusive).<br/>Pass `null` to use the minimum date value.                    |
-| **to**           | `Date`                     | Get the range of time series entries ending at this timestamp (inclusive).<br/>Pass `null` to use the maximum date value.                        |
-| **start**        | `number`                   | Paging first entry.<br>E.g. 50 means the first page would start at the 50th time series entry. <br> Default: 0, for the first time-series entry. |
-| **pageSize**     | `number`                   | Paging page-size.<br>E.g. set `pageSize` to 10 to retrieve pages of 10 entries.<br>Default: `int.MaxValue`, for all time series entries.         |
-| **includes**     | `(includeBuilder) => void` | Builder function with a fluent API<br>containing the `includeTags` and `includeDocument` methods.                                               |
+| Parameter        | Type                       | Description                                                                                                                                                   |
+|------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **from**         | `Date`                     | Get the range of time series entries starting from this timestamp (inclusive).<br/>Pass `null` to use the minimum date value.                                 |
+| **to**           | `Date`                     | Get the range of time series entries ending at this timestamp (inclusive).<br/>Pass `null` to use the maximum date value.                                     |
+| **start**        | `number`                   | Paging first entry.<br>E.g. 50 means the first page would start at the 50th time series entry. <br> Default: 0, for the first time-series entry.              |
+| **pageSize**     | `number`                   | Paging page-size.<br>E.g. set `pageSize` to 10 to retrieve pages of 10 entries.<br>Default: the equivalent of C# `int.MaxValue`, for all time series entries. |
+| **includes**     | `(includeBuilder) => void` | Builder function with a fluent API<br>containing the `includeTags` and `includeDocument` methods.                                                             |
 
 | Return value                 |                                              |
 |------------------------------|----------------------------------------------|

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -766,37 +766,44 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     session.SaveChanges();
                 }
 
-                const string documentId = "employees/1-A";
-
                 #region timeseries_region_Get-Single-Time-Series
-                // Get all values of a single time-series
-                TimeSeriesRangeResult singleTimeSeriesDetails = store.Operations.Send(
-                    new GetTimeSeriesOperation(documentId, "HeartRates", DateTime.MinValue, DateTime.MaxValue));
+                // Define the get operation
+                var getTimeSeriesOp = new GetTimeSeriesOperation(
+                    "employees/1-A", // The document ID    
+                    "HeartRates", // The time series name
+                    DateTime.MinValue, // Entries range start
+                    DateTime.MaxValue); // Entries range end
+                
+                // Execute the operation by passing it to 'Operations.Send'
+                TimeSeriesRangeResult timeSeriesEntries = store.Operations.Send(getTimeSeriesOp);
+
+                // Access entries
+                var firstEntryReturned = timeSeriesEntries.Entries[0];
                 #endregion
 
                 #region timeseries_region_Get-Multiple-Time-Series
-                // Get value ranges from two time-series using GetMultipleTimeSeriesOperation
-                TimeSeriesDetails multipleTimesSeriesDetails = store.Operations.Send(
-                        new GetMultipleTimeSeriesOperation(documentId, new List<TimeSeriesRange>
-                            {
-                                new TimeSeriesRange
-                                {
-                                    Name = "ExerciseHeartRate",
-                                    From = baseTime.AddHours(1),
-                                    To = baseTime.AddHours(10)
-                                },
-
-                                new TimeSeriesRange
-                                {
-                                    Name = "RestHeartRate",
-                                    From = baseTime.AddHours(11),
-                                    To = baseTime.AddHours(20)
-                                }
-                            }));
+                // Define the get operation
+                var getMultipleTimeSeriesOp = new GetMultipleTimeSeriesOperation("employees/1-A",
+                    new List<TimeSeriesRange>
+                    {
+                        new TimeSeriesRange
+                        {
+                            Name = "ExerciseHeartRates", From = baseTime.AddHours(1), To = baseTime.AddHours(10)
+                        },
+                        new TimeSeriesRange
+                        {
+                            Name = "RestHeartRates", From = baseTime.AddHours(11), To = baseTime.AddHours(20)
+                        }
+                    });
+                    
+                // Execute the operation by passing it to 'Operations.Send'
+                TimeSeriesDetails timesSeriesEntries = store.Operations.Send(getMultipleTimeSeriesOp);
+                
+                // Access entries
+                var timeSeriesEntry = timesSeriesEntries.Values["ExerciseHeartRates"][0].Entries[0];
                 #endregion
             }
         }
-
 
         [Fact]
         public void UseTimeSeriesBatchOperation()
@@ -2916,8 +2923,14 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             public class GetTimeSeriesOperation
             {
                 #region GetTimeSeriesOperation-Definition
-                public GetTimeSeriesOperation(string docId, string timeseries, DateTime? @from = null,
-                    DateTime? to = null, int start = 0, int pageSize = int.MaxValue)
+                public GetTimeSeriesOperation(
+                    string docId, 
+                    string timeseries,
+                    DateTime? from = null,
+                    DateTime? to = null,
+                    int start = 0,
+                    int pageSize = int.MaxValue,
+                    bool returnFullResults = false)
                 #endregion
                 { }
             }
@@ -2925,19 +2938,31 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             #region TimeSeriesRangeResult-class
             public class TimeSeriesRangeResult
             {
-                public DateTime From, To;
+                // Timestamp of first entry returned
+                public DateTime From;
+                
+                // Timestamp of last entry returned
+                public DateTime To;
+                
+                // The resulting entries
+                // Will be empty if requesting an entries range that does Not exist
                 public TimeSeriesEntry[] Entries;
+                
+                // The number of entries returned
+                // Will be undefined if not all entries of this time series were returned
                 public long? TotalResults;
-
-                //..
             }
             #endregion
 
             public class GetMultipleTimeSeriesOperation
             {
                 #region GetMultipleTimeSeriesOperation-Definition
-                public GetMultipleTimeSeriesOperation(string docId,
-                    IEnumerable<TimeSeriesRange> ranges, int start = 0, int pageSize = int.MaxValue)
+                public GetMultipleTimeSeriesOperation(
+                        string docId,
+                        IEnumerable<TimeSeriesRange> ranges,
+                        int start = 0,
+                        int pageSize = int.MaxValue,
+                        bool returnFullResults = false)
                 #endregion
                 { }
             }
@@ -2945,15 +2970,19 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             #region TimeSeriesRange-class
             public class TimeSeriesRange
             {
-                public string Name;
-                public DateTime From, To;
+                public string Name;   // Name of time series
+                public DateTime From; // Get time series entries starting from this timestamp (inclusive).
+                public DateTime To;   // Get time series entries ending at this timestamp (inclusive).
             }
             #endregion
 
             #region TimeSeriesDetails-class
             public class TimeSeriesDetails
             {
+                // The document ID
                 public string Id { get; set; }
+                
+                // Dictionary of time series name to the time series results 
                 public Dictionary<string, List<TimeSeriesRangeResult>> Values { get; set; }
             }
             #endregion

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getOperation.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getOperation.js
@@ -1,0 +1,111 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function getOperation() {
+    {
+        //region get_1
+        // Define the get operation
+        var getTimeSeriesOp = new GetTimeSeriesOperation(
+            "employees/1-A",  // The document ID    
+            "HeartRates");    // The time series name
+
+        // Execute the operation by passing it to 'operations.send'
+        const timeSeriesEntries = await documentStore.operations.send(getTimeSeriesOp);
+        
+        // Access entries
+        const firstEntryReturned = timeSeriesEntries.entries[0];
+        //endregion
+
+        //region get_2
+        const baseTime = new Date();
+        
+        const startTime1 = new Date(baseTime.getTime() + 60_000 * 5);
+        const endTime1 = new Date(baseTime.getTime() + 60_000 * 10);
+
+        const startTime2 = new Date(baseTime.getTime() + 60_000 * 15);
+        const endTime2 = new Date(baseTime.getTime() + 60_000 * 20);
+        
+        // Define the get operation
+        const getMultipleTimeSeriesOp = new GetMultipleTimeSeriesOperation(
+            "employees/1-A",
+            [
+                {
+                    name: "ExerciseHeartRates",
+                    from: startTime1,
+                    to: endTime1
+                },
+                {
+                    name: "RestHeartRates",
+                    from: startTime2,
+                    to: endTime2
+                }
+            ]));
+
+        // Execute the operation by passing it to 'operations.send'
+        const timesSeriesEntries = await documentStore.operations.send(getMultipleTimeSeriesOp);
+        
+        // Access entries
+        const timeSeriesEntry = timesSeriesEntries.values.get("ExerciseHeartRates")[0].entries[0];
+        //endregion
+    }
+}
+
+//region syntax_1
+// Available overloads:
+// ====================
+const getTimeSeriesOp = new GetTimeSeriesOperation(docId, timeseries);
+const getTimeSeriesOp = new GetTimeSeriesOperation(docId, timeseries, from, to);
+const getTimeSeriesOp = new GetTimeSeriesOperation(docId, timeseries, from, to, start);
+const getTimeSeriesOp = new GetTimeSeriesOperation(docId, timeseries, from, to, start, pageSize);
+//endregion
+
+//region syntax_2
+class TimeSeriesRangeResult {
+    // Timestamp of first entry returned
+    from; // Date;
+
+    // Timestamp of last entry returned
+    to; // Date;
+
+    // The resulting entries
+    // Will be empty if requesting an entries range that does Not exist
+    entries; // TimeSeriesEntry[];
+    
+    // The number of entries returned
+    // Will be undefined if not all entries of this time series were returned
+    totalResults; // number
+}
+//endregion
+
+//region syntax_3
+// Available overloads:
+// ====================
+const getMultipleTimeSeriesOp = new GetMultipleTimeSeriesOperation(docId, ranges);
+const getMultipleTimeSeriesOp = new GetMultipleTimeSeriesOperation(docId, ranges, start, pageSize);
+//endregion
+
+//region syntax_4
+// The TimeSeriesRange object:
+// ===========================
+{
+    // Name of time series
+    name, // string
+    
+    // Get time series entries starting from this timestamp (inclusive).    
+    from, // Date
+
+    // Get time series entries ending at this timestamp (inclusive).
+    to  // Date
+}
+//endregion
+
+//region syntax_5
+class TimeSeriesDetails {
+    // The document ID
+    id; // string
+    
+    // Dictionary of time series name to the time series results 
+    values; // Map<string, TimeSeriesRangeResult[]>
+}
+//endregion

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -767,37 +767,44 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     session.SaveChanges();
                 }
 
-                const string documentId = "employees/1-A";
-
                 #region timeseries_region_Get-Single-Time-Series
-                // Get all values of a single time-series
-                TimeSeriesRangeResult singleTimeSeriesDetails = store.Operations.Send(
-                    new GetTimeSeriesOperation(documentId, "HeartRates", DateTime.MinValue, DateTime.MaxValue));
+                // Define the get operation
+                var getTimeSeriesOp = new GetTimeSeriesOperation(
+                    "employees/1-A", // The document ID
+                    "HeartRates", // The time series name
+                    DateTime.MinValue, // Entries range start
+                    DateTime.MaxValue); // Entries range end
+                
+                // Execute the operation by passing it to 'Operations.Send'
+                TimeSeriesRangeResult timeSeriesEntries = store.Operations.Send(getTimeSeriesOp);
+
+                // Access entries
+                var firstEntryReturned = timeSeriesEntries.Entries[0];
                 #endregion
 
                 #region timeseries_region_Get-Multiple-Time-Series
-                // Get value ranges from two time-series using GetMultipleTimeSeriesOperation
-                TimeSeriesDetails multipleTimesSeriesDetails = store.Operations.Send(
-                        new GetMultipleTimeSeriesOperation(documentId, new List<TimeSeriesRange>
-                            {
-                                new TimeSeriesRange
-                                {
-                                    Name = "ExerciseHeartRate",
-                                    From = baseTime.AddHours(1),
-                                    To = baseTime.AddHours(10)
-                                },
-
-                                new TimeSeriesRange
-                                {
-                                    Name = "RestHeartRate",
-                                    From = baseTime.AddHours(11),
-                                    To = baseTime.AddHours(20)
-                                }
-                            }));
+                // Define the get operation
+                var getMultipleTimeSeriesOp = new GetMultipleTimeSeriesOperation("employees/1-A",
+                    new List<TimeSeriesRange>
+                    {
+                        new TimeSeriesRange
+                        {
+                            Name = "ExerciseHeartRates", From = baseTime.AddHours(1), To = baseTime.AddHours(10)
+                        },
+                        new TimeSeriesRange
+                        {
+                            Name = "RestHeartRates", From = baseTime.AddHours(11), To = baseTime.AddHours(20)
+                        }
+                    });
+                    
+                // Execute the operation by passing it to 'Operations.Send'
+                TimeSeriesDetails timesSeriesEntries = store.Operations.Send(getMultipleTimeSeriesOp);
+                
+                // Access entries
+                var timeSeriesEntry = timesSeriesEntries.Values["ExerciseHeartRates"][0].Entries[0];
                 #endregion
             }
         }
-
 
         [Fact]
         public void UseTimeSeriesBatchOperation()
@@ -2917,8 +2924,14 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             public class GetTimeSeriesOperation
             {
                 #region GetTimeSeriesOperation-Definition
-                public GetTimeSeriesOperation(string docId, string timeseries, DateTime? @from = null,
-                    DateTime? to = null, int start = 0, int pageSize = int.MaxValue)
+                public GetTimeSeriesOperation(
+                    string docId, 
+                    string timeseries,
+                    DateTime? from = null,
+                    DateTime? to = null,
+                    int start = 0,
+                    int pageSize = int.MaxValue,
+                    bool returnFullResults = false)
                 #endregion
                 { }
             }
@@ -2926,19 +2939,31 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             #region TimeSeriesRangeResult-class
             public class TimeSeriesRangeResult
             {
-                public DateTime From, To;
+                // Timestamp of first entry returned
+                public DateTime From;
+                
+                // Timestamp of last entry returned
+                public DateTime To;
+                
+                // The resulting entries
+                // Will be empty if requesting an entries range that does Not exist
                 public TimeSeriesEntry[] Entries;
+                
+                // The number of entries returned
+                // Will be undefined if not all entries of this time series were returned
                 public long? TotalResults;
-
-                //..
             }
             #endregion
 
             public class GetMultipleTimeSeriesOperation
             {
                 #region GetMultipleTimeSeriesOperation-Definition
-                public GetMultipleTimeSeriesOperation(string docId,
-                    IEnumerable<TimeSeriesRange> ranges, int start = 0, int pageSize = int.MaxValue)
+                public GetMultipleTimeSeriesOperation(
+                        string docId,
+                        IEnumerable<TimeSeriesRange> ranges,
+                        int start = 0,
+                        int pageSize = int.MaxValue,
+                        bool returnFullResults = false)
                 #endregion
                 { }
             }
@@ -2946,15 +2971,19 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             #region TimeSeriesRange-class
             public class TimeSeriesRange
             {
-                public string Name;
-                public DateTime From, To;
+                public string Name;   // Name of time series
+                public DateTime From; // Get time series entries starting from this timestamp (inclusive).
+                public DateTime To;   // Get time series entries ending at this timestamp (inclusive).
             }
             #endregion
 
             #region TimeSeriesDetails-class
             public class TimeSeriesDetails
             {
+                // The document ID
                 public string Id { get; set; }
+                
+                // Dictionary of time series name to the time series results 
                 public Dictionary<string, List<TimeSeriesRangeResult>> Values { get; set; }
             }
             #endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2848/Node.js-Document-extensions-Time-series-Client-API-Operations-Get-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2852/Document-extensions-Time-series-Client-API-Operations-Get-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/operations/get.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/getOperation.js
```