### PR TITLE
Enable PHP support in documentation

### DIFF
--- a/Documentation/5.4/Samples/php/ClientApi/session/phpSample.php
+++ b/Documentation/5.4/Samples/php/ClientApi/session/phpSample.php
@@ -1,0 +1,13 @@
+# region php_region
+$session = DocumentStoreHolder::getStore()->openSession();
+try {
+    $company = $session->load(Company::class, "companies/5-A");
+
+    $company->setName($companyName);
+
+    $session->saveChanges();
+            
+} finally {
+    $session->close();
+}
+# endregion

--- a/Raven.Documentation.Parser/Data/CodeBlockLanguage.cs
+++ b/Raven.Documentation.Parser/Data/CodeBlockLanguage.cs
@@ -15,6 +15,7 @@
         Plain,
         PowerShell,
         Python,
+        Php,
         Ruby,
         Sql,
         Xml

--- a/Raven.Documentation.Parser/Data/Language.cs
+++ b/Raven.Documentation.Parser/Data/Language.cs
@@ -22,6 +22,10 @@
         [Description("Python")]
         Python,
 
+        [FileExtension(".php")]
+        [Description("PHP")]
+        Php,
+
         [FileExtension(".js")]
         [Description("Node.js")]
         NodeJs,

--- a/Raven.Documentation.Parser/Helpers/DocumentBuilding/CodeBlockHelper.cs
+++ b/Raven.Documentation.Parser/Helpers/DocumentBuilding/CodeBlockHelper.cs
@@ -134,6 +134,9 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                 case Language.Python:
                     content = ExtractSectionFromPythonFile(section, Path.Combine(samplesDirectory, file));
                     break;
+                case Language.Php:
+                    content = ExtractSectionFromPhpFile(section, Path.Combine(samplesDirectory, file));
+                    break;
                 default:
                     throw new NotSupportedException(language.ToString());
             }
@@ -227,6 +230,9 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                 case Language.Python:
                     content = ExtractSectionFromPythonFile(section, Path.Combine(samplesDirectory, file));
                     break;
+                case Language.Php:
+                    content = ExtractSectionFromPhpFile(section, Path.Combine(samplesDirectory, file));
+                    break;
                 default:
                     throw new NotSupportedException(language.ToString());
             }
@@ -255,6 +261,26 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
         }
 
         private static string ExtractSectionFromPythonFile(string section, string filePath)
+        {
+            if (File.Exists(filePath) == false)
+                throw new FileNotFoundException(string.Format("File '{0}' does not exist.", filePath), filePath);
+
+            var content = File.ReadAllText(filePath);
+            var startText = string.Format("# region {0}", section);
+            var indexOfStart = content.IndexOf(startText, StringComparison.OrdinalIgnoreCase);
+            if (indexOfStart == -1)
+                throw new InvalidOperationException(string.Format("Section '{0}' not found in '{1}'.", section, filePath));
+
+            var start = content.IndexOf(startText, StringComparison.OrdinalIgnoreCase) + startText.Length;
+            var end = content.IndexOf("# endregion", start, StringComparison.OrdinalIgnoreCase);
+            var sectionContent = content.Substring(start, end - start);
+            if (sectionContent.EndsWith("//"))
+                sectionContent = sectionContent.TrimEnd(new[] { '/' });
+
+            return NormalizeContent(sectionContent);
+        }
+
+        private static string ExtractSectionFromPhpFile(string section, string filePath)
         {
             if (File.Exists(filePath) == false)
                 throw new FileNotFoundException(string.Format("File '{0}' does not exist.", filePath), filePath);
@@ -343,6 +369,8 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                     return "language-javascript";
                 case Language.Python:
                     return "language-python";
+                case Language.Php:
+                    return "language-php";
                 default:
                     throw new NotSupportedException(language.ToString());
             }
@@ -366,6 +394,8 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                     return "language-xml";
                 case CodeBlockLanguage.Python:
                     return "language-python";
+                case CodeBlockLanguage.Php:
+                    return "language-php";
                 case CodeBlockLanguage.Bash:
                     return "language-bash";
                 case CodeBlockLanguage.Batch:
@@ -403,6 +433,8 @@ namespace Raven.Documentation.Parser.Helpers.DocumentBuilding
                     return "HTTP";
                 case Language.Python:
                     return "Python";
+                case Language.Php:
+                    return "Php";
                 default:
                     throw new NotSupportedException(language.ToString());
             }

--- a/Raven.Documentation.Parser/ParserOptions.cs
+++ b/Raven.Documentation.Parser/ParserOptions.cs
@@ -52,6 +52,8 @@ namespace Raven.Documentation.Parser
                     return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "java", "src", "test", "java", "net", "ravendb");
                 case Language.Python:
                     return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "python");
+                case Language.Php:
+                    return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "php");
                 case Language.NodeJs:
                     return Path.Combine(PathToDocumentationDirectory, documentationVersion, "Samples", "nodejs");
                 default:

--- a/Raven.Documentation.Web.Core/ViewModels/Models.cs
+++ b/Raven.Documentation.Web.Core/ViewModels/Models.cs
@@ -184,6 +184,8 @@ namespace Raven.Documentation.Web.Core.ViewModels
                     return "http";
                 case Language.Python:
                     return "python";
+                case Language.Php:
+                    return "php";
                 default:
                     return "general";
             }

--- a/Raven.Documentation.Web/App_Start/RouteConfig.cs
+++ b/Raven.Documentation.Web/App_Start/RouteConfig.cs
@@ -11,7 +11,7 @@ namespace Raven.Documentation.Web
     public class RouteConfig
     {
         private const string RouteAvailableVersions = "1.0|2.0|2.5|3.0|3.5|4.0|4.1|4.2|5.0|5.1|5.2|5.3|5.4|6.0|6.1";
-        private const string RouteAvailableLanguages = "csharp|java|nodejs|http|python";
+        private const string RouteAvailableLanguages = "csharp|java|nodejs|http|python|php";
 
         public static void RegisterRoutes(RouteCollection routes)
         {


### PR DESCRIPTION
Related issue: 
[RDoc-2943](https://issues.hibernatingrhinos.com/issue/RDoc-2943/Enable-PHP-support-in-documentation)