### PR TITLE
RDoc-2940 External replication task: Fix definition of Name param

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
@@ -81,7 +81,7 @@ The required elements of an External Replication task are:
   * **ConnectionStringName**  
     The connection string name.  
   * **Name**  
-    The target database name.
+    The External Replication task name.
 
 {CODE ExternalReplication@Server\OngoingTasks\ExternalReplicationSamples.cs /}
 

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/OngoingTasks/ExternalReplicationSamples.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/Server/OngoingTasks/ExternalReplicationSamples.cs
@@ -47,7 +47,7 @@ namespace Raven.Documentation.Samples.Server.OngoingTasks.ExternalReplicationSam
                 new UpdateExternalReplicationOperation(new ExternalReplication
             {
                 ConnectionStringName = connectionStrName,
-                Name = "targetDatabaseName",
+                Name = "task-name",
             }));
 
             #endregion
@@ -78,7 +78,7 @@ namespace Raven.Documentation.Samples.Server.OngoingTasks.ExternalReplicationSam
                 new UpdateExternalReplicationOperation(new ExternalReplication
             {
                 ConnectionStringName = connectionStrName,
-                Name = "targetDatabaseName",
+                Name = "task-name",
                 MentorNode = "B",
                 DelayReplicationFor = TimeSpan.FromMinutes(30)
             }));

--- a/Documentation/5.3/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
@@ -81,7 +81,7 @@ The required elements of an External Replication task are:
   * **ConnectionStringName**  
     The connection string name.  
   * **Name**  
-    The target database name.
+    The External Replication task name.
 
 {CODE ExternalReplication@Server\OngoingTasks\ExternalReplicationSamples.cs /}
 

--- a/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/Server/OngoingTasks/ExternalReplicationSamples.cs
+++ b/Documentation/5.3/Samples/csharp/Raven.Documentation.Samples/Server/OngoingTasks/ExternalReplicationSamples.cs
@@ -47,7 +47,7 @@ namespace Raven.Documentation.Samples.Server.OngoingTasks.ExternalReplicationSam
                 new UpdateExternalReplicationOperation(new ExternalReplication
             {
                 ConnectionStringName = connectionStrName,
-                Name = "targetDatabaseName",
+                Name = "task-name",
             }));
 
             #endregion
@@ -78,7 +78,7 @@ namespace Raven.Documentation.Samples.Server.OngoingTasks.ExternalReplicationSam
                 new UpdateExternalReplicationOperation(new ExternalReplication
             {
                 ConnectionStringName = connectionStrName,
-                Name = "targetDatabaseName",
+                Name = "task-name",
                 MentorNode = "B",
                 DelayReplicationFor = TimeSpan.FromMinutes(30)
             }));

--- a/Documentation/6.0/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
@@ -90,7 +90,7 @@ The required elements of an External Replication task are:
   * **ConnectionStringName**  
     The connection string name.  
   * **Name**  
-    The target database name.
+    The External Replication task name.
 
 {CODE ExternalReplication@Server\OngoingTasks\ExternalReplicationSamples.cs /}
 

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Server/OngoingTasks/ExternalReplicationSamples.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Server/OngoingTasks/ExternalReplicationSamples.cs
@@ -47,7 +47,7 @@ namespace Raven.Documentation.Samples.Server.OngoingTasks.ExternalReplicationSam
                 new UpdateExternalReplicationOperation(new ExternalReplication
             {
                 ConnectionStringName = connectionStrName,
-                Name = "targetDatabaseName",
+                Name = "task-name",
             }));
 
             #endregion
@@ -78,7 +78,7 @@ namespace Raven.Documentation.Samples.Server.OngoingTasks.ExternalReplicationSam
                 new UpdateExternalReplicationOperation(new ExternalReplication
             {
                 ConnectionStringName = connectionStrName,
-                Name = "targetDatabaseName",
+                Name = "task-name",
                 MentorNode = "B",
                 DelayReplicationFor = TimeSpan.FromMinutes(30)
             }));


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2940/External-replication-task-Fix-definition-of-Name-param