### PR TITLE
RDoc-2865 [Node.js] Document extensions > Time series > Client API > Javascript support [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/javascript-support.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/javascript-support.dotnet.markdown
@@ -1,0 +1,139 @@
+﻿# Time Series: JavaScript Support
+---
+
+{NOTE: }
+
+* With the introduction of time series, RavenDB has extended its [JavaScript support](../../../server/kb/JavaScript-engine)
+  to include manipulations involving time series data when patching [single](../../../client-api/operations/patching/single-document#patching-how-to-perform-single-document-patch-operations)
+  or [multiple](../../../client-api/operations/patching/set-based) documents.
+
+* Time series capabilities can be achieved via JavaScript when using the following methods:
+  * [session.Advanced.Defer](../../../document-extensions/timeseries/client-api/session/patch) - perform patch via the _Session_
+  * [PatchOperation](../../../document-extensions/timeseries/client-api/operations/patch#patchoperation) - perform patch via a _Store_ operation
+  * [PatchByQueryOperation](../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation) - perform query & patch via a _Store_ operation
+
+* The server treats timestamps passed in the scripts as **UTC**, no conversion is applied by the client to local time.
+
+* In this page:  
+  * [JavaScript time series API methods](../../../document-extensions/timeseries/client-api/javascript-support#javascript-time-series-api-methods)  
+     * [timeseries - choose a time series](../../../document-extensions/timeseries/client-api/javascript-support#section)  
+     * [timeseries.append - append an entry](../../../document-extensions/timeseries/client-api/javascript-support#section-1)  
+     * [timeseries.delete - delete entries](../../../document-extensions/timeseries/client-api/javascript-support#section-2)  
+     * [timeseries.get - get entries](../../../document-extensions/timeseries/client-api/javascript-support#section-3)  
+  * [Examples](../../../document-extensions/timeseries/client-api/javascript-support#examples)  
+
+{NOTE/}
+
+---
+
+{PANEL: JavaScript time series API methods}
+
+The JavaScript time series API includes these methods:  
+
+---
+
+#### `timeseries (doc, name)`  
+
+Choose a time series by the ID of its owner document and by the series name.  
+
+| Parameter | Type                                      | Description                                                                                              |
+|-----------|-------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| **doc**   | `string` <br> or <br> `document instance` | Document ID, e.g. `timeseries('users/1-A', 'StockPrice')` <br><br> e.g. `timeseries(this, 'StockPrice')` |
+| **name**  | `string`                                  | Time Series Name                                                                                         |
+
+#### `timeseries.append`  
+
+You can use two overloads, to append **tagged** or **untagged** time series entries.
+
+* `timeseries.append (timestamp, values)`     
+* `timeseries.append (timestamp, values, tag)`
+
+| Parameter     | Type       | Description  |
+|---------------|------------|--------------|
+| **timestamp** | `DateTime` | Timestamp    |
+| **values**    | `double[]` | Values       |
+| **tag**       | `string`   | Tag          |
+
+#### `timeseries.delete (from, to)`  
+
+Use this method to delete a range of entries from a document.  
+
+| Parameter           | Type       | Description                                                                                |
+|---------------------|------------|--------------------------------------------------------------------------------------------|
+| **from** (optional) | `DateTime` | Entries will be deleted starting at this timestamp (inclusive)<br> Default: `DateTime.Min` |
+| **to** (optional)   | `DateTime` | Entries will be deleted up to this timestamp (inclusive)<br> Default: `DateTime.Max`       |
+
+#### `timeseries.get (from, to)`  
+
+Use this method to retrieve a range of time series entries.  
+
+| Parameter           | Type       | Description                                                                                 |
+|---------------------|------------|---------------------------------------------------------------------------------------------|
+| **from** (optional) | `DateTime` | Get time series entries starting from this timestamp (inclusive)<br>Default: `DateTime.Min` |
+| **to** (optional)   | `DateTime` | Get time series entries ending at this timestamp (inclusive)<br>Default: `DateTime.Max`     |
+
+**Return Type**:  
+Values are returned in an array of time series entries, i.e. -
+
+{CODE-BLOCK:json}
+[
+	{
+		"Timestamp" : ...
+		"Tag": ...
+		"Values": ...
+		"IsRollup": ...
+	},
+	{
+		"Timestamp" : ...
+		"Tag": ...
+		"Values": ...
+		"IsRollup": ...
+	}
+	...
+]
+{CODE-BLOCK/}
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+This example shows a script that appends 100 entries to time series "HeartRates" in document "Users/john".  
+The script is passed to method [session.Advanced.Defer](../../../document-extensions/timeseries/client-api/session/patch).
+
+{CODE TS_region-Session_Patch-Append-TS-Entries@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}
+
+{NOTE/}
+{NOTE: }
+
+This example shows a script that deletes time series "HeartRates" for documents that match the specified query.
+The script is passed to the [PatchByQueryOperation](../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation)  operation.
+  
+{CODE TS_region-PatchByQueryOperation-Delete-From-Multiple-Docs@DocumentExtensions\TimeSeries\TimeSeriesTests.cs /}  
+
+{NOTE/}
+{PANEL/}
+
+## Related articles
+
+**Javascript**  
+[Knowledge Base: JavaScript Engine](../../../server/kb/javascript-engine)  
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Patching Time Series**  
+[Patching in a Session](../../../document-extensions/timeseries/client-api/session/patch)  
+[Patching Operation](../../../document-extensions/timeseries/client-api/operations/patch#patchoperation)  
+[Patch By Query Operation](../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/javascript-support.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/javascript-support.js.markdown
@@ -1,0 +1,139 @@
+﻿# Time Series: JavaScript Support
+---
+
+{NOTE: }
+
+* With the introduction of time series, RavenDB has extended its [JavaScript support](../../../server/kb/JavaScript-engine)
+  to include manipulations involving time series data when patching [single](../../../client-api/operations/patching/single-document#patching-how-to-perform-single-document-patch-operations)
+  or [multiple](../../../client-api/operations/patching/set-based) documents.
+
+* Time series capabilities can be achieved via JavaScript when using the following methods:
+  * [session.advanced.defer](../../../document-extensions/timeseries/client-api/session/patch) - perform patch via the _session_
+  * [PatchOperation](../../../document-extensions/timeseries/client-api/operations/patch#patchoperation) - perform patch via a _store_ operation
+  * [PatchByQueryOperation](../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation) - perform query & patch via a _store_ operation
+
+* The server treats timestamps passed in the scripts as **UTC**, no conversion is applied by the client to local time.
+
+* In this page:  
+  * [JavaScript time series API methods](../../../document-extensions/timeseries/client-api/javascript-support#javascript-time-series-api-methods)  
+     * [timeseries - choose a time series](../../../document-extensions/timeseries/client-api/javascript-support#section)  
+     * [timeseries.append - append an entry](../../../document-extensions/timeseries/client-api/javascript-support#section-1)  
+     * [timeseries.delete - delete entries](../../../document-extensions/timeseries/client-api/javascript-support#section-2)  
+     * [timeseries.get - get entries](../../../document-extensions/timeseries/client-api/javascript-support#section-3)  
+  * [Examples](../../../document-extensions/timeseries/client-api/javascript-support#examples)  
+
+{NOTE/}
+
+---
+
+{PANEL: JavaScript time series API methods}
+
+The JavaScript time series API includes these methods:  
+
+---
+
+#### `timeseries (doc, name)`  
+
+Choose a time series by the ID of its owner document and by the series name.  
+
+| Parameter | Type                                      | Description                                                                                              |
+|-----------|-------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| **doc**   | `string` <br> or <br> `document instance` | Document ID, e.g. `timeseries('users/1-A', 'StockPrice')` <br><br> e.g. `timeseries(this, 'StockPrice')` |
+| **name**  | `string`                                  | Time Series Name                                                                                         |
+
+#### `timeseries.append`  
+
+You can use two overloads, to append **tagged** or **untagged** time series entries.
+
+* `timeseries.append (timestamp, values)`     
+* `timeseries.append (timestamp, values, tag)`
+
+| Parameter     | Type       | Description  |
+|---------------|------------|--------------|
+| **timestamp** | `Date`     | Timestamp    |
+| **values**    | `number[]` | Values       |
+| **tag**       | `string`   | Tag          |
+
+#### `timeseries.delete (from, to)`  
+
+Use this method to delete a range of entries from a document.  
+
+| Parameter           | Type     | Description                                                                                         |
+|---------------------|----------|-----------------------------------------------------------------------------------------------------|
+| **from** (optional) | `Date`   | Entries will be deleted starting at this timestamp (inclusive).<br>Default: the minimum date value. |
+| **to** (optional)   | `Date`   | Entries will be deleted up to this timestamp (inclusive).<br>Default: the maximum date value.       |
+
+#### `timeseries.get (from, to)`  
+
+Use this method to retrieve a range of time series entries.  
+
+| Parameter           | Type     | Description                                                                                            |
+|---------------------|----------|--------------------------------------------------------------------------------------------------------|
+| **from** (optional) | `Date`   | Get time series entries starting from this timestamp (inclusive).<br> Default: The minimum date value. |
+| **to** (optional)   | `Date`   | Get time series entries ending at this timestamp (inclusive).<br> Default: The maximum date value.     |
+
+**Return Type**:  
+Values are returned in an array of time series entries, i.e. -
+
+{CODE-BLOCK:json}
+[
+	{
+		"Timestamp" : ...
+		"Tag": ...
+		"Values": ...
+		"IsRollup": ...
+	},
+	{
+		"Timestamp" : ...
+		"Tag": ...
+		"Values": ...
+		"IsRollup": ...
+	}
+	...
+]
+{CODE-BLOCK/}
+
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+This example shows a script that appends 100 entries to time series "HeartRates" in document "Users/john".  
+The script is passed to method [session.Advanced.Defer](../../../document-extensions/timeseries/client-api/session/patch).
+
+{CODE:nodejs js_support_1@documentExtensions\timeSeries\client-api\javascriptSupport.js /}
+
+{NOTE/}
+{NOTE: }
+
+This example shows a script that deletes time series "HeartRates" for documents that match the specified query.
+The script is passed to the [PatchByQueryOperation](../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation)  operation.
+  
+{CODE:nodejs js_support_2@documentExtensions\timeSeries\client-api\javascriptSupport.js /}
+
+{NOTE/}
+{PANEL/}
+
+## Related articles
+
+**Javascript**  
+[Knowledge Base: JavaScript Engine](../../../server/kb/javascript-engine)  
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Patching Time Series**  
+[Patching in a Session](../../../document-extensions/timeseries/client-api/session/patch)  
+[Patching Operation](../../../document-extensions/timeseries/client-api/operations/patch#patchoperation)  
+[Patch By Query Operation](../../../document-extensions/timeseries/client-api/operations/patch#patchbyqueryoperation)  
+
+**Querying and Indexing**  
+[Time Series Querying](../../../document-extensions/timeseries/querying/overview-and-syntax)  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/javaScriptSupport.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/javaScriptSupport.js
@@ -1,0 +1,110 @@
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function javascriptSupport() {
+
+    const session = documentStore.openSession();
+    await session.store(new User("John"), "users/john");
+
+    const optionalTag = "watches/fitbit";
+    const baseTime = new Date();
+    baseTime.setUTCHours(0);
+
+    const tsf = session.timeSeriesFor("users/john", "HeartRates");
+    for (let i = 0; i < 10; i++)
+    {
+        const nextMinute = new Date(baseTime.getTime() + 60_000 * i);
+        const nextMeasurement = 65 + i;
+        tsf.append(nextMinute, nextMeasurement, optionalTag);
+    }
+
+    await session.saveChanges();
+    
+    {
+        //region js_support_1
+        const baseTime = new Date();
+
+        // Prepare random values and timestamps to patch
+        const values = [];
+        const timeStamps = [];
+
+        for (let i = 0; i < 100; i++) {
+            const randomValue = 65 + Math.round(20 * Math.random());
+            values.push(randomValue);
+
+            // NOTE: the timestamp passed in the patch request script should be in UTC
+            const timeStamp = new Date(baseTime.getTime() + 60_000 * i);
+            const utcDate = new Date(timeStamp.getTime() + timeStamp.getTimezoneOffset() * 60_000);
+            timeStamps.push(utcDate);
+        }
+
+        // Define the patch request
+        // ========================
+
+        const patchRequest = new PatchRequest();
+
+        // Provide a JavaScript script, use the 'append' method
+        // Note: "args." can be replaced with "$". E.g.: "args.tag" => "$tag"
+        patchRequest.script = `
+            for(var i = 0; i < args.values.length; i++)
+            {
+                timeseries(id(this), args.timeseries)
+                .append (
+                    new Date(args.timeStamps[i]),
+                    args.values[i],
+                    args.tag);
+            }`;
+
+        // Provide values for the params used within the script
+        patchRequest.values = {
+            timeseries: "HeartRates",
+            timeStamps: timeStamps,
+            values: values,
+            tag: "watches/fitbit"
+        }
+
+        // Define the patch command
+        const patchCommand = new PatchCommandData("users/john", null, patchRequest, null)
+
+        // Pass the patch command to 'defer'
+        session.advanced.defer(patchCommand);
+
+        // Call saveChanges for the patch request to execute on the server
+        await session.saveChanges();
+        //endregion
+
+        //region js_support_2
+        const indexQuery = new IndexQuery();
+
+        indexQuery.query = `
+            from users as u
+            where u.age < 30
+            update
+            {
+                timeseries(u, "HeartRates").delete()
+            }`;
+
+        const deleteByQueryOp = new PatchByQueryOperation(indexQuery);
+
+        // Execute the operation: 
+        // Time series "HeartRates" will be deleted for all users with age < 30
+        await documentStore.operations.send(deleteByQueryOp);
+        //endregion
+        //endregion
+    }
+}
+
+//region user_class
+class User {
+    constructor(
+        name = '',
+        age = 0
+    ) {
+        Object.assign(this, {
+            name,
+            age
+        });
+    }
+}
+//endregion

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -1283,26 +1283,26 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     {
                         Name = "John"
                     };
-                    session.Store(user);
+                    session.Store(user, "users/john");
                     session.SaveChanges();
                 }
 
                 using (var session = store.OpenSession())
                 {
-                    var baseline = DateTime.Today;
+                    #region TS_region-Session_Patch-Append-TS-Entries
+                    var baseline = DateTime.UtcNow;
 
                     // Create arrays of timestamps and random values to patch
-                    List<double> values = new List<double>();
-                    List<DateTime> timeStamps = new List<DateTime>();
+                    var values = new List<double>();
+                    var timeStamps = new List<DateTime>();
 
-                    for (var cnt = 0; cnt < 100; cnt++)
+                    for (var i = 0; i < 100; i++)
                     {
                         values.Add(68 + Math.Round(19 * new Random().NextDouble()));
-                        timeStamps.Add(baseline.AddSeconds(cnt));
+                        timeStamps.Add(baseline.AddMinutes(i));
                     }
 
-                    #region TS_region-Session_Patch-Append-TS-Entries
-                    session.Advanced.Defer(new PatchCommandData("users/1-A", null,
+                    session.Advanced.Defer(new PatchCommandData("users/john", null,
                         new PatchRequest
                         {
                             Script = @"
@@ -1311,15 +1311,15 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                                 {
                                     timeseries(id(this), $timeseries)
                                     .append (
-                                      new Date($timeStamps[i]), 
-                                      $values[i], 
-                                      $tag);
+                                        new Date($timeStamps[i]), 
+                                        $values[i], 
+                                        $tag);
                                 }",
 
                             Values =
                             {
                                 { "timeseries", "HeartRates" },
-                                { "timeStamps", timeStamps},
+                                { "timeStamps", timeStamps },
                                 { "values", values },
                                 { "tag", "watches/fitbit" }
                             }
@@ -1327,12 +1327,9 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
 
                     session.SaveChanges();
                     #endregion
-
                 }
             }
         }
-
-
 
         // Patching: Append and Remove multiple time-series entries
         // Using PatchOperation
@@ -2290,14 +2287,14 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 var result = store.Operations.Send(getExerciseHeartRateOperation).WaitForCompletion();
 
                 #region TS_region-PatchByQueryOperation-Delete-From-Multiple-Docs
-                // Delete time-series from all users
                 PatchByQueryOperation deleteOperation = new PatchByQueryOperation(new IndexQuery
                 {
                     Query = @"from Users as u
-                                update
-                                {
-                                    timeseries(u, $name).delete($from, $to)
-                                }",
+                              where u.age < 30
+                              update
+                              {
+                                  timeseries(u, $name).delete($from, $to)
+                              }",
                     QueryParameters = new Parameters
                             {
                                 { "name", "HeartRates" },
@@ -2305,12 +2302,11 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                                 { "to", DateTime.MaxValue }
                             }
                 });
+                
                 store.Operations.Send(deleteOperation);
                 #endregion
             }
         }
-
-
 
         // patching a document a single time-series entry
         // using PatchByQueryOperation


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2865/Node.js-Document-extensions-Time-series-Client-API-Javascript-support-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied for the `C#` article, to be done in a separate dedicated issue:
 TBD..

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/client-api/javascript-support.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/client-api/javaScriptSupport.js
```