### PR TITLE
RDoc-3115 Create document store article: copy missing languages to higher versions

### DIFF
--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.java.markdown
@@ -1,0 +1,42 @@
+# Client API: How to Create a Document Store
+
+To create an instance of the `DocumentStore` you need to specify a list of URL addresses that point to RavenDB server nodes.
+
+{WARNING:Important}
+Do not open a `DocumentStore` using URL addresses that point to nodes outside your cluster.
+{WARNING/}
+
+{CODE:java document_store_creation@ClientApi\CreatingDocumentStore.java /}
+
+This will instantiate a communication channel between your application and the local RavenDB server instance.
+
+##Initialization
+
+To be able to work on the `DocumentStore`, you will have to call the `initialize` method to get the fully initialized instance of `IDocumentStore`.
+
+{NOTE:Conventions}
+
+The conventions are frozen after `DocumentStore` initialization so they need to be set before `initialize` is called.
+
+{NOTE/}
+
+##Singleton
+
+Because the document store is a heavyweight object, there should only be one instance created per application (singleton). The document store is a thread safe object and its typical
+initialization looks like the following:
+
+{CODE:java document_store_holder@ClientApi\CreatingDocumentStore.java /}
+
+{NOTE If you use more than one instance of `DocumentStore` you should dispose it after use. /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../client-api/session/what-is-a-session-and-how-does-it-work)
+
+### Document Store
+
+- [What is a Document Store](../client-api/what-is-a-document-store)
+- [Setting up Default Database](../client-api/setting-up-default-database)
+- [Setting up Authentication and Authorization](../client-api/setting-up-authentication-and-authorization)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/creating-document-store.js.markdown
@@ -1,0 +1,43 @@
+# Client API: How to Create a Document Store
+
+To create an instance of the `DocumentStore` you need to specify a list of URL addresses that point to RavenDB server nodes.
+
+{CODE:nodejs document_store_ctor@client-api\creatingDocumentStore.js /}
+
+{WARNING:Important}
+Do not open a `DocumentStore` using URL addresses that point to nodes outside your cluster.
+{WARNING/}
+
+{CODE:nodejs document_store_creation@client-api\creatingDocumentStore.js /}
+
+The above snippet is going to instantiate a communication channel between your application and the local RavenDB server instance.
+
+##Initialization
+
+A `DocumentStore` instance must be initialized before use by calling the `.initialize()` method.
+
+{NOTE:Conventions}
+
+After `DocumentStore` initialization, the conventions are frozen - modification attempts are going to result with error. Conventions need to be set *before* `.initialize()` is called.
+
+{NOTE/}
+
+##Singleton
+
+Because the document store is a heavyweight object, there should only be one instance created per application (a singleton - simple to achieve in Node.js by wrapping it in a module). Typical initialization of a document store looks as follows:
+
+{CODE:nodejs document_store_holder@client-api\creatingDocumentStore.js /}
+
+{NOTE If you use more than one instance of `DocumentStore`, you should dispose it after use by calling its `.dispose()` method. /}
+
+## Related Articles
+
+### Session
+
+- [What is a Session and How Does it Work](../client-api/session/what-is-a-session-and-how-does-it-work)
+
+### Document Store
+
+- [What is a Document Store](../client-api/what-is-a-document-store)
+- [Setting up Default Database](../client-api/setting-up-default-database)
+- [Setting up Authentication and Authorization](../client-api/setting-up-authentication-and-authorization)

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/CreatingDocumentStore.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/ClientApi/CreatingDocumentStore.java
@@ -1,0 +1,33 @@
+package net.ravendb.ClientApi;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+
+public class CreatingDocumentStore {
+    public CreatingDocumentStore() {
+        //region document_store_creation
+        try (IDocumentStore store = new DocumentStore( new String[]{ "http://localhost:8080" }, "Northwind")) {
+            store.initialize();
+
+
+        }
+        //endregion
+    }
+
+
+
+    //region document_store_holder
+    public static class DocumentStoreHolder {
+
+        private static IDocumentStore store;
+
+        static {
+            store = new DocumentStore(new String[]{ "http://localhost:8080" }, "Northwind");
+        }
+
+        public static IDocumentStore getStore() {
+            return store;
+        }
+    }
+    //endregion
+}

--- a/Documentation/6.0/Samples/nodejs/client-api/creatingDocumentStore.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/creatingDocumentStore.js
@@ -1,0 +1,23 @@
+import { DocumentStore } from "ravendb";
+
+let urls, database, authOptions;
+
+{
+    //region document_store_ctor
+    new DocumentStore(urls, [database], [authOptions]);
+    //endregion
+}
+
+{
+    //region document_store_creation
+    const store = new DocumentStore(["http://localhost:8080"], "Northwind");
+    store.initialize();
+    //endregion
+}
+
+//region document_store_holder
+// documentStoreHolder.js
+const store = new DocumentStore("http://localhost:8080", "Northwind");
+store.initialize();
+export { store as documentStore }; 
+//endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3115/Create-document-store-article-copy-missing-languages-to-higher-versions

---

In this PR, the missing files were only copied over from v5.2 to the higher version v6.0, 
No changes were made to the inner text. 

This is done since those other languages don't "bubble up" automatically when only the `*.dotnet.markdown` exists in the 'higher' folder.

A separate issue should be opened if we want to improve the inner text of those articles.