### PR TITLE
RDoc-2922 [Node.js] Document extensions > Time series > Indexing time series [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.dotnet.markdown
@@ -119,8 +119,8 @@ There are two main ways to create a time series index:
 
     {CODE-TABS}
 {CODE-TAB:csharp:Map_index index_1@DocumentExtensions\TimeSeries\Indexing.cs /}
-{CODE-TAB:csharp:JS_index index_2@DocumentExtensions\TimeSeries\Indexing.cs /}
-{CODE-TAB:csharp:NonTyped_index index_3@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB:csharp:NonTyped_index index_2@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB:csharp:JS_index index_3@DocumentExtensions\TimeSeries\Indexing.cs /}
 {CODE-TAB:csharp:IndexDefinition index_definition_1@DocumentExtensions\TimeSeries\Indexing.cs /}
 {CODE-TAB:csharp:IndexDefinition_builder index_definition_2@DocumentExtensions\TimeSeries\Indexing.cs /}
     {CODE-TABS/}

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.dotnet.markdown
@@ -1,0 +1,365 @@
+﻿# Indexing Time Series
+---
+
+{NOTE: }
+
+* [Static](../../studio/database/indexes/indexes-overview#index-types) time series indexes can be created from your client application or from the Studio.
+
+* Indexing allows for fast retrieval of the indexed time series data when querying a time series.
+
+* The API for creating time series indexes is very similar to (and it inherits from) the API for  
+  [creating document indexes](../../indexes/creating-and-deploying).  
+
+* In this page:  
+  * [Time series indexes vs Document indexes](../../document-extensions/timeseries/indexing#time-series-indexes-vs-document-indexes)
+  * [Ways to create a time series index](../../document-extensions/timeseries/indexing#ways-to-create-a-time-series-index)
+  * [Examples of time series indexes](../../document-extensions/timeseries/indexing#examples-of-time-series-indexes)
+      * [Map index - index single time series from single collection](../../document-extensions/timeseries/indexing#map-index---index-single-time-series-from-single-collection)
+      * [Map index - index all time series from single collection](../../document-extensions/timeseries/indexing#map-index---index-all-time-series-from-single-collection)
+      * [Map index - index all time series from all collections](../../document-extensions/timeseries/indexing#map-index---index-all-time-series-from-all-collections)
+      * [Multi-Map index - index time series from several collections](../../document-extensions/timeseries/indexing#multi-map-index---index-time-series-from-several-collections)
+      * [Map-Reduce index](../../document-extensions/timeseries/indexing#map-reduce-index)
+  * [Syntax](../../document-extensions/timeseries/indexing#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Time series indexes vs Document indexes}
+
+{NOTE: }
+
+**Auto-Indexes**:
+
+* Time series index:  
+  Dynamic time series indexes are Not created in response to queries.
+
+* Document index:  
+  [Auto-indexes](../../studio/database/indexes/indexes-overview#indexes-types) are created in response to dynamic queries.
+
+{NOTE/}
+{NOTE: }
+
+**Data source**:
+
+* Time series index:
+
+    * Time series indexes process **[segments](../../document-extensions/timeseries/design#segmentation)** that contain time series entries.  
+      The entries are indexed through the segment they are stored in, for example, using a LINQ syntax that resembles this one:
+
+      {CODE-BLOCK:sql}
+from segment in timeseries
+from entry in segment
+...
+      {CODE-BLOCK/}
+
+    * The following items can be indexed per index-entry in a time series index:
+        * Values & timestamp of a time series entry
+        * The entry tag
+        * Content from a document referenced by the tag
+        * Properties of the containing segment (see **[`TimeSeriesSegment`](../../document-extensions/timeseries/indexing#section-5)**)
+
+* Document index:
+
+    * The index processes fields from your JSON documents.  
+      Documents are indexed through the collection they belong to, for example, using this LINQ syntax:
+
+      {CODE-BLOCK:sql}
+from employee in employees
+...
+      {CODE-BLOCK/}
+
+{NOTE/}
+{NOTE: }
+
+**Query results**:
+
+* Time series index:  
+  When [querying](../../document-extensions/timeseries/querying/using-indexes) a time series index, each result item corresponds to the type defined by the **index-entry** in the index definition,
+  (unless results are [projected](../../../document-extensions/timeseries/querying/using-indexes#project-results)). The documents themselves are not returned.
+
+* Document index:  
+  The resulting objects are the document entities (unless results are [projected](../../../indexes/querying/projections)).
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Ways to create a time series index}
+
+There are two main ways to create a time series index:
+
+1. Create a class that inherits from one of the following abstract index creation task classes:
+    * [`AbstractTimeSeriesIndexCreationTask`](../../document-extensions/timeseries/indexing#section)
+      for [map](../../indexes/map-indexes) and [map-reduce](../../indexes/map-reduce-indexes) time series indexes.
+    * [`AbstractMultiMapTimeSeriesIndexCreationTask`](../../document-extensions/timeseries/indexing#section-1)
+      for [multi-map](../../indexes/multi-map-indexes) time series indexes.
+    * [`AbstractJavaScriptTimeSeriesIndexCreationTask`](../../document-extensions/timeseries/indexing#section-2)
+      for static [javascript indexes](../../indexes/javascript-indexes).
+
+2. Deploy a time series index definition via [PutIndexesOperation](../../client-api/operations/maintenance/indexes/put-indexes):
+   * Create a [`TimeSeriesIndexDefinition`](../../document-extensions/timeseries/indexing#section-3) directly.  
+   * Create a strongly typed index definition using [`TimeSeriesIndexDefinitionBuilder`](../../document-extensions/timeseries/indexing#section-4).  
+
+{PANEL/}
+
+{PANEL: Examples of time series indexes}
+
+{NOTE: }
+
+#### Map index - index single time series from single collection
+
+---
+
+* In this index, we index data from the "StockPrices" time series entries in the "Companies" collection (`TradeVolume`, `Date`).   
+
+* In addition, we index the containing document id (`DocumentID`), which is obtained from the segment,  
+  and some content from the document referenced by the entry's Tag (`EmployeeName`).
+ 
+* Each tab below presents one of the different [ways](../../document-extensions/timeseries/indexing#ways-to-create-a-time-series-index) the index can be defined.
+
+    {CODE-TABS}
+{CODE-TAB:csharp:Map_index index_1@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB:csharp:JS_index index_2@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB:csharp:NonTyped_index index_3@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB:csharp:IndexDefinition index_definition_1@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB:csharp:IndexDefinition_builder index_definition_2@DocumentExtensions\TimeSeries\Indexing.cs /}
+    {CODE-TABS/}
+
+* Querying this index, you can retrieve the indexed time series data while filtering by any of the index-fields.
+ 
+    {CODE-TABS}
+{CODE-TAB:csharp:Query_example_1 query_1@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB-BLOCK:sql:RQL_1}
+from index "StockPriceTimeSeriesFromCompanyCollection"
+where "CompanyID" == "Comapnies/91-A"
+{CODE-TAB-BLOCK/}
+{CODE-TAB:csharp:Query_example_2 query_2@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TAB-BLOCK:sql:RQL_2}
+from index "StockPriceTimeSeriesFromCompanyCollection"
+where "TradeVolume" > 150_000_000
+select distinct CompanyID
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Map index - index all time series from single collection
+
+---
+
+{CODE-TABS}
+{CODE-TAB:csharp:Map_index index_4@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Map index - index all time series from all collections
+
+---
+
+{CODE-TABS}
+{CODE-TAB:csharp:Map_index index_5@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Multi-Map index - index time series from several collections
+
+---
+
+{CODE-TABS}
+{CODE-TAB:csharp:Multi_Map_index index_6@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: } 
+
+#### Map-Reduce index
+
+---
+
+{CODE-TABS}
+{CODE-TAB:csharp:Map_Reduce_index index_7@DocumentExtensions\TimeSeries\Indexing.cs /}
+{CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+---
+
+### `AbstractTimeSeriesIndexCreationTask`
+
+{CODE-BLOCK: csharp}
+// To define a Map index inherit from:
+// ===================================
+public abstract class AbstractTimeSeriesIndexCreationTask<TDocument> { }
+// Time series that belong to documents of the specified `TDocument` type will be indexed. 
+
+// To define a Map-Reduce index inherit from:
+// ==========================================
+public abstract class AbstractTimeSeriesIndexCreationTask<TDocument, TReduceResult> { }
+// Specify both the document type and the reduce type
+
+// Methods available in AbstractTimeSeriesIndexCreationTask class:
+// ===============================================================
+
+// Set a map function for the specified time series
+protected void AddMap(string timeSeries,
+    Expression<Func<IEnumerable<TimeSeriesSegment>, IEnumerable>> map);
+
+// Set a map function for all time series 
+protected void AddMapForAll(
+    Expression<Func<IEnumerable<TimeSeriesSegment>, IEnumerable>> map);
+{CODE-BLOCK/}
+
+---
+
+### `AbstractMultiMapTimeSeriesIndexCreationTask`
+
+{CODE-BLOCK: csharp}
+// To define a Multi-Map index inherit from:
+// =========================================
+public abstract class AbstractMultiMapTimeSeriesIndexCreationTask { }
+
+// Methods available in AbstractMultiMapTimeSeriesIndexCreationTask class:
+// =======================================================================
+
+// Set a map function for all time series with the specified name
+// that belong to documents of type `TSource`
+protected void AddMap<TSource>(string timeSeries,
+    Expression<Func<IEnumerable<TimeSeriesSegment>, IEnumerable>> map);
+
+// Set a map function for all time series that belong to documents of type `TBase`
+// or any type that inherits from `TBase`
+protected void AddMapForAll<TBase>(
+    Expression<Func<IEnumerable<TimeSeriesSegment>,IEnumerable>> map);
+{CODE-BLOCK/}
+
+---
+
+### `AbstractJavaScriptTimeSeriesIndexCreationTask`
+ 
+{CODE-BLOCK: csharp}
+// To define a JavaScript index inherit from:
+// ==========================================
+public abstract class AbstractJavaScriptTimeSeriesIndexCreationTask
+{    
+    public HashSet<string> Maps; // The set of JavaScript map functions for this index
+    protected string Reduce;     // The JavaScript reduce function
+}
+{CODE-BLOCK/}
+
+Learn more about JavaScript indexes in [JavaScript Indexes](../../indexes/javascript-indexes).
+
+---
+
+### `TimeSeriesIndexDefinition`
+
+{CODE-BLOCK: csharp}
+public class TimeSeriesIndexDefinition : IndexDefinition
+{CODE-BLOCK/}
+
+While `TimeSeriesIndexDefinition` is currently functionally equivalent to the regular [`IndexDefinition`](../../indexes/creating-and-deploying#using-maintenance-operations) class from which it inherits,
+it is recommended to use `TimeSeriesIndexDefinition` when creating a time series index definition in case additional functionality is added in future versions of RavenDB.
+
+---
+
+### `TimeSeriesIndexDefinitionBuilder`
+
+{CODE-BLOCK: csharp}
+public class TimeSeriesIndexDefinitionBuilder<TDocument>
+{ 
+    public TimeSeriesIndexDefinitionBuilder(string indexName = null)  
+}
+{CODE-BLOCK/}
+
+{WARNING: }
+**Note**:  
+
+* Currently, class `TimeSeriesIndexDefinitionBuilder` does Not support API methods from abstract class `AbstractCommonApiForIndexes`,
+  such as `LoadDocument` or `Recurse`.
+
+* Use one of the other index creation methods if needed.   
+{WARNING/}
+
+---
+
+### `TimeSeriesSegment`
+
+* Segment properties include the entries data and aggregated values that RavenDB automatically updates in the segment's header.
+
+* The following segment properties can be indexed:
+
+    {CODE-BLOCK: csharp}
+public sealed class TimeSeriesSegment
+{
+    // The ID of the document this time series belongs to
+    public string DocumentId { get; set; }
+ 
+    // The name of the time series this segment belongs to
+    public string Name { get; set; }
+  
+    // The smallest values from all entries in the segment
+    // The first array item is the Min of all first values, etc.
+    public double[] Min { get; set; }
+
+    // The largest values from all entries in the segment
+    // The first array item is the Max of all first values, etc.
+    public double[] Max { get; set; }
+  
+    // The sum of all values from all entries in the segment 
+    // The first array item is the Sum of all first values, etc.
+    public double[] Sum { get; set; }
+  
+    // The number of entries in the segment
+    public int Count { get; set; }
+  
+    // The timestamp of the first entry in the segment
+    public DateTime Start { get; set; }
+  
+    // The timestamp of the last entry in the segment
+    public DateTime End { get; set; }
+  
+    // The segment's entries themselves
+    public TimeSeriesEntry[] Entries { get; set; }
+}
+    {CODE-BLOCK/}
+
+* These are the properties of a `TimeSeriesEntry` which can be indexed:
+
+    {CODE-BLOCK: csharp}
+public class TimeSeriesEntry
+{
+    public DateTime Timestamp;
+    public string Tag;
+    public double[] Values;
+
+    // This is exactly equivalent to Values[0]
+    public double Value;
+}
+    {CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles  
+
+### Time Series  
+[Time Series Overview](../../document-extensions/timeseries/overview)  
+[API Overview](../../document-extensions/timeseries/client-api/overview)  
+
+### Indexes  
+[What are Indexes](../../indexes/what-are-indexes)  
+[Creating and Deploying Indexes](../../indexes/creating-and-deploying)  
+[Map Indexes](../../indexes/map-indexes)  
+[Multi-Map Indexes](../../indexes/multi-map-indexes)  
+[Map-Reduce Indexes](../../indexes/map-reduce-indexes)  
+[JavaScript Indexes](../../indexes/javascript-indexes)  
+[Indexing Related Documents](../../indexes/indexing-related-documents)  
+
+### Client-API  
+[Working with Document IDs](../../client-api/document-identifiers/working-with-document-identifiers)  

--- a/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.js.markdown
@@ -1,0 +1,267 @@
+﻿# Indexing Time Series
+---
+
+{NOTE: }
+
+* [Static](../../studio/database/indexes/indexes-overview#index-types) time series indexes can be created from your client application or from the Studio.
+
+* Indexing allows for fast retrieval of the indexed time series data when querying a time series.
+
+* In this page:  
+  * [Time series indexes vs Document indexes](../../document-extensions/timeseries/indexing#time-series-indexes-vs-document-indexes)
+  * [Ways to create a time series index](../../document-extensions/timeseries/indexing#ways-to-create-a-time-series-index)
+  * [Examples of time series indexes](../../document-extensions/timeseries/indexing#examples-of-time-series-indexes)
+      * [Map index - index single time series from single collection](../../document-extensions/timeseries/indexing#map-index---index-single-time-series-from-single-collection)
+      * [Map index - index all time series from single collection](../../document-extensions/timeseries/indexing#map-index---index-all-time-series-from-single-collection)
+      * [Map index - index all time series from all collections](../../document-extensions/timeseries/indexing#map-index---index-all-time-series-from-all-collections)
+      * [Multi-Map index - index time series from several collections](../../document-extensions/timeseries/indexing#multi-map-index---index-time-series-from-several-collections)
+      * [Map-Reduce index](../../document-extensions/timeseries/indexing#map-reduce-index)
+  * [Syntax](../../document-extensions/timeseries/indexing#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Time series indexes vs Document indexes}
+
+{NOTE: }
+
+**Auto-Indexes**:
+
+* Time series index:  
+  Dynamic time series indexes are Not created in response to queries.
+
+* Document index:  
+  [Auto-indexes](../../studio/database/indexes/indexes-overview#indexes-types) are created in response to dynamic queries.
+
+{NOTE/}
+{NOTE: }
+
+**Data source**:
+
+* Time series index:
+
+    * Time series indexes process **[segments](../../document-extensions/timeseries/design#segmentation)** that contain time series entries.  
+      The entries are indexed through the segment they are stored in.
+    * The following items can be indexed per index-entry in a time series index:
+        * Values & timestamp of a time series entry
+        * The entry tag
+        * Content from a document referenced by the tag
+        * Properties of the containing segment (see **[segment properties](../../document-extensions/timeseries/indexing#segment-properties)**)
+
+* Document index:
+
+    * The index processes fields from your JSON documents.  
+      Documents are indexed through the collection they belong to.
+
+{NOTE/}
+{NOTE: }
+
+**Query results**:
+
+* Time series index:  
+  When [querying](../../document-extensions/timeseries/querying/using-indexes) a time series index, each result item corresponds to the type defined by the **index-entry** in the index definition,
+  (unless results are [projected](../../../document-extensions/timeseries/querying/using-indexes#project-results)). The documents themselves are not returned.
+
+* Document index:  
+  The resulting objects are the document entities (unless results are [projected](../../../indexes/querying/projections)).
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Ways to create a time series index}
+
+There are two main ways to create a time series index:
+
+1. Create a class that inherits from the abstract index class [`AbstractRawJavaScriptTimeSeriesIndexCreationTask`](../../document-extensions/timeseries/indexing#section).
+
+2. Create a [`TimeSeriesIndexDefinition`](../../document-extensions/timeseries/indexing#section-1) 
+   and deploy the time series index definition via [PutIndexesOperation](../../client-api/operations/maintenance/indexes/put-indexes).
+
+{PANEL/}
+
+{PANEL: Examples of time series indexes}
+
+{NOTE: }
+
+#### Map index - index single time series from single collection
+
+---
+
+* In this index, we index data from the "StockPrices" time series entries in the "Companies" collection (`tradeVolume`, `date`).   
+
+* In addition, we index the containing document id (`documentID`), which is obtained from the segment,  
+  and some content from the document referenced by the entry's Tag (`employeeName`).
+ 
+    {CODE-TABS}
+{CODE-TAB:nodejs:Map_index index_1@documentExtensions\timeSeries\indexing.js /}
+{CODE-TAB:nodejs:IndexDefinition index_definition_1@documentExtensions\timeSeries\indexing.js /}
+    {CODE-TABS/}
+
+* Querying this index, you can retrieve the indexed time series data while filtering by any of the index-fields.
+ 
+    {CODE-TABS}
+{CODE-TAB:nodejs:Query_example_1 query_1@documentExtensions\timeSeries\indexing.js /}
+{CODE-TAB-BLOCK:sql:RQL_1}
+from index "StockPriceTimeSeriesFromCompanyCollection"
+where "companyID" == "Comapnies/91-A"
+{CODE-TAB-BLOCK/}
+{CODE-TAB:nodejs:Query_example_2 query_2@documentExtensions\timeSeries\indexing.js /}
+{CODE-TAB-BLOCK:sql:RQL_2}
+from index "StockPriceTimeSeriesFromCompanyCollection"
+where "tradeVolume" > 150_000_000
+select distinct companyID
+{CODE-TAB-BLOCK/}
+    {CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Map index - index all time series from single collection
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Map_index index_2@documentExtensions\timeSeries\indexing.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Map index - index all time series from all collections
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Map_index index_3@documentExtensions\timeSeries\indexing.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: }
+
+#### Multi-Map index - index time series from several collections
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Multi_Map_index index_4@documentExtensions\timeSeries\indexing.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{NOTE: } 
+
+#### Map-Reduce index
+
+---
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Map_Reduce_index index_5@documentExtensions\timeSeries\indexing.js /}
+{CODE-TABS/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Syntax}
+
+---
+
+### `AbstractRawJavaScriptTimeSeriesIndexCreationTask`
+ 
+{CODE-BLOCK: javascript}
+// To define a raw JavaScript index extend the following class:
+// ============================================================
+abstract class AbstractRawJavaScriptTimeSeriesIndexCreationTask
+{    
+    // The set of JavaScript map functions for this index
+    maps; // Set<string>
+
+    // The JavaScript reduce function
+    reduce; // string
+}
+{CODE-BLOCK/}
+
+---
+
+### `TimeSeriesIndexDefinition`
+
+{CODE-BLOCK: javascript}
+class TimeSeriesIndexDefinition extends IndexDefinition
+{CODE-BLOCK/}
+
+While `TimeSeriesIndexDefinition` is currently functionally equivalent to the regular [`IndexDefinition`](../../indexes/creating-and-deploying#using-maintenance-operations) class from which it inherits,
+it is recommended to use `TimeSeriesIndexDefinition` when creating a time series index definition in case additional functionality is added in future versions of RavenDB.
+
+---
+
+### Segment properties
+
+* Segment properties include the entries data and aggregated values that RavenDB automatically updates in the segment's header.
+
+* **Unlike the C# client**, class `TimeSeriesSegment` is Not defined in the Node.js client.  
+  However, the following are the segment properties that can be indexed from your raw javascript index definition which the server recognizes:  
+  
+    {CODE-BLOCK: javascript}
+// The ID of the document this time series belongs to
+DocumentId; // string
+
+// The name of the time series this segment belongs to
+Name; // string
+
+// The smallest values from all entries in the segment
+// The first array item is the Min of all first values, etc.
+Min; // number[]
+
+// The largest values from all entries in the segment
+// The first array item is the Max of all first values, etc.
+Max; // number[]
+
+// The sum of all values from all entries in the segment
+// The first array item is the Sum of all first values, etc.
+Sum; // number[]
+
+// The number of entries in the segment
+Count; // number
+
+// The timestamp of the first entry in the segment
+Start; // Date
+
+// The timestamp of the last entry in the segment
+End; // Date
+
+// The segment's entries themselves
+Entries; // TimeSeriesEntry[]
+    {CODE-BLOCK/}
+
+* These are the properties of a `TimeSeriesEntry` which can be indexed:
+
+    {CODE-BLOCK: javascript}
+class TimeSeriesEntry
+{
+    timestamp; // Date
+    tag;       // string
+    values;    // number[]
+
+    // This is equivalent to values[0]
+    value;     // number
+}
+    {CODE-BLOCK/}
+
+{PANEL/}
+
+## Related articles  
+
+### Time Series  
+[Time Series Overview](../../document-extensions/timeseries/overview)  
+[API Overview](../../document-extensions/timeseries/client-api/overview)  
+
+### Indexes  
+[What are Indexes](../../indexes/what-are-indexes)  
+[Creating and Deploying Indexes](../../indexes/creating-and-deploying)  
+[Map Indexes](../../indexes/map-indexes)  
+[Multi-Map Indexes](../../indexes/multi-map-indexes)  
+[Map-Reduce Indexes](../../indexes/map-reduce-indexes)  
+[JavaScript Indexes](../../indexes/javascript-indexes)  
+[Indexing Related Documents](../../indexes/indexing-related-documents)  
+
+### Client-API  
+[Working with Document IDs](../../client-api/document-identifiers/working-with-document-identifiers)  

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Indexing.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Indexing.cs
@@ -1,0 +1,362 @@
+﻿using System;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes.TimeSeries;
+using Raven.Client.Documents.Operations.Indexes;
+using System.Collections.Generic;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.DocumentExtensions.TimeSeries
+{
+    class TimeSeriesIndexes
+    {
+        #region index_1
+        public class StockPriceTimeSeriesFromCompanyCollection : AbstractTimeSeriesIndexCreationTask<Company>
+        {
+            // The index-entry:
+            // ================
+            public class IndexEntry
+            {
+                // The index-fields:
+                // =================
+                public double TradeVolume { get; set; }
+                public DateTime Date { get; set; }
+                public string CompanyID { get; set; }
+                public string EmployeeName { get; set; }
+            }
+            
+            public StockPriceTimeSeriesFromCompanyCollection()
+            { 
+                // Call 'AddMap', specify the time series name to be indexed 
+                AddMap("StockPrices", timeseries =>
+                        from segment in timeseries
+                        from entry in segment.Entries
+                        
+                        // Can load the document referenced in the TAG:
+                        let employee = LoadDocument<Employee>(entry.Tag)
+                        
+                        // Define the content of the index-fields:
+                        // =======================================
+                        select new IndexEntry()
+                        {
+                            // Retrieve content from the time series ENTRY:
+                            TradeVolume = entry.Values[4],
+                            Date = entry.Timestamp.Date,
+                            
+                            // Retrieve content from the SEGMENT:
+                            CompanyID = segment.DocumentId,
+                            
+                            // Retrieve content from the loaded DOCUMENT:
+                            EmployeeName = employee.FirstName + " " + employee.LastName 
+                        });
+            }
+        }
+        #endregion
+
+        #region index_2
+        public class StockPriceTimeSeriesFromCompanyCollection_JS : 
+            AbstractJavaScriptTimeSeriesIndexCreationTask
+        {
+            public StockPriceTimeSeriesFromCompanyCollection_JS()
+            {
+                Maps = new HashSet<string> { @"
+                    timeSeries.map('Companies', 'StockPrices', function (segment) {
+
+                        return segment.Entries.map(entry => {
+                            let employee = load(entry.Tag, 'Employees');
+
+                            return {
+                                TradeVolume: entry.Values[4],
+                                Date: new Date(entry.Timestamp.getFullYear(),
+                                               entry.Timestamp.getMonth(),
+                                               entry.Timestamp.getDate()),
+                                CompanyID: segment.DocumentId,
+                                EmployeeName: employee.FirstName + ' ' + employee.LastName
+                            };
+                        });
+                    })"
+                };
+            }
+        }
+        #endregion
+        
+        #region index_3
+        public class StockPriceTimeSeriesFromCompanyCollection_NonTyped : AbstractTimeSeriesIndexCreationTask 
+        {
+            public override TimeSeriesIndexDefinition CreateIndexDefinition()
+            {
+                return new TimeSeriesIndexDefinition
+                {
+                    Name = "StockPriceTimeSeriesFromCompanyCollection_NonTyped",
+                    Maps =
+                    {
+                        @"
+                        from segment in timeSeries.Companies.StockPrices 
+                        from entry in segment.Entries
+  
+                        let employee = LoadDocument(entry.Tag, ""Employees"")
+
+                        select new 
+                        { 
+                            TradeVolume = entry.Values[4], 
+                            Date = entry.Timestamp.Date,
+                            CompanyID = segment.DocumentId,
+                            EmployeeName = employee.FirstName + ' ' + employee.LastName 
+                        }"
+                    }
+                };
+            }
+        }
+        #endregion
+        
+        #region index_4
+        public class AllTimeSeriesFromCompanyCollection : AbstractTimeSeriesIndexCreationTask<Company>
+        {
+            public class IndexEntry
+            {
+                public double Value { get; set; }
+                public DateTime Date { get; set; }
+            }
+            
+            public AllTimeSeriesFromCompanyCollection()
+            {
+                // Call 'AddMapForAll' to index ALL the time series in the 'Companies' collection 
+                // ==============================================================================
+                AddMapForAll(timeseries =>
+                    from segment in timeseries
+                    from entry in segment.Entries
+                        
+                    select new IndexEntry()
+                    {
+                        Value = entry.Value,
+                        Date = entry.Timestamp.Date
+                    });
+            }
+        }
+        #endregion
+        
+        #region index_5
+        // Inherit from AbstractTimeSeriesIndexCreationTask<object>
+        // Specify <object> as the type to index from ALL collections
+        // ==========================================================
+        
+        public class AllTimeSeriesFromAllCollections : AbstractTimeSeriesIndexCreationTask<object>
+        {
+            public class IndexEntry
+            {
+                public double Value { get; set; }
+                public DateTime Date { get; set; }
+                public string DocumentID { get; set; }
+            }
+            
+            public AllTimeSeriesFromAllCollections()
+            {
+                AddMapForAll(timeseries =>
+                    from segment in timeseries
+                    from entry in segment.Entries
+                        
+                    select new IndexEntry()
+                    {
+                        Value = entry.Value,
+                        Date = entry.Timestamp.Date,
+                        DocumentID = segment.DocumentId
+                    });
+            }
+        }
+        #endregion
+
+        #region index_6
+        public class Vehicles_ByLocation : AbstractMultiMapTimeSeriesIndexCreationTask
+        {
+            public class IndexEntry
+            {
+                public double Latitude { get; set; }
+                public double Longitude { get; set; }
+                public DateTime Date { get; set; }
+                public string DocumentID { get; set; }
+            }
+            
+            public Vehicles_ByLocation()
+            {
+                // Call 'AddMap' for each collection you wish to index
+                // ===================================================
+                
+                AddMap<Plane>(
+                    "GPS_Coordinates",timeSeries =>
+                        from segment in timeSeries
+                        from entry in segment.Entries
+                        select new IndexEntry()
+                        {
+                            Latitude = entry.Values[0],
+                            Longitude = entry.Values[1],
+                            Date = entry.Timestamp.Date,
+                            DocumentID = segment.DocumentId
+                        });
+
+                AddMap<Ship>(
+                    "GPS_Coordinates",timeSeries =>
+                        from segment in timeSeries
+                        from entry in segment.Entries
+                        select new IndexEntry()
+                        {
+                            Latitude = entry.Values[0],
+                            Longitude = entry.Values[1],
+                            Date = entry.Timestamp.Date,
+                            DocumentID = segment.DocumentId
+                        });
+            }
+        }
+        #endregion
+
+        #region index_7
+        public class TradeVolume_PerDay_ByCountry : 
+            AbstractTimeSeriesIndexCreationTask<Company, TradeVolume_PerDay_ByCountry.Result>
+        {
+            public class Result
+            {
+                public double TotalTradeVolume { get; set; }
+                public DateTime Date { get; set; }
+                public string Country { get; set; }
+            }
+
+            public TradeVolume_PerDay_ByCountry()
+            {
+                // Define the Map part:
+                AddMap("StockPrices", timeSeries =>
+                    from segment in timeSeries
+                    from entry in segment.Entries
+                    
+                    let company = LoadDocument<Company>(segment.DocumentId)
+                    
+                    select new Result
+                    {
+                        Date = entry.Timestamp.Date,
+                        Country = company.Address.Country,
+                        TotalTradeVolume = entry.Values[4]
+                    });
+
+                // Define the Reduce part:
+                Reduce = results =>
+                    from r in results
+                    group r by new {r.Date, r.Country}
+                    into g
+                    select new Result
+                    {
+                        Date = g.Key.Date,
+                        Country = g.Key.Country,
+                        TotalTradeVolume = g.Sum(x => x.TotalTradeVolume)
+                    };
+            }
+        }
+        #endregion
+        
+        public void IndexDefinitionExamples()
+        {
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "http://localhost:8080" },
+                Database = "products"
+            };
+            documentStore.Initialize();
+
+            #region index_definition_1
+            // Define the 'index definition'
+            var indexDefinition = new TimeSeriesIndexDefinition
+                {
+                    Name = "StockPriceTimeSeriesFromCompanyCollection ",
+                    Maps =
+                    {
+                        @"
+                        from segment in timeSeries.Companies.StockPrices 
+                        from entry in segment.Entries 
+
+                        let employee = LoadDocument(entry.Tag, ""Employees"")
+
+                        select new 
+                        { 
+                            TradeVolume = entry.Values[4], 
+                            Date = entry.Timestamp.Date,
+                            CompanyID = segment.DocumentId,
+                            EmployeeName = employee.FirstName + ' ' + employee.LastName 
+                        }"
+                    }
+                };
+            
+            // Deploy the index to the server via 'PutIndexesOperation'
+            documentStore.Maintenance.Send(new PutIndexesOperation(indexDefinition));
+            #endregion
+
+            #region index_definition_2
+            // Create the index builder
+            var TSIndexDefBuilder =
+                new TimeSeriesIndexDefinitionBuilder<Company>("StockPriceTimeSeriesFromCompanyCollection ");
+            
+            TSIndexDefBuilder.AddMap("StockPrices", timeseries => 
+                from segment in timeseries
+                from entry in segment.Entries
+                
+                // Note:
+                // Class TimeSeriesIndexDefinitionBuilder does not support the 'LoadDocument' API method.
+                // Use one of the other index creation methods if needed.
+                
+                select new
+                {
+                    TradeVolume = entry.Values[4],
+                    Date = entry.Timestamp.Date,
+                    ComapnyID = segment.DocumentId
+                });
+
+            // Build the index definition
+            var indexDefinitionFromBuilder = TSIndexDefBuilder.ToIndexDefinition(documentStore.Conventions);
+            
+            // Deploy the index to the server via 'PutIndexesOperation'
+            documentStore.Maintenance.Send(new PutIndexesOperation(indexDefinitionFromBuilder));
+            #endregion
+            
+            #region query_1
+            using (var session = documentStore.OpenSession())
+            {
+                // Retrieve time series data for the specified company:
+                // ====================================================
+                List<StockPriceTimeSeriesFromCompanyCollection.IndexEntry> results = session
+                   .Query<StockPriceTimeSeriesFromCompanyCollection.IndexEntry,
+                       StockPriceTimeSeriesFromCompanyCollection>()
+                   .Where(x => x.CompanyID == "Companies/91-A")
+                   .ToList();
+            }
+            
+            // Results will include data from all 'StockPrices' entries in document 'Companies/91-A'. 
+            #endregion
+            
+            #region query_2
+            using (var session = documentStore.OpenSession())
+            {
+                // Find what companies had a very high trade volume:
+                // ==================================================
+                List<string> results = session
+                    .Query<StockPriceTimeSeriesFromCompanyCollection.IndexEntry,
+                        StockPriceTimeSeriesFromCompanyCollection>()
+                    .Where(x => x.TradeVolume >  150_000_000)
+                    .Select(x => x.CompanyID)
+                    .Distinct()
+                    .ToList();
+            }
+            
+            // Results will contain company "Companies/65-A"
+            // since it is the only company with time series entries having such high trade volume.
+            #endregion
+        }
+    }
+
+    internal class Ship
+    {
+    }
+
+    internal class Plane
+    {
+    }
+
+    internal class User
+    {
+    }
+}

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Indexing.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Indexing.cs
@@ -54,33 +54,6 @@ namespace Raven.Documentation.Samples.DocumentExtensions.TimeSeries
         #endregion
 
         #region index_2
-        public class StockPriceTimeSeriesFromCompanyCollection_JS : 
-            AbstractJavaScriptTimeSeriesIndexCreationTask
-        {
-            public StockPriceTimeSeriesFromCompanyCollection_JS()
-            {
-                Maps = new HashSet<string> { @"
-                    timeSeries.map('Companies', 'StockPrices', function (segment) {
-
-                        return segment.Entries.map(entry => {
-                            let employee = load(entry.Tag, 'Employees');
-
-                            return {
-                                TradeVolume: entry.Values[4],
-                                Date: new Date(entry.Timestamp.getFullYear(),
-                                               entry.Timestamp.getMonth(),
-                                               entry.Timestamp.getDate()),
-                                CompanyID: segment.DocumentId,
-                                EmployeeName: employee.FirstName + ' ' + employee.LastName
-                            };
-                        });
-                    })"
-                };
-            }
-        }
-        #endregion
-        
-        #region index_3
         public class StockPriceTimeSeriesFromCompanyCollection_NonTyped : AbstractTimeSeriesIndexCreationTask 
         {
             public override TimeSeriesIndexDefinition CreateIndexDefinition()
@@ -104,6 +77,33 @@ namespace Raven.Documentation.Samples.DocumentExtensions.TimeSeries
                             EmployeeName = employee.FirstName + ' ' + employee.LastName 
                         }"
                     }
+                };
+            }
+        }
+        #endregion
+
+        #region index_3
+        public class StockPriceTimeSeriesFromCompanyCollection_JS : 
+            AbstractJavaScriptTimeSeriesIndexCreationTask
+        {
+            public StockPriceTimeSeriesFromCompanyCollection_JS()
+            {
+                Maps = new HashSet<string> { @"
+                    timeSeries.map('Companies', 'StockPrices', function (segment) {
+
+                        return segment.Entries.map(entry => {
+                            let employee = load(entry.Tag, 'Employees');
+
+                            return {
+                                TradeVolume: entry.Values[4],
+                                Date: new Date(entry.Timestamp.getFullYear(),
+                                               entry.Timestamp.getMonth(),
+                                               entry.Timestamp.getDate()),
+                                CompanyID: segment.DocumentId,
+                                EmployeeName: employee.FirstName + ' ' + employee.LastName
+                            };
+                        });
+                    })"
                 };
             }
         }

--- a/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/indexing.js
+++ b/Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/indexing.js
@@ -1,0 +1,221 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function indexing() {
+
+    //region index_1
+    class StockPriceTimeSeriesFromCompanyCollection extends
+        AbstractRawJavaScriptTimeSeriesIndexCreationTask {
+        
+        constructor() {
+            super();
+
+            this.maps.add(`
+                // Call timeSeries.map(), pass:
+                // * The collection to index
+                // * The time series name
+                // * The fuction that defines the index-entries
+                // ============================================
+                timeSeries.map("Companies", "StockPrices", function (segment) {
+                     
+                     // Return the index-entries:
+                     // =========================
+                     return segment.Entries.map(entry => {
+                          let employee = load(entry.Tag, "Employees");
+                     
+                         // Define the index-fields per entry:
+                         // ==================================
+                         
+                         return {
+                             // Retrieve content from the time series ENTRY:
+                             tradeVolume: entry.Values[4],
+                             date: new Date(entry.Timestamp),
+                             
+                             // Retrieve content from the SEGMENT:
+                             companyID: segment.DocumentId,
+                             
+                             // Retrieve content from the loaded DOCUMENT:
+                             employeeName: employee.FirstName + " " + employee.LastName
+                         };
+                     });
+                })
+            `);
+        }
+    }
+    //endregion
+    
+    //region index_2
+    class AllTimeSeriesFromCompanyCollection extends AbstractRawJavaScriptTimeSeriesIndexCreationTask {
+
+        constructor() {
+            super();
+         
+            this.maps.add(`
+                // Call timeSeries.map(), pass:
+                // * The collection to index and the function that defines the index-entries
+                // * No time series is specified - so ALL time series from the collection will be indexed
+                // ======================================================================================
+                timeSeries.map("Companies", function (segment) {
+                     
+                     return segment.Entries.map(entry => ({
+                         value: entry.Value,
+                         date: new Date(entry.Timestamp)
+                     }));
+                })
+            `);
+        }
+    }
+    //endregion
+    
+    //region index_3
+    class AllTimeSeriesFromAllCollections extends AbstractRawJavaScriptTimeSeriesIndexCreationTask {
+
+        constructor() {
+            super();
+
+            this.maps.add(`
+                // No collection and time series are specified -
+                // so ALL time series from ALL collections will be indexed
+                // =======================================================
+                timeSeries.map(function (segment) {
+                     
+                     return segment.Entries.map(entry => ({
+                         value: entry.Value,
+                         date: new Date(entry.Timestamp),
+                         documentID: segment.DocumentId,
+                     }));
+                })
+            `);
+        }
+    }
+    //endregion
+    
+    //region index_4
+    class Vehicles_ByLocation  extends AbstractRawJavaScriptTimeSeriesIndexCreationTask {
+        
+        constructor() {
+            super();
+
+            // Call 'timeSeries.map()' for each collection you wish to index
+            // =============================================================
+            
+            this.maps.add(`
+                timeSeries.map("Planes", "GPS_Coordinates", function (segment) {
+                     
+                     return segment.Entries.map(entry => ({
+                          latitude: entry.Values[0],
+                          longitude: entry.Values[1],
+                          date: new Date(entry.Timestamp),
+                          documentID: segment.DocumentId
+                     }));
+                })
+            `);
+
+            this.maps.add(`
+                timeSeries.map("Ships", "GPS_Coordinates", function (segment) {
+                     
+                     return segment.Entries.map(entry => ({
+                          latitude: entry.Values[0],
+                          longitude: entry.Values[1],
+                          date: new Date(entry.Timestamp),
+                          documentID: segment.DocumentId
+                     }));
+                })
+            `);
+        }
+    }
+    //endregion
+
+    //region index_5
+    class TradeVolume_PerDay_ByCountry extends AbstractRawJavaScriptTimeSeriesIndexCreationTask {
+
+        constructor() {
+            super();
+
+            // Define the Map part:
+            this.maps.add(`
+                timeSeries.map("Companies", "StockPrices", function (segment) {
+                     
+                     return segment.Entries.map(entry => {
+                          let company = load(segment.DocumentId, "Companies");
+                         
+                         return {
+                             date: new Date(entry.Timestamp),
+                             country: company.Address.Country,
+                             totalTradeVolume: entry.Values[4],
+                         };
+                     });
+                })
+            `);
+
+            // Define the Reduce part:
+            this.reduce = `
+                groupBy(x => ({date: x.date, country: x.country}))
+                    .aggregate(g => {
+                        return {
+                            date: g.key.date,
+                            country: g.key.country,
+                            totalTradeVolume: g.values.reduce((sum, x) => x.totalTradeVolume + sum, 0)
+                        };
+                    })
+            `;
+        }
+    }
+    //endregion
+
+    {
+        //region index_definition_1
+        const timeSeriesIndexDefinition = new TimeSeriesIndexDefinition();
+        
+        timeSeriesIndexDefinition.name = "StockPriceTimeSeriesFromCompanyCollection";
+        
+        timeSeriesIndexDefinition.maps = new Set([`
+            from segment in timeSeries.Companies.StockPrices
+            from entry in segment.Entries
+
+            let employee = LoadDocument(entry.Tag, "Employees")
+
+            select new
+            {
+                tradeVolume = entry.Values[4],
+                date = entry.Timestamp.Date,
+                companyID = segment.DocumentId,
+                employeeName = employee.FirstName + " " + employee.LastName
+            }`
+        ]);
+
+        // Deploy the index to the server via 'PutIndexesOperation'
+        await documentStore.maintenance.send(new PutIndexesOperation(timeSeriesIndexDefinition));
+        //endregion
+        
+        //region query_1
+        const results = await session
+             // Retrieve time series data for the specified company:
+             // ====================================================
+            .query({ indexName: "StockPriceTimeSeriesFromCompanyCollection" })
+            .whereEquals("companyID", "Companies/91-A")
+            .all();
+        
+        // Results will include data from all 'StockPrices' entries in document 'Companies/91-A'. 
+        //endregion
+
+        //region query_2
+        const results = await session
+             // Find what companies had a very high trade volume:
+             // ==================================================
+            .query({ indexName: "StockPriceTimeSeriesFromCompanyCollection" })
+            .whereGreaterThan("tradeVolume", 150_000_000)
+            .selectFields(["companyID"])
+            .distinct()
+            .all();
+
+        // Results will contain company "Companies/65-A"
+        // since it is the only company with time series entries having such high trade volume.
+        //endregion
+    }
+}
+
+


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2922/Node.js-Document-extensions-Time-series-Indexing-time-series-Replace-C-samples

---

**Important notes for this PR:**

* In this PR,  the sample code for `Node.js` was applied 
  and - text was improved for both `Node.js` and `C#`

* Still, there are fixes to be applied, to be done in a separate dedicated issue:
https://issues.hibernatingrhinos.com/issue/RDoc-2928/Document-extensions-Time-series-Indexing-time-series-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.js.markdown
Documentation/5.4/Samples/nodejs/documentExtensions/timeSeries/indexing.js
```

**C#**: @aviv86 
* C# files to review:
```
Documentation/5.4/Raven.Documentation.Pages/document-extensions/timeseries/indexing.dotnet.markdown
Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/DocumentExtensions/TimeSeries/Indexing.cs
```