### PR TITLE
RDoc-3127 Add a link to 'What is and what is not replicated' + some fixes

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
@@ -4,30 +4,31 @@
 {NOTE: }
 
 * Schedule an **External Replication Task** to have a _live_ replica of your data in another database:  
-  * In a separate RavenDB cluster [on local machines](../../start/getting-started) or [a cloud instance](../../cloud/cloud-overview), 
-    which can be used as a failover if the source cluster is down.  
-    {INFO: }
-    The External Replication task **does _not_ create a backup** of your data and indexes.  
-    See more in [Backup -vs- Replication](../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
-    {INFO/}
+  * In a separate RavenDB cluster [on local machines](../../start/getting-started) or [a cloud instance](../../cloud/cloud-overview),  
+    which can be used as a failover if the source cluster is down.
   * In the same cluster if you want a live copy that won't be a client failover target.
 
-* "Live" means that the replica is up to date at all times. Any changes in the source database will be reflected in the replica once they occur.  
+* "Live" means that the replica is up to date at all times.  
+  Any changes in the source database will be reflected in the replica once they occur.  
 
-* This ongoing task replicates one-way - from the source to the destination.
+* This ongoing task replicates **one-way**, from the source to the destination.  
+  For additional functionality such as filtration and two-way replication consider [Hub/Sink Replication](../../server/ongoing-tasks/hub-sink-replication).  
 
-* For additional functionality such as filtration and two-way replication consider [Hub/Sink Replication](../../server/ongoing-tasks/hub-sink-replication).  
+* To replicate between two separate, secure RavenDB servers,  
+  you need to [pass a client certificate](../../server/ongoing-tasks/external-replication#step-by-step-guide) from the source server to the destination.
 
-* To replicate between two separate, secure RavenDB servers, you need to [pass a client certificate](../../server/ongoing-tasks/external-replication#step-by-step-guide) from the source server to the destination.
+* The External Replication task **does _not_ create a backup** of your data and indexes.  
+  See more in [Backup -vs- Replication](../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
 
-In this page: 
+---
 
-* [General Information about External Replication Task](../../server/ongoing-tasks/external-replication#general-information-about-external-replication-task)
-* [Code Sample](../../server/ongoing-tasks/external-replication#code-sample)
-* [Step-by-Step Guide](../../server/ongoing-tasks/external-replication#step-by-step-guide)
-* [Definition](../../server/ongoing-tasks/external-replication#definition)  
-* [Offline Behavior](../../server/ongoing-tasks/external-replication#offline-behavior)
-* [Delayed Replication](../../server/ongoing-tasks/external-replication#delayed-replication)
+* In this page:   
+  * [General Information about External Replication Task](../../server/ongoing-tasks/external-replication#general-information-about-external-replication-task)
+  * [Code Sample](../../server/ongoing-tasks/external-replication#code-sample)
+  * [Step-by-Step Guide](../../server/ongoing-tasks/external-replication#step-by-step-guide)
+  * [Definition](../../server/ongoing-tasks/external-replication#definition)  
+  * [Offline Behavior](../../server/ongoing-tasks/external-replication#offline-behavior)
+  * [Delayed Replication](../../server/ongoing-tasks/external-replication#delayed-replication)
 
 {NOTE/}
 
@@ -41,11 +42,13 @@ In this page:
    * [Counters](../../document-extensions/counters/overview)
    * [Time Series](../../document-extensions/timeseries/overview)
 
+---
+
 **What is _not_ being replicated:**  
 
   * Server and cluster level features:  
     * [Indexes](../../indexes/creating-and-deploying)  
-    * [Conflict resolver definitions](../../server/clustering/replication/replication-conflicts#conflict-resolution-script)  
+    * [Conflict resolution scripts](../../server/clustering/replication/replication-conflicts#conflict-resolution-script)  
     * [Compare-Exchange](../../client-api/operations/compare-exchange/overview)
     * [Subscriptions](../../client-api/data-subscriptions/what-are-data-subscriptions)
     * [Identities](../../server/kb/document-identifier-generation#strategy--3)  
@@ -54,17 +57,28 @@ In this page:
       * [Backup](../../studio/database/tasks/backup-task)
       * [Hub/Sink Replication](../../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview)
 
-{NOTE: Why are cluster-level features not replicated?}
-To provide for architecture that prevents conflicts between clusters, especially when ACID transactions are important, 
-RavenDB is designed so that data ownership is at the cluster level.  
-To learn more, see [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system).
-{NOTE/}
+        {NOTE: }
+          
+        **Why are cluster-level features not replicated?**  
+          
+        RavenDB is designed with a cluster-level data ownership model to prevent conflicts between clusters,  
+        especially in scenarios where ACID transactions are critical.  
+      
+        This approach ensures that certain features, such as policies, configurations, and ongoing tasks,  
+        remain specific to each cluster, avoiding potential inconsistencies.  
+      
+        To explore this concept further, refer to the [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system) blog post.
+          
+        {NOTE/}
+
+---
 
 **Conflicts:**  
 
   * Two databases that have an External Replication task defined between them will detect and resolve document 
     [conflicts](../../server/clustering/replication/replication-conflicts) according to each database's conflict resolution policy.  
-  * It is recommended to have the same [policy configuration](../../server/clustering/replication/replication-conflicts#configuring-conflict-resolution-using-the-client) on both the source and the target databases.  
+  * It is recommended to have the same [policy configuration](../../server/clustering/replication/replication-conflicts#configuring-conflict-resolution-using-the-client)
+    on both the source and the target databases.  
 
 {PANEL/}
 

--- a/Documentation/5.2/Raven.Documentation.Pages/studio/database/tasks/ongoing-tasks/ravendb-etl-task.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/studio/database/tasks/ongoing-tasks/ravendb-etl-task.markdown
@@ -22,7 +22,7 @@
   * [Passing Certificate Between Secure Clusters](../../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task#passing-certificate-between-secure-clusters)  
   * [RavenDB ETL Task - Details in Tasks List View](../../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task#ravendb-etl-task---details-in-tasks-list-view)  
   * [RavenDB ETL Task - Offline Behaviour](../../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task#ravendb-etl-task---offline-behaviour)  
-  * [RavenDB ETL Task -vs- Replication Task](../../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task#ravendb-etl-task--vs--replication-task)  
+  * [RavenDB ETL Task -vs- External Replication Task](../../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task#ravendb-etl-task--vs--external-replication-task)  
 {NOTE/}
 
 ---
@@ -121,32 +121,37 @@
     then when the destination node is down, RavenDB ETL will simply start transferring data to one of the other nodes specified.  
 {PANEL/}
 
-{PANEL: RavenDB ETL Task -vs- Replication Task}
+{PANEL: RavenDB ETL Task -vs- External Replication Task}
 
 1. **Data ownership**:  
 
     * When a RavenDB node performs an **ETL** to another node it is _not_ replicating the data, it is _writing_ it.  
-      In other words, we always _overwrite_ whatever exists on the other side, there is no [conflict handling](../../../../studio/database/settings/conflict-resolution).  
+      In other words, we always _overwrite_ whatever exists on the destination database, and there is no [conflict handling](../../../../studio/database/settings/conflict-resolution).  
 
     * The source database for the ETL process is the owner of the data.  
-      This means that [as long as the destination collection is the same as the source](../../../../server/ongoing-tasks/etl/raven#deletions), 
-      any modifications done to the data sent by ETL on the destination database side are lost when overwriting occurs.  
+      This means that [as long as the destination collection is the same as the source](../../../../server/ongoing-tasks/etl/raven#deletions),  
+      any modifications made to the data sent by ETL on the destination database are lost when overwriting occurs.  
+      **If you modify a document loaded by ETL, your modifications will be lost** when the ETL process deletes and loads the updated document into the destination database.
 
-    * If you need to modify the data that's transferred to the destination side, 
+    * If you need to modify the data that's transferred to the destination database,  
       you should create a companion document in the destination database instead of modifying the data sent directly.  
-      **If you modify a document that is loaded by ETL, your modifications will be lost** when the ETL process deletes and loads the updated document in the destination server.  
       The rule is:  With ETL destination documents, you can look but don't touch.  
 
-    * On the other hand, data that is replicated with RavenDB's [External Replication Task](../../../../studio/database/tasks/ongoing-tasks/external-replication-task) does _not_ overwrite existing documents.  
+    * **On the other hand**, data that is replicated with RavenDB's [External Replication Task](../../../../studio/database/tasks/ongoing-tasks/external-replication-task) does _not_ overwrite existing documents.
       Conflicts are created and handled according to the destination database policy defined.  
-      This means that you _can_ change the replicated data on the destination database and conflicts will be solved.  
+      This means that with an External Replication Task you _can_ change the replicated data on the destination database and conflicts will be solved.  
 
-2. **Data content**:  
+2. **Data content**:
 
-    * With the replication Task, _all_ documents contained in the database are replicated to the destination database _without_ any content modification.  
+    * In **ETL**, the document content sent can be filtered and modified using the supplied transformation script. 
+      Additionally, partial data can be sent by selecting specific collections.
 
-    * Whereas in ETL, the document content sent can be filtered and modified with the supplied transformation script.  
-      In addition, partial data can be sent as specific collections can be selected.  
+    * In contrast, with the **External Replication Task**, _all_ documents in the database, along with their related data,  
+      are replicated to the destination database _without_ any content modification.
+      
+    * Refer to section [what is being replicated](../../../../server/ongoing-tasks/external-replication#general-information-about-external-replication-task) 
+      for exact details on what is and isn’t replicated in the External Replication Task.
+
 {PANEL/}
 
 ## Related Articles

--- a/Documentation/5.3/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
+++ b/Documentation/5.3/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
@@ -3,31 +3,32 @@
 
 {NOTE: }
 
-* Schedule an **External Replication Task** to have a _live_ replica of your data in another database:  
-  * In a separate RavenDB cluster [on local machines](../../start/getting-started) or [a cloud instance](../../cloud/cloud-overview), 
-    which can be used as a failover if the source cluster is down.  
-    {INFO: }
-    The External Replication task **does _not_ create a backup** of your data and indexes.  
-    See more in [Backup -vs- Replication](../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
-    {INFO/}
-  * In the same cluster if you want a live copy that won't be a client failover target.
+* Schedule an **External Replication Task** to have a _live_ replica of your data in another database:
+    * In a separate RavenDB cluster [on local machines](../../start/getting-started) or [a cloud instance](../../cloud/cloud-overview),  
+      which can be used as a failover if the source cluster is down.
+    * In the same cluster if you want a live copy that won't be a client failover target.
 
-* "Live" means that the replica is up to date at all times. Any changes in the source database will be reflected in the replica once they occur.  
+* "Live" means that the replica is up to date at all times.  
+  Any changes in the source database will be reflected in the replica once they occur.
 
-* This ongoing task replicates one-way - from the source to the destination.
+* This ongoing task replicates **one-way**, from the source to the destination.  
+  For additional functionality such as filtration and two-way replication consider [Hub/Sink Replication](../../server/ongoing-tasks/hub-sink-replication).
 
-* For additional functionality such as filtration and two-way replication consider [Hub/Sink Replication](../../server/ongoing-tasks/hub-sink-replication).  
+* To replicate between two separate, secure RavenDB servers,  
+  you need to [pass a client certificate](../../server/ongoing-tasks/external-replication#step-by-step-guide) from the source server to the destination.
 
-* To replicate between two separate, secure RavenDB servers, you need to [pass a client certificate](../../server/ongoing-tasks/external-replication#step-by-step-guide) from the source server to the destination.
+* The External Replication task **does _not_ create a backup** of your data and indexes.  
+  See more in [Backup -vs- Replication](../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
 
-In this page: 
+---
 
-* [General Information about External Replication Task](../../server/ongoing-tasks/external-replication#general-information-about-external-replication-task)
-* [Code Sample](../../server/ongoing-tasks/external-replication#code-sample)
-* [Step-by-Step Guide](../../server/ongoing-tasks/external-replication#step-by-step-guide)
-* [Definition](../../server/ongoing-tasks/external-replication#definition)  
-* [Offline Behavior](../../server/ongoing-tasks/external-replication#offline-behavior)
-* [Delayed Replication](../../server/ongoing-tasks/external-replication#delayed-replication)
+* In this page: 
+  * [General Information about External Replication Task](../../server/ongoing-tasks/external-replication#general-information-about-external-replication-task)
+  * [Code Sample](../../server/ongoing-tasks/external-replication#code-sample)
+  * [Step-by-Step Guide](../../server/ongoing-tasks/external-replication#step-by-step-guide)
+  * [Definition](../../server/ongoing-tasks/external-replication#definition)  
+  * [Offline Behavior](../../server/ongoing-tasks/external-replication#offline-behavior)
+  * [Delayed Replication](../../server/ongoing-tasks/external-replication#delayed-replication)
 
 {NOTE/}
 
@@ -41,11 +42,13 @@ In this page:
    * [Counters](../../document-extensions/counters/overview)
    * [Time Series](../../document-extensions/timeseries/overview)
 
+---
+
 **What is _not_ being replicated:**  
 
   * Server and cluster level features:  
     * [Indexes](../../indexes/creating-and-deploying)  
-    * [Conflict resolver definitions](../../server/clustering/replication/replication-conflicts#conflict-resolution-script)  
+    * [Conflict resolution scripts](../../server/clustering/replication/replication-conflicts#conflict-resolution-script)  
     * [Compare-Exchange](../../client-api/operations/compare-exchange/overview)
     * [Subscriptions](../../client-api/data-subscriptions/what-are-data-subscriptions)
     * [Identities](../../server/kb/document-identifier-generation#strategy--3)  
@@ -54,17 +57,28 @@ In this page:
       * [Backup](../../studio/database/tasks/backup-task)
       * [Hub/Sink Replication](../../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview)
 
-{NOTE: Why are cluster-level features not replicated?}
-To provide for architecture that prevents conflicts between clusters, especially when ACID transactions are important, 
-RavenDB is designed so that data ownership is at the cluster level.  
-To learn more, see [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system).
-{NOTE/}
+        {NOTE: }
+
+        **Why are cluster-level features not replicated?**
+
+        RavenDB is designed with a cluster-level data ownership model to prevent conflicts between clusters,  
+        especially in scenarios where ACID transactions are critical.
+
+        This approach ensures that certain features, such as policies, configurations, and ongoing tasks,  
+        remain specific to each cluster, avoiding potential inconsistencies.
+
+        To explore this concept further, refer to the [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system) blog post.
+
+        {NOTE/}
+
+---
 
 **Conflicts:**  
 
   * Two databases that have an External Replication task defined between them will detect and resolve document 
     [conflicts](../../server/clustering/replication/replication-conflicts) according to each database's conflict resolution policy.  
-  * It is recommended to have the same [policy configuration](../../server/clustering/replication/replication-conflicts#configuring-conflict-resolution-using-the-client) on both the source and the target databases.  
+  * It is recommended to have the same [policy configuration](../../server/clustering/replication/replication-conflicts#configuring-conflict-resolution-using-the-client) 
+    on both the source and the target databases.  
 
 {PANEL/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/ongoing-tasks/external-replication.markdown
@@ -3,77 +3,89 @@
 
 {NOTE: }
 
-* Schedule an **External Replication Task** to have a _live_ replica of your data in another database:  
-  * In a separate RavenDB cluster [on local machines](../../start/getting-started) or [a cloud instance](../../cloud/cloud-overview), 
-    which can be used as a failover if the source cluster is down.  
-    {INFO: }
-    The External Replication task **does _not_ create a backup** of your data and indexes.  
-    See more in [Backup -vs- Replication](../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
-    {INFO/}
-  * In the same cluster if you want a live copy that won't be a client failover target.
+* Schedule an **External Replication Task** to have a _live_ replica of your data in another database:
+    * In a separate RavenDB cluster [on local machines](../../start/getting-started) or [a cloud instance](../../cloud/cloud-overview),  
+      which can be used as a failover if the source cluster is down.
+    * In the same cluster if you want a live copy that won't be a client failover target.
 
-* "Live" means that the replica is up to date at all times. Any changes in the source database will be reflected in the replica once they occur.  
+* "Live" means that the replica is up to date at all times.  
+  Any changes in the source database will be reflected in the replica once they occur.
 
-* This ongoing task replicates one-way - from the source to the destination.
+* This ongoing task replicates **one-way**, from the source to the destination.  
+  For additional functionality such as filtration and two-way replication consider [Hub/Sink Replication](../../server/ongoing-tasks/hub-sink-replication).
 
-* For additional functionality such as filtration and two-way replication consider [Hub/Sink Replication](../../server/ongoing-tasks/hub-sink-replication).  
+* To replicate between two separate, secure RavenDB servers,  
+  you need to [pass a client certificate](../../server/ongoing-tasks/external-replication#step-by-step-guide) from the source server to the destination.
 
-* To replicate between two separate, secure RavenDB servers, you need to [pass a client certificate](../../server/ongoing-tasks/external-replication#step-by-step-guide) from the source server to the destination.
+* The External Replication task **does _not_ create a backup** of your data and indexes.  
+  See more in [Backup -vs- Replication](../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
 
-In this page: 
+---
 
-* [General Information about External Replication Task](../../server/ongoing-tasks/external-replication#general-information-about-external-replication-task)
-* [Code Sample](../../server/ongoing-tasks/external-replication#code-sample)
-* [Step-by-Step Guide](../../server/ongoing-tasks/external-replication#step-by-step-guide)
-* [Definition](../../server/ongoing-tasks/external-replication#definition)  
-* [Offline Behavior](../../server/ongoing-tasks/external-replication#offline-behavior)
-* [Delayed Replication](../../server/ongoing-tasks/external-replication#delayed-replication)
+* In this page: 
+  * [General Information about External Replication Task](../../server/ongoing-tasks/external-replication#general-information-about-external-replication-task)
+  * [Code Sample](../../server/ongoing-tasks/external-replication#code-sample)
+  * [Step-by-Step Guide](../../server/ongoing-tasks/external-replication#step-by-step-guide)
+  * [Definition](../../server/ongoing-tasks/external-replication#definition)  
+  * [Offline Behavior](../../server/ongoing-tasks/external-replication#offline-behavior)
+  * [Delayed Replication](../../server/ongoing-tasks/external-replication#delayed-replication)
 
 {NOTE/}
 
 {PANEL: General Information about External Replication Task}
 
-## What IS being replicated
+**What is being replicated:**
 
-All database documents and related data:  
+* All database documents and related data:
+    * [Attachments](../../document-extensions/attachments/what-are-attachments)
+    * [Revisions](../../document-extensions/revisions/overview)
+    * [Counters](../../document-extensions/counters/overview)
+    * [Time Series](../../document-extensions/timeseries/overview)
 
-* [Attachments](../../document-extensions/attachments/what-are-attachments)  
-* [Revisions](../../document-extensions/revisions/overview)  
-* [Counters](../../document-extensions/counters/overview)  
-* [Time Series](../../document-extensions/timeseries/overview)  
+---
 
-##  What is NOT being replicated
+**What is _not_ being replicated:**
 
-Server and cluster level features:  
+* Server and cluster level features:
+    * [Indexes](../../indexes/creating-and-deploying)
+    * [Conflict resolution scripts](../../server/clustering/replication/replication-conflicts#conflict-resolution-script)
+    * [Compare-Exchange](../../client-api/operations/compare-exchange/overview)
+    * [Subscriptions](../../client-api/data-subscriptions/what-are-data-subscriptions)
+    * [Identities](../../server/kb/document-identifier-generation#strategy--3)
+    * Ongoing tasks
+        * [ETL](../../server/ongoing-tasks/etl/basics)
+        * [Backup](../../studio/database/tasks/backup-task)
+        * [Hub/Sink Replication](../../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview)
 
-* [Indexes](../../indexes/creating-and-deploying)  
-* [Conflict resolver definitions](../../server/clustering/replication/replication-conflicts#conflict-resolution-script)  
-* [Compare-Exchange](../../client-api/operations/compare-exchange/overview)
-* [Subscriptions](../../client-api/data-subscriptions/what-are-data-subscriptions)
-* [Identities](../../server/kb/document-identifier-generation#strategy--3)  
-* Ongoing tasks
-   * [ETL](../../server/ongoing-tasks/etl/basics)
-   * [Backup](../../studio/database/tasks/backup-task)
-   * [Hub/Sink Replication](../../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview)
+          {NOTE: }
 
-## Why are Cluster-Level Features Not Replicated?
+          **Why are cluster-level features not replicated?**
 
-To provide for architecture that prevents conflicts between clusters, 
-especially when ACID transactions are important, RavenDB is designed 
-so that data ownership is at the cluster level.  
-To learn more, see [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system).  
+          RavenDB is designed with a cluster-level data ownership model to prevent conflicts between clusters,  
+          especially in scenarios where ACID transactions are critical.
 
-## Conflicts
+          This approach ensures that certain features, such as policies, configurations, and ongoing tasks,  
+          remain specific to each cluster, avoiding potential inconsistencies.
 
-* Two databases that have an External Replication task defined between them will detect and resolve document 
-  [conflicts](../../server/clustering/replication/replication-conflicts) according to each database's conflict resolution policy.  
-* It is recommended to have the same [policy configuration](../../server/clustering/replication/replication-conflicts#configuring-conflict-resolution-using-the-client) 
-  on both the source and the target databases.  
+          To explore this concept further, refer to the [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system) blog post.
 
-## Sharding Support
+          {NOTE/}
+
+---
+
+**Conflicts:**
+
+* Two databases that have an External Replication task defined between them will detect and resolve document
+  [conflicts](../../server/clustering/replication/replication-conflicts) according to each database's conflict resolution policy.
+* It is recommended to have the same [policy configuration](../../server/clustering/replication/replication-conflicts#configuring-conflict-resolution-using-the-client)
+  on both the source and the target databases.
+
+---
+
+**Sharding Support:**
 
 External replication is supported by both [sharded](../../sharding/overview) and non-sharded databases.  
-Learn more about the way ETL works on a sharded database [here](../../sharding/external-replication).  
+Learn more about the way ETL works on a sharded database [here](../../sharding/external-replication).
 
 {PANEL/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/studio/database/tasks/ongoing-tasks/external-replication-task.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/studio/database/tasks/ongoing-tasks/external-replication-task.markdown
@@ -5,25 +5,23 @@
 
 * Schedule an **External Replication Task** in order to have a _live_ replica of your data in another database:  
   * In the same cluster if you want a live copy that won't be a client failover target.
-  * In a separate RavenDB cluster [on local machines](../../../../start/getting-started) or [a cloud instance](../../../../cloud/cloud-overview), 
-    which can be used as a failover if the source cluster is down.  
-     * Note: External Replication task does _not_ create a backup of your data and indexes.  
-       See more in [Backup -vs- Replication](../../../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
+  * In a separate RavenDB cluster [on local machines](../../../../start/getting-started) or [a cloud instance](../../../../cloud/cloud-overview),  
+    which can be used as a failover if the source cluster is down.
 
-* "Live" means that the replica is up to date at all times. Any changes in the source database will be reflected in the replica once they occur.  
+* "Live" means that the replica is up to date at all times.  
+  Any changes in the source database will be reflected in the replica once they occur.  
 
-* This ongoing task replicates one-way - from the source to the destination.
+* This ongoing task replicates **one-way**, from the source to the destination. For additional functionality,  
+  such as filtration and two-way (master-master) replication, consider [Hub/Sink Replication](../../../../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview).  
 
-* For additional functionality, such as filtration and two-way (master-master) replication,  
-  consider [Hub/Sink Replication](../../../../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview).  
+* To replicate between two separate, secure RavenDB servers,  
+  you need to [pass a client certificate](../../../../studio/database/tasks/ongoing-tasks/external-replication-task#step-by-step-guide) from the source server to the destination.
 
-* To replicate between two separate, secure RavenDB servers, you need to [pass a client certificate](../../../../studio/database/tasks/ongoing-tasks/external-replication-task#step-by-step-guide) from the source server to the destination.
+* External replication can be a comfortable means of data migration into a [sharded](../../../../sharding/overview) database.  
+  You can read more about this option in the sharding documentation [external replication](../../../../sharding/external-replication) and [migration](../../../../sharding/migration) sections.  
 
-* External replication can be a comfortable means of data migration 
-  into a [sharded](../../../../sharding/overview) database.  
-  You can read more about this option in the sharding documentation 
-  [external replication](../../../../sharding/external-replication) 
-  and [migration](../../../../sharding/migration) sections.  
+* The External Replication task **does _not_ create a backup** of your data and indexes.  
+  See more in [Backup -vs- Replication](../../studio/database/tasks/backup-task#backup-task--vs--replication-task)
 
 * In this page:  
   * [General Information about External Replication Task](../../../../studio/database/tasks/ongoing-tasks/external-replication-task#general-information-about-external-replication-task)
@@ -46,6 +44,8 @@
     * [Counters](../../../../document-extensions/counters/overview)
     * [Time Series](../../../../document-extensions/timeseries/overview)
 
+---
+
 **What is _not_ being replicated:**  
 
   * Server and cluster level features:  
@@ -59,13 +59,21 @@
       * [Backup](../../../../studio/database/tasks/backup-task)
       * [Hub/Sink Replication](../../../../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview)
 
-{NOTE: Why are some cluster-level features not replicated?}
-To provide for architecture that prevents conflicts between clusters, especially when ACID transactions are important, 
-RavenDB is designed so that data ownership is at the cluster level.  
-To learn more, see [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system).
+        {NOTE: }
 
-It is also best to ensure that each cluster defines policies, configurations, and ongoing tasks that are relevant to it.  
-{NOTE/}
+        **Why are cluster-level features not replicated?**
+
+        RavenDB is designed with a cluster-level data ownership model to prevent conflicts between clusters,  
+        especially in scenarios where ACID transactions are critical.
+
+        This approach ensures that certain features, such as policies, configurations, and ongoing tasks,  
+        remain specific to each cluster, avoiding potential inconsistencies.
+
+        To explore this concept further, refer to the [Data Ownership in a Distributed System](https://ayende.com/blog/196769-B/data-ownership-in-a-distributed-system) blog post.
+
+        {NOTE/}
+
+---
 
 **Conflicts:**  
 


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3127/Add-a-link-to-What-is-and-what-is-not-replicated

* The missing link was added in file:
   `Documentation/5.2/Raven.Documentation.Pages/studio/database/tasks/ongoing-tasks/ravendb-etl-task.markdown`

* Some text improvements were added in related files
