### PR TITLE
[PHP] Operations batch 4 [Replace C# samples]

### DIFF
--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/load-balance-behavior.php.markdown
@@ -1,0 +1,164 @@
+# Load balance behavior
+
+---
+
+{NOTE: }
+
+* The `loadBalanceBehavior` configuration allows you to specify which sessions should 
+  communicate with the same node.  
+ 
+* Sessions that are assigned the **same context** will have all their _Read_ & _Write_ 
+  requests routed to the **same node**. Gain load balancing by assigning **different contexts** 
+  to **different sessions**.  
+
+---
+
+* In this page:
+    * [LoadBalanceBehavior options](../../../client-api/configuration/load-balance/load-balance-behavior#loadbalancebehavior-options)
+    * [Initialize LoadBalanceBehavior on the client](../../../client-api/configuration/load-balance/load-balance-behavior#initialize-loadbalancebehavior-on-the-client)
+    * [Set LoadBalanceBehavior on the server:](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server)
+        * [By operation](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---by-operation)
+        * [From Studio](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server---from-studio)
+    * [When to use](../../../client-api/configuration/load-balance/load-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: LoadBalanceBehavior options }
+
+### `None` (default option)
+
+* Requests will be handled based on the `ReadBalanceBehavior` configuration.  
+  See the conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+   * **_Read_** requests:  
+     The client will calculate the target node from the configured [ReadBalanceBehavior Option](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options).  
+   * **_Write_** requests:  
+     Will be sent to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).  
+     The data will then be replicated to all the other nodes in the database group.
+ 
+---
+
+### `UseSessionContext`
+
+* **Load-balance**
+
+  * When this option is enabled, the client will calculate the target node from the session-id.  
+    The session-id is hashed from a **context string** and an optional **seed** given by the user.  
+    The context string together with the seed are referred to as **"The session context"**.
+  
+  * Per session, the client will select a node from the topology list based on this session-context.  
+    So sessions that use the **same** context will target the **same** node.
+  
+  * All **_Read & Write_** requests made on the session (i.e a query or a load request, etc.)  
+    will address this calculated node.  
+    _Read & Write_ requests that are made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))  
+    will go to the preferred node.
+
+  * All _Write_ requests will be replicated to all the other nodes in the database group as usual.
+
+* **Failover**  
+
+  * In case of a failure, the client will try to access the next node from the topology nodes list.
+
+{PANEL/}
+
+{PANEL: Initialize LoadBalanceBehavior on the client }
+
+* The `LoadBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the load balance behavior for the default database that is set on the store.
+
+* This setting can be **overriden** by setting 'LoadBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/load-balance-behavior#set-loadbalancebehavior-on-the-server).
+
+---
+
+**Initialize conventions**:
+
+{CODE:php LoadBalance_1@ClientApi\Configuration\LoadBalance\LoadBalance.php /}
+{CODE:php LoadBalance_6@ClientApi\Configuration\LoadBalance\LoadBalance.php /}
+
+---
+
+**Session usage**:
+
+{CODE:php LoadBalance_2@ClientApi\Configuration\LoadBalance\LoadBalance.php /}
+{CODE:php LoadBalance_3@ClientApi\Configuration\LoadBalance\LoadBalance.php /}
+
+{PANEL/}
+
+{PANEL: Set LoadBalanceBehavior on the server }
+
+{NOTE: }
+
+**Note**:  
+
+* Setting the load balance behavior on the server, either by an **Operation** or from the **Studio**,  
+  only 'enables the feature' and sets the seed.
+
+* For the feature to be in effect, you still need to define the context string itself:  
+  * either, per session, call the advanced `setContext` method  
+  * or, set a default document store value using `setLoadBalancerPerSessionContextSelector`  
+
+{NOTE/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - by operation:
+
+* The `LoadBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).
+
+* The operation can modify the default database only, or all databases - see examples below.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{CODE-TABS}
+{CODE-TAB:php:Operation_For_Default_Database LoadBalance_4@ClientApi\Configuration\LoadBalance\LoadBalance.php /}
+{CODE-TAB:php:Operation_For_All_Databases LoadBalance_5@ClientApi\Configuration\LoadBalance\LoadBalance.php /}
+{CODE-TABS/}
+
+---
+
+#### Set LoadBalanceBehavior on the server - from Studio:
+
+* The `LoadBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Distributing _Read & Write_ requests among the cluster nodes can be beneficial  
+  when a set of sessions handle a specific set of documents or similar data.  
+  Load balancing can be achieved by routing requests from the sessions that handle similar topics to the same node, while routing other sessions to other nodes.  
+ 
+* Another usage example can be setting the session's context to be the current user.  
+  Thus spreading the _Read & Write_ requests per user that logs into the application.  
+
+* Once setting the load balance to be per session-context,  
+  in the case when detecting that many or all sessions send requests to the same node,  
+  a further level of node randomization can be added by changing the seed.  
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Read balance behavior](../../../client-api/configuration/load-balance/read-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/configuration/load-balance/read-balance-behavior.php.markdown
@@ -1,0 +1,129 @@
+# Read balance behavior
+
+ ---
+
+{NOTE: }
+
+* When set, the `ReadBalanceBehavior` configuration will be in effect according to the   
+  conditional flow described in [Client logic for choosing a node](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).
+
+* Once configuration is in effect then:  
+  * **_Read_** requests - will be sent to the node determined by the configured option - see below.
+  * **_Write_** requests - are always sent to the preferred node.  
+    The data will then be replicated to all the other nodes in the database group. 
+  * Upon a node failure, the node to failover to is also determined by the defined option.  
+
+* In this page:
+    * [ReadBalanceBehavior options](../../../client-api/configuration/load-balance/read-balance-behavior#readbalancebehavior-options)  
+    * [Initialize ReadBalanceBehavior on the client](../../../client-api/configuration/load-balance/read-balance-behavior#initialize-readbalancebehavior-on-the-client)  
+    * [Set ReadBalanceBehavior on the server:](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server)  
+        * [By operation](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---by-operation)  
+        * [From Studio](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server---from-studio)  
+    * [When to use](../../../client-api/configuration/load-balance/read-balance-behavior#when-to-use)
+     
+{NOTE/}
+
+---
+
+{PANEL: readBalanceBehavior options }
+
+### `None` (default option)
+
+  * **Read-balance**  
+    No read balancing will occur.  
+    The client will always send _Read_ requests to the [preferred node](../../../client-api/configuration/load-balance/overview#the-preferred-node).
+  * **Failover**  
+    The client will failover nodes in the order they appear in the [topology nodes list](../../../studio/database/settings/manage-database-group#database-group-topology---actions).
+
+---
+
+### `RoundRobin`
+
+* **Read-balance**
+  * Each session opened is assigned an incremental session-id number.  
+    **Per session**, the client will select the next node from the topology list based on this internal session-id.  
+  * All _Read_ requests made on the session (i.e a query or a load request, etc.)  
+    will address the calculated node.  
+  * A _Read_ request that is made on the store (i.e. executing an [operation](../../../client-api/operations/what-are-operations))   
+    will go to the preferred node.  
+* **Failover**  
+  In case of a failure, the client will try the next node from the topology nodes list.  
+
+---
+
+### `FastestNode`
+
+  * **Read-balance**  
+    All _Read_ requests will go to the fastest node.  
+    The fastest node is determined by a [Speed Test](../../../client-api/cluster/speed-test).
+  * **Failover**  
+    In case of a failure, a speed test will be triggered again,  
+    and in the meantime the client will use the preferred node.
+
+{PANEL/}
+
+{PANEL: Initialize ReadBalanceBehavior on the client }
+
+* The `ReadBalanceBehavior` convention can be set **on the client** when initializing the Document Store.  
+  This will set the read balance behavior for the default database that is set on the store.  
+
+* This setting can be **overriden** by setting 'ReadBalanceBehavior' on the server, see [below](../../../client-api/configuration/load-balance/read-balance-behavior#set-readbalancebehavior-on-the-server).   
+
+{CODE:php ReadBalance_1@ClientApi\Configuration\LoadBalance\ReadBalance.php /}
+
+{PANEL/}
+
+{PANEL: Set ReadBalanceBehavior on the server }
+
+#### Set ReadBalanceBehavior on the server - by operation:
+
+* The `ReadBalanceBehavior` configuration can be set **on the server** by sending an [operation](../../../client-api/operations/what-are-operations).  
+
+* The operation can modify the default database only, or all databases - see examples below.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{CODE-TABS}
+{CODE-TAB:php:Operation_For_Default_Database ReadBalance_2@ClientApi\Configuration\LoadBalance\ReadBalance.php /}
+{CODE-TAB:php:Operation_For_All_Databases ReadBalance_3@ClientApi\Configuration\LoadBalance\ReadBalance.php /}
+{CODE-TABS/}
+
+#### Set ReadBalanceBehavior on the server - from Studio:
+
+* The `ReadBalanceBehavior` configuration can be set from the Studio's [Client Configuration view](../../../studio/database/settings/client-configuration-per-database).  
+  Setting it from the Studio will set this configuration directly **on the server**.  
+
+* Once configuration on the server has changed, the running client will get updated with the new settings.  
+  See [keeping client up-to-date](../../../client-api/configuration/load-balance/overview#keeping-the-client-topology-up-to-date).  
+
+{PANEL/}
+
+{PANEL: When to use }
+
+* Setting the read balance behavior is beneficial when you only care about distributing the _Read_ requests among the cluster nodes,
+  and when all _Write_ requests can go to the same node.
+
+* Using the 'FastestNode' option is beneficial when some nodes in the system are known to be faster than others,
+  thus letting the fastest node serve each read request.
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are operations](../../../client-api/operations/what-are-operations)
+
+### Configuration
+
+- [Load balancing client requests - overview](../../../client-api/configuration/load-balance/overview)
+- [Load balance behavior](../../../client-api/configuration/load-balance/load-balance-behavior)
+- [Conventions](../../../client-api/configuration/conventions)
+- [Querying](../../../client-api/configuration/querying)
+
+### Client Configuration in Studio
+
+- [Requests Configuration in Studio](../../../studio/server/client-configuration)
+- [Requests Configuration per Database](../../../studio/database/settings/client-configuration-per-database)
+- [Database-group-topology](../../../studio/database/settings/manage-database-group#database-group-topology---view)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-database.php.markdown
@@ -1,0 +1,67 @@
+# Switch Operations to a Different Database
+
+---
+
+{NOTE: }
+
+* By default, all operations work on the default database defined in the [Document Store](../../../client-api/creating-document-store).
+
+* **To operate on a different database**, use the `for_database` method.  
+  If the requested database doesn't exist on the server, an exception will be thrown.
+
+* In this page:
+    * [Common operation: `forDatabase`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#common-operation:-fordatabase)
+    * [Maintenance operation: `maintenance.for_database`](../../../client-api/operations/how-to/switch-operations-to-a-different-database#maintenance-operation:-maintenance.for_database)
+{NOTE/}
+
+---
+
+{PANEL: Common operation: `forDatabase`}
+
+* For reference, all common operations are listed [here](../../../client-api/operations/what-are-operations#common-operations).
+
+{CODE:php for_database_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.php /}
+
+---
+
+**Syntax**:
+
+{CODE:php syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.php /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **$databaseName** | `?string` | Name of the database to operate on |
+
+| Return Value | Description |
+| - | - |
+| `OperationExecutor` | New instance of Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+{PANEL: Maintenance operation: `maintenance.for_database`}
+
+* For reference, all maintenance operations are listed [here](../../../client-api/operations/what-are-operations#maintenance-operations).
+
+{CODE:php for_database_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.php /}
+
+---
+
+**Syntax**:
+
+{CODE:php syntax_2@ClientApi\Operations\HowTo\SwitchOperationsToDifferentDatabase.php /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **$databaseName** | `?string` | Name of the database to operate on |
+
+| Return Value | Description |
+| - | - |
+| `MaintenanceOperationExecutor` | New instance of Maintenance Operation Executor that is scoped to the requested database |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-node.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-node.dotnet.markdown
@@ -1,0 +1,44 @@
+# Switch Operations to a Different Node
+
+---
+
+{NOTE: }
+
+* By default, when working with multiple nodes,  
+  all client requests will access the server node that is defined by the client configuration.  
+  (Learn more in: [Load balancing client requests](../../../client-api/configuration/load-balance/overview)).
+
+* However, **server maintenance operations** can be executed on a specific node by using the `ForNode` method.  
+  (An exception is thrown if that node is not available).
+
+* In this page:
+    * [Server-maintenance operations - ForNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node#server-maintenance-operations---fornode)
+{NOTE/}
+
+---
+
+{PANEL: Server maintenance operations - ForNode}
+
+* For reference, all server maintenance operations are listed [here](../../../client-api/operations/what-are-operations#server-maintenance-operations).
+
+{CODE for_node_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentNode.cs /}
+
+**Syntax**:
+
+{CODE syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentNode.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **nodeTag** | string | The tag of the node to operate on |
+
+| Return Value | |
+| - | - |
+| `ServerOperationExecutor` | New instance of Server Operation Executor that is scoped to the requested node |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-node.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-node.js.markdown
@@ -1,0 +1,44 @@
+# Switch Operations to a Different Node
+
+---
+
+{NOTE: }
+
+* By default, when working with multiple nodes,  
+  all client requests will access the server node that is defined by the client configuration.  
+  (Learn more in: [Load balancing client requests](../../../client-api/configuration/load-balance/overview)).
+
+* However, **server maintenance operations** can be executed on a specific node by using the `forNode` method.  
+  (An exception is thrown if that node is not available).
+
+* In this page:
+    * [Server maintenance operations - forNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node#server-maintenance-operations---fornode)
+{NOTE/}
+
+---
+
+{PANEL: Server maintenance operations - forNode}
+
+* For reference, all server maintenance operations are listed [here](../../../client-api/operations/what-are-operations#server-maintenance-operations).
+
+{CODE:nodejs for_node_1@client-api\Operations\HowTo\switchOperationsToDifferentNode.js /}
+
+**Syntax**:
+
+{CODE:nodejs syntax_1@client-api\Operations\HowTo\switchOperationsToDifferentNode.js /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **nodeTag** | string | The tag of the node to operate on |
+
+| Return Value | |
+| - | - |
+| `Promise<ServerOperationExecutor>` | A promise that returns a new instance of Server Operation Executor<br>scoped to the requested node |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-node.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/how-to/switch-operations-to-a-different-node.php.markdown
@@ -1,0 +1,44 @@
+# Switch Operations to a Different Node
+
+---
+
+{NOTE: }
+
+* By default, when working with multiple nodes,  
+  all client requests will access the server node that is defined by the client configuration.  
+  (Learn more in: [Load balancing client requests](../../../client-api/configuration/load-balance/overview)).
+
+* However, **server maintenance operations** can be executed on a specific node by using the `forNode` method.  
+  (An exception is thrown if that node is not available).
+
+* In this page:
+    * [Server-maintenance operations - ForNode](../../../client-api/operations/how-to/switch-operations-to-a-different-node#server-maintenance-operations---fornode)
+{NOTE/}
+
+---
+
+{PANEL: Server maintenance operations - ForNode}
+
+* For reference, all server maintenance operations are listed [here](../../../client-api/operations/what-are-operations#server-maintenance-operations).
+
+{CODE:php for_node_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentNode.php /}
+
+**Syntax**:
+
+{CODE:php syntax_1@ClientApi\Operations\HowTo\SwitchOperationsToDifferentNode.php /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **$nodeTag** | `string` | The tag of the node to operate on |
+
+| Return Value | |
+| - | - |
+| `ServerOperationExecutor` | New instance of Server Operation Executor that is scoped to the requested node |
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+
+- [What are Operations](../../../client-api/operations/what-are-operations)

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/add-database-node.php.markdown
@@ -1,0 +1,61 @@
+# Adding a Database Node
+
+---
+
+{NOTE: }
+
+* When creating a database, you can specify the number of replicas for that database.  
+  This determines the number of database instances in the database-group.
+
+* **The number of replicas can be dynamically increased** even after the database is up and running,  
+  by adding more nodes to the database-group.  
+
+* The nodes added must already exist in the [cluster topology](../../../server/clustering/rachis/cluster-topology).
+
+* Once a new node is added to the database-group,  
+  the cluster assigns a mentor node (from the existing database-group nodes) to update the new node.
+
+* In this page:
+    * [Add database node - random](../../../client-api/operations/server-wide/add-database-node#add-database-node---random)
+    * [Add database node - specific](../../../client-api/operations/server-wide/add-database-node#add-database-node---specific)
+    * [Syntax](../../../client-api/operations/server-wide/add-database-node#syntax)  
+{NOTE/}
+
+---
+
+{PANEL: Add database node - random}
+
+* Use `AddDatabaseNodeOperation` to add another database-instance to the database-group.
+* The node added will be a random node from the existing cluster nodes.   
+
+{CODE:php add_1@ClientApi\Operations\Server\AddDatabaseNode.php /}
+
+{PANEL/}
+
+{PANEL: Add database node - specific}
+
+* You can specify the node tag to add.  
+* This node must already exist in the cluster topology.
+
+{CODE:php add_2@ClientApi\Operations\Server\AddDatabaseNode.php /}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:php syntax@ClientApi\Operations\Server\AddDatabaseNode.php /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **$databaseName** | `?string` | Name of a database for which to add the node. |
+| **$nodeTag** | `?string` | Tag of node to add.<br>Default: a random node from the existing cluster topology will be added. |
+
+| Object returned by Send operation:<br>`DatabasePutResult` | Type | Description |
+| - | - | - |
+| $name | `string` | Database name |
+| $topology | `DatabaseTopology` | The database topology |
+| $nodesAddedTo | `StringArray` | New nodes added to the cluster topology.<br>Will be 0 for this operation. |
+| $raftCommandIndex | `int` | Raft command index |
+
+{PANEL/}
+

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
@@ -105,6 +105,14 @@ The following example will compact all indexes and documents.
 | - | - | - |
 | **$compactSettings** | `?CompactSettings` | Settings for the compact operation |
 
+| `$compactSettings` | Type | Description |
+| - | - | - |
+| **$databaseName** | `?string` | Name of database to compact. Mandatory param. |
+| **$documents** | `bool` | Indicates if documents should be compacted. Optional param. |
+| **$indexes** | `?StringArray` | List of index names to compact. Optional param. |
+| **$skipOptimizeIndexes** | `bool` | `true` - Skip Lucene's index optimization while compacting<br>`false` - Lucene's index optimization will take place while compacting |
+| | | **Note**: Either **$documents** or **$indexes** (or both) must be specified |
+
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
@@ -105,7 +105,7 @@ The following example will compact all indexes and documents.
 | - | - | - |
 | **$compactSettings** | `?CompactSettings` | Settings for the compact operation |
 
-| `$compactSettings` | Type | Description |
+| `$compactSettings` class parameters | Type | Description |
 | - | - | - |
 | **$databaseName** | `?string` | Name of database to compact. Mandatory param. |
 | **$documents** | `bool` | Indicates if documents should be compacted. Optional param. |

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
@@ -10,7 +10,7 @@
 
 * **During compaction the database will be offline**.  
   The operation is a executed asynchronously as a background operation and can be waited for 
-  using `wait_for_completion`.  
+  using `waitForCompletion()`.  
 
 * The operation will **compact the database on one node**.  
   To compact all database-group nodes, the command must be sent to each node separately.  
@@ -28,8 +28,10 @@
       * [Compact documents](../../../client-api/operations/server-wide/compact-database#examples)  
       * [Compact specific indexes](../../../client-api/operations/server-wide/compact-database#compact-specific-indexes)  
       * [Compact all indexes](../../../client-api/operations/server-wide/compact-database#compact-all-indexes)  
+      * [Compact on other nodes](../../../client-api/operations/server-wide/compact-database#compact-on-other-nodes)  
   * [Compaction triggers compression](../../../client-api/operations/server-wide/compact-database#compaction-triggers-compression)  
   * [Compact from Studio](../../../client-api/operations/server-wide/compact-database#compact-from-studio)  
+  * [Syntax](../../../client-api/operations/server-wide/compact-database#syntax)  
 
 {NOTE/}
 
@@ -41,7 +43,7 @@
 
 The following example will compact only **documents** for the specified database.  
 
-{CODE:python compact_0@ClientApi\Operations\Server\Compact.py /}
+{CODE:php compact_0@ClientApi\Operations\Server\Compact.php /}
 
 ---
 
@@ -49,7 +51,7 @@ The following example will compact only **documents** for the specified database
 
 The following example will compact only specific indexes.
 
-{CODE:python compact_1@ClientApi\Operations\Server\Compact.py /}
+{CODE:php compact_1@ClientApi\Operations\Server\Compact.php /}
 
 ---
 
@@ -57,8 +59,18 @@ The following example will compact only specific indexes.
 
 The following example will compact all indexes and documents.  
 
-{CODE:python compact_2@ClientApi\Operations\Server\Compact.py /}
+{CODE:php compact_2@ClientApi\Operations\Server\Compact.php /}
 
+---
+
+#### Compact on other nodes:
+
+* By default, an operation executes on the server node that is defined by the [client configuration](../../../client-api/configuration/load-balance/overview#client-logic-for-choosing-a-node).  
+* The following example will compact the database on all [member](../../../server/clustering/rachis/cluster-topology#nodes-states-and-types) nodes from its database-group topology.  
+  `forNode` is used to execute the operation on a specific node.   
+
+{CODE:php compact_3@ClientApi\Operations\Server\Compact.php /}
+ 
 {PANEL/}
 
 {PANEL: Compaction triggers compression}
@@ -85,7 +97,15 @@ The following example will compact all indexes and documents.
 
 {PANEL/}
 
+{PANEL: Syntax}
 
+{CODE:csharp syntax@ClientApi\Operations\Server\Compact.cs /}
+
+| Parameters | Type | Description |
+| - | - | - |
+| **$compactSettings** | `?CompactSettings` | Settings for the compact operation |
+
+{PANEL/}
 
 ## Related Articles
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.php.markdown
@@ -12,6 +12,7 @@
   * [Enable/Disable database from the Client API](../../../client-api/operations/server-wide/toggle-databases-state#enable/disable-database-from-the-client-api)  
       * [Enable database](../../../client-api/operations/server-wide/toggle-databases-state#enable-database)
       * [Disable database](../../../client-api/operations/server-wide/toggle-databases-state#disable-database)
+      * [Syntax](../../../client-api/operations/server-wide/toggle-databases-state#syntax)     
   * [Disable database via the file system](../../../client-api/operations/server-wide/toggle-databases-state#disable-database-via-the-file-system)
 
 {NOTE/}
@@ -29,6 +30,19 @@
 #### Disable database: 
 
 {CODE:php disable@ClientApi\Operations\Server\ToggleDatabasesState.php /}
+
+---
+
+#### Syntax: 
+
+{CODE:python syntax_1@ClientApi\Operations\Server\ToggleDatabasesState.py /}
+
+| Parameter          | Type    | Description                                                                                      |
+|--------------------|---------|---------------------------------------------------------------------------------------|
+| **$databaseName**  | `string` / `StringArray` / `array`  | Name or list of names of database/s whose state to toggle |
+| **$disable**       | `bool`  | `true` - request to disable the database(s)<br>`talse`- request to enable the database(s) |
+
+{CODE:python syntax_2@ClientApi\Operations\Server\ToggleDatabasesState.py /}
 
 {PANEL/}
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/toggle-databases-state.php.markdown
@@ -1,0 +1,64 @@
+# Toggle Databases State Operation <br> (Enable / Disable)
+---
+
+{NOTE: }
+
+* Use `ToggleDatabasesStateOperation` to enable/disable a single database or multiple databases.
+
+* The database will be enabled/disabled on all nodes in the [database-group](../../../studio/database/settings/manage-database-group).
+
+* In this page:
+
+  * [Enable/Disable database from the Client API](../../../client-api/operations/server-wide/toggle-databases-state#enable/disable-database-from-the-client-api)  
+      * [Enable database](../../../client-api/operations/server-wide/toggle-databases-state#enable-database)
+      * [Disable database](../../../client-api/operations/server-wide/toggle-databases-state#disable-database)
+  * [Disable database via the file system](../../../client-api/operations/server-wide/toggle-databases-state#disable-database-via-the-file-system)
+
+{NOTE/}
+
+---
+
+{PANEL: Enable/Disable database from the Client API}
+
+#### Enable database:  
+
+{CODE:php enable@ClientApi\Operations\Server\ToggleDatabasesState.php /}
+
+---
+
+#### Disable database: 
+
+{CODE:php disable@ClientApi\Operations\Server\ToggleDatabasesState.php /}
+
+{PANEL/}
+
+{PANEL: Disable database via the file system}
+
+It may sometimes be useful to disable a database manually, through the file system.  
+
+* To **manually disable** a database:  
+ 
+  * Place a file named `disable.marker` in the [database directory](../../../server/storage/directory-structure).  
+  * The `disable.marker` file can be empty,  
+    and can be created by any available method, e.g. using the File Explorer, a terminal, or code.
+  
+* Attempting to use a manually disabled database will generate the following exception:  
+
+         Unable to open database: '{DatabaseName}', 
+         it has been manually disabled via the file: '{disableMarkerPath}'. 
+         To re-enable, remove the disable.marker and reload the database.
+  
+* To **enable** a manually disabled database:
+  
+  * First, remove the `disable.marker` file from the database directory. 
+  * Then, [reload the database](../../../studio/database/settings/database-settings#how-to-reload-the-database).
+
+{PANEL/}
+
+## Related Articles
+
+### Operations
+- [Database settings operations](../../../client-api/operations/maintenance/configuration/database-settings-operation)  
+
+### Studio
+- [Database-group](../../../studio/database/settings/manage-database-group)

--- a/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentNode.cs
+++ b/Documentation/5.4/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/HowTo/SwitchOperationsToDifferentNode.cs
@@ -1,0 +1,45 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+
+namespace Raven.Documentation.Samples.ClientApi.Operations.HowTo
+{
+    public class SwitchOperationsToDifferentNode
+    {
+        private interface OperationsForDatabaseSyntax
+        {
+            #region syntax_1
+            ServerOperationExecutor ForNode(string nodeTag);
+            #endregion
+        }
+
+        public void SwitchOperationToDifferentNode()
+        {
+            #region for_node_1
+            // Default node access can be defined on the store
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { "ServerURL_1", "ServerURL_2", "..." },
+                Database = "DefaultDB",
+                Conventions = new DocumentConventions
+                {
+                    // For example:
+                    // With ReadBalanceBehavior set to: 'FastestNode':
+                    // Client READ requests will address the fastest node
+                    // Client WRITE requests will address the preferred node
+                    ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+                }
+            }.Initialize();
+            
+            using (documentStore)
+            {
+                // Use 'ForNode' to override the default node configuration
+                // The Maintenance.Server operation will be executed on the specified node
+                var dbNames = documentStore.Maintenance.Server.ForNode("C")
+                    .Send(new GetDatabaseNamesOperation(0, 25));
+            }
+            #endregion
+        }
+    }
+}

--- a/Documentation/5.4/Samples/nodejs/client-api/operations/HowTo/switchOperationsToDifferentNode.js
+++ b/Documentation/5.4/Samples/nodejs/client-api/operations/HowTo/switchOperationsToDifferentNode.js
@@ -1,0 +1,32 @@
+﻿import { DocumentStore } from "ravendb";
+
+const documentStore = new DocumentStore();
+
+async function addDatabaseNode() {
+    {
+        //region for_node_1
+        // Default node access can be defined on the store        
+        const documentStore = new DocumentStore(["serverUrl_1", "serverUrl_2", "..."], "DefaultDB");
+        
+        // For example:
+        // With readBalanceBehavior set to: 'FastestNode':
+        // Client READ requests will address the fastest node
+        // Client WRITE requests will address the preferred node
+        documentStore.conventions.readBalanceBehavior = "FastestNode";
+        documentStore.initialize();
+        
+        // Use 'forNode' to override the default node configuration 
+        // Get a server operation executor for a specific node
+        const serverOpExecutor = await documentStore.maintenance.server.forNode("C");
+
+        // The maintenance.server operation will be executed on the specified node 'C'
+        const dbNames = await serverOpExecutor.send(new GetDatabaseNamesOperation(0, 25));
+        //endregion
+    }
+}
+
+{
+    //region syntax_1
+    await store.maintenance.server.forNode(nodeTag);
+    //endregion
+}

--- a/Documentation/5.4/Samples/php/ClientApi/Configuration/LoadBalance/LoadBalance.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Configuration/LoadBalance/LoadBalance.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace RavenDB\Samples\ClientApi\Configuration\LoadBalance;
+
+use RavenDB\Documents\Conventions\DocumentConventions;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Operations\Configuration\ClientConfiguration;
+use RavenDB\Documents\Operations\Configuration\PutClientConfigurationOperation;
+use RavenDB\Http\LoadBalanceBehavior;
+use RavenDB\Samples\Infrastructure\Entity\Employee;
+
+class LoadBalance
+{
+    public function loadBalanceExamples(): void
+    {
+        # region LoadBalance_1
+        // Initialize 'LoadBalanceBehavior' on the client:
+        $documentStore = new DocumentStore(["ServerURL_1", "ServerURL_2", "..."], "DefaultDB");
+
+        $conventions = new DocumentConventions();
+        // Enable the session-context feature
+        // If this is not enabled then a context string set in a session will be ignored
+        $conventions->setLoadBalanceBehavior(LoadBalanceBehavior::useSessionContext());
+
+
+        // Assign a method that sets the default context string
+        // This string will be used for sessions that do Not provide a context string
+        // A sample GetDefaultContext method is defined below
+        $conventions->setLoadBalancerPerSessionContextSelector(\Closure::fromCallable([$this, 'GetDefaultContext']));
+
+        // Set a seed
+        // The seed is 0 by default, provide any number to override
+        $conventions->setLoadBalancerContextSeed(5);
+
+        $documentStore->setConventions($conventions);
+        $documentStore->initialize();
+        # endregion
+
+        # region LoadBalance_2
+        // Open a session that will use the DEFAULT store values:
+        $session = $documentStore->openSession();
+        try {
+            // For all Read & Write requests made in this session,
+            // node to access is calculated from string & seed values defined on the store
+            $employee = $session->load(Employee::class, "employees/1-A");
+        } finally {
+            $session->close();
+        }
+        # endregion
+
+        # region LoadBalance_3
+        // Open a session that will use a UNIQUE context string:
+        $session = $documentStore->openSession();
+        try {
+            // Call SetContext, pass a unique context string for this session
+            $session->advanced()->getSessionInfo()->setContext("SomeOtherContext");
+
+            // For all Read & Write requests made in this session,
+            // node to access is calculated from the unique string & the seed defined on the store
+            $employee = $session->load(Employee::class, "employees/1-A");
+        } finally {
+            $session->close();
+        }
+        # endregion
+
+        # region LoadBalance_4
+        // Setting 'LoadBalanceBehavior' on the server by sending an operation:
+        $documentStore = new DocumentStore();
+        try {
+            // Define the client configuration to put on the server
+            $configurationToSave = new ClientConfiguration();
+            // Enable the session-context feature
+            // If this is not enabled then a context string set in a session will be ignored
+            $configurationToSave->setLoadBalanceBehavior(LoadBalanceBehavior::useSessionContext());
+
+            // Set a seed
+            // The seed is 0 by default, provide any number to override
+            $configurationToSave->setLoadBalancerContextSeed(10);
+
+            // NOTE:
+            // The session's context string is Not set on the server
+            // You still need to set it on the client:
+            //   * either as a convention on the document store
+            //   * or pass it to 'SetContext' method on the session
+
+            // Configuration will be in effect when Disabled is set to false
+            $configurationToSave->setDisabled(false);
+
+
+            // Define the put configuration operation for the DEFAULT database
+            $putConfigurationOp = new PutClientConfigurationOperation($configurationToSave);
+
+            // Execute the operation by passing it to Maintenance.Send
+            $documentStore->maintenance()->send($putConfigurationOp);
+
+            // After the operation has executed:
+            // all Read & Write requests, per session, will address the node calculated from:
+            //   * the seed set on the server &
+            //   * the session's context string set on the client
+        } finally {
+            $documentStore->close();
+        }
+        # endregion
+
+        # region LoadBalance_5
+        // Setting 'LoadBalanceBehavior' on the server by sending an operation:
+        $documentStore = new DocumentStore();
+        try {
+            // Define the client configuration to put on the server
+            $configurationToSave = new ClientConfiguration();
+            // Enable the session-context feature
+            // If this is not enabled then a context string set in a session will be ignored
+            $configurationToSave->setLoadBalanceBehavior(LoadBalanceBehavior::useSessionContext());
+
+            // Set a seed
+            // The seed is 0 by default, provide any number to override
+            $configurationToSave->setLoadBalancerContextSeed(10);
+
+            // NOTE:
+            // The session's context string is Not set on the server
+            // You still need to set it on the client:
+            //   * either as a convention on the document store
+            //   * or pass it to 'SetContext' method on the session
+
+            // Configuration will be in effect when Disabled is set to false
+            $configurationToSave->setDisabled(false);
+
+
+            // Define the put configuration operation for ALL databases
+            $putConfigurationOp = new PutServerWideClientConfigurationOperation($configurationToSave);
+
+            // Execute the operation by passing it to Maintenance.Server.Send
+            $documentStore->maintenance()->server()->send($putConfigurationOp);
+
+            // After the operation has executed:
+            // all Read & Write requests, per session, will address the node calculated from:
+            //   * the seed set on the server &
+            //   * the session's context string set on the client
+        } finally {
+            $documentStore->close();
+        }
+        # endregion
+    }
+
+    # region LoadBalance_6
+    // A customized method for getting a default context string
+    private function GetDefaultContext(string $dbName): string
+    {
+        // Method is invoked by RavenDB with the database name
+        // Use that name - or return any string of your choice
+        return "DefaultContextString";
+    }
+    # endregion
+}

--- a/Documentation/5.4/Samples/php/ClientApi/Configuration/LoadBalance/ReadBalance.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Configuration/LoadBalance/ReadBalance.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace RavenDB\Samples\ClientApi\Configuration\LoadBalance;
+
+use RavenDB\Documents\Conventions\DocumentConventions;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Operations\Configuration\ClientConfiguration;
+use RavenDB\Documents\Operations\Configuration\PutClientConfigurationOperation;
+use RavenDB\Http\ReadBalanceBehavior;
+
+class ReadBalance
+{
+    public function samples(): void
+    {
+        # region ReadBalance_1
+        // Initialize 'ReadBalanceBehavior' on the client:
+        $documentStore = new DocumentStore(["ServerURL_1", "ServerURL_2", "..."], "DefaultDB");
+
+        $conventions = new DocumentConventions();
+        // With ReadBalanceBehavior set to: 'FastestNode':
+        // Client READ requests will address the fastest node
+        // Client WRITE requests will address the preferred node
+        $conventions->setReadBalanceBehavior(ReadBalanceBehavior::fastestNode());
+
+        $documentStore->setConventions($conventions);
+        $documentStore->initialize();
+        # endregion
+
+        # region ReadBalance_2
+        // Setting 'ReadBalanceBehavior' on the server by sending an operation:
+        $documentStore = new DocumentStore();
+        try {
+            // Define the client configuration to put on the server
+            $clientConfiguration = new ClientConfiguration();
+            // Replace 'FastestNode' (from example above) with 'RoundRobin'
+            $clientConfiguration->setReadBalanceBehavior(ReadBalanceBehavior::roundRobin());
+
+            // Define the put configuration operation for the DEFAULT database
+            $putConfigurationOp = new PutClientConfigurationOperation($clientConfiguration);
+
+            // Execute the operation by passing it to Maintenance.Send
+            $documentStore->maintenance()->send($putConfigurationOp);
+
+            // After the operation has executed:
+            // All WRITE requests will continue to address the preferred node
+            // READ requests, per session, will address a different node based on the RoundRobin logic
+        } finally {
+            $documentStore->close();
+        }
+        # endregion
+
+        # region ReadBalance_3
+        // Setting 'ReadBalanceBehavior' on the server by sending an operation:
+        $documentStore = new DocumentStore();
+        try {
+            // Define the client configuration to put on the server
+            $clientConfiguration = new ClientConfiguration();
+
+            // Replace 'FastestNode' (from example above) with 'RoundRobin'
+            $clientConfiguration->setReadBalanceBehavior(ReadBalanceBehavior::roundRobin());
+
+            // Define the put configuration operation for the ALL databases
+            $putConfigurationOp = new PutServerWideClientConfigurationOperation($clientConfiguration);
+
+            // Execute the operation by passing it to Maintenance.Server.Send
+            $documentStore->maintenance()->server()->send($putConfigurationOp);
+
+            // After the operation has executed:
+            // All WRITE requests will continue to address the preferred node
+            // READ requests, per session, will address a different node based on the RoundRobin logic
+        } finally {
+            $documentStore->close();
+        }
+        # endregion
+    }
+}

--- a/Documentation/5.4/Samples/php/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Operations/HowTo/SwitchOperationsToDifferentDatabase.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace RavenDB\Samples\ClientApi\Operations\HowTo;
+
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Operations\GetStatisticsOperation;
+use RavenDB\Documents\Operations\MaintenanceOperationExecutor;
+use RavenDB\Documents\Operations\OperationExecutor;
+use RavenDB\Documents\Operations\Revisions\GetRevisionsOperation;
+use RavenDB\Samples\Infrastructure\Orders\Company;
+use RavenDB\Samples\Infrastructure\Orders\Order;
+
+class SwitchOperationsToDifferentDatabase
+{
+    public function SwitchOperationToDifferentDatabase() : void
+    {
+        # region for_database_1
+        // Define default database on the store
+        $documentStore = new DocumentStore(
+            ["yourServerURL"],
+            "DefaultDB"
+        );
+        $documentStore->initialize();
+
+        try {
+            // Use 'ForDatabase', get operation executor for another database
+            /** @var OperationExecutor $opExecutor */
+            $opExecutor = $documentStore->operations()->forDatabase("AnotherDB");
+
+            // Send the operation, e.g. 'GetRevisionsOperation' will be executed on "AnotherDB"
+            $revisionsInAnotherDB = $opExecutor->send(new GetRevisionsOperation(Order::class, "Orders/1-A"));
+
+            // Without 'ForDatabase', the operation is executed "DefaultDB"
+            $revisionsInDefaultDB = $documentStore->operations()->send(new GetRevisionsOperation(Company::class, "Company/1-A"));
+        } finally {
+            $documentStore->close();
+        }
+        # endregion
+    }
+
+    public function SwitchMaintenanceOperationToDifferentDatabase(): void
+    {
+        # region for_database_2
+        // Define default database on the store
+        $documentStore = new DocumentStore(
+            [ "yourServerURL" ],
+            "DefaultDB"
+        );
+        $documentStore->initialize();
+
+        try {
+            // Use 'ForDatabase', get maintenance operation executor for another database
+            /** @var MaintenanceOperationExecutor $opExecutor */
+            $opExecutor = $documentStore->maintenance()->forDatabase("AnotherDB");
+
+            // Send the maintenance operation, e.g. get database stats for "AnotherDB"
+            $statsForAnotherDB = $opExecutor->send(new GetStatisticsOperation());
+
+            // Without 'ForDatabase', the stats are retrieved for "DefaultDB"
+            $statsForDefaultDB = $documentStore->maintenance()->send(new GetStatisticsOperation());
+        } finally {
+            $documentStore->close();
+        }
+        # endregion
+    }
+}
+
+/*
+interface OperationsForDatabaseSyntax
+{
+    # region syntax_1
+    public function forDatabase(?string $databaseName): OperationExecutor;
+    # endregion
+}
+*/
+
+/*
+interface MaintenanceForDatabaseSyntax
+{
+    # region syntax_2
+    public function forDatabase(?string $databaseName): MaintenanceOperationExecutor;
+    # endregion
+}
+*/

--- a/Documentation/5.4/Samples/php/ClientApi/Operations/HowTo/SwitchOperationsToDifferentNode.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Operations/HowTo/SwitchOperationsToDifferentNode.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace RavenDB\Samples\ClientApi\Operations\HowTo;
+
+use RavenDB\Documents\Conventions\DocumentConventions;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Http\ReadBalanceBehavior;
+use RavenDB\ServerWide\Operations\GetDatabaseNamesOperation;
+
+class SwitchOperationsToDifferentNode
+{
+    public function samples(): void
+    {
+        # region for_node_1
+        // Default node access can be defined on the store
+        $documentStore = new DocumentStore(
+            ["ServerURL_1", "ServerURL_2", "..."],
+            "DefaultDB"
+        );
+
+        $conventions = new DocumentConventions();
+
+        // For example:
+        // With ReadBalanceBehavior set to: 'FastestNode':
+        // Client READ requests will address the fastest node
+        // Client WRITE requests will address the preferred node
+        $conventions->setReadBalanceBehavior(ReadBalanceBehavior::fastestNode());
+        $documentStore->setConventions($conventions);
+
+        $documentStore->initialize();
+
+        try {
+            // Use 'ForNode' to override the default node configuration
+            // The Maintenance.Server operation will be executed on the specified node
+            $dbNames = $documentStore->maintenance()->server()->forNode("C")
+                ->send(new GetDatabaseNamesOperation(0, 25));
+        } finally {
+            $documentStore->close();
+        }
+        # endregion
+    }
+}
+
+/*
+interface OperationsForDatabaseSyntax
+{
+    # region syntax_1
+    public function forNode(string $nodeTag): ServerOperationExecutor
+    # endregion
+}
+*/

--- a/Documentation/5.4/Samples/php/ClientApi/Operations/Server/AddDatabaseNode.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Operations/Server/AddDatabaseNode.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace RavenDB\Samples\ClientApi\Operations\Server;
+
+use RavenDB\Documents\DocumentStore;
+use RavenDB\ServerWide\Operations\AddDatabaseNodeOperation;
+use RavenDB\ServerWide\Operations\DatabasePutResult;
+
+class AddDatabaseNode
+{
+    public function samples(): void
+    {
+        $store = new DocumentStore();
+        try {
+            # region add_1
+            // Create the AddDatabaseNodeOperation
+            // Add a random node to 'Northwind' database-group
+            $addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind");
+
+            // Execute the operation by passing it to Maintenance.Server.Send
+            /** @var DatabasePutResult $result */
+            $result = $store->maintenance()->server()->send($addDatabaseNodeOp);
+
+            // Can access the new topology
+            $numberOfReplicas = count($result->getTopology()->getMembers());
+            # endregion
+        } finally {
+            $store->close();
+        }
+
+        $store = new DocumentStore();
+        try {
+            # region add_2
+            // Create the AddDatabaseNodeOperation
+            // Add node C to 'Northwind' database-group
+            $addDatabaseNodeOp = new AddDatabaseNodeOperation("Northwind", "C");
+
+            // Execute the operation by passing it to Maintenance.Server.Send
+            /** @var DatabasePutResult $result */
+            $result = $store->maintenance()->server()->send($addDatabaseNodeOp);
+            # endregion
+        } finally {
+            $store->close();
+        }
+    }
+}
+
+/*
+interface IFoo
+{
+    # region syntax
+    AddDatabaseNodeOperation(?string $databaseName, ?string $nodeTag = null)
+    # endregion
+}
+*/

--- a/Documentation/5.4/Samples/php/ClientApi/Operations/Server/Compact.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Operations/Server/Compact.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace RavenDB\Samples\ClientApi\Operations\Server;
+
+use RavenDB\Constants\PhpClient;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Operations\Indexes\GetIndexNamesOperation;
+use RavenDB\Documents\Operations\Operation;
+use RavenDB\Documents\Operations\OperationIdResult;
+use RavenDB\Documents\Operations\CompactDatabaseOperation;
+use RavenDB\ServerWide\CompactSettings;
+use RavenDB\ServerWide\DatabaseRecordWithEtag;
+use RavenDB\ServerWide\GetDatabaseRecordOperation;
+use RavenDB\Type\StringArrayResult;
+
+class Compact
+{
+    public function samples(): void
+    {
+        $documentStore = new DocumentStore();
+        try {
+            # region compact_0
+
+            // Define the compact settings
+            $settings = new CompactSettings();
+            $settings->setDatabaseName("Northwind");
+            // Set 'Documents' to true to compact all documents in database
+            // Indexes are not set and will not be compacted
+            $settings->setDocuments(true);
+
+
+            // Define the compact operation, pass the settings
+            /** @var OperationIdResult  $compactOp */
+            $compactOp = new CompactDatabaseOperation($settings);
+
+            // Execute compaction by passing the operation to Maintenance.Server.Send
+            /** @var Operation $operation */
+            $operation = $documentStore->maintenance()->server()->send($compactOp);
+
+            // Wait for operation to complete, during compaction the database is offline
+            $operation->waitForCompletion();
+            # endregion
+        } finally {
+            $documentStore->close();
+        }
+
+        $documentStore = new DocumentStore();
+        try {
+            # region compact_1
+            // Define the compact settings
+            $settings = new CompactSettings();
+
+            // Database to compact
+            $settings->setDatabaseName("Northwind");
+
+            // Setting 'Documents' to false will compact only the specified indexes
+            $settings->setDocuments(false);
+
+            // Specify which indexes to compact
+            $settings->setIndexes([ "Orders/Totals", "Orders/ByCompany" ]);
+
+            // Optimize indexes is Lucene's feature to gain disk space and efficiency
+            // Set whether to skip this optimization when compacting the indexes
+            $settings->setSkipOptimizeIndexes(false);
+
+
+            // Define the compact operation, pass the settings
+            /** @var OperationIdResult $compactOp */
+            $compactOp = new CompactDatabaseOperation($settings);
+
+            // Execute compaction by passing the operation to Maintenance.Server.Send
+            /** @var Operation $operation */
+            $operation = $documentStore->maintenance()->server()->send($compactOp);
+            // Wait for operation to complete
+            $operation->waitForCompletion();
+            # endregion
+            } finally {
+                $documentStore->close();
+            }
+
+
+        $documentStore = new DocumentStore();
+        try {
+            # region compact_2
+            // Get all indexes names in the database using the 'GetIndexNamesOperation' operation
+            // Use 'ForDatabase' if the target database is different than the default database defined on the store
+            /** @var StringArrayResult $allIndexNames */
+            $allIndexNames = $documentStore->maintenance()->forDatabase("Northwind")
+                    ->send(new GetIndexNamesOperation(0, PhpClient::INT_MAX_VALUE));
+
+            // Define the compact settings
+            $settings = new CompactSettings();
+            $settings->setDatabaseName("Northwind");    // Database to compact
+            $settings->setDocuments(true);              // Compact all documents
+            $settings->setIndexes($allIndexNames->getArrayCopy());      // All indexes will be compacted
+            $settings->setSkipOptimizeIndexes(true);    // Skip Lucene's indexes optimization
+
+            // Define the compact operation, pass the settings
+            /** @var OperationIdResult $compactOp */
+            $compactOp = new CompactDatabaseOperation($settings);
+
+            // Execute compaction by passing the operation to Maintenance.Server.Send
+            /** @var Operation $operation */
+            $operation = $documentStore->maintenance()->server()->send($compactOp);
+
+            // Wait for operation to complete
+            $operation->waitForCompletion();
+            # endregion
+        } finally {
+            $documentStore->close();
+        }
+
+        $documentStore = new DocumentStore();
+        try {
+            # region compact_3
+            // Get all member nodes in the database-group using the 'GetDatabaseRecordOperation' operation
+            /** @var DatabaseRecordWithEtag $databaseRecord */
+            $databaseRecord = $documentStore->maintenance()->server()->send(new GetDatabaseRecordOperation("Northwind"));
+
+            $allMemberNodes = $databaseRecord->getTopology()->getMembers();
+
+            // Define the compact settings as needed
+            $settings = new CompactSettings();
+
+            $settings->setDatabaseName("Northwind");
+            $settings->setDocuments(true); //Compact all documents in database
+
+            // Execute the compact operation on each member node
+            foreach ($allMemberNodes as $nodeTag) {
+                // Define the compact operation, pass the settings
+                /** @var OperationIdResult $compactOp */
+                $compactOp = new CompactDatabaseOperation($settings);
+
+                // Execute the operation on a specific node
+                // Use `ForNode` to specify the node to operate on
+                /** @var Operation $operation */
+                $operation = $documentStore->maintenance()->server()->forNode($nodeTag)->send($compactOp);
+                // Wait for operation to complete
+                $operation->waitForCompletion();
+            }
+            # endregion
+        } finally {
+            $documentStore->close();
+        }
+    }
+}
+
+/*
+interface IFoo
+{
+    # region syntax
+    CompactDatabaseOperation(?CompactSettings $compactSettings)
+    # endregion
+}
+*/

--- a/Documentation/5.4/Samples/php/ClientApi/Operations/Server/ToggleDatabasesState.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Operations/Server/ToggleDatabasesState.php
@@ -20,7 +20,7 @@ class ToggleDatabasesState
             // To enable multiple databases use:
             // $enableDatabaseOp = new ToggleDatabasesStateOperation([ "DB1", "DB2", ... ], false);
 
-            // Execute the operation by passing it to the 'send' method
+            // Execute the operation by passing it to Maintenance.Server.Send
             /** @var DisableDatabaseToggleResult $toggleResult */
             $toggleResult = $documentStore->maintenance()->server()->send($enableDatabaseOp);
             # endregion
@@ -34,7 +34,7 @@ class ToggleDatabasesState
             // To disable multiple databases use:
             // $disableDatabaseOp = new ToggleDatabasesStateOperation([ "DB1", "DB2", ... ], true);
 
-            // Execute the operation by passing it to the 'send' method
+            // Execute the operation by passing it to Maintenance.Server.Send
             /** @var DisableDatabaseToggleResult $toggleResult */
             $toggleResult = $documentStore->maintenance()->server()->send($disableDatabaseOp);
             # endregion
@@ -44,3 +44,24 @@ class ToggleDatabasesState
         }
     }
 }
+
+/*
+# region syntax_1
+ToggleDatabasesStateOperation(string|StringArray|array $databaseName, bool $disable = false);
+# endregion
+*/
+
+/*
+# region syntax_2
+// Executing the operation returns the following object:
+class DisableDatabaseToggleResult
+{
+    private bool $disabled = false;     // Is database disabled
+    private ?string $name = null;       // Name of the database
+    private bool $success = false;      // Has request succeeded
+    private ?string $reason = null;     // Reason for success or failure
+
+    // ... getters and setters
+}
+# endregion
+*/

--- a/Documentation/5.4/Samples/php/ClientApi/Operations/Server/ToggleDatabasesState.php
+++ b/Documentation/5.4/Samples/php/ClientApi/Operations/Server/ToggleDatabasesState.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace RavenDB\Samples\ClientApi\Operations\Server;
+
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Operations\DisableDatabaseToggleResult;
+use RavenDB\Documents\Operations\ToggleDatabasesStateOperation;
+
+class ToggleDatabasesState
+{
+    public function samples(): void
+    {
+        $documentStore = new DocumentStore();
+        try {
+            # region enable
+            // Define the toggle state operation
+            // specify the database name & pass 'false' to enable
+            $enableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", false);
+
+            // To enable multiple databases use:
+            // $enableDatabaseOp = new ToggleDatabasesStateOperation([ "DB1", "DB2", ... ], false);
+
+            // Execute the operation by passing it to the 'send' method
+            /** @var DisableDatabaseToggleResult $toggleResult */
+            $toggleResult = $documentStore->maintenance()->server()->send($enableDatabaseOp);
+            # endregion
+
+
+            # region disable
+            // Define the toggle state operation
+            // specify the database name(s) & pass 'true' to disable
+            $disableDatabaseOp = new ToggleDatabasesStateOperation("Northwind", true);
+
+            // To disable multiple databases use:
+            // $disableDatabaseOp = new ToggleDatabasesStateOperation([ "DB1", "DB2", ... ], true);
+
+            // Execute the operation by passing it to the 'send' method
+            /** @var DisableDatabaseToggleResult $toggleResult */
+            $toggleResult = $documentStore->maintenance()->server()->send($disableDatabaseOp);
+            # endregion
+
+        } finally {
+            $documentStore->close();
+        }
+    }
+}


### PR DESCRIPTION
Related issues:
[RDoc-3110](https://issues.hibernatingrhinos.com/issue/RDoc-3110/PHP-Client-API-Operations-Server-Wide-Add-database-node-Replace-C-samples) Client API > Operations > Server Wide > Add database node
[RDoc-3109](https://issues.hibernatingrhinos.com/issue/RDoc-3109/PHP-Client-API-Operations-Server-Wide-Compact-database-Replace-C-samples) Client API > Operations > Server Wide > Compact database
[RDoc-3108](https://issues.hibernatingrhinos.com/issue/RDoc-3108/PHP-Client-API-Operations-Server-Wide-Toggle-database-state-Replace-C-samples) Client API > Operations > Server Wide > Toggle database state
[RDoc-3107](https://issues.hibernatingrhinos.com/issue/RDoc-3107/PHP-Client-API-Operations-How-to-Switch-operation-to-diff-database-Replace-C-samples) Client API > Operations > How to > Switch operation to diff database
[RDoc-3106](https://issues.hibernatingrhinos.com/issue/RDoc-3106/PHP-Client-API-Operations-How-to-Switch-operation-to-diff-node-Replace-C-samples) Client API > Operations > How to > Switch operation to diff node
[RDoc-3105](https://issues.hibernatingrhinos.com/issue/RDoc-3105/PHP-Client-API-Configuration-Load-balancing-client-requests-Read-balance-behavior-Replace-C-samples) Client API > Configuration > Load balancing client requests > Read balance behavior
[RDoc-3104](https://issues.hibernatingrhinos.com/issue/RDoc-3104/PHP-Client-API-Configuration-Load-balancing-client-requests-Load-balance-behavior-Replace-C-samples) Client API > Configuration > Load balancing client requests > Load balance behavior