### PR TITLE
RDoc-3062 Add the LongCountLazily() overload to syntax

### DIFF
--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToPerformQueriesLazily.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Querying/HowToPerformQueriesLazily.cs
@@ -236,7 +236,10 @@ namespace Raven.Documentation.Samples.ClientApi.Session.Querying
             #region syntax_2
             // Lazy count query overloads:
             Lazy<int> CountLazily<T>();
+            Lazy<long> LongCountLazily<T>();
+            
             Lazy<Task<int>> CountLazilyAsync<T>(CancellationToken token = default(CancellationToken));
+            Lazy<Task<long>> LongCountLazilyAsync<T>(CancellationToken token = default(CancellationToken));
             #endregion
 
             #region syntax_3


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3062/Document-LongCountLazily