### PR TITLE
RDoc-2878 [Node.js] Document extensions > Time series > Querying > Filtering [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/filtering.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/filtering.dotnet.markdown
@@ -1,0 +1,128 @@
+﻿# Filtering Time Series Queries
+
+---
+
+{NOTE: }
+
+* In addition to limiting time series query results by specifying the [range of entries](../../../document-extensions/timeseries/querying/choosing-query-range) to retrieve,
+  you can filter the time series entries by their **values**, **tag**, or by the contents of a **document referenced in the tag**.
+
+* For an overview of the available time series queries, please refer to [Time series querying](../../../document-extensions/timeseries/client-api/session/querying).
+
+* In this page:  
+  * [Filter by value](../../../document-extensions/timeseries/querying/filtering#filter-by-value)
+  * [Filter by tag](../../../document-extensions/timeseries/querying/filtering#filter-by-tag)
+  * [Filter by referenced document](../../../document-extensions/timeseries/querying/filtering#filter-by-referenced-document)
+
+{NOTE/}
+
+---
+
+{PANEL: Filter by value}
+
+* A time series entry can have up to 32 [values](../../../document-extensions/timeseries/overview#values).
+
+* A time series query can filter entries based on these values.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query filter_entries_1@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:DocumentQuery filter_entries_2@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:RawQuery filter_entries_3@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees 
+select timeseries (
+    from HeartRates
+    between "2020-05-17T00:00:00.0000000"
+    and "2020-05-17T00:10:00.0000000"
+    // Use the "where Value" clause to filter entries by the value
+    where Value > 75
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Filter by tag}
+
+* A time series entry can have an optional [tag](../../../document-extensions/timeseries/overview#tags).
+
+* A time series query can filter entries based on this tag.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query filter_entries_4@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:DocumentQuery filter_entries_5@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:RawQuery filter_entries_6@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees
+select timeseries (
+    from HeartRates
+    between "2020-05-17T00:00:00.0000000"
+    and "2020-05-17T00:10:00.0000000"
+    // Use the "where Tag" clause to filter entries by the tag string content
+    where Tag == "watches/fitbit"
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query filter_entries_7@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:DocumentQuery filter_entries_8@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:RawQuery filter_entries_9@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees  
+select timeseries (
+    from HeartRates
+    between "2020-05-17T00:00:00.0000000"
+    and "2020-05-17T00:10:00.0000000"
+    // Use the "where Tag in" clause to filter by various tag options
+    where Tag in ("watches/apple", "watches/samsung", "watches/xiaomi")
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Filter by referenced document}
+
+* A time series entry's [tag](../../../document-extensions/timeseries/overview#tags) can contain the **ID of a document**.
+
+* A time series query can filter entries based on the contents of this referenced document.  
+  The referenced document is loaded, and entries are filtered by its properties.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query filter_entries_10@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:DocumentQuery filter_entries_11@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB:csharp:RawQuery filter_entries_12@DocumentExtensions\TimeSeries\FilterTimeSeriesQuery.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Companies
+where Address.Country == "USA"
+select timeseries (
+    from StockPrices
+    // Use 'load Tag' to load the employee document referenced in the tag
+    load Tag as employeeDoc
+    // Use 'where <property>' to filter entries by the properties of the loaded document
+    where employeeDoc.Title == "Sales Manager"
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+## Related articles
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Time Series Indexing**  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Time Series Queries**  
+[Range Selection](../../../document-extensions/timeseries/querying/choosing-query-range)  
+[Aggregation and Projection](../../../document-extensions/timeseries/querying/aggregation-and-projections)  
+[Indexed Time Series Queries](../../../document-extensions/timeseries/querying/using-indexes)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/filtering.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/filtering.js.markdown
@@ -1,0 +1,124 @@
+﻿# Filtering Time Series Queries
+
+---
+
+{NOTE: }
+
+* In addition to limiting time series query results by specifying the [range of entries](../../../document-extensions/timeseries/querying/choosing-query-range) to retrieve,
+  you can filter the time series entries by their **values**, **tag**, or by the contents of a **document referenced in the tag**.
+
+* For an overview of the available time series queries, please refer to [Time series querying](../../../document-extensions/timeseries/client-api/session/querying).
+
+* In this page:  
+  * [Filter by value](../../../document-extensions/timeseries/querying/filtering#filter-by-value)
+  * [Filter by tag](../../../document-extensions/timeseries/querying/filtering#filter-by-tag)
+  * [Filter by referenced document](../../../document-extensions/timeseries/querying/filtering#filter-by-referenced-document)
+
+{NOTE/}
+
+---
+
+{PANEL: Filter by value}
+
+* A time series entry can have up to 32 [values](../../../document-extensions/timeseries/overview#values).
+
+* A time series query can filter entries based on these values.  
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query filter_entries_1@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB:nodejs:RawQuery filter_entries_2@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees 
+select timeseries (
+    from HeartRates
+    between "2020-05-17T00:00:00.0000000"
+    and "2020-05-17T00:10:00.0000000"
+    // Use the "where Value" clause to filter entries by the value
+    where Value > 75
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Filter by tag}
+
+* A time series entry can have an optional [tag](../../../document-extensions/timeseries/overview#tags).
+
+* A time series query can filter entries based on this tag.  
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query filter_entries_3@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB:nodejs:RawQuery filter_entries_4@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees
+select timeseries (
+    from HeartRates
+    between "2020-05-17T00:00:00.0000000"
+    and "2020-05-17T00:10:00.0000000"
+    // Use the "where Tag" clause to filter entries by the tag string content
+    where Tag == "watches/fitbit"
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query filter_entries_5@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB:nodejs:RawQuery filter_entries_6@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Employees  
+select timeseries (
+    from HeartRates
+    between "2020-05-17T00:00:00.0000000"
+    and "2020-05-17T00:10:00.0000000"
+    // Use the "where Tag in" clause to filter by various tag options
+    where Tag in ("watches/apple", "watches/samsung", "watches/xiaomi")
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Filter by referenced document}
+
+* A time series entry's [tag](../../../document-extensions/timeseries/overview#tags) can contain the **ID of a document**.
+
+* A time series query can filter entries based on the contents of this referenced document.  
+  The referenced document is loaded, and entries are filtered by its properties.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query filter_entries_7@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB:nodejs:RawQuery filter_entries_8@documentExtensions\timeSeries\querying\filterTimeSeriesQuery.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Companies
+where Address.Country == "USA"
+select timeseries (
+    from StockPrices
+    // Use 'load Tag' to load the employee document referenced in the tag
+    load Tag as employeeDoc
+    // Use 'where <property>' to filter entries by the properties of the loaded document
+    where employeeDoc.Title == "Sales Manager"
+)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+## Related articles
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Time Series Indexing**  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Time Series Queries**  
+[Range Selection](../../../document-extensions/timeseries/querying/choosing-query-range)  
+[Aggregation and Projection](../../../document-extensions/timeseries/querying/aggregation-and-projections)  
+[Indexed Time Series Queries](../../../document-extensions/timeseries/querying/using-indexes)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/FilterTimeSeriesQuery.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/FilterTimeSeriesQuery.cs
@@ -1,0 +1,284 @@
+﻿using System;
+using System.Linq;
+using Raven.Client.Documents;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.DocumentExtensions.TimeSeries
+{
+    public class FilterTimeSeriesQuery
+    {
+        public async Task FilterTimeSeries()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_1
+                    // For example, in the "HeartRates" time series,
+                    // retrieve only entries where the value exceeds 75 BPM 
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var query = session.Query<Employee>()
+                        .Select(employee => RavenQuery
+                            .TimeSeries(employee, "HeartRates", from, to)
+                            // Call 'Where' to filter entries by the value
+                            .Where(ts => ts.Value > 75)
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_2
+                    // For example, in the "HeartRates" time series,
+                    // retrieve only entries where the value exceeds 75 BPM
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var query = session.Advanced.DocumentQuery<Employee>()
+                        .SelectTimeSeries(builder => builder.From("HeartRates")
+                            .Between(from, to)
+                            // Call 'Where' to filter entries by the value
+                            .Where(ts => ts.Value > 75)
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_3
+                    // For example, in the "HeartRates" time series,
+                    // retrieve only entries where the value exceeds 75 BPM
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var query = session.Advanced.RawQuery<TimeSeriesRawResult>(@"
+                        from Employees
+                        select timeseries (
+                            from HeartRates
+                            between $from and $to
+                            // Use the 'where Value' clause to filter by the value
+                            where Value > 75
+                        )")
+                        .AddParameter("from", from)
+                        .AddParameter("to", to);
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_4
+                    // Retrieve only entries where the tag string content is "watches/fitbit"
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var query = session.Query<Employee>()
+                        .Select(employee => RavenQuery
+                            .TimeSeries(employee, "HeartRates", from, to)
+                            // Call 'Where' to filter entries by the tag
+                            .Where(ts => ts.Tag == "watches/fitbit")
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_5
+                    // Retrieve only entries where the tag string content is "watches/fitbit"
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var query = session.Advanced.DocumentQuery<Employee>()
+                        .SelectTimeSeries(builder => builder.From("HeartRates")
+                            .Between(from, to)
+                            // Call 'Where' to filter entries by the tag
+                            .Where(ts => ts.Tag == "watches/fitbit")
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_6
+                    // Retrieve only entries where the tag string content is "watches/fitbit"
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var query = session.Advanced.RawQuery<TimeSeriesRawResult>(@"
+                        from Employees
+                        select timeseries (
+                            from HeartRates
+                            between $from and $to
+                            // Use the 'where Tag' clause to filter entries by the tag string content
+                            where Tag == 'watches/fitbit'
+                        )")
+                        .AddParameter("from", from)
+                        .AddParameter("to", to);
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_7
+                    // Retrieve only entries where the tag string content is one of several options
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var optionalTags = new[] {"watches/apple", "watches/samsung", "watches/xiaomi"};
+
+                    var query = session.Query<Employee>()
+                        .Select(employee => RavenQuery
+                            .TimeSeries(employee, "HeartRates", from, to)
+                            // Call 'Where' to filter entries by the tag
+                            .Where(ts =>
+                                ts.Tag == "watches/apple" || ts.Tag == "watches/samsung" || ts.Tag == "watches/xiaomi")
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_8
+                    // Retrieve only entries where the tag string content is one of several options
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var optionalTags = new[] {"watches/apple", "watches/samsung", "watches/xiaomi"};
+
+                    var query = session.Advanced.DocumentQuery<Employee>()
+                        .SelectTimeSeries(builder => builder.From("HeartRates")
+                            .Between(from, to)
+                            // Call 'Where' to filter entries by the tag
+                            .Where(ts =>
+                                ts.Tag == "watches/apple" || ts.Tag == "watches/samsung" || ts.Tag == "watches/xiaomi")
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_9
+                    // Retrieve only entries where the tag string content is one of several options
+
+                    var baseTime = new DateTime(2020, 5, 17, 00, 00, 00);
+                    var from = baseTime;
+                    var to = baseTime.AddMinutes(10);
+
+                    var optionalTags = new[] {"watches/apple", "watches/samsung", "watches/xiaomi"};
+
+                    var query = session.Advanced.RawQuery<TimeSeriesRawResult>(@"
+                        from Employees
+                        select timeseries (
+                            from HeartRates
+                            between $from and $to
+                            // Use the 'where Tag in' clause to filter by various tag options
+                            where Tag in ($optionalTags)
+                        )")
+                        .AddParameter("from", from)
+                        .AddParameter("to", to)
+                        .AddParameter("optionalTags", optionalTags);
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_10
+                    // Retrieve entries that reference a document that has "Sales Manager" in its 'Title' property
+
+                    var query = session.Query<Company>()
+                        // Query companies from USA
+                        .Where(c => c.Address.Country == "USA")
+                        .Select(company => RavenQuery
+                            .TimeSeries(company, "StockPrices")
+                            // Use 'LoadByTag' to load the employee document referenced in the tag
+                            .LoadByTag<Employee>()
+                            // Use 'Where' to filter the entries by the 'Title' property of the loaded document
+                            .Where((ts, employeeDoc) => employeeDoc.Title == "Sales Manager")
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_11
+                    // Retrieve entries that reference a document that has "Sales Manager" in its 'Title' property
+
+                    var query = session.Advanced.DocumentQuery<Company>()
+                        // Query companies from USA
+                        .WhereEquals(company => company.Address.Country, "USA")
+                        .SelectTimeSeries(builder => builder.From("StockPrices")
+                            // Use 'LoadByTag' to load the employee document referenced in the tag
+                            .LoadByTag<Employee>()
+                            // Use 'Where' to filter the entries by the 'Title' property of the loaded document
+                            .Where((ts, employeeDoc) => employeeDoc.Title == "Sales Manager")
+                            .ToList());
+
+                    var results = query.ToList();
+                    #endregion
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    #region filter_entries_12
+                    // Retrieve entries that reference a document that has "Sales Manager" in its 'Title' property
+
+                    var query = session.Advanced.RawQuery<Company>(@"
+                        from Companies
+                        where Address.Country == 'USA'
+                        select timeseries (
+                            from StockPrices
+                            // Use 'load Tag' to load the employee document referenced in the tag
+                            load Tag as employeeDoc
+                            // Use 'where <property>' to filter entries by the properties of the loaded document 
+                            where employeeDoc.Title == 'Sales Manager'
+                        )"
+                    );
+
+                    var results = query.ToList();
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -1971,48 +1971,6 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     var result = query.ToList();
                 }
 
-                using (var session = store.OpenSession())
-                {
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    #region ts_region_Filter-By-load-Tag-Raw-RQL
-                    // Raw query with no aggregation - Select syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
-                        session.Advanced.RawQuery<TimeSeriesRawResult>(@"
-                            from Companies as c where c.Address.Country = 'USA'
-                            select timeseries(
-                                from StockPrices
-                                   load Tag as emp
-                                   where emp.Title == 'Sales Representative'
-                            )");
-
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
-                    #endregion
-                }
-
-                // Query - LINQ format - LoadByTag to find a stock broker
-                using (var session = store.OpenSession())
-                {
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    #region ts_region_Filter-By-LoadByTag-LINQ
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<Company>()
-
-                            // Choose user profiles of users under the age of 30
-                            .Where(c => c.Address.Country == "USA")
-                            .Select(q => RavenQuery.TimeSeries(q, "StockPrices")
-
-                            .LoadByTag<Employee>()
-                            .Where((ts, src) => src.Title == "Sales Representative")
-
-                            .ToList());
-
-                    var result = query.ToList();
-                    #endregion
-                }
-
                 /*
                                 // Query - LINQ format
                                 using (var session = store.OpenSession())
@@ -2036,7 +1994,6 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                                     var result = query.ToList();
                                 }
                 */
-
             }
         }
 

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/filterTimeSeriesQuery.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/filterTimeSeriesQuery.js
@@ -1,0 +1,155 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function filterTimeSeriesQuery() {
+    {
+        //region filter_entries_1
+        // For example, in the "HeartRates" time series,
+        // retrieve only entries where the value exceeds 75 BPM 
+        
+        const tsQueryText = `
+            from HeartRates
+            between "2020-05-17T00:00:00.0000000"
+            and "2020-05-17T00:10:00.0000000"
+            // Use the "where Value" clause to filter entries by the value
+            where Value > 75`;
+        
+        const query = session.query({ collection: "employees" })
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+        
+        const results = await query.all();
+        //endregion
+
+        //region filter_entries_2
+        // For example, in the "HeartRates" time series,
+        // retrieve only entries where the value exceeds 75 BPM 
+        
+        const rql = `
+            from Employees
+            select timeseries (
+                from HeartRates
+                between "2020-05-17T00:00:00.0000000"
+                and "2020-05-17T00:10:00.0000000"
+                // Use the 'where Value' clause to filter by the value
+                where Value > 75
+            )`;
+
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult);
+
+        const result = await query.all();
+        //endregion
+
+        //region filter_entries_3
+        // Retrieve only entries where the tag string content is "watches/fitbit"
+
+        const tsQueryText = `
+            from HeartRates
+            between "2020-05-17T00:00:00.0000000"
+            and "2020-05-17T00:10:00.0000000"
+            // Use the "where Tag" clause to filter entries by the tag string content
+            where Tag == "watches/fitbit"`;
+
+        const query = session.query({ collection: "employees" })
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        const results = await query.all();
+        //endregion
+
+        //region filter_entries_4
+        // Retrieve only entries where the tag string content is "watches/fitbit"
+        
+        const rql = `
+            from Employees
+            select timeseries (
+                from HeartRates
+                between "2020-05-17T00:00:00.0000000"
+                and "2020-05-17T00:10:00.0000000"
+                // Use the 'where Tag' clause to filter entries by the tag string content
+                where Tag == 'watches/fitbit'
+            )`;
+
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult);
+
+        const result = await query.all();
+        //endregion
+
+        //region filter_entries_5
+        // Retrieve only entries where the tag string content is one of several options
+        
+        const tsQueryText = `
+            from HeartRates
+            between "2020-05-17T00:00:00.0000000"
+            and "2020-05-17T00:10:00.0000000"
+            // Use the "where Tag in" clause to filter by various tag options
+            where Tag in ("watches/apple", "watches/samsung", "watches/xiaomi")`;
+
+        const query = session.query({ collection: "employees" })
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        const results = await query.all();
+        //endregion
+
+        //region filter_entries_6
+        // Retrieve only entries where the tag string content is one of several options
+
+        const optionalTags = ["watches/apple", "watches/samsung", "watches/xiaomi"];
+        
+        const rql = `
+            from Employees
+            select timeseries (
+                from HeartRates
+                between "2020-05-17T00:00:00.0000000"
+                and "2020-05-17T00:10:00.0000000"
+                // Use the 'where Tag in' clause to filter by various tag options
+                where Tag in ($optionalTags)
+            )`;
+
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult)
+            .addParameter("optionalTags", optionalTags);
+
+        const result = await query.all();
+        //endregion
+
+        //region filter_entries_7
+        // Retrieve entries that reference a document that has "Sales Manager" in its 'Title' property
+        
+        const tsQueryText = `
+            from StockPrices
+                // Use 'load Tag' to load the employee document referenced in the tag
+                load Tag as employeeDoc
+                // Use 'where <property>' to filter entries by the properties of the loaded document
+                where employeeDoc.Title == "Sales Manager"`;
+
+        const query = session.query({ collection: "companies" })
+            .whereEquals("Address.Country", "USA")
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        const results = await query.all();
+        //endregion
+
+        //region filter_entries_8
+        // Retrieve entries that reference a document that has "Sales Manager" in its 'Title' property
+
+        const rql = `
+            from Companies
+            where Address.Country == 'USA'
+            select timeseries (
+                from StockPrices
+                // Use 'load Tag' to load the employee document referenced in the tag
+                load Tag as employeeDoc
+                // Use 'where <property>' to filter entries by the properties of the loaded document 
+                where employeeDoc.Title == 'Sales Manager'
+            )`;
+
+        const query = session.advanced.rawQuery(rql, TimeSeriesRawResult);
+
+        const result = await query.all();
+        //endregion
+    }
+}
+
+
+

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -1974,48 +1974,6 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                     var result = query.ToList();
                 }
 
-                using (var session = store.OpenSession())
-                {
-                    // May 17 2020, 00:00:00
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    #region ts_region_Filter-By-load-Tag-Raw-RQL
-                    // Raw query with no aggregation - Select syntax
-                    IRawDocumentQuery<TimeSeriesRawResult> nonAggregatedRawQuery =
-                        session.Advanced.RawQuery<TimeSeriesRawResult>(@"
-                            from Companies as c where c.Address.Country = 'USA'
-                            select timeseries(
-                                from StockPrices
-                                   load Tag as emp
-                                   where emp.Title == 'Sales Representative'
-                            )");
-
-                    var nonAggregatedRawQueryResult = nonAggregatedRawQuery.ToList();
-                    #endregion
-                }
-
-                // Query - LINQ format - LoadByTag to find a stock broker
-                using (var session = store.OpenSession())
-                {
-                    var baseline = new DateTime(2020, 5, 17, 00, 00, 00);
-
-                    #region ts_region_Filter-By-LoadByTag-LINQ
-                    IRavenQueryable<TimeSeriesRawResult> query =
-                        (IRavenQueryable<TimeSeriesRawResult>)session.Query<Company>()
-
-                            // Choose user profiles of users under the age of 30
-                            .Where(c => c.Address.Country == "USA")
-                            .Select(q => RavenQuery.TimeSeries(q, "StockPrices")
-
-                            .LoadByTag<Employee>()
-                            .Where((ts, src) => src.Title == "Sales Representative")
-
-                            .ToList());
-
-                    var result = query.ToList();
-                    #endregion
-                }
-
                 /*
                                 // Query - LINQ format
                                 using (var session = store.OpenSession())


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2878/Node.js-Document-extensions-Time-series-Querying-Filtering-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2879/Document-extensions-Time-series-Querying-Filtering-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/filtering.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/filterTimeSeriesQuery.js
```