### PR TITLE
[PHP] Client API session batch 5 (Configuration) [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-change-maximum-number-of-requests-per-session.php.markdown
@@ -1,0 +1,39 @@
+# Session: How to Change Maximum Number of Requests per Session
+
+By default, the maximum number of requests that a session can send the server is **30**.  
+This number, if everything is done correctly, should never be reached since remote 
+calls are expensive and the number of remote calls per "session" should be as close 
+to **1** as possible.  
+If the limit is reached, it may indicate a `Select N+1` problem or some other misuse 
+of the session object.
+
+Nevertheless, if needed, this number can be changed for a single session or for all sessions.
+
+## Single session
+
+To modify the maximum number of requests for a **single** session, 
+set the value of the session `maxNumberOfRequestsPerSession` property.
+
+You can do this using the **advanced session** `setMaxNumberOfRequestsPerSession` method.
+
+{CODE:php max_requests_1@ClientApi\Session\Configuration\MaxRequests.php /}
+
+## All sessions
+
+To modify the maximum number of requests for **all** sessions (on a particular store), 
+set the value of the DocumentStore conventions `maxNumberOfRequestsPerSession` property.
+
+You can do this using the **store** `setMaxNumberOfRequestsPerSession` method.
+
+{CODE:php max_requests_2@ClientApi\Session\Configuration\MaxRequests.php /}
+
+{INFO: }
+The maximum number of requests for all sessions can also be configured by via injected client 
+configuration from the Server. Read more about this [here](../../../studio/server/client-configuration).
+{INFO/}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-collection-assignment-for-entities.php.markdown
@@ -1,0 +1,27 @@
+# Session: How to Customize Collection Assignment for Entities
+
+Entities are grouped on the server side into [collections](../../faq/what-is-a-collection).  
+A collection's name is determined by the type of the entities in it.  
+To find the name of an entity's collection, use [`findCollectionName`](../../configuration/identifier-generation/global#findcollectionname).  
+
+## Example
+
+By default, a collection name is the pluralized form of an entity's type.  
+Entities of type `Category`, for example, will belong to the `Categories` collection.  
+To modify this behavior, use `setFindCollectionName`.  
+
+{CODE:php custom_collection_name@ClientApi\Session\Configuration\CustomizeCollectionAssignmentForEntities.php /}
+
+This can become very useful when there is a need to deal with [polymorphic data](../../../indexes/indexing-polymorphic-data).
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize the Identity Property Lookup for Entities](../../../client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities)
+
+### FAQ
+
+- [What is a Collection?](../../../client-api/faq/what-is-a-collection)  

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-id-generation-for-entities.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-id-generation-for-entities.php.markdown
@@ -1,0 +1,29 @@
+# Session: How to Customize ID Generation for Entities
+---
+
+{NOTE: }
+
+RavenDB provides sveral ways to create document IDs.  
+
+- To get familiar with basic built-in ID generation strategies before starting to customize entity 
+  identifiers, please see:  
+  [Working with Document Identifiers](../../../client-api/document-identifiers/working-with-document-identifiers)  
+
+- To learn about conventions related to ID customization, please see the following articles, 
+  presentnig conventions that can be applied to all entity types or to a particular type.  
+   - [Global ID Generation Conventions](../../../client-api/configuration/identifier-generation/global)  
+   - [Type-specific ID Generation Conventions](../../../client-api/configuration/identifier-generation/type-specific)  
+
+{NOTE/}
+
+## Related articles
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../server/kb/document-identifier-generation)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.dotnet.markdown
@@ -1,0 +1,27 @@
+# Session: How to Customize the Identity Property Lookup for Entities
+
+The client must know which property of your entity is considered as an identity. By default, it always looks for the `Id` property (case-sensitive). This behavior can be changed by overwriting one of our conventions called `FindIdentityProperty`.
+
+## Syntax
+
+{CODE identity_1@ClientApi\Session\Configuration\FindIdentityProperty.cs /}
+
+`MemberInfo` will represent the member of a stored entity, and return value (bool) will indicate if given member is an identity property.
+
+## Example
+
+The simplest example would be to check if the property name is equal to 'Identifier'.
+
+{CODE identity_2@ClientApi\Session\Configuration\FindIdentityProperty.cs /}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize Collection Assignment for Entities](../../../client-api/session/configuration/how-to-customize-collection-assignment-for-entities)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../server/kb/document-identifier-generation)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.java.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.java.markdown
@@ -1,0 +1,27 @@
+# Session: How to Customize the Identity Property Lookup for Entities
+
+The client must know which property of your entity is considered as an identity. By default, it always looks for the `id` field (case-sensitive). This behavior can be changed by overwriting one of our conventions called `findIdentityProperty`.
+
+## Syntax
+
+{CODE:java identity_1@ClientApi\Session\Configuration\FindIdentityProperty.java /}
+
+`PropertyDescriptor` will represent the property of a stored entity, and return value (bool) will indicate if given member is an identity property.
+
+## Example
+
+The simplest example would be to check if the property name is equal to 'Identifier'.
+
+{CODE:java identity_2@ClientApi\Session\Configuration\FindIdentityProperty.java /}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize Collection Assignment for Entities](../../../client-api/session/configuration/how-to-customize-collection-assignment-for-entities)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../server/kb/document-identifier-generation)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.js.markdown
@@ -1,0 +1,25 @@
+# Session: How to Customize the Identity Property Lookup for Entities
+
+The client must know which property of your entity is considered as an identity. By default, it always looks for the `id` field (case-sensitive). This behavior can be changed by overwriting one of our conventions called `identityProperty`.
+
+## Syntax
+
+{CODE:nodejs identity_1@client-api\session\configuration\findIdentityProperty.js /}
+
+## Example
+
+Here's how to change it to `Identifier` field.
+
+{CODE:nodejs identity_2@client-api\session\configuration\findIdentityProperty.js /}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize Collection Assignment for Entities](../../../client-api/session/configuration/how-to-customize-collection-assignment-for-entities)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../server/kb/document-identifier-generation)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-identity-property-lookup-for-entities.php.markdown
@@ -1,0 +1,29 @@
+# Session: How to Customize the Identity Property Lookup for Entities
+
+* When a client handles an entity, it must know which property is the entity's identifier.  
+  By default, the client always looks for the `Id` property (case-sensitive).  
+
+* This behavior can be changed by overwriting the `FindIdentityProperty` convention.  
+  To do so, use the `setFindIdentityProperty` method.  
+
+## Syntax
+
+{CODE:php identity_1@ClientApi\Session\Configuration\FindIdentityProperty.php /}
+
+## Example
+
+The simplest example would be to check if the property name is equal to 'Identifier'.
+
+{CODE:php identity_2@ClientApi\Session\Configuration\FindIdentityProperty.php /}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+- [How to Customize ID Generation for Entities](../../../client-api/session/configuration/how-to-customize-id-generation-for-entities)
+- [How to Customize Collection Assignment for Entities](../../../client-api/session/configuration/how-to-customize-collection-assignment-for-entities)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../server/kb/document-identifier-generation)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-caching.php.markdown
@@ -1,0 +1,24 @@
+# Disable Caching per Session
+
+To reduce the overhead of sending the documents over the network, 
+client library is caching the HTTP responses and sends only ETags to Server. 
+
+If the request was previously cached giving the Server an opportunity to send back `304 Not Modified` 
+without any content data or sending the up-to-date results, this will update the cache. 
+
+This behavior can be changed globally by disabling the HTTP Cache size (more [here](../../../client-api/configuration/conventions#maxhttpcachesize)).  
+It can also be changed per session, using the `setNoCaching` method.
+
+## Example
+
+{CODE:php disable_caching@ClientApi\Session\Configuration\DisableCaching.php /}
+
+## Related Articles
+
+### Session
+
+- [What is a session and how does it work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a session](../../../client-api/session/opening-a-session)
+- [Storing entities](../../../client-api/session/storing-entities)
+- [Loading entities](../../../client-api/session/loading-entities)
+- [Saving changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.php.markdown
@@ -1,0 +1,80 @@
+# Disable Entity Tracking
+
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `saveChanges` is called.  
+
+* **Tracking can be disabled** by any of the following:  
+    * [Disable tracking for a specific entity in a session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-for-a-specific-entity-in-a-session)
+    * [Disable tracking for all entities in a session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-for-all-entities-in-a-session)
+    * [Disable tracking for query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-for-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking for a specific entity in a session}
+
+* Tracking can be disabled for a specific entity in the session.  
+* Once tracking is disabled for the entity -  
+  * Any changes made to this entity will be ignored for `saveChanges`.  
+  * Performing another `load` for this entity will Not generate another call to the server.
+  
+**Example**
+
+{CODE:php disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.php /}
+
+{PANEL/}
+
+{PANEL: Disable tracking for all entities in a session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `store` will Not be available (an exception will be thrown if used).
+  * Calling `load` or `query` will generate a call to the server and create new entities instances.  
+
+{CODE:php disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.php /}
+
+{PANEL/}
+
+{PANEL: Disable tracking for query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE-TABS}
+{CODE-TAB:php:query disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.php /}
+{CODE-TAB:php:documentQuery disable_tracking_3_documentQuery@ClientApi\Session\Configuration\DisableTracking.php /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
+* This customization will apply to all sessions opened for this document store.
+* Use the `setShouldIgnoreEntityChanges` method to do so.  
+
+#### Example:
+
+{CODE:php disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.php /}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/session/configuration/how-to-enable-optimistic-concurrency.php.markdown
@@ -1,0 +1,119 @@
+# How to Enable Optimistic Concurrency
+---
+
+{NOTE: }
+
+* By default, optimistic concurrency checks are **disabled**. Changes made outside of the session object will be overwritten. 
+  Concurrent changes to the same document will use the _Last Write Wins_ strategy so a lost update anomaly is possible 
+  with the default configuration of the [session](../../../client-api/session/what-is-a-session-and-how-does-it-work).
+
+* Optimistic concurrency can be **enabled** for:
+   * A specific document  
+   * A specific session (enable on a per-session basis)  
+   * All sessions (enable globally, at the document store level)  
+
+* With optimistic concurrency enabled, RavenDB will generate a concurrency exception (and abort all modifications in 
+  the current transaction) when trying to save a document that has been modified on the server side after the client 
+  loaded and modified it.
+
+* The `ConcurrencyException` that might be thrown upon the `saveChanges` call needs to be handled by the caller. 
+  The operation can be retried (the document needs to be reloaded since it got changed meanwhile) or handle the error 
+  in a way that is suitable in a given scenario.
+
+* In this page:
+  * [Enable for specific session](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-session)
+  * [Enable globally](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-globally)
+  * [Disable for specific document (when enabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#disable-for-specific-document-(when-enabled-on-session))
+  * [Enable for specific document (when disabled on session)](../../../client-api/session/configuration/how-to-enable-optimistic-concurrency#enable-for-specific-document-(when-disabled-on-session)) 
+
+{WARNING: }
+
+* Note that the `UseOptimisticConcurrency` setting only applies to documents that have been modified by the current session. 
+  E.g., if you load documents `users/1-A` and `users/2-A` in a session, make modifications only to `users/1-A`, and then call `saveChanges`, 
+  the operation will succeed regardless of the optimistic concurrency setting, even if `users/2-A` has been changed by another process in the meantime.
+
+* However, if you modify both documents and attempt to save changes with optimistic concurrency enabled, an exception will be raised 
+  if `users/2-A` has been modified externally.  
+  In this case, the updates to both `users/1-A` and `users/2-A` will be cancelled.
+
+{WARNING/}
+
+{INFO: }
+
+A detailed description of transactions and concurrency control in RavenDB is available here: 
+[Transaction support in RavenDB](../../../client-api/faq/transaction-support)
+
+{INFO/}
+
+{NOTE/}
+
+---
+
+{PANEL: Enable for specific session}
+
+Enable optimistic concurrency for a session using the advanced session `setUseOptimisticConcurrency` method.
+
+{CODE:php optimistic_concurrency_1@ClientApi\Session\Configuration\OptimisticConcurrency.php /}
+
+{WARNING: }
+
+* Enabling optimistic concurrency in a session will ensure that changes made to a document will only be persisted 
+  if the version of the document sent in the `saveChanges` call matches its version from the time it was initially 
+  read (loaded from the server).
+ 
+* Note that it's necessary to enable optimistic concurrency for ALL sessions that modify the documents for 
+  which you want to guarantee that no writes will be silently discarded.  
+  If optimistic concurrency is enabled in some sessions but not in others, and they modify the same documents, 
+  the risk of the lost update anomaly still exists.
+
+{WARNING/}
+
+{PANEL/}
+
+{PANEL: Enable globally}
+
+* Optimistic concurrency can also be enabled for all sessions that are opened under a document store.
+
+* Use the store `setUseOptimisticConcurrency` method to enable globally.
+
+{CODE:php optimistic_concurrency_2@ClientApi\Session\Configuration\OptimisticConcurrency.php /}
+
+{PANEL/}
+
+{PANEL: Disable for specific document (when enabled on session)}
+
+* Optimistic concurrency can be _disabled_ when **storing** a specific document,  
+  even when it is _enabled_ for an entire session (or globally).
+
+* This is done by passing `None` as a change vector value to the [store](../../../client-api/session/storing-entities) method.
+
+{CODE:php optimistic_concurrency_3@ClientApi\Session\Configuration\OptimisticConcurrency.php /}
+
+{PANEL/}
+
+{PANEL: Enable for specific document (when disabled on session)}
+
+* Optimistic concurrency can be _enabled_ when **storing** a specific document,  
+  even when it is _disabled_ for an entire session (or globally).
+
+* This is done by passing an empty string as the change vector value to the [store](../../../client-api/session/storing-entities) method.  
+  Setting the change vector to an empty string will cause RavenDB to ensure that this document is a new one and doesn't already exist.  
+  A `ConcurrencyException` will be thrown if the document already exists. 
+
+* If you do not provide a change vector or if the change vector is `None`, optimistic concurrency will be disabled.  
+
+* Setting optimistic concurrency for a specific document overrides the advanced session `setUseOptimisticConcurrency` operation.  
+
+{CODE:php optimistic_concurrency_4@ClientApi\Session\Configuration\OptimisticConcurrency.php /}
+
+{PANEL/}
+
+## Related articles
+
+### Configuration
+
+- [Conventions](../../../client-api/configuration/conventions)
+
+### FAQ
+
+- [Transaction Support in RavenDB](../../../client-api/faq/transaction-support)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/FindIdentityProperty.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/FindIdentityProperty.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Reflection;
+using Raven.Client.Documents;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class FindIdentityProperty
+    {
+        private interface IFoo
+        {
+            #region identity_1
+            Func<MemberInfo, bool> FindIdentityProperty { get; set; }
+            #endregion
+        }
+
+        public FindIdentityProperty()
+        {
+            using (var store = new DocumentStore())
+            {
+                #region identity_2
+                store.Conventions.FindIdentityProperty = memberInfo => memberInfo.Name == "Identifier";
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/FindIdentityProperty.java
+++ b/Documentation/5.4/Samples/java/src/test/java/net/ravendb/ClientApi/Session/Configuration/FindIdentityProperty.java
@@ -1,0 +1,24 @@
+package net.ravendb.ClientApi.Session.Configuration;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+
+import java.beans.PropertyDescriptor;
+import java.util.function.Function;
+
+public class FindIdentityProperty {
+
+    private interface IFoo {
+        //region identity_1
+        public void setFindIdentityProperty(Function<PropertyDescriptor, Boolean> findIdentityProperty);
+        //endregion
+    }
+
+    public FindIdentityProperty() {
+        try (IDocumentStore store = new DocumentStore()) {
+            //region identity_2
+            store.getConventions().setFindIdentityProperty(property -> "Identifier".equals(property.getName()));
+            //endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/session/configuration/findIdentityProperty.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/session/configuration/findIdentityProperty.js
@@ -1,0 +1,18 @@
+import { DocumentStore, DocumentConventions } from "ravendb";
+
+const store = new DocumentStore();
+
+{
+
+    {
+        //region identity_1
+        store.conventions.identityProperty;
+        //endregion
+    }
+
+    {
+        //region identity_2
+        store.conventions.identityProperty = "Identifier"; 
+        //endregion
+    }
+}

--- a/Documentation/5.4/Samples/php/ClientApi/session/Configuration/CustomizeCollectionAssignmentForEntities.php
+++ b/Documentation/5.4/Samples/php/ClientApi/session/Configuration/CustomizeCollectionAssignmentForEntities.php
@@ -1,0 +1,23 @@
+<?php
+
+use RavenDB\Documents\Conventions\DocumentConventions;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Samples\Infrastructure\Orders\Category;
+
+class CustomizeCollectionAssignmentForEntities
+{
+    public function example(): void
+    {
+        $store = new DocumentStore();
+
+        # region custom_collection_name
+        $store->getConventions()->setFindCollectionName(function($className) {
+            if (is_subclass_of($className, Category::class)) {
+                return "ProductGroups";
+            }
+
+            return DocumentConventions::defaultGetCollectionName($className);
+        });
+        # endregion
+    }
+}

--- a/Documentation/5.4/Samples/php/ClientApi/session/Configuration/DisableCaching.php
+++ b/Documentation/5.4/Samples/php/ClientApi/session/Configuration/DisableCaching.php
@@ -1,0 +1,29 @@
+<?php
+
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Session\SessionOptions;
+
+class DisableCaching
+{
+    public function example(): void
+    {
+        $store = new DocumentStore();
+
+        try {
+            # region disable_caching
+            $sessionOptions = new SessionOptions();
+            $sessionOptions->setNoCaching(true);
+
+            $session = $store->openSession($sessionOptions);
+            try {
+                // code here
+            } finally {
+                $session->close();
+            }
+            # endregion
+        } finally {
+            $store->close();
+
+        }
+    }
+}

--- a/Documentation/5.4/Samples/php/ClientApi/session/Configuration/DisableTracking.php
+++ b/Documentation/5.4/Samples/php/ClientApi/session/Configuration/DisableTracking.php
@@ -1,0 +1,147 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use RavenDB\Documents\Conventions\DocumentConventions;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Session\SessionOptions;
+use RavenDB\Samples\Infrastructure\Orders\Product;
+
+class DisableTracking extends TestCase
+{
+    public function example(): void
+    {
+        $store = new DocumentStore();
+
+        try {
+            $session = $store->openSession();
+            try {
+                # region disable_tracking_1
+                // Load a product entity, the session will track its changes
+                /** @var Product $product */
+                $product = $session->load(Product::class, "products/1-A");
+
+                // Disable tracking for the loaded product entity
+                $session->advanced()->ignoreChangesFor($product);
+
+                // The following change will be ignored for SaveChanges
+                $product->setUnitsInStock($product->getUnitsInStock() + 1);
+
+                $session->saveChanges();
+                # endregion
+            } finally {
+                $session->close();
+            }
+
+            # region disable_tracking_2
+            $sessionOptions = new SessionOptions();
+            // Disable tracking for all entities in the session's options
+            $sessionOptions->setNoTracking(true);
+
+            $session = $store->openSession($sessionOptions);
+            try {
+                // Load any entity, it will Not be tracked by the session
+                /** @var Employee $employee1 */
+                $employee1 = $session->load(Employee::class, "employees/1-A");
+
+                // Loading again from same document will result in a new entity instance
+                $employee2 = $session->load(Employee::class, "employees/1-A");
+
+                // Entities instances are not the same
+                $this->assertNotEquals($employee1, $employee2);
+            } finally {
+                $session->close();
+            }
+            # endregion
+
+            # region disable_tracking_3
+            $session = $store->openSession();
+            try {
+                // Define a query
+                /** @var array<Employee> $employeesResults */
+                $employeesResults = $session->query(Employee::class)
+                    // Set NoTracking, all resulting entities will not be tracked
+                    ->noTracking()
+                    ->whereEquals("FirstName", "Robert")
+                    ->toList();
+
+                // The following modification will not be tracked for SaveChanges
+                $firstEmployee = $employeesResults[0];
+                $firstEmployee->setLastName("NewName");
+
+                // Change to 'firstEmployee' will not be persisted
+                $session->saveChanges();
+            } finally {
+                $session->close();
+            }
+            # endregion
+
+            # region disable_tracking_3_documentQuery
+            $session = $store->openSession();
+            try {
+                // Define a query
+                /** @var array<Employee> $employeesResults */
+                $employeesResults = $session->advanced()->documentQuery(Employee::class)
+                    // Set NoTracking, all resulting entities will not be tracked
+                    ->noTracking()
+                    ->whereEquals("FirstName", "Robert")
+                    ->toList();
+
+                // The following modification will not be tracked for SaveChanges
+                $firstEmployee = $employeesResults[0];
+                $firstEmployee->setLastName("NewName");
+
+                // Change to 'firstEmployee' will not be persisted
+                $session->saveChanges();
+            } finally {
+                $session->close();
+            }
+            # endregion
+        } finally {
+            $store->close();
+        }
+
+
+        # region disable_tracking_4
+        // Define the 'ignore' convention on your document store
+        $conventions = new DocumentConventions();
+        $conventions->setShouldIgnoreEntityChanges(
+        // Define for which entities tracking should be disabled
+        // Tracking will be disabled ONLY for entities of type Employee whose FirstName is Bob
+            function ($session, $entity, $id) {
+                return $entity instanceof Employee && $entity->getFirstName() == "Bob";
+            }
+        );
+
+        $store = new DocumentStore();
+        $store->setConventions($conventions);
+        $store->initialize();
+        try {
+            $session = $store->openSession();
+            try {
+                $employee1 = new Employee();
+                $employee1->setId("employees/1");
+                $employee1->setFirstName("Alice");
+
+                $employee2 = new Employee();
+                $employee2->setId("employees/2");
+                $employee2->setFirstName("Bob");
+
+                $session->store($employee1);      // This entity will be tracked
+                $session->store($employee2);      // Changes to this entity will be ignored
+
+                $session->saveChanges();          // Only employee1 will be persisted
+
+                $employee1->setFirstName("Bob");  // Changes to this entity will now be ignored
+                $employee2->setFirstName("Alice");// This entity will now be tracked
+
+                $session->saveChanges();          // Only employee2 is persisted
+            } finally {
+                $session->close();
+            }
+        } finally {
+            $store->close();
+        }
+        # endregion
+
+    }
+}

--- a/Documentation/5.4/Samples/php/ClientApi/session/Configuration/FindIdentityProperty.php
+++ b/Documentation/5.4/Samples/php/ClientApi/session/Configuration/FindIdentityProperty.php
@@ -1,0 +1,27 @@
+<?php
+
+use RavenDB\Documents\DocumentStore;
+
+interface FooInterface
+{
+    # region identity_1
+    public function setFindIdentityProperty(?Closure $findIdentityProperty): void;
+    # endregion
+}
+
+class FindIdentityProperty
+{
+    public function example(): void
+    {
+        $store = new DocumentStore();
+        try {
+            # region identity_2
+            $store->getConventions()->setFindIdentityProperty(function($property) {
+                    return "Identifier" == $property->getName();
+            });
+            # endregion
+        } finally {
+            $store->close();
+        }
+    }
+}

--- a/Documentation/5.4/Samples/php/ClientApi/session/Configuration/MaxRequests.php
+++ b/Documentation/5.4/Samples/php/ClientApi/session/Configuration/MaxRequests.php
@@ -1,0 +1,27 @@
+<?php
+
+use RavenDB\Documents\DocumentStore;
+
+class MaxRequests
+{
+    public function example(): void
+    {
+        $store = new DocumentStore();
+        try {
+            $session = $store->openSession();
+            try {
+                # region max_requests_1
+                $session->advanced()->setMaxNumberOfRequestsPerSession(50);
+                # endregion
+            } finally {
+                $session->close();
+            }
+
+            # region max_requests_2
+            $store->getConventions()->setMaxNumberOfRequestsPerSession(100);
+            # endregion
+        } finally {
+            $store->close();
+        }
+    }
+}

--- a/Documentation/5.4/Samples/php/ClientApi/session/Configuration/OptimisticConcurrency.php
+++ b/Documentation/5.4/Samples/php/ClientApi/session/Configuration/OptimisticConcurrency.php
@@ -1,0 +1,105 @@
+<?php
+
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Samples\Infrastructure\Orders\Product;
+
+class OptimisticConcurrency
+{
+    public function examples(): void
+    {
+        $store = new DocumentStore();
+        try {
+            # region optimistic_concurrency_1
+            $session = $store->openSession();
+            try {
+                $session->advanced()->setUseOptimisticConcurrency(true);
+
+                $product = new Product();
+                $product->setName("Some Name");
+
+                $session->store($product, "products/999");
+                $session->saveChanges();
+
+                $otherSession = $store->openSession();
+                try {
+                    $otherProduct = $otherSession->load(Product::class, "products/999");
+                    $otherProduct->setName("Other Name");
+
+                    $otherSession->saveChanges();
+                } finally {
+                    $otherSession->close();
+                }
+
+                $product->setName("Better Name");
+                $session->saveChanges(); //  will throw ConcurrencyException
+            } finally {
+                $session->close();
+            }
+            # endregion
+
+            # region optimistic_concurrency_2
+            $store->getConventions()->setUseOptimisticConcurrency(true);
+
+            $session = $store->openSession();
+            try {
+                $isSessionUsingOptimisticConcurrency = $session->advanced()->isUseOptimisticConcurrency(); // will return true
+            } finally {
+                $session->close();
+            }
+            # endregion
+
+            # region optimistic_concurrency_3
+            $session = $store->openSession();
+            try {
+                $product = new Product();
+                $product->setName("Some Name");
+
+                $session->store(product, "products/999");
+                $session->saveChanges();
+            } finally {
+                $session->close();
+            }
+
+            $session = $store->openSession();
+            try {
+                $session->advanced()->setUseOptimisticConcurrency(true);
+
+                $product = new Product();
+                $product->setName("Some Other Name");
+
+                $session->store(product, null, "products/999");
+                $session->saveChanges(); // will NOT throw Concurrency exception
+            } finally {
+                $session->close();
+            }
+            # endregion
+
+            # region optimistic_concurrency_4
+            $session = $store->openSession();
+            try {
+                $product = new Product();
+                $product->setName("Some Name");
+                $session->store($product, "products/999");
+                $session->saveChanges();
+            } finally {
+                $session->close();
+            }
+
+            $session = $store->openSession();
+            try {
+                $session->advanced()->setUseOptimisticConcurrency(false); // default value
+
+                $product = new Product();
+                $product->setName("Some Other Name");
+
+                $session->store(product, "", "products/999");
+                $session->saveChanges(); // will throw Concurrency exception
+            } finally {
+                $session->close();
+            }
+            # endregion
+        } finally {
+            $store->close();
+        }
+    }
+}

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-id-generation-for-entities.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-customize-id-generation-for-entities.php.markdown
@@ -1,0 +1,29 @@
+# Session: How to Customize ID Generation for Entities
+---
+
+{NOTE: }
+
+RavenDB provides sveral ways to create document IDs.  
+
+- To get familiar with basic built-in ID generation strategies before starting to customize entity 
+  identifiers, please see:  
+  [Working with Document Identifiers](../../../client-api/document-identifiers/working-with-document-identifiers)  
+
+- To learn about conventions related to ID customization, please see the following articles, 
+  presentnig conventions that can be applied to all entity types or to a particular type.  
+   - [Global ID Generation Conventions](../../../client-api/configuration/identifier-generation/global)  
+   - [Type-specific ID Generation Conventions](../../../client-api/configuration/identifier-generation/type-specific)  
+
+{NOTE/}
+
+## Related articles
+
+### Document Identifiers
+
+- [Working with Document Identifiers](../../../client-api/document-identifiers/working-with-document-identifiers)
+- [Global ID Generation Conventions](../../../client-api/configuration/identifier-generation/global)
+- [Type-specific ID Generation Conventions](../../../client-api/configuration/identifier-generation/type-specific)
+
+### Knowledge Base
+
+- [Document Identifier Generation](../../../server/kb/document-identifier-generation)


### PR DESCRIPTION
Related issues:
[RDoc-3043](https://issues.hibernatingrhinos.com/issue/RDoc-3043/PHP-Client-API-Session-Configuration-Customize-ID-generation-for-entities-Replace-C-samples) Configuration > Customize ID generation for entities
[RDoc-3044](https://issues.hibernatingrhinos.com/issue/RDoc-3044/PHP-Client-API-Session-Configuration-Customize-collection-assignment-for-entities-Replace-C-samples) Configuration > Customize collection assignment for entities
[RDoc-3045](https://issues.hibernatingrhinos.com/issue/RDoc-3045/PHP-Client-API-Session-Configuration-Change-max-number-of-requests-per-session-Replace-C-samples) Configuration > Change max number of requests per session
[RDoc-3046](https://issues.hibernatingrhinos.com/issue/RDoc-3046/PHP-Client-API-Session-Configuration-Enable-optimistic-concurrency-Replace-C-samples) Configuration > Enable optimistic concurrency
[RDoc-3047](https://issues.hibernatingrhinos.com/issue/RDoc-3047/PHP-Client-API-Session-Configuration-Disable-tracking-Replace-C-samples) Configuration > Disable tracking
[RDoc-3048](https://issues.hibernatingrhinos.com/issue/RDoc-3048/PHP-Client-API-Session-Configuration-Disable-caching-Replace-C-samples) Configuration > Disable caching
[RDoc-3049](https://issues.hibernatingrhinos.com/issue/RDoc-3049/PHP-Client-API-Session-Configuration-FindIdentityProperty-Replace-C-samples) Configuration > How to customize identity property lookup for entities