### PR TITLE
RDoc-2880 [Node.js] Document extensions > Time series > Querying > Aggregating values [Replace C# samples]

### DIFF
--- a/Documentation/5.1/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.markdown
@@ -66,7 +66,7 @@ _secondary_ aggregation by the [time series `tag`](../../../document-extensions/
 * **First()** - values of the first series entry  
 * **Last()** - values of the last series entry  
 * **Count()** - overall number of values in series entries  
-* **Percentile(<number between 0 and 1.0>)** - the value that divides the other 
+* **Percentile(<number between 1 and 100>)** - the value that divides the other 
 values in the series by the given ratio.  
 * **Slope()** - the difference in value divided by the difference in time between 
 the first and last entries.  

--- a/Documentation/5.1/Raven.Documentation.Pages/document-extensions/timeseries/querying/statistics.markdown
+++ b/Documentation/5.1/Raven.Documentation.Pages/document-extensions/timeseries/querying/statistics.markdown
@@ -36,8 +36,8 @@ series, and less than the remaining 10%.
 * LINQ method: `Percentile()`  
 
 The percentile method can be used to calculate any percentile in a time 
-series or range of time series entries. It takes one `double` value between 
-0 and 100. This represents the percent of the time series values that 
+series or range of time series entries. It takes one `double` value that is greater than 
+0 and less than or equal to 100. This represents the percent of the time series values that 
 should be smaller than the result.  
 
 See examples [below](../../../document-extensions/timeseries/querying/statistics#examples).  

--- a/Documentation/5.2/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.markdown
@@ -66,7 +66,7 @@ _secondary_ aggregation by the [time series `tag`](../../../document-extensions/
 * **First()** - values of the first series entry  
 * **Last()** - values of the last series entry  
 * **Count()** - overall number of values in series entries  
-* **Percentile(<number between 0 and 1.0>)** - the value that divides the other 
+* **Percentile(<number between 1 and 100>)** - the value that divides the other 
 values in the series by the given ratio.  
 * **Slope()** - the difference in value divided by the difference in time between 
 the first and last entries.  

--- a/Documentation/5.2/Raven.Documentation.Pages/document-extensions/timeseries/querying/statistics.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/document-extensions/timeseries/querying/statistics.markdown
@@ -36,8 +36,8 @@ series, and less than the remaining 10%.
 * LINQ method: `Percentile()`  
 
 The percentile method can be used to calculate any percentile in a time 
-series or range of time series entries. It takes one `double` value between 
-0 and 100. This represents the percent of the time series values that 
+series or range of time series entries. It takes one `double` value that is greater than
+0 and less than or equal to 100. This represents the percent of the time series values that 
 should be smaller than the result.  
 
 See examples [below](../../../document-extensions/timeseries/querying/statistics#examples).  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
@@ -19,7 +19,7 @@
     },
     {
         "Path": "aggregation-and-projections.markdown",
-        "Name": "Aggregation and Projections",
+        "Name": "Aggregating Values",
         "DiscussionId": "b399492f-c034-4406-810c-58ecd8c59115",
         "Mappings": []
     },

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.dotnet.markdown
@@ -32,6 +32,7 @@
   First, you can group the time series entries based on the specified time frame.  
   The following time units are available:
 
+  * `Milliseconds`
   * `Seconds`
   * `Minutes`
   * `Hours`

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.dotnet.markdown
@@ -300,6 +300,7 @@ select timeseries (
   This provides immediate context and makes it easier to interpret the time series data.
 
     {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_8@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
 {CODE-TAB-BLOCK:sql:RQL_declare_syntax}
 declare timeseries SP(c)
 {
@@ -311,7 +312,7 @@ declare timeseries SP(c)
 
 from "Companies" as c
 // Project the company's name along with the time series query results to make results more clear
-select c.Name, SP(c)
+select SP(c) as MinMaxValues, c.Name as CompanyName
 {CODE-TAB-BLOCK/}
 {CODE-TAB-BLOCK:sql:RQL_select_syntax}
 from "Companies" as c
@@ -320,7 +321,8 @@ select timeseries (
     where Values[4] > 500000
     group by "7 day"
     select max(), min()
-), c.Name // Project property 'Name' from the company document
+) as MinMaxValues,
+c.Name as CompanyName // Project property 'Name' from the company document
 {CODE-TAB-BLOCK/}
     {CODE-TABS/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.dotnet.markdown
@@ -1,0 +1,358 @@
+﻿# Aggregating Time Series Values
+
+---
+
+{NOTE: }
+
+* Time series queries can easily generate powerful statistics by applying an aggregation function  
+  (such as Min, Max, Count, Average, etc.) to a group of entries within a chosen time frame,  
+  such as an hour or a week.
+
+* For an overview of the available time series queries, please refer to [Time series querying](../../../document-extensions/timeseries/client-api/session/querying).
+
+* In this page:  
+  * [Grouping and aggregation options](../../../document-extensions/timeseries/querying/aggregation-and-projections#grouping-and-aggregation-options)  
+  * [Examples](../../../document-extensions/timeseries/querying/aggregation-and-projections#Examples)
+      * [Aggregate entries with single value](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-with-single-value)
+      * [Aggregate entries with multiple values](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-with-multiple-values)
+      * [Aggregate entries without grouping by time frame](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-without-grouping-by-time-frame)
+      * [Aggregate entries filtered by referenced document](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-filtered-by-referenced-document)
+      * [Secondary grouping by tag](../../../document-extensions/timeseries/querying/aggregation-and-projections#secondary-grouping-by-tag)
+      * [Group by dynamic criteria](../../../document-extensions/timeseries/querying/aggregation-and-projections#group-by-dynamic-criteria)
+      * [Project document data in addition to aggregated data](../../../document-extensions/timeseries/querying/aggregation-and-projections#project-document-data-in-addition-to-aggregated-data)
+  * [Syntax](../../../document-extensions/timeseries/querying/aggregation-and-projections#syntax)  
+
+{NOTE/}
+
+---
+
+{PANEL: Grouping and aggregation options}
+
+* **Group entries by time frame**:  
+  First, you can group the time series entries based on the specified time frame.  
+  The following time units are available:
+
+  * `Seconds`
+  * `Minutes`
+  * `Hours`
+  * `Days`
+  * `Months`
+  * `Quarters` 
+  * `Years`
+
+* **Secondary grouping**:  
+  After grouping by a time unit, you can also perform a _secondary grouping_ by the time series [tag](../../../document-extensions/timeseries/overview#tags).
+
+* **Aggregate values**:  
+  You can select one or more aggregation functions to retrieve aggregated values for each group.  
+  The resulting aggregated values are **projected** to the client in the query result.  
+  The following functions are available:
+
+  * `Min()` - the lowest value
+  * `Max()` - the highest value
+  * `Sum()` - sum of all values
+  * `Average()` - the average value
+  * `First()` - value of first entry
+  * `Last()` - value of last entry
+  * `Percentile(<percentage>)` - The value under which the specified percentage of values fall
+  * `Slope()` - the change in value divided by the change in time between the first and last entries 
+  * `StandardDeviation()` - the standard deviation of all values (a measure of how spread out the values are from the average)
+  * `Count()` - The result of Count() is always returned, even if you do not explicitly request it.
+     * When each entry has a single value:  
+       Returns the number of entries.  
+     * When each entry has multiple values:  
+       Returns an array of the size of the number of values.  
+       Each array element contains the number of entries having a measurement for that value.  
+
+{NOTE: }
+
+**Execute all aggregation functions**:  
+When the query does Not explicitly select a specific aggregation function,  
+the server will implicitly execute ALL available aggregation functions (except for Percentile, Slope, and StandardDeviation) for each group.
+
+{NOTE/}
+{NOTE: }
+
+**Get aggregated values without grouping**:  
+When selecting aggregation functions WITHOUT first grouping the time series entries,  
+the aggregation calculations will be executed over the entire set of time series entries instead of per group of entries.
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+#### Aggregate entries with single value
+
+---
+
+* Each entry in the "HeartRates" time series within the Employees collection contains a single value.
+
+* In this example, for each employee document, we group entries from the "HeartRates" time series  
+  by a 1-hour time frame and then project the lowest and highest values of each group.
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_1@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+  // Query collection Employees
+  from "Employees"
+  // Project the time series data:
+  select timeseries (
+      from HeartRates
+      // Use 'group by' to group the time series entries by the specified time frame
+      group by "1 hour"   // Group entries into consecutive 1-hour groups
+      // Use 'select' to choose aggregation functions that will be evaluated for each group
+      select min(), max() // Project the lowest and highest value of each group
+  )
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Aggregate entries with multiple values  
+
+---
+
+* Each entry in the "StockPrices" time series within the Companies collection holds five values:  
+  Values[0] - **Open** - stock price when trade opens  
+  Values[1] - **Close** - stock price when trade ends  
+  Values[2] - **High** - highest stock price during trade time  
+  Values[3] - **Low** - lowest stock price during trade time  
+  Values[4] - **Volume** - overall trade volume  
+
+* In this example, for each company that is located in USA, we group entries from the "StockPrices" time series  
+  by a 7-day time frame and then project the highest and lowest values of each group.
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_2@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB-BLOCK:sql:RQL_declare_syntax}
+declare timeseries SP(c)
+{
+    from c.StockPrices
+    where Values[4] > 500_000 // Query stock price behavior when trade volume is high
+    group by "7 days"         // Group entries into consecutive 7-day groups
+    select max(), min()       // Project the lowest and highest value of each group
+}
+
+from "Companies" as c
+  // Query only USA companies:
+  where c.Address.Country == "USA"
+  // Project the time series data:
+  select SP(c)
+{CODE-TAB-BLOCK/}
+{CODE-TAB-BLOCK:sql:RQL_select_syntax}
+from "Companies" as c
+// Query only USA companies:
+where c.Address.Country = 'USA'
+    // Project the time series data:
+    select timeseries (
+        from StockPrices
+        where Values[4] > 500000 // Query stock price behavior when trade volume is high
+        group by "7 day"         // Group entries into consecutive 7-day groups
+        select max(), min()      // Project the lowest and highest value of each group
+    )
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+* Since each entry holds 5 values, the query will project:  
+  * 5 `Max` values for each group (the highest Values[0], highest Values[1], etc.) and
+  * 5 `Min` values for each group (the lowest Values[0], lowest Values[1], etc.)
+
+{NOTE/}
+{NOTE: }
+
+#### Aggregate entries without grouping by time frame  
+
+---
+
+* This example is similar to the one above, except that time series entries are Not grouped by a time frame.
+
+* The highest and lowest values are collected from the entire set of time series entries that match the query criteria.
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_3@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare timeseries SP(c)
+{
+    from c.StockPrices
+    where Values[4] > 500_000
+    select max(), min()
+}
+
+from "Companies" as c
+where c.Address.Country == "USA"
+select SP(c)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+* Since no grouping is done, results wil include the highest and lowest Open, Close, High, Low, and Volume values 
+  for ALL entries in the time series that match the query criteria.
+
+{NOTE/}
+{NOTE: }
+
+#### Aggregate entries filtered by referenced document
+
+---
+
+* The tag in each entry in the "StockPrices" series contains an Employee document ID.
+
+* In this example, we load this [referenced document](../../../document-extensions/timeseries/querying/filtering#filter-by-referenced-document)
+  and filter the entries by its properties.
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_4@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies" as c
+select timeseries(
+    from StockPrices
+    // Load the referenced document into variable 'employee'
+    load Tag as employee
+    // Filter entries by the 'Title' field of the employee document
+    where employee.Title == "Sales Representative"
+    group by "1 month"
+    select min(), max()
+)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+  
+* Only entries that reference an employee with title 'Sales Representative' will be grouped by 1 month,  
+  and the results will include the highest and lowest values for each group.
+
+{NOTE/}
+{NOTE: }
+
+#### Secondary grouping by tag
+
+---
+
+* In this example, we perform secondary grouping by the entries' tags.
+
+* The tag in each entry in the "StockPrices" series contains an Employee document ID.
+
+* "StockPrices" entries are grouped by 6 months and then by the tags of the entries within that time frame.
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_5@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies"
+select timeseries (
+    from StockPrices
+    // Use the 'tag' keyword to perform a secondary grouping by the entries' tags.
+    group by "6 months", tag  // Group by months and by tag
+    select max(), min()       // Project the highest and lowest values of each group
+)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Group by dynamic criteria
+
+---
+
+Starting in version 5.2, the LINQ method `GroupBy()` can take a switch statement or a method as an argument.
+
+* In this example, we pass a switch statement to the `GroupBy()` method. 
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_6@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB:csharp:GroupingInterval_Enum grouping_enum@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies"
+select timeseries (
+    from StockPrices
+    group by "1 year"
+    select average
+)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+* In this example, we pass the `GroupingFunction()` metod to the `GroupBy()` method.
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Query aggregation_7@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB:csharp:Grouping_function grouping_function@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies"
+select timeseries (
+    from StockPrices
+    group by "1 year"
+    select average
+)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Project document data in addition to aggregated data
+
+---
+
+* In addition to projecting the aggregated time series data, you can project data from the parent document that contains the time series.
+ 
+* In this example, projecting the **company name** alongside the query results clearly associates each entry in the result set with a specific company.
+  This provides immediate context and makes it easier to interpret the time series data.
+
+    {CODE-TABS}
+{CODE-TAB-BLOCK:sql:RQL_declare_syntax}
+declare timeseries SP(c)
+{
+    from c.StockPrices
+    where Values[4] > 500_000 // Query stock price behavior when trade volume is high
+    group by "7 days"         // Group entries into consecutive 7-day groups
+    select max(), min()       // Project the lowest and highest value of each group
+}
+
+from "Companies" as c
+// Project the company's name along with the time series query results to make results more clear
+select c.Name, SP(c)
+{CODE-TAB-BLOCK/}
+{CODE-TAB-BLOCK:sql:RQL_select_syntax}
+from "Companies" as c
+select timeseries (
+    from StockPrices
+    where Values[4] > 500000
+    group by "7 day"
+    select max(), min()
+), c.Name // Project property 'Name' from the company document
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE syntax_1@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE syntax_2@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+{CODE syntax_3@DocumentExtensions\TimeSeries\Querying\AggregatingValues.cs /}
+
+{PANEL/}
+
+## Related articles
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Time Series Indexing**  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Time Series Queries**  
+[Range Selection](../../../document-extensions/timeseries/querying/choosing-query-range)  
+[Filtering](../../../document-extensions/timeseries/querying/filtering)  
+[Indexed Time Series Queries](../../../document-extensions/timeseries/querying/using-indexes)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  
+
+**Querying**  
+[Querying: Projections](../../../indexes/querying/projections)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.js.markdown
@@ -270,7 +270,7 @@ declare timeseries SP(c)
 
 from "Companies" as c
 // Project the company's name along with the time series query results to make results more clear
-select c.Name, SP(c)
+select SP(c) as MinMaxValues, c.Name as CompanyName
 {CODE-TAB-BLOCK/}
 {CODE-TAB-BLOCK:sql:RQL_select_syntax}
 from "Companies" as c
@@ -279,7 +279,8 @@ select timeseries (
     where Values[4] > 500000
     group by "7 day"
     select max(), min()
-), c.Name // Project property 'Name' from the company document
+) as MinMaxValues,
+c.Name as CompanyName // Project property 'Name' from the company document
 {CODE-TAB-BLOCK/}
     {CODE-TABS/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.js.markdown
@@ -30,13 +30,14 @@
   First, you can group the time series entries based on the specified time frame.  
   The following time units are available:
 
-  * `seconds`  ( seconds/ second / s )
-  * `minutes`  ( minutes / minute / min )
-  * `hours`    ( hours / hour / h )
-  * `days`     ( days / day / d )
-  * `months`   ( months / month / mon / mo )
-  * `quarters` ( quarters / quarter / q )
-  * `years`    ( years / year / y )
+  * `milliseconds` ( milliseconds / milli / ms)
+  * `seconds`      ( seconds/ second / s )
+  * `minutes`      ( minutes / minute / min )
+  * `hours`        ( hours / hour / h )
+  * `days`         ( days / day / d )
+  * `months`       ( months / month / mon / mo )
+  * `quarters`     ( quarters / quarter / q )
+  * `years`        ( years / year / y )
 
 * **Secondary grouping**:  
   After grouping by a time unit, you can also perform a _secondary grouping_ by the time series [tag](../../../document-extensions/timeseries/overview#tags).

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.js.markdown
@@ -1,0 +1,309 @@
+﻿# Aggregating Time Series Values
+
+---
+
+{NOTE: }
+
+* Time series queries can easily generate powerful statistics by applying an aggregation function  
+  (such as Min, Max, Count, Average, etc.) to a group of entries within a chosen time frame,  
+  such as an hour or a week.
+
+* For an overview of the available time series queries, please refer to [Time series querying](../../../document-extensions/timeseries/client-api/session/querying).
+
+* In this page:  
+  * [Grouping and aggregation options](../../../document-extensions/timeseries/querying/aggregation-and-projections#grouping-and-aggregation-options)  
+  * [Examples](../../../document-extensions/timeseries/querying/aggregation-and-projections#Examples)
+      * [Aggregate entries with single value](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-with-single-value)
+      * [Aggregate entries with multiple values](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-with-multiple-values)
+      * [Aggregate entries without grouping by time frame](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-without-grouping-by-time-frame)
+      * [Aggregate entries filtered by referenced document](../../../document-extensions/timeseries/querying/aggregation-and-projections#aggregate-entries-filtered-by-referenced-document)
+      * [Secondary grouping by tag](../../../document-extensions/timeseries/querying/aggregation-and-projections#secondary-grouping-by-tag)
+      * [Project document data in addition to aggregated data](../../../document-extensions/timeseries/querying/aggregation-and-projections#project-document-data-in-addition-to-aggregated-data)
+
+{NOTE/}
+
+---
+
+{PANEL: Grouping and aggregation options}
+
+* **Group entries by time frame**:  
+  First, you can group the time series entries based on the specified time frame.  
+  The following time units are available:
+
+  * `seconds`  ( seconds/ second / s )
+  * `minutes`  ( minutes / minute / min )
+  * `hours`    ( hours / hour / h )
+  * `days`     ( days / day / d )
+  * `months`   ( months / month / mon / mo )
+  * `quarters` ( quarters / quarter / q )
+  * `years`    ( years / year / y )
+
+* **Secondary grouping**:  
+  After grouping by a time unit, you can also perform a _secondary grouping_ by the time series [tag](../../../document-extensions/timeseries/overview#tags).
+
+* **Aggregate values**:  
+  You can select one or more aggregation functions to retrieve aggregated values for each group.  
+  The resulting aggregated values are **projected** to the client in the query result.  
+  The following functions are available:
+
+  * `min()` - the lowest value
+  * `max()` - the highest value
+  * `sum()` - sum of all values
+  * `average()` - the average value
+  * `first()` - value of first entry
+  * `last()` - value of last entry
+  * `percentile(<percentage>)` - The value under which the specified percentage of values fall
+  * `slope` - the change in value divided by the change in time between the first and last entries 
+  * `standardDeviation()` - the standard deviation of all values (a measure of how spread out the values are from the average)
+  * `count()` - The result of Count() is always returned, even if you do not explicitly request it.
+     * When each entry has a single value:  
+       Returns the number of entries.  
+     * When each entry has multiple values:  
+       Returns an array of the size of the number of values.  
+       Each array element contains the number of entries having a measurement for that value.  
+
+{NOTE: }
+
+**Execute all aggregation functions**:  
+When the query does Not explicitly select a specific aggregation function,  
+the server will implicitly execute ALL available aggregation functions (except for Percentile, Slope, and StandardDeviation) for each group.
+
+{NOTE/}
+{NOTE: }
+
+**Get aggregated values without grouping**:  
+When selecting aggregation functions WITHOUT first grouping the time series entries,  
+the aggregation calculations will be executed over the entire set of time series entries instead of per group of entries.
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Examples}
+
+{NOTE: }
+
+#### Aggregate entries with single value
+
+---
+
+* Each entry in the "HeartRates" time series within the Employees collection contains a single value.
+
+* In this example, for each employee document, we group entries from the "HeartRates" time series  
+  by a 1-hour time frame and then project the lowest and highest values of each group.
+
+    {CODE-TABS}
+{CODE-TAB:nodejs:Query aggregation_1@documentExtensions\timeSeries\querying\aggregatingValues.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+  // Query collection Employees
+  from "Employees"
+  // Project the time series data:
+  select timeseries (
+      from HeartRates
+      // Use 'group by' to group the time series entries by the specified time frame
+      group by "1 hour"   // Group entries into consecutive 1-hour groups
+      // Use 'select' to choose aggregation functions that will be evaluated for each group
+      select min(), max() // Project the lowest and highest value of each group
+  )
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Aggregate entries with multiple values  
+
+---
+
+* Each entry in the "StockPrices" time series within the Companies collection holds five values:  
+  Values[0] - **Open** - stock price when trade opens  
+  Values[1] - **Close** - stock price when trade ends  
+  Values[2] - **High** - highest stock price during trade time  
+  Values[3] - **Low** - lowest stock price during trade time  
+  Values[4] - **Volume** - overall trade volume  
+
+* In this example, for each company that is located in USA, we group entries from the "StockPrices" time series  
+  by a 7-day time frame and then project the highest and lowest values of each group.
+
+    {CODE-TABS}
+{CODE-TAB:nodejs:Query aggregation_2@documentExtensions\timeSeries\querying\aggregatingValues.js /}
+{CODE-TAB-BLOCK:sql:RQL_declare_syntax}
+declare timeseries SP(c)
+{
+    from c.StockPrices
+    where Values[4] > 500_000 // Query stock price behavior when trade volume is high
+    group by "7 days"         // Group entries into consecutive 7-day groups
+    select max(), min()       // Project the lowest and highest value of each group
+}
+
+from "Companies" as c
+  // Query only USA companies:
+  where c.Address.Country == "USA"
+  // Project the time series data:
+  select SP(c)
+{CODE-TAB-BLOCK/}
+{CODE-TAB-BLOCK:sql:RQL_select_syntax}
+from "Companies" as c
+// Query only USA companies:
+where c.Address.Country = 'USA'
+    // Project the time series data:
+    select timeseries (
+        from StockPrices
+        where Values[4] > 500000 // Query stock price behavior when trade volume is high
+        group by "7 day"         // Group entries into consecutive 7-day groups
+        select max(), min()      // Project the lowest and highest value of each group
+    )
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+* Since each entry holds 5 values, the query will project:  
+  * 5 `Max` values for each group (the highest Values[0], highest Values[1], etc.) and
+  * 5 `Min` values for each group (the lowest Values[0], lowest Values[1], etc.)
+
+{NOTE/}
+{NOTE: }
+
+#### Aggregate entries without grouping by time frame  
+
+---
+
+* This example is similar to the one above, except that time series entries are Not grouped by a time frame.
+
+* The highest and lowest values are collected from the entire set of time series entries that match the query criteria.
+
+    {CODE-TABS}
+{CODE-TAB:nodejs:Query aggregation_3@documentExtensions\timeSeries\querying\aggregatingValues.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+declare timeseries SP(c)
+{
+    from c.StockPrices
+    where Values[4] > 500_000
+    select max(), min()
+}
+
+from "Companies" as c
+where c.Address.Country == "USA"
+select SP(c)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+* Since no grouping is done, results wil include the highest and lowest Open, Close, High, Low, and Volume values 
+  for ALL entries in the time series that match the query criteria.
+
+{NOTE/}
+{NOTE: }
+
+#### Aggregate entries filtered by referenced document
+
+---
+
+* The tag in each entry in the "StockPrices" series contains an Employee document ID.
+
+* In this example, we load this [referenced document](../../../document-extensions/timeseries/querying/filtering#filter-by-referenced-document)
+  and filter the entries by its properties.
+
+    {CODE-TABS}
+{CODE-TAB:nodejs:Query aggregation_4@documentExtensions\timeSeries\querying\aggregatingValues.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies" as c
+select timeseries(
+    from StockPrices
+    // Load the referenced document into variable 'employee'
+    load Tag as employee
+    // Filter entries by the 'Title' field of the employee document
+    where employee.Title == "Sales Representative"
+    group by "1 month"
+    select min(), max()
+)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+  
+* Only entries that reference an employee with title 'Sales Representative' will be grouped by 1 month,  
+  and the results will include the highest and lowest values for each group.
+
+{NOTE/}
+{NOTE: }
+
+#### Secondary grouping by tag
+
+---
+
+* In this example, we perform secondary grouping by the entries' tags.
+
+* The tag in each entry in the "StockPrices" series contains an Employee document ID.
+
+* "StockPrices" entries are grouped by 6 months and then by the tags of the entries within that time frame.
+
+    {CODE-TABS}
+{CODE-TAB:nodejs:Query aggregation_5@documentExtensions\timeSeries\querying\aggregatingValues.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from "Companies"
+select timeseries (
+    from StockPrices
+    // Use the 'tag' keyword to perform a secondary grouping by the entries' tags.
+    group by "6 months", tag  // Group by months and by tag
+    select max(), min()       // Project the highest and lowest values of each group
+)
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Project document data in addition to aggregated data
+
+---
+
+* In addition to projecting the aggregated time series data, you can project data from the parent document that contains the time series.
+ 
+* In this example, projecting the **company name** alongside the query results clearly associates each entry in the result set with a specific company.
+  This provides immediate context and makes it easier to interpret the time series data.
+
+    {CODE-TABS}
+{CODE-TAB-BLOCK:sql:RQL_declare_syntax}
+declare timeseries SP(c)
+{
+    from c.StockPrices
+    where Values[4] > 500_000 // Query stock price behavior when trade volume is high
+    group by "7 days"         // Group entries into consecutive 7-day groups
+    select max(), min()       // Project the lowest and highest value of each group
+}
+
+from "Companies" as c
+// Project the company's name along with the time series query results to make results more clear
+select c.Name, SP(c)
+{CODE-TAB-BLOCK/}
+{CODE-TAB-BLOCK:sql:RQL_select_syntax}
+from "Companies" as c
+select timeseries (
+    from StockPrices
+    where Values[4] > 500000
+    group by "7 day"
+    select max(), min()
+), c.Name // Project property 'Name' from the company document
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+## Related articles
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Time Series Indexing**  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Time Series Queries**  
+[Range Selection](../../../document-extensions/timeseries/querying/choosing-query-range)  
+[Filtering](../../../document-extensions/timeseries/querying/filtering)  
+[Indexed Time Series Queries](../../../document-extensions/timeseries/querying/using-indexes)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  
+
+**Querying**  
+[Querying: Projections](../../../indexes/querying/projections)  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/AggregatingValues.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/AggregatingValues.cs
@@ -210,6 +210,33 @@ namespace Raven.Documentation.Samples.DocumentExtensions.TimeSeries.Querying
                     List<TimeSeriesAggregationResult> results = query.ToList();
                     #endregion
                 }
+                
+                // Project document data as well
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_8
+                    var query = session.Query<Company>()
+                        .Select(company => new
+                        {
+                            // Projecting time series data:
+                            MinMaxValues = RavenQuery.TimeSeries(company, "StockPrices")
+                                .Where(e => e.Values[4] > 500_000)
+                                .GroupBy(g => g.Days(7))
+                                .Select(x => new
+                                {
+                                    Min = x.Min(),
+                                    Max = x.Max(),
+                                })
+                                .ToList(),
+                            
+                            // Projecting the company name:
+                            CompanyName = company.Name 
+                        });
+                    
+                    // Execute the query
+                    var results = query.ToList();
+                    #endregion
+                }
             }
         }
     }

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/AggregatingValues.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/AggregatingValues.cs
@@ -1,0 +1,279 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.DocumentExtensions.TimeSeries.Querying
+{
+    class AggregatingValues
+    {
+        #region grouping_enum
+        public enum GroupingInterval
+        {
+            Hour,
+            Day,
+            Month,
+            Year
+        }
+        #endregion
+        
+        #region grouping_function
+        public static ITimeSeriesAggregationOperations GroupingFunction(ITimePeriodBuilder builder,
+            string input)
+        {
+            if (input == "year")
+            {
+                return builder.Years(1);
+            }
+            
+            if (input == "month")
+            {
+                return builder.Months(1);
+            }
+            
+            return builder.Days(1);
+        }
+        #endregion
+        
+        public void Examples()
+        {
+            using (var store = new DocumentStore())
+            {
+                // Aggregate entries with single value
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_1
+                    var query = session.Query<Employee>()
+                        .Select(u => RavenQuery
+                            .TimeSeries(u, "HeartRates")
+                             // Call 'GroupBy' to group the time series entries by a time frame
+                            .GroupBy(g => g.Hours(1))
+                             // Call 'Select' to choose aggregation functions that will be evaluated for each group
+                            .Select(g => new
+                            {
+                                // Project the lowest and highest value of each group
+                                Min = g.Min(),
+                                Max = g.Max()
+                            })
+                            .ToList());
+
+                    // Execute the query
+                    List<TimeSeriesAggregationResult> results = query.ToList();
+                    #endregion
+                }
+                
+                // Aggregate entries with multiple values  
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_2
+                    var query = session.Query<Company>()
+                         // Query only USA companies:
+                        .Where(c => c.Address.Country == "USA")
+                        .Select(u => RavenQuery
+                             .TimeSeries(u, "StockPrices")
+                             // Query stock price behavior when trade volume is high
+                            .Where(ts => ts.Values[4] > 500000)
+                             // Group entries into consecutive 7-day groups
+                            .GroupBy(g => g.Days(7))
+                             // Project the lowest and highest value of each group
+                            .Select(g => new
+                            {
+                                Min = g.Min(),
+                                Max = g.Max()
+                            })
+                            .ToList());
+
+                    // Execute the query
+                    List<TimeSeriesAggregationResult> results = query.ToList();
+                    #endregion
+                }
+                
+                // Aggregate entries without grouping by time frame  
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_3
+                    var query = session.Query<Company>()
+                        .Where(c => c.Address.Country == "USA")
+                        .Select(u => RavenQuery
+                            .TimeSeries(u, "StockPrices")
+                            .Where(ts => ts.Values[4] > 500000)
+                            // Project the lowest and highest value of ALL entries that match the query criteria
+                            .Select(g => new
+                            {
+                                Min = g.Min(),
+                                Max = g.Max()
+                            })
+                            .ToList());
+
+                    // Execute the query
+                    List<TimeSeriesAggregationResult> results = query.ToList();
+                    #endregion
+                }
+                
+                // Aggregate entries filtered by referenced document
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_4
+                    var query = session.Query<Company>()
+                        .Select(u => RavenQuery
+                            .TimeSeries(u, "StockPrices")
+                             // Call 'LoadByTag' to load the document referenced by the tag
+                            .LoadByTag<Employee>()
+                             // Filter entries: 
+                             // Process only entries that reference an employee with the Sales title
+                            .Where((entry, employee) => employee.Title == "Sales Representative")
+                            .GroupBy(g =>g.Months(1))
+                            .Select(g => new
+                            {
+                                Min = g.Min(),
+                                Max = g.Max()
+                            })
+                            .ToList());
+
+                    // Execute the query
+                    List<TimeSeriesAggregationResult> results = query.ToList();
+                    #endregion
+                }
+                
+                // Secondary aggregation by tag
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_5
+                    var query = session.Query<Company>()
+                        .Select(u => RavenQuery
+                            .TimeSeries(u, "StockPrices")
+                            .GroupBy(g => g
+                                 // First group by 6 months   
+                                .Months(6)
+                                 // Then group by tag
+                                .ByTag())
+                            .Select(g => new
+                            {  
+                                // Project the highest and lowest values of each group
+                                Min = g.Min(),
+                                Max = g.Max()
+                            })
+                            .ToList());
+
+                    // Execute the query
+                    List<TimeSeriesAggregationResult> results = query.ToList();
+                    #endregion
+                }
+                
+                // Group by dynamic criteria 1
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_6
+                    var grouping = GroupingInterval.Year; // Dynamic input from the client
+                    
+                    var groupingAction = grouping switch 
+                    {
+                        GroupingInterval.Year => (Action<ITimePeriodBuilder>)(builder => builder.Years(1)),
+                        GroupingInterval.Month=> (Action<ITimePeriodBuilder>)(builder => builder.Months(1)),
+                        GroupingInterval.Day => (Action<ITimePeriodBuilder>)(builder => builder.Days(1))
+                    };
+
+                    var query = session.Query<Company>()
+                        .Select(c => RavenQuery
+                            .TimeSeries(c, "StockPrices")
+                            .GroupBy(groupingAction)
+                            .Select(g => new
+                            {
+                                Ave = g.Average()
+                            })
+                            .ToList());
+                    
+                    // Execute the query
+                    List<TimeSeriesAggregationResult> results = query.ToList();
+                    #endregion
+                }
+                
+                // Group by dynamic criteria 2
+                using (var session = store.OpenSession())
+                {
+                    #region aggregation_7
+                    var query = session.Query<Company>()
+                        .Select(c => RavenQuery
+                            .TimeSeries(c, "StockPrices")
+                            .GroupBy(builder => GroupingFunction(builder, "year"))
+                            .Select(g => new
+                            {
+                                Ave = g.Average()
+                            })
+                            .ToList());
+                    
+                    // Execute the query
+                    List<TimeSeriesAggregationResult> results = query.ToList();
+                    #endregion
+                }
+            }
+        }
+    }
+    /*
+    #region syntax_1
+    public interface ITimeSeriesQueryable
+    {
+       
+        ITimeSeriesQueryable Where(Expression<Func<TimeSeriesEntry, bool>> predicate);
+
+        ITimeSeriesQueryable Offset(TimeSpan offset);
+
+        ITimeSeriesQueryable Scale(double value);
+
+        ITimeSeriesQueryable FromLast(Action<ITimePeriodBuilder> timePeriod);
+
+        ITimeSeriesQueryable FromFirst(Action<ITimePeriodBuilder> timePeriod);
+
+        ITimeSeriesLoadQueryable<TEntity> LoadByTag<TEntity>();
+
+        // GroupBy overloads:
+        ITimeSeriesAggregationQueryable GroupBy(string s);
+        ITimeSeriesAggregationQueryable GroupBy(Action<ITimePeriodBuilder> timePeriod);
+
+        // Select method:
+        ITimeSeriesAggregationQueryable Select(
+            Expression<Func<ITimeSeriesGrouping, object>> selector);
+
+        TimeSeriesRawResult ToList();
+    }
+    #endregion
+    */
+    
+    /*
+    #region syntax_2
+    public interface ITimePeriodBuilder
+    {
+        ITimeSeriesAggregationOperations Milliseconds(int duration);
+        ITimeSeriesAggregationOperations Seconds(int duration);
+        ITimeSeriesAggregationOperations Minutes(int duration);
+        ITimeSeriesAggregationOperations Hours(int duration);
+        ITimeSeriesAggregationOperations Days(int duration);
+        ITimeSeriesAggregationOperations Months(int duration);
+        ITimeSeriesAggregationOperations Quarters(int duration);
+        ITimeSeriesAggregationOperations Years(int duration);
+    }
+    #endregion
+    */
+    
+    /*
+    #region syntax_3
+    public interface ITimeSeriesGrouping
+    {
+        double[] Max();
+        double[] Min();
+        double[] Sum();
+        double[] Average();
+        double[] First();
+        double[] Last();
+        long[] Count();
+        double[] Percentile(double number);
+        double[] Slope();
+        double[] StandardDeviation();
+    } 
+    #endregion
+    */
+}

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/aggregatingValues.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/aggregatingValues.js
@@ -1,0 +1,88 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function aggregatingValues() {
+    {
+        //region aggregation_1
+        // Define the time series query part (expressed in RQL):
+        const tsQueryText = `
+            from HeartRates
+            // Use 'group by' to group the time series entries by the specified time frame
+            group by "1 hour"
+            // Use 'select' to choose aggregation functions that will be evaluated
+            // Project the lowest and highest value of each group
+            select min(), max()`;
+
+        // Define the query:
+        const query = session.query({ collection: "employees" })
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        // Execute the query:
+        const results = await query.all();
+        //endregion
+
+        //region aggregation_2
+        const tsQueryText = `
+            from StockPrices
+            // Query stock price behavior when trade volume is high
+            where Values[4] > 500000 
+            // Group entries into consecutive 7-day groups
+            group by "7 day"
+            // Project the lowest and highest value of each group         
+            select max(), min()`;
+
+        const query = session.query({ collection: "companies" })
+            .whereEquals("Address.Country", "USA")
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        const results = await query.all();
+        //endregion
+
+        //region aggregation_3
+        const tsQueryText = `
+            from StockPrices
+            where Values[4] > 500_000
+            select max(), min()`;
+
+        const query = session.query({ collection: "companies" })
+            .whereEquals("Address.Country", "USA")
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        const results = await query.all();
+        //endregion
+
+        //region aggregation_4
+        const tsQueryText = `
+            from StockPrices
+            // Load the referenced document into variable 'employee'
+            load Tag as employee
+            // Filter entries by the 'Title' field of the employee document
+            where employee.Title == "Sales Representative"
+            group by "1 month"
+            select min(), max()`;
+
+        const query = session.query({ collection: "companies" })
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        const results = await query.all();
+        //endregion
+
+        //region aggregation_5
+        const tsQueryText = `
+            from StockPrices
+            // Use the 'tag' keyword to perform a secondary grouping by the entries' tags
+            // Group by months and by tag
+            group by "6 months", tag
+            // Project the highest and lowest values of each group  
+            select max(), min()`;
+
+        const query = session.query({ collection: "companies" })
+            .selectTimeSeries(b => b.raw(tsQueryText), TimeSeriesRawResult);
+
+        const results = await query.all();
+        //endregion
+    }
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
@@ -19,7 +19,7 @@
     },
     {
         "Path": "aggregation-and-projections.markdown",
-        "Name": "Aggregation and Projections",
+        "Name": "Aggregating Values",
         "DiscussionId": "b399492f-c034-4406-810c-58ecd8c59115",
         "Mappings": []
     },


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2880/Node.js-Document-extensions-Time-series-Querying-Aggregations-projections-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied, to be done in a separate dedicated issue:
  https://issues.hibernatingrhinos.com/issue/RDoc-2885/Document-extensions-Time-series-Querying-Aggregating-Values-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/aggregatingValues.js
```

**C#**: @aviv86 
* C# files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/aggregation-and-projections.dotnet.markdown
Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/AggregatingValues.cs
```