### PR TITLE
RDoc-3058 Cloud: Cloud -> Scaling - remove GCP instance scaling restrictions warning

### DIFF
--- a/Documentation/4.2/Raven.Documentation.Pages/cloud/cloud-scaling.markdown
+++ b/Documentation/4.2/Raven.Documentation.Pages/cloud/cloud-scaling.markdown
@@ -70,11 +70,6 @@ You can upscale or downscale only within the current Product Tier. The *Developm
 for example, can upscale to **Dev50**, but not to the Production Tier **PB10** configuration.  
 Your databases and data will be automatically migrated into your new configuration.
 
-{INFO: }
-Changing product type between **P** and **PB** configurations is not possible in **GCP**.
-{INFO/}
-
-
 {PANEL/}
 {PANEL: Scaling - Change Storage} 
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDoc-3058/Cloud-Cloud-Scaling-remove-GCP-scaling-restrictions-warning