### PR TITLE
RDoc-2884 [Node.js] Document extensions > Time series > Querying > Querying time series indexes [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
@@ -31,7 +31,7 @@
     },
     {
         "Path": "using-indexes.markdown",
-        "Name": "Using Indexes",
+        "Name": "Querying Time Series Indexes",
         "DiscussionId": "b399492f-c034-4406-810c-58ecd8c59115",
         "Mappings": []
     },

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.dotnet.markdown
@@ -1,0 +1,194 @@
+﻿# Querying Time Series Indexes
+
+---
+
+{NOTE: }
+
+* **Time series index**:
+
+    * STATIC-time-series-indexes can be defined from the [Client API](../../../document-extensions/timeseries/indexing) or using the [Studio](../../../studio/database/indexes/create-map-index).  
+      Such an index can be queried in the same way as a regular index that indexes documents.  
+      (See [Querying an index](../../../indexes/querying/query-index)).
+    
+    * AUTO-time-series-indexes are Not generated automatically by the server when making a time series query.
+
+* **The contents of the query results**:
+
+    * Unlike a documents index, where the source data are your JSON documents,  
+      the source data for a time series index are the time series entries within the documents.
+
+    * When querying a **documents index**:  
+      the resulting objects are the document entities (unless results are [projected](../../../indexes/querying/projections)).
+  
+    * When querying a **time series index**:  
+      each item in the results is of the type defined by the **index-entry** in the index definition,  
+      (unless results are [projected](../../../document-extensions/timeseries/querying/using-indexes#project-results)). 
+      The documents themselves are not returned.
+
+* In this page:
+    * [Sample index](../../../document-extensions/timeseries/querying/using-indexes#sample-index)
+    * [Querying the index](../../../document-extensions/timeseries/querying/using-indexes#querying-the-index)
+        * [Query all time series entries](../../../document-extensions/timeseries/querying/using-indexes#query-all-time-series-entries)
+        * [Filter query results](../../../document-extensions/timeseries/querying/using-indexes#filter-query-results)
+        * [Order query results](../../../document-extensions/timeseries/querying/using-indexes#order-query-results)
+        * [Project results](../../../document-extensions/timeseries/querying/using-indexes#project-results)
+    * [Syntax](../../../document-extensions/timeseries/querying/using-indexes#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Sample Index}
+
+* The following is a time series map-index that will be used in the query examples throughout this article.
+
+* Each **index-entry** consists of:
+  * Three index-fields obtained from the "HeartRates" time series entries: `BPM`, `Date`, and `Tag`.
+  * One index-field obtained from the time series [segment](../../../document-extensions/timeseries/indexing#timeseriessegment-object) header: `EmployeeID`.
+  * One index-field obtained from the loaded employee document: `EmployeeName`.
+
+* When querying this time series index:  
+  * The resulting items correspond to the time series entries that match the query predicate.  
+  * Each item in the results will be of type `TsIndex.IndexEntry`, which is the index-entry.  
+    Different result types may be returned when the query [projects the results](../../../document-extensions/timeseries/querying/using-indexes#project-results).
+
+{CODE sample_ts_index@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+
+{PANEL/}
+
+{PANEL: Querying the index} 
+ 
+{NOTE: }
+
+<a id="query-all-time-series-entries" /> **Query all time series entries**:
+
+---
+
+No filtering is applied in this query.  
+Results will include ALL entries from time series "HeartRates".
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_index_1@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:Query_async query_index_2@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:DocumentQuery query_index_3@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:RawQuery query_index_4@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+{CODE-TAB-BLOCK/} 
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="filter-query-results" /> **Filter query results**:
+
+---
+
+In this example, time series entries are filtered by the query.  
+The query predicate is applied to the index-fields.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_index_5@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:Query_async query_index_6@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:DocumentQuery query_index_7@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:RawQuery query_index_8@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+where EmployeeName == "Robert King" and BPM > 85.0
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="order-query-results" /> **Order query results**:
+
+---
+
+Results can be ordered by any of the index-fields.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_index_9@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:Query_async query_index_10@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:DocumentQuery query_index_11@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:RawQuery query_index_12@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+where BPM < 58.0
+order by Date desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="project-results" /> **Project results**:
+
+---
+
+* Instead of returning the entire `TsIndex.IndexEntry` object for each result item,  
+  you can return only partial fields.
+
+* Learn more about projecting query results in [Project Index Query Results](../../../indexes/querying/projections).
+
+* In this example, we query for time series entries with a very high BPM value.  
+  We retrieve entries with BPM value > 100 but return only the _EmployeeID_ for each entry.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_index_13@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:Query_async query_index_14@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:DocumentQuery query_index_15@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:Projection_class employee_details_class@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB:csharp:RawQuery query_index_16@DocumentExtensions\TimeSeries\Querying\QueryingTsIndex.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+where BPM > 100.0
+select distinct EmployeeID
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+   
+* `session.Query`  
+
+    {CODE-BLOCK: JSON}
+    IRavenQueryable<T> Query<T, TIndexCreator>() where TIndexCreator 
+    : AbstractCommonApiForIndexes, new();
+    {CODE-BLOCK/}
+
+* `DocumentQuery`  
+    
+    {CODE-BLOCK: JSON}
+    IDocumentQuery<T> DocumentQuery<T, TIndexCreator>() where TIndexCreator 
+    : AbstractCommonApiForIndexes, new();
+    {CODE-BLOCK/}
+
+| Parameter          | Description        |
+|--------------------|--------------------|
+| **T**              | The results class  |
+| **TIndexCreator**  | Index              |
+
+{PANEL/}
+
+## Related articles
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Time Series Indexing**  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Time Series Queries**  
+[Range Selection](../../../document-extensions/timeseries/querying/choosing-query-range)  
+[Filtering](../../../document-extensions/timeseries/querying/filtering)  
+[Aggregation and Projection](../../../document-extensions/timeseries/querying/aggregation-and-projections)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.dotnet.markdown
@@ -14,10 +14,10 @@
 
 * **The contents of the query results**:
 
-    * Unlike a documents index, where the source data are your JSON documents,  
+    * Unlike a document index, where the source data are your JSON documents,  
       the source data for a time series index are the time series entries within the documents.
 
-    * When querying a **documents index**:  
+    * When querying a **document index**:  
       the resulting objects are the document entities (unless results are [projected](../../../indexes/querying/projections)).
   
     * When querying a **time series index**:  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.js.markdown
@@ -1,0 +1,161 @@
+﻿# Querying Time Series Indexes
+
+---
+
+{NOTE: }
+
+* **Time series index**:
+
+    * STATIC-time-series-indexes can be defined from the [Client API](../../../document-extensions/timeseries/indexing) or using the [Studio](../../../studio/database/indexes/create-map-index).  
+      Such an index can be queried in the same way as a regular index that indexes documents.  
+      (See [Querying an index](../../../indexes/querying/query-index)).
+    
+    * AUTO-time-series-indexes are Not generated automatically by the server when making a time series query.
+
+* **The contents of the query results**:
+
+    * Unlike a documents index, where the source data are your JSON documents,  
+      the source data for a time series index are the time series entries within the documents.
+
+    * When querying a **documents index**:  
+      the resulting objects are the document entities (unless results are [projected](../../../indexes/querying/projections)).
+  
+    * When querying a **time series index**:  
+      each item in the results is of the type defined by the **index-entry** in the index definition,  
+      (unless results are [projected](../../../document-extensions/timeseries/querying/using-indexes#project-results)). 
+      The documents themselves are not returned.
+
+* In this page:
+    * [Sample index](../../../document-extensions/timeseries/querying/using-indexes#sample-index)
+    * [Querying the index](../../../document-extensions/timeseries/querying/using-indexes#querying-the-index)
+        * [Query all time series entries](../../../document-extensions/timeseries/querying/using-indexes#query-all-time-series-entries)
+        * [Filter query results](../../../document-extensions/timeseries/querying/using-indexes#filter-query-results)
+        * [Order query results](../../../document-extensions/timeseries/querying/using-indexes#order-query-results)
+        * [Project results](../../../document-extensions/timeseries/querying/using-indexes#project-results)
+
+{NOTE/}
+
+---
+
+{PANEL: Sample Index}
+
+* The following is a time series map-index that will be used in the query examples throughout this article.
+
+* Each **index-entry** consists of:
+  * Three index-fields obtained from the "HeartRates" time series entries: `bpm`, `date`, and `tag`.
+  * One index-field obtained from the time series [segment](../../../document-extensions/timeseries/indexing#timeseriessegment-object) header: `employeeID`.
+  * One index-field obtained from the loaded employee document: `employeeName`.
+
+* When querying this time series index:  
+  * The resulting items correspond to the time series entries that match the query predicate.  
+  * Each item in the results will in the shape of the defined index-entry.  
+    Different result types may be returned when the query [projects the results](../../../document-extensions/timeseries/querying/using-indexes#project-results).
+
+{CODE:nodejs sample_ts_index@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+
+{PANEL/}
+
+{PANEL: Querying the index} 
+ 
+{NOTE: }
+
+<a id="query-all-time-series-entries" /> **Query all time series entries**:
+
+---
+
+No filtering is applied in this query.  
+Results will include ALL entries from time series "HeartRates".
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_index_1@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB:nodejs:RawQuery query_index_2@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+{CODE-TAB-BLOCK/} 
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="filter-query-results" /> **Filter query results**:
+
+---
+
+In this example, time series entries are filtered by the query.  
+The query predicate is applied to the index-fields.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_index_3@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB:nodejs:RawQuery query_index_4@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+where employeeName == "Robert King" and bpm >= 85
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+<a id="order-query-results" /> **Order query results**:
+
+---
+
+Results can be ordered by any of the index-fields.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_index_5@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB:nodejs:RawQuery query_index_6@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+where bpm < 58
+order by date desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+
+{NOTE: }
+
+<a id="project-results" /> **Project results**:
+
+---
+
+* Instead of returning the entire index entry object for each result item,  
+  you can return only partial fields.
+
+* Learn more about projecting query results in [Project Index Query Results](../../../indexes/querying/projections).
+
+* In this example, we query for time series entries with a very high BPM value.  
+  We retrieve entries with BPM value > 100 but return only the _employeeID_ for each entry.
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_index_7@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB:nodejs:RawQuery query_index_8@documentExtensions\timeSeries\querying\queryingTsIndex.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "TsIndex"
+where bpm > 100
+select distinct employeeID
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+## Related articles
+
+**Time Series Overview**  
+[Time Series Overview](../../../document-extensions/timeseries/overview)  
+
+**Studio Articles**  
+[Studio Time Series Management](../../../studio/database/document-extensions/time-series)  
+
+**Time Series Indexing**  
+[Time Series Indexing](../../../document-extensions/timeseries/indexing)  
+
+**Time Series Queries**  
+[Range Selection](../../../document-extensions/timeseries/querying/choosing-query-range)  
+[Filtering](../../../document-extensions/timeseries/querying/filtering)  
+[Aggregation and Projection](../../../document-extensions/timeseries/querying/aggregation-and-projections)  
+
+**Policies**  
+[Time Series Rollup and Retention](../../../document-extensions/timeseries/rollup-and-retention)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.js.markdown
@@ -14,10 +14,10 @@
 
 * **The contents of the query results**:
 
-    * Unlike a documents index, where the source data are your JSON documents,  
+    * Unlike a document index, where the source data are your JSON documents,  
       the source data for a time series index are the time series entries within the documents.
 
-    * When querying a **documents index**:  
+    * When querying a **document index**:  
       the resulting objects are the document entities (unless results are [projected](../../../indexes/querying/projections)).
   
     * When querying a **time series index**:  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/queryingTsIndex.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/queryingTsIndex.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Linq;
+using Raven.Client.Documents;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Indexes.TimeSeries;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.DocumentExtensions.TimeSeries.Querying
+{
+    public class QueryingTsIndex
+    {
+        public DocumentStore getDocumentStore()
+        {
+            DocumentStore store = new DocumentStore
+            {
+                Urls = new[] { "http://localhost:8080" },
+                Database = "TestDB"
+            };
+            store.Initialize();
+
+            return store;
+        }
+        
+        #region sample_ts_index
+        public class TsIndex : AbstractTimeSeriesIndexCreationTask<Employee>
+        {
+            // The index-entry:
+            // ================
+            public class IndexEntry
+            {
+                // The index-fields:
+                // =================
+                public double BPM { get; set; }
+                public DateTime Date { get; set; }
+                public string Tag { get; set; }
+                public string EmployeeID { get; set; }
+                public string EmployeeName { get; set; }
+            }
+
+            public TsIndex()
+            {
+                AddMap("HeartRates", timeSeries => 
+                    from segment in timeSeries
+                    from entry in segment.Entries
+                    
+                    let employee = LoadDocument<Employee>(segment.DocumentId)
+                    
+                    // Define the content of the index-fields:
+                    // =======================================
+                    select new IndexEntry()
+                    {
+                        BPM = entry.Values[0],
+                        Date = entry.Timestamp,
+                        Tag = entry.Tag,
+                        EmployeeID = segment.DocumentId,
+                        EmployeeName = employee.FirstName + " " + employee.LastName 
+                    });
+            }
+        }
+        #endregion
+        
+        #region employee_details_class
+        // This class is used when projecting index-fields via DocumentQuery
+        public class EmployeeDetails
+        {
+            public string EmployeeName { get; set; }
+            public string EmployeeID { get; set; }
+        }
+        #endregion
+        
+        public async Task IndexQuery()
+        {
+            using (var store = getDocumentStore())
+            {
+                #region query_index_1
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session
+                         // Query the index
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                         // Query for all entries w/o any filtering
+                        .ToList();
+                    
+                    // Access results:
+                    TsIndex.IndexEntry entryResult = results[0];
+                    string employeeName = entryResult.EmployeeName;
+                    double BPM = entryResult.BPM;
+                }
+                #endregion
+                
+                #region query_index_2
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    List<TsIndex.IndexEntry> results = await asyncSession
+                         // Query the index
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                         // Query for all entries w/o any filtering
+                        .ToListAsync();
+                }
+                #endregion
+                
+                #region query_index_3
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session.Advanced
+                         // Query the index
+                        .DocumentQuery<TsIndex.IndexEntry, TsIndex>()
+                         // Query for all entries w/o any filtering
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_4
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session.Advanced
+                         // Query the index for all entries w/o any filtering
+                        .RawQuery<TsIndex.IndexEntry>($@"
+                              from index 'TsIndex'
+                         ")
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_5
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                         // Retrieve only time series entries with high BPM values for a specific employee
+                        .Where(x => x.EmployeeName == "Robert King" && x.BPM > 85)
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_6
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    List<TsIndex.IndexEntry> results = await asyncSession
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                         // Retrieve only time series entries with high BPM values for a specific employee
+                        .Where(x => x.EmployeeName == "Robert King" && x.BPM > 85)
+                        .ToListAsync();
+                }
+                #endregion
+                
+                #region query_index_7
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session.Advanced
+                        .DocumentQuery<TsIndex.IndexEntry, TsIndex>()
+                         // Retrieve only time series entries with high BPM values for a specific employee
+                        .WhereEquals(x => x.EmployeeName, "Robert King")
+                        .AndAlso()
+                        .WhereGreaterThan(x => x.BPM, 85)
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_8
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session.Advanced
+                         // Retrieve only time series entries with high BPM values for a specific employee
+                        .RawQuery<TsIndex.IndexEntry>($@"
+                              from index 'TsIndex'
+                              where EmployeeName == 'Robert King' and BPM > 85.0 
+                         ")
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_9
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                         // Retrieve time series entries where employees had a low BPM value
+                        .Where(x => x.BPM < 58)
+                         // Order by the 'Date' index-field (descending order)
+                        .OrderByDescending(x => x.Date)
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_10
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    List<TsIndex.IndexEntry> results = await asyncSession
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                         // Retrieve time series entries where employees had a low BPM value
+                        .Where(x => x.BPM < 58)
+                         // Order by the 'Date' index-field (descending order)
+                        .OrderByDescending(x => x.Date)
+                        .ToListAsync();
+                }
+                #endregion
+                
+                #region query_index_11
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session.Advanced
+                        .DocumentQuery<TsIndex.IndexEntry, TsIndex>()
+                         // Retrieve time series entries where employees had a low BPM value
+                        .WhereLessThan(x => x.BPM, 58)
+                         // Order by the 'Date' index-field (descending order)
+                        .OrderByDescending(x => x.Date)
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_12
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session.Advanced
+                         // Retrieve entries with low BPM value and order by 'Date' descending
+                        .RawQuery<TsIndex.IndexEntry>($@"
+                              from index 'TsIndex'
+                              where BPM < 58.0
+                              order by Date desc
+                         ")
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_13
+                using (var session = store.OpenSession())
+                {
+                    List<string> results = session
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                        .Where(x => x.BPM > 100)
+                         // Return only the EmployeeID index-field in the results
+                        .Select(x => x.EmployeeID)
+                         // Optionally: call 'Distinct' to remove duplicates from results
+                        .Distinct()
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_14
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    List<string> results = await asyncSession
+                        .Query<TsIndex.IndexEntry, TsIndex>()
+                        .Where(x => x.BPM > 100)
+                         // Return only the EmployeeID index-field in the results
+                        .Select(x => x.EmployeeID)
+                         // Optionally: call 'Distinct' to remove duplicates from results
+                        .Distinct()
+                        .ToListAsync();
+                }
+                #endregion
+                
+                #region query_index_15
+                var fieldsToProject = new string[] {
+                    "EmployeeID"
+                };
+                
+                using (var session = store.OpenSession())
+                {
+                    List<EmployeeDetails> results = session.Advanced
+                        .DocumentQuery<TsIndex.IndexEntry, TsIndex>()
+                        .WhereGreaterThan(x => x.BPM, 100)
+                         // Return only the EmployeeID index-field in the results
+                        .SelectFields<EmployeeDetails>(fieldsToProject)
+                         // Optionally: call 'Distinct' to remove duplicates from results
+                        .Distinct()
+                        .ToList();
+                }
+                #endregion
+                
+                #region query_index_16
+                using (var session = store.OpenSession())
+                {
+                    List<TsIndex.IndexEntry> results = session.Advanced
+                         // Return only the EmployeeID index-field in the results
+                        .RawQuery<TsIndex.IndexEntry>($@"
+                              from index 'TsIndex'
+                              where BPM > 100.0
+                              select distinct EmployeeID
+                         ")
+                        .ToList();
+                }
+                #endregion
+            }
+        }
+    }
+}
+

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/TimeSeriesTests.cs
@@ -2741,7 +2741,7 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
 
                 store.Maintenance.Send(new StopIndexingOperation());
 
-                var timeSeriesIndex = new SimpleIndex();
+                var timeSeriesIndex = new TsIndex();
                 var indexDefinition = timeSeriesIndex.CreateIndexDefinition();
 
                 timeSeriesIndex.Execute(store);
@@ -2749,60 +2749,6 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
                 store.Maintenance.Send(new StartIndexingOperation());
 
                 //WaitForIndexing(store);
-
-                #region ts_region_Index-TS-Queries-1-session-Query
-                // Query time-series index using session.Query
-                using (var session = store.OpenSession())
-                {
-                    List<SimpleIndex.Result> results =
-                        session.Query<SimpleIndex.Result, SimpleIndex>()
-                        .ToList();
-                }
-                #endregion
-
-                #region ts_region_Index-TS-Queries-2-session-Query-with-Linq
-                // Enhance the query using LINQ expressions
-                var chosenDate = new DateTime(2020, 5, 20);
-                using (var session = store.OpenSession())
-                {
-                    List<SimpleIndex.Result> results =
-                        session.Query<SimpleIndex.Result, SimpleIndex>()
-                        .Where(w => w.Date < chosenDate)
-                        .OrderBy(o => o.HeartBeat)
-                        .ToList();
-                }
-                #endregion
-
-                #region ts_region_Index-TS-Queries-3-DocumentQuery
-                // Query time-series index using DocumentQuery
-                using (var session = store.OpenSession())
-                {
-                    List<SimpleIndex.Result> results =
-                        session.Advanced.DocumentQuery<SimpleIndex.Result, SimpleIndex>()
-                        .ToList();
-                }
-                #endregion
-
-                #region ts_region_Index-TS-Queries-4-DocumentQuery-with-Linq
-                // Query time-series index using DocumentQuery with Linq-like expressions
-                using (var session = store.OpenSession())
-                {
-                    List<SimpleIndex.Result> results =
-                        session.Advanced.DocumentQuery<SimpleIndex.Result, SimpleIndex>()
-                        .WhereEquals("Tag", "watches/fitbit")
-                        .ToList();
-                }
-                #endregion
-
-                #region ts_region_Index-TS-Queries-5-session-Query-Async
-                // Time-series async index query using session.Query
-                using (var session = store.OpenAsyncSession())
-                {
-                    List<SimpleIndex.Result> results =
-                        await session.Query<SimpleIndex.Result, SimpleIndex>()
-                        .ToListAsync();
-                }
-                #endregion
             }
         }
 
@@ -2845,32 +2791,35 @@ namespace Documentation.Samples.DocumentExtensions.TimeSeries
             }
         }
 
-        #region ts_region_Index-TS-Queries-6-Index-Definition-And-Results-Class
-        public class SimpleIndex : AbstractTimeSeriesIndexCreationTask<Employee>
+        #region sample_ts_index
+        public class TsIndex : AbstractTimeSeriesIndexCreationTask<Employee>
         {
-
-            public class Result
+            public class IndexEntry
             {
-                public double HeartBeat { get; set; }
+                // The index-fields:
+                public double BPM { get; set; }
                 public DateTime Date { get; set; }
-                public string User { get; set; }
                 public string Tag { get; set; }
+                public string EmployeeID { get; set; }
+                public string EmployeeName { get; set; }
             }
 
-            public SimpleIndex()
+            public TsIndex()
             {
-                AddMap(
-                    "HeartRates",
-                    timeSeries => from ts in timeSeries
-                                  from entry in ts.Entries
-                                  select new
-                                  {
-                                      HeartBeat =
-                                        entry.Values[0],
-                                      entry.Timestamp.Date,
-                                      User = ts.DocumentId,
-                                      Tag = entry.Tag
-                                  });
+                AddMap("HeartRates", timeSeries => 
+                    from segment in timeSeries
+                    from entry in segment.Entries
+                    let employee = LoadDocument<Employee>(segment.DocumentId)
+                    
+                    // Define the content of the index-fields:
+                    select new IndexEntry()
+                    {
+                        BPM = entry.Values[0],
+                        Date = entry.Timestamp.Date,
+                        Tag = entry.Tag,
+                        EmployeeID = segment.DocumentId,
+                        EmployeeName = employee.FirstName + " " + employee.LastName 
+                    });
             }
         }
         #endregion

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/queryingTsIndex.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/queryingTsIndex.js
@@ -1,0 +1,121 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function queryTsIndex() {
+
+    //region sample_ts_index
+    class TsIndex extends AbstractRawJavaScriptTimeSeriesIndexCreationTask {
+        constructor() {
+            super();
+
+            this.maps.add(`
+                timeSeries.map("Employees", function (segment) {
+                     let employee = load(segment.DocumentId, "Employees")
+                     
+                     // Return the index-entry:
+                     return segment.Entries.map(entry => ({
+                     
+                         // Define the index-fields:
+                         bpm: entry.Values[0],
+                         date: new Date(entry.Timestamp),
+                         tag: entry.Tag
+                         employeeID: segment.DocumentId,
+                         employeeName: employee.FirstName + " " + employee.LastName
+                     }));
+                })
+            `;
+        }
+    }
+    //endregion
+    
+    {
+        //region query_index_1
+        const results = await session
+             // Query the index 
+            .query({ indexName: "TsIndex" })
+             // Query for all entries w/o any filtering
+            .all();
+
+        // Access results:
+        const entryResult = results[0];
+        const employeeName = entryResult.employeeName;
+        const bpm = entryResult.bpm;
+        //endregion
+
+        //region query_index_2
+        const results = await session
+             // Provide RQL to rawQuery
+            .advanced.rawQuery("from index 'TsIndex'")
+             // Execute the query
+            .all();
+        //endregion
+
+        //region query_index_3
+        const results = await session
+            .query({ indexName: "TsIndex" })
+             // Retrieve only time series entries with high BPM values for a specific employee
+            .whereEquals("employeeName", "Robert King")
+            .whereGreaterThanOrEqual("bpm", 85)
+            .all();
+        //endregion
+
+        //region query_index_4
+        const results = await session
+             // Retrieve only time series entries with high BPM values for a specific employee
+            .advanced.rawQuery(`
+                 from index "TsIndex"
+                 where employeeName == "Robert King" and bpm > 85.0
+            `)
+            .all();
+        //endregion
+
+        //region query_index_5
+        const results = await session
+            .query({ indexName: "TsIndex" })
+             // Retrieve time series entries where employees had a low BPM value
+            .whereLessThan("bpm", 58)
+             // Order by the 'date' index-field (descending order)
+            .orderByDescending("date")
+            .all();
+        //endregion
+
+        //region query_index_6
+        const results = await session
+             // Retrieve entries with low BPM value and order by 'date' descending
+            .advanced.rawQuery(`
+                  from index "TsIndex"
+                  where bpm < 58
+                  order by date desc
+            `)
+            .all();
+        //endregion
+
+        //region query_index_7
+        const results = await session
+            .query({ indexName: "TsIndex" })
+            .whereGreaterThanOrEqual("bpm", 100)
+             // Return only the employeeID index-field in the results
+            .selectFields(["employeeID"])
+             // Optionally: call 'distinct' to remove duplicates from results
+            .distinct()
+            .all();
+        //endregion
+
+        //region query_index_8
+        const results = await session
+             // Return only the employeeID index-field in the results
+            .advanced.rawQuery(`
+                 from index "TsIndex"
+                 where bpm >= 100
+                 select distinct employeeID
+            `)
+            .all();
+        //endregion 
+    }
+}
+
+
+

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/queryingTsIndex.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/queryingTsIndex.js
@@ -12,7 +12,7 @@ async function queryTsIndex() {
             super();
 
             this.maps.add(`
-                timeSeries.map("Employees", function (segment) {
+                timeSeries.map("Employees", "HeartRates", function (segment) {
                      let employee = load(segment.DocumentId, "Employees")
                      
                      // Return the index-entry:

--- a/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/document-extensions/timeseries/querying/.docs.json
@@ -31,7 +31,7 @@
     },
     {
         "Path": "using-indexes.markdown",
-        "Name": "Using Indexes",
+        "Name": "Querying Time Series Indexes",
         "DiscussionId": "b399492f-c034-4406-810c-58ecd8c59115",
         "Mappings": []
     },


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2884/Node.js-Document-extensions-Time-series-Querying-Using-Indexes-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/querying/queryingTsIndex.js
```

**C#**: @aviv86 
* C# files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/querying/using-indexes.dotnet.markdown
Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Querying/queryingTsIndex.cs
```