### PR TITLE
RDoc-3008 [Node.js] Subscriptions > Advanced > Revisions support

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.dotnet.markdown
@@ -1,0 +1,176 @@
+# Data Subscriptions: Revisions Support
+
+---
+
+{NOTE: }
+
+* When the [Revisions feature](../../../document-extensions/revisions/overview) is enabled, a document revision is created with each change made to the document.  
+  Each revision contains a snapshot of the document at the time of modification, forming a complete audit trail.
+  
+* The **Data Subscription** feature supports subscribing not only to documents but also to their **revisions**.  
+  This functionality allows the subscribed client to track changes made to documents over time.
+ 
+* The revisions support is specified within the subscription definition.  
+  See how to create and consume it in the examples below.
+
+* In this page:  
+  * [Regular subscription vs Revisions subscription](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#regular-subscription-vs-revisions-subscription)
+  * [Revisions processing order](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#revisions-processing-order)  
+  * [Simple creation and consumption](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#simple-creation-and-consumption)   
+  * [Filtering revisions](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#filtering-revisions)   
+  * [Projecting fields from revisions](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#projecting-fields-from-revisions)   
+
+{NOTE/}
+
+---
+
+{PANEL: Regular subscription vs Revisions subscription}
+
+{NOTE: }
+
+##### Regular subscription
+---
+
+* **Processed items**:  
+  The subscription processes **documents** from the defined collection.  
+  Only the latest version of the document is processed, even if the document has revisions.
+* **Query access scope**:  
+  The subscription query running on the server has access only to the latest/current version of the documents.
+* **Data sent to client**:   
+  Each item in the batch sent to the client contains a single document (or a projection of it),   
+  as defined in the subscription.
+
+{NOTE/}
+{NOTE: }
+
+##### Revisions subscription
+---
+
+* **Processed items**:   
+  The subscription processes all **revisions** of documents from the defined collection,  
+  including revisions of deleted documents from the revision bin if they have not been purged.
+* **Query access scope**:  
+  For each revision, the subscription query running on the server has access to both the currently processed revision and its previous revision.
+* **Data sent to client**:  
+  By default, unless the subscription query is [projecting specific fields](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#projecting-fields-from-revisions),
+  each item in the batch sent to the client contains both the processed revision (`Result.Current`) and its preceding revision (`Result.Previous`).
+  If the document has just been created, the previous revision will be `null`. 
+
+---
+
+{WARNING: }
+
+* In order for the revisions subscription to work,  
+  [Revisions must be configured](../../../document-extensions/revisions/overview#defining-a-revisions-configuration) and enabled for the collection the subscription manages.
+
+* A document that has no revisions will Not be processed,
+  so make sure that your revisions configuration does not purge revisions before the subscription has a chance to process them.
+
+{WARNING/}
+
+{NOTE/}
+{PANEL/}
+
+{PANEL: Revisions processing order}
+
+In the revisions subscription, revisions are processed in pairs of subsequent entries.  
+For example, consider the following User document:  
+
+{CODE-BLOCK:json}
+{
+    Name: "James",
+    Age: "21"
+}
+{CODE-BLOCK/}
+ 
+We update this User document in two consecutive operations:  
+
+* Update the 'Age' field to the value of 22  
+* Update the 'Age' field to the value of 23  
+
+The subscription worker in the client will receive pairs of revisions ( _Previous_ & _Current_ )  
+within each item in the batch in the following order:  
+
+| Batch item | Previous                       | Current                        |
+|------------|--------------------------------|--------------------------------| 
+| item #1    | `null`                         | `{ Name: "James", Age: "21" }` |
+| item #2    | `{ Name: "James", Age: "21" }` | `{ Name: "James", Age: "22" }` |
+| item #3    | `{ Name: "James", Age: "22" }` | `{ Name: "James", Age: "23" }` |
+ 
+{PANEL/}
+
+{PANEL: Simple creation and consumption}
+
+Here we set up a basic revisions subscription that will deliver pairs of consecutive _Order_ document revisions to the client:
+
+**Create subscription**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Generic_syntax create_simple_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE-TAB:csharp:RQL_syntax create_simple_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE-TABS/}
+
+**Consume subscription**:
+
+{CODE use_simple_revision_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+
+{PANEL/}
+
+{PANEL: Filtering revisions}
+
+Here we set up a revisions subscription that will send the client only document revisions in which the order was shipped to Mexico.
+
+**Create subscription**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Generic_syntax create_filtered_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE-TAB:csharp:RQL_syntax create_filtered_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE-TABS/}
+
+**Consume subscription**:
+
+{CODE consume_filtered_revisions_subscription@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+
+{PANEL/}
+
+{PANEL: Projecting fields from revisions}
+
+Here we define a revisions subscription that will filter the revisions and send projected data to the client.
+
+**Create subscription**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Generic_syntax create_projected_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE-TAB:csharp:RQL_syntax create_projected_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE-TAB:csharp:Projection_class projection_class@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE-TABS/}
+
+**Consume subscription**:
+
+Since the revision fields are projected into the `OrderRevenues` class in the subscription definition,  
+each item received in the batch uses this projected class format instead of the default `Result.Previous` and `Result.Current` fields, 
+as was demonstrated in the [simple example](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#simple-creation-and-consumption).
+
+{CODE consume_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+
+{PANEL/}
+
+## Related Articles
+
+**Data Subscriptions**:
+
+- [What are Data Subscriptions](../../../client-api/data-subscriptions/what-are-data-subscriptions)
+- [How to Create a Data Subscription](../../../client-api/data-subscriptions/creation/how-to-create-data-subscription)
+- [How to Consume a Data Subscription](../../../client-api/data-subscriptions/consumption/how-to-consume-data-subscription)
+
+**Session**:
+
+- [Revisions API Overview](../../../document-extensions/revisions/client-api/overview)
+
+**Document Extensions**:
+
+- [Revisions Overview](../../../document-extensions/revisions/overview)
+
+**Knowledge Base**:
+
+- [JavaScript Engine](../../../server/kb/javascript-engine)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.java.markdown
@@ -1,0 +1,106 @@
+# Data Subscriptions: Revisions Support
+
+---
+
+{NOTE: }
+
+* The **Data Subscription** feature supports subscribing not only to documents, but also to [document revisions](../../../document-extensions/revisions/overview).  
+
+* The revisions support is defined within the subscription.  
+  A [Revisions Configuration](../../../document-extensions/revisions/client-api/operations/configure-revisions) must be defined for the subscribed collection.  
+
+* While a regular subscription processes a single document, a Revisions subscription processes **pairs of subsequent document revisions**.  
+    
+    Using this functionality allows you to keep track of each change made in a document, as well as compare pairs of subsequent versions of the document.  
+    
+    Both revisions are accessible for filtering and projection.  
+
+* In this page:  
+  * [Revisions processing order](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#revisions-processing-order)  
+  * [Simple declaration and usage](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#simple-declaration-and-usage)   
+  * [Revisions processing and projection](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#revisions-processing-and-projection)  
+
+{NOTE/}
+
+---
+
+{PANEL: Revisions processing order}
+
+The Revisions feature allows the tracking of changes made in a document, by storing the audit trail of its changes over time. 
+An audit trail entry is called a **Document Revision**, and is comprised of a document snapshot.  
+Read more about revisions [here](../../../document-extensions/revisions/overview).  
+
+In a data subscription, revisions will be processed in pairs of subsequent entries.  
+For example, consider the following User document:  
+
+`{
+    Name:'James',
+    Age:'21'
+}`
+
+We update the User document twice, in separate operations:  
+
+* We update the 'Age' field to the value of 22  
+* We update the 'Age' field to the value of 23  
+
+The data subscriptions revisions processing mechanism will receive pairs of revisions in the following order:  
+
+| # | Previous                     | Current                      |
+|---|------------------------------|------------------------------| 
+| 1 | `null`                       | `{ Name:'James', Age:'21' }` |
+| 2 | `{ Name:'James', Age:'21' }` | `{ Name:'James', Age:'22' }` |
+| 3 | `{ Name:'James', Age:'22' }` | `{ Name:'James', Age:'23' }` |
+ 
+{WARNING: }
+The revisions subscription will be able to function properly only if the revisions it needs to process are available.
+Please make sure that your revisions configuration doesn't purge revisions before the subscription had the chance to process them.  
+{WARNING/}
+
+{PANEL/}
+
+{PANEL: Simple declaration and usage}
+
+Here we declare a simple revisions subscription that will send pairs of subsequent document revisions to the client:
+
+Creation:
+{CODE-TABS}
+{CODE-TAB:java:Generic-syntax create_simple_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.java /}
+{CODE-TAB:java:RQL-syntax create_simple_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.java /}
+{CODE-TABS/}
+
+Consumption:
+{CODE:java use_simple_revision_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.java /}
+
+{PANEL/}
+
+{PANEL: Revisions processing and projection}
+
+Here we declare a revisions subscription that will filter and project data from revisions pairs:
+
+Creation:
+{CODE:java create_projected_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.java /}
+
+Consumption:
+{CODE:java use_simple_revision_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.java /}
+
+{PANEL/}
+
+## Related Articles
+
+**Data Subscriptions**:
+
+- [What are Data Subscriptions](../../../client-api/data-subscriptions/what-are-data-subscriptions)
+- [How to Create a Data Subscription](../../../client-api/data-subscriptions/creation/how-to-create-data-subscription)
+- [How to Consume a Data Subscription](../../../client-api/data-subscriptions/consumption/how-to-consume-data-subscription)
+
+**Session**:
+
+- [Revisions API Overview](../../../document-extensions/revisions/client-api/overview)
+
+**Document Extensions**:
+
+- [Revisions Overview](../../../document-extensions/revisions/overview)
+
+**Knowledge Base**:
+
+- [JavaScript Engine](../../../server/kb/javascript-engine)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.js.markdown
@@ -18,7 +18,6 @@
   * [Revisions processing order](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#revisions-processing-order)  
   * [Simple creation and consumption](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#simple-creation-and-consumption)   
   * [Filtering revisions](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#filtering-revisions)   
-  * [Projecting fields from revisions](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#projecting-fields-from-revisions)   
 
 {NOTE/}
 
@@ -52,8 +51,8 @@
 * **Query access scope**:  
   For each revision, the subscription query running on the server has access to both the currently processed revision and its previous revision.
 * **Data sent to client**:  
-  By default, unless the subscription query is [projecting specific fields](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#projecting-fields-from-revisions),
-  each item in the batch sent to the client contains both the processed revision (`Result.Current`) and its preceding revision (`Result.Previous`).
+  By default, unless the subscription query is projecting specific fields,
+  each item in the batch sent to the client contains both the processed revision (`result.current`) and its preceding revision (`result.previous`).
   If the document has just been created, the previous revision will be `null`. 
 
 ---
@@ -88,7 +87,7 @@ We update this User document in two consecutive operations:
 * Update the 'Age' field to the value of 22  
 * Update the 'Age' field to the value of 23  
 
-The subscription worker in the client will receive pairs of revisions ( _Previous_ & _Current_ )  
+The subscription worker in the client will receive pairs of revisions ( _previous_ & _current_ )  
 within each item in the batch in the following order:  
 
 | Batch item | Previous                       | Current                        |
@@ -105,14 +104,11 @@ Here we set up a basic revisions subscription that will deliver pairs of consecu
 
 **Create subscription**:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Generic_syntax create_simple_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-{CODE-TAB:csharp:RQL_syntax create_simple_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-{CODE-TABS/}
+{CODE:nodejs revisions_1@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
 
 **Consume subscription**:
 
-{CODE use_simple_revision_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE:nodejs revisions_2@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
 
 {PANEL/}
 
@@ -122,36 +118,11 @@ Here we set up a revisions subscription that will send the client only document 
 
 **Create subscription**:
 
-{CODE-TABS}
-{CODE-TAB:csharp:Generic_syntax create_filtered_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-{CODE-TAB:csharp:RQL_syntax create_filtered_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-{CODE-TABS/}
+{CODE:nodejs revisions_3@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
 
 **Consume subscription**:
 
-{CODE consume_filtered_revisions_subscription@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-
-{PANEL/}
-
-{PANEL: Projecting fields from revisions}
-
-Here we define a revisions subscription that will filter the revisions and send projected data to the client.
-
-**Create subscription**:
-
-{CODE-TABS}
-{CODE-TAB:csharp:Generic_syntax create_projected_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-{CODE-TAB:csharp:RQL_syntax create_projected_revisions_subscription_RQL@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-{CODE-TAB:csharp:Projection_class projection_class@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
-{CODE-TABS/}
-
-**Consume subscription**:
-
-Since the revision fields are projected into the `OrderRevenues` class in the subscription definition,  
-each item received in the batch has the format of this projected class instead of the default `Result.Previous` and `Result.Current` fields, 
-as was demonstrated in the [simple example](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#simple-creation-and-consumption).
-
-{CODE consume_revisions_subscription_generic@ClientApi\DataSubscriptions\DataSubscriptions.cs /}
+{CODE:nodejs revisions_4@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.js.markdown
@@ -17,7 +17,8 @@
   * [Regular subscription vs Revisions subscription](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#regular-subscription-vs-revisions-subscription)
   * [Revisions processing order](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#revisions-processing-order)  
   * [Simple creation and consumption](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#simple-creation-and-consumption)   
-  * [Filtering revisions](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#filtering-revisions)   
+  * [Filtering revisions](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#filtering-revisions)
+  * [Projecting fields from revisions](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#projecting-fields-from-revisions)
 
 {NOTE/}
 
@@ -123,6 +124,27 @@ Here we set up a revisions subscription that will send the client only document 
 **Consume subscription**:
 
 {CODE:nodejs revisions_4@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
+
+{PANEL/}
+
+{PANEL: Projecting fields from revisions}
+
+Here we define a revisions subscription that will filter the revisions and send projected data to the client.
+
+**Create subscription**:
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Subscription_definition revisions_5@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
+{CODE-TAB:nodejs:Projection_class projection_class@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
+{CODE-TABS/}
+
+**Consume subscription**:
+
+Since the revision fields are projected into the `OrderRevenues` class in the subscription definition,  
+each item received in the batch has the format of this projected class instead of the default `result.previous` and `result.current` fields,
+as was demonstrated in the [simple example](../../../client-api/data-subscriptions/advanced-topics/subscription-with-revisioning#simple-creation-and-consumption).
+
+{CODE:nodejs revisions_6@client-api\dataSubscriptions\advanced\revisionsSubscription.js /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
@@ -458,6 +458,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             {
                 foreach (var item in batch.Items)
                 {
+                    // Access the projected content:
                     Console.WriteLine($@"Revenue for order with ID: {item.Id}
                                          has grown from {item.Result.PreviousRevenue}
                                          to {item.Result.CurrentRevenue}");

--- a/Documentation/5.4/Samples/nodejs/client-api/dataSubscriptions/advanced/revisionsSubscription.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/dataSubscriptions/advanced/revisionsSubscription.js
@@ -1,0 +1,151 @@
+import * as assert from "assert";
+import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+const session = documentStore.openSession();
+
+async function revisionsSubscription() {
+
+    {
+        //region revisions_1
+        const subscriptionName = await documentStore.subscriptions.create({
+            // Add (Revisions = true) to your subscription RQL
+            query: "From Orders (Revisions = true)"
+        });
+        //endregion
+    }
+    
+    {
+        //region revisions_2
+        const workerOptions = { subscriptionName };
+
+        const worker = 
+            documentStore.subscriptions.getSubscriptionWorkerForRevisions(workerOptions);
+
+        worker.on("batch", (batch, callback) => {
+            try {
+                for (const item of batch.items) {
+
+                    // Access the previous revision via 'result.previous'
+                    const previousRevision = item.result.previous;
+
+                    // Access the current revision via 'result.current'
+                    const currentRevision = item.result.current;
+                }
+                callback();
+                
+            } catch (err) {
+                callback(err);
+            }
+        });
+        //endregion
+    }
+    
+    {
+        //region revisions_3
+        const subscriptionName = await documentStore.subscriptions.create({
+            // Provide filtering logic
+            // Only revisions that where shipped to Mexico will be sent to subscribed clients
+            query: `declare function isSentToMexico(doc) { 
+                        return doc.Current.ShipTo.Country == 'Mexico'
+                    }
+
+                    from 'Orders' (Revisions = true) as doc
+                    where isSentToMexico(doc) == true`
+        });
+        //endregion
+    }
+    
+    {
+        //region revisions_4
+        const workerOptions = { subscriptionName };
+
+        const worker =
+            documentStore.subscriptions.getSubscriptionWorkerForRevisions(workerOptions);
+
+        worker.on("batch", (batch, callback) => {
+            try {
+                for (const item of batch.items) {
+                    console.log(`
+                        This is a revision of document ${item.id}.
+                        The order in this revision was shipped at ${item.result.current.ShippedAt}.
+                    `);
+                }
+                callback();
+
+            } catch (err) {
+                callback(err);
+            }
+        });
+        //endregion
+    }
+    
+    //////////////
+    /// Note: regions revisions_5 & revisions_6 are currently not referenced in the markdown
+    /// I'm keeping them here to be used once issue RDBC-876 is fixed
+    //////////////
+    
+    {
+        //region revisions_5
+        const subscriptionName = await documentStore.subscriptions.create({
+            // Filter revisions by the revenue delta.
+            // The subscription will only process revisions where the revenue
+            // is higher than in the preceding revision by 2500.
+            
+            query: `declare function isRevenueDeltaAboveThreshold(doc, threshold) { 
+                        return doc.Previous !== null && doc.Current.Lines.map(function(x) {
+                            return x.PricePerUnit * x.Quantity;
+                        }).reduce((a, b) => a + b, 0) > doc.Previous.Lines.map(function(x) { 
+                            return x.PricePerUnit * x.Quantity;
+                        }).reduce((a, b) => a + b, 0) + threshold
+                    }
+
+                    from 'Orders' (Revisions = true) as doc
+                    where isRevenueDeltaAboveThreshold(doc, 2500)
+
+                    // Define the projected fields that will be sent to the client:
+                    select {
+                        previousRevenue: doc.Previous.Lines.map(function(x) {
+                            return x.PricePerUnit * x.Quantity;
+                        }).reduce((a, b) => a + b, 0),
+      
+                        currentRevenue: doc.Current.Lines.map(function(x) {
+                            return x.PricePerUnit * x.Quantity;
+                        }).reduce((a, b) => a + b, 0)
+                    }`
+        });
+        //endregion
+    }
+    
+    {        
+        //region revisions_6
+        const workerOptions = { subscriptionName: subscriptionName, documentType: MyProjection };
+
+        const worker =
+            documentStore.subscriptions.getSubscriptionWorkerForRevisions(workerOptions);
+
+        worker.on("batch", (batch, callback) => {
+            try {
+                for (const item of batch.items) {
+                    console.log(`
+                        Revenue for order with ID: ${item.id}
+                        has grown from ${item.result.previousRevenue}
+                        to ${item.result.currentRevenue}
+                    `);
+                }
+                callback();
+
+            } catch (err) {
+                callback(err);
+            }
+        });
+        //endregion
+    }
+}
+
+class OrderRevenues {
+    constructor() {
+        this.previousRevenue;
+        this.currentRevenue;
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/dataSubscriptions/advanced/revisionsSubscription.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/dataSubscriptions/advanced/revisionsSubscription.js
@@ -20,6 +20,7 @@ async function revisionsSubscription() {
         const workerOptions = { subscriptionName };
 
         const worker = 
+            // Use method `getSubscriptionWorkerForRevisions`
             documentStore.subscriptions.getSubscriptionWorkerForRevisions(workerOptions);
 
         worker.on("batch", (batch, callback) => {
@@ -80,11 +81,6 @@ async function revisionsSubscription() {
         //endregion
     }
     
-    //////////////
-    /// Note: regions revisions_5 & revisions_6 are currently not referenced in the markdown
-    /// I'm keeping them here to be used once issue RDBC-876 is fixed
-    //////////////
-    
     {
         //region revisions_5
         const subscriptionName = await documentStore.subscriptions.create({
@@ -119,14 +115,20 @@ async function revisionsSubscription() {
     
     {        
         //region revisions_6
-        const workerOptions = { subscriptionName: subscriptionName, documentType: MyProjection };
+        const workerOptions = { 
+            subscriptionName: subscriptionName,
+            documentType: OrderRevenues
+        };
 
         const worker =
-            documentStore.subscriptions.getSubscriptionWorkerForRevisions(workerOptions);
+            // Note: in this case, where each resulting item in the batch is a projected object
+            // and not the revision itself, we use method `getSubscriptionWorker`
+            documentStore.subscriptions.getSubscriptionWorker(workerOptions);
 
         worker.on("batch", (batch, callback) => {
             try {
                 for (const item of batch.items) {
+                    // Access the projected content:
                     console.log(`
                         Revenue for order with ID: ${item.id}
                         has grown from ${item.result.previousRevenue}
@@ -143,9 +145,11 @@ async function revisionsSubscription() {
     }
 }
 
+//region projection_class
 class OrderRevenues {
     constructor() {
         this.previousRevenue;
         this.currentRevenue;
     }
 }
+//endregion

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
@@ -457,6 +457,7 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             {
                 foreach (var item in batch.Items)
                 {
+                    // Access the projected content:
                     Console.WriteLine($@"Revenue for order with ID: {item.Id}
                                          has grown from {item.Result.PreviousRevenue}
                                          to {item.Result.CurrentRevenue}");

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/DataSubscriptions/DataSubscriptions.cs
@@ -321,77 +321,145 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
 
             #region create_simple_revisions_subscription_generic
             subscriptionName = store.Subscriptions.Create(
+                // Use <Revision<documentClassType>> as the type for the processed items
+                // e.g. <Revision<Order>>
                 new SubscriptionCreationOptions<Revision<Order>>());
             #endregion
 
             #region create_simple_revisions_subscription_RQL
             subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
             {
+                // Add (Revisions = true) to your subscription RQL
                 Query = @"From Orders (Revisions = true)"
             });
             #endregion
 
             #region use_simple_revision_subscription_generic
-            SubscriptionWorker<Revision<Order>> revisionWorker = store.Subscriptions.GetSubscriptionWorker<Revision<Order>>(subscriptionName);
+            SubscriptionWorker<Revision<Order>> revisionsWorker = 
+                // Specify <Revision<Order>> as the type of the processed items
+                store.Subscriptions.GetSubscriptionWorker<Revision<Order>>(subscriptionName);
 
-            await revisionWorker.Run((SubscriptionBatch<Revision<Order>> x) =>
+            await revisionsWorker.Run((SubscriptionBatch<Revision<Order>> batch) =>
             {
-                foreach (var documentsPair in x.Items)
+                foreach (var item in batch.Items)
                 {
-                    var prev = documentsPair.Result.Previous;
-                    var current = documentsPair.Result.Current;
+                    // Access the previous revision via 'Result.Previous'
+                    var previousRevision = item.Result.Previous;
 
-                    ProcessOrderChanges(prev, current);
+                    // Access the current revision via 'Result.Current'
+                    var currentRevision = item.Result.Current;
+
+                    // Provide your own processing logic:
+                    ProcessOrderRevisions(previousRevision, currentRevision);
                 }
-            }
-            );
+            });
             #endregion
 
-            void ProcessOrderChanges(Order prev, Order cur)
+            void ProcessOrderRevisions(Order prev, Order cur)
             {
-
             }
+            
+            #region create_filtered_revisions_subscription_generic
+            subscriptionName = store.Subscriptions.Create(
+                // Specify <Revision<Order>> as the type of the processed items
+                new SubscriptionCreationOptions<Revision<Order>>()
+                {
+                    // Provide filtering logic
+                    // Only revisions that where shipped to Mexico will be sent to subscribed clients
+                    Filter = revision => revision.Current.ShipTo.Country == "Mexico",
+                });
+            #endregion
+
+            #region create_filtered_revisions_subscription_RQL
+            subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
+            {
+                Query = @"declare function isSentToMexico(doc) { 
+                              return doc.Current.ShipTo.Country == 'Mexico'
+                          }
+
+                          from 'Orders' (Revisions = true) as doc
+                          where isSentToMexico(doc) == true"
+            });
+            #endregion
+            
+            #region consume_filtered_revisions_subscription
+            SubscriptionWorker<Revision<Order>> worker =
+                store.Subscriptions.GetSubscriptionWorker<Revision<Order>>(subscriptionName);
+
+            await worker.Run(batch =>
+            {
+                foreach (var item in batch.Items)
+                {
+                    Console.WriteLine($@"
+                        This is a revision of document {item.Id}.
+                        The order in this revision was shipped at {item.Result.Current.ShippedAt}.");
+                }
+            });
+            #endregion
             
             #region create_projected_revisions_subscription_generic
             subscriptionName = store.Subscriptions.Create(
+                // Specify <Revision<Order>> as the type of the processed items within the query
                 new SubscriptionCreationOptions<Revision<Order>>()
                 {
-                    Filter = tuple => tuple.Current.Lines.Count > tuple.Previous.Lines.Count,
-                    Projection = tuple => new
+                    // Filter revisions by the revenue delta.
+                    // The subscription will only process revisions where the revenue
+                    // is higher than in the preceding revision by 2500.
+                    Filter = revision =>
+                        revision.Previous != null &&
+                        revision.Current.Lines.Sum(x => x.PricePerUnit * x.Quantity) > 
+                        revision.Previous.Lines.Sum(x => x.PricePerUnit * x.Quantity) + 2500,
+                    
+                    // Define the projected fields that will be sent to the client
+                    Projection = revision => new OrderRevenues()
                     {
-                        PreviousRevenue = tuple.Previous.Lines.Sum(x => x.PricePerUnit * x.Quantity),
-                        CurrentRevenue = tuple.Current.Lines.Sum(x => x.PricePerUnit * x.Quantity)
+                        PreviousRevenue = 
+                            revision.Previous.Lines.Sum(x => x.PricePerUnit * x.Quantity),
+                        
+                        CurrentRevenue = 
+                            revision.Current.Lines.Sum(x => x.PricePerUnit * x.Quantity)
                     }
                 });
             #endregion
 
             #region create_projected_revisions_subscription_RQL
-            subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
+            subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
             {
-                Query = @"declare function getOrderLinesSum(doc){
-                                var sum = 0;
-                                for (var i in doc.Lines) { sum += doc.Lines[i];}
-                                return sum;
-                            }
+                Query = @"declare function isRevenueDeltaAboveThreshold(doc, threshold) { 
+                              return doc.Previous !== null && doc.Current.Lines.map(function(x) {
+                                  return x.PricePerUnit * x.Quantity;
+                              }).reduce((a, b) => a + b, 0) > doc.Previous.Lines.map(function(x) { 
+                                  return x.PricePerUnit * x.Quantity;
+                              }).reduce((a, b) => a + b, 0) + threshold
+                          }
 
-                        From Orders (Revisions = true)
-                        Where getOrderLinesSum(this.Current)  > getOrderLinesSum(this.Previous)
-                        Select 
-                        {
-                            PreviousRevenue: getOrderLinesSum(this.Previous),
-                            CurrentRevenue: getOrderLinesSum(this.Current)                            
-                        }"
+                          from 'Orders' (Revisions = true) as doc
+                          where isRevenueDeltaAboveThreshold(doc, 2500)
+
+                          select {
+                              PreviousRevenue: doc.Previous.Lines.map(function(x) {
+                                  return x.PricePerUnit * x.Quantity;
+                              }).reduce((a, b) => a + b, 0),
+
+                              CurrentRevenue: doc.Current.Lines.map(function(x) {
+                                  return x.PricePerUnit * x.Quantity;
+                              }).reduce((a, b) => a + b, 0)
+                          }"
             });
             #endregion
 
             #region consume_revisions_subscription_generic
-            SubscriptionWorker<OrderRevenues> revenuesComparisonWorker = store.Subscriptions.GetSubscriptionWorker<OrderRevenues>(subscriptionName);
+            SubscriptionWorker<OrderRevenues> revenuesComparisonWorker =
+                // Use the projected class type 'OrderRevenues' for the items the worker will process
+                store.Subscriptions.GetSubscriptionWorker<OrderRevenues>(subscriptionName);
 
-            await revenuesComparisonWorker.Run(x =>
+            await revenuesComparisonWorker.Run(batch =>
             {
-                foreach (var item in x.Items)
+                foreach (var item in batch.Items)
                 {
-                    Console.WriteLine($"Revenue for order with Id: {item.Id} grown from {item.Result.PreviousRevenue} to {item.Result.CurrentRevenue}");
+                    Console.WriteLine($@"Revenue for order with ID: {item.Id}
+                                         has grown from {item.Result.PreviousRevenue}
+                                         to {item.Result.CurrentRevenue}");
                 }
             });
             #endregion
@@ -619,11 +687,13 @@ namespace Raven.Documentation.Samples.ClientApi.DataSubscriptions
             public static void Error(string text, Exception ex) { }
         }
 
+        #region projection_class
         public class OrderRevenues
         {
-            public int PreviousRevenue { get; set; }
-            public int CurrentRevenue { get; set; }
+            public decimal PreviousRevenue { get; set; }
+            public decimal CurrentRevenue { get; set; }
         }
+        #endregion
 
         public class OrderAndCompany
         {


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3008/Node.js-Client-API-Data-subscriptions-Advanced-Revisions-support-Replace-C-samples

---

**Notes for this PR:**

* In this PR
  * Sample code for `Node.js` was applied 
  * Some text was improved

* Still, there are fixes to be applied to this article for all languages - to be done in a separate dedicated issue:
https://issues.hibernatingrhinos.com/issue/RDoc-3050/Client-API-Data-subscriptions-Advanced-Revisions-support-Fix-article

---

**Node.js**: @ml054 
* Node.js files to review:
```
Documentation/5.4/Raven.Documentation.Pages/client-api/data-subscriptions/advanced-topics/subscription-with-revisioning.js.markdown
Documentation/5.4/Samples/nodejs/client-api/dataSubscriptions/advanced/revisionsSubscription.js
```