### PR TITLE
RDoc-3155 Remove Transaction Modes

### DIFF
--- a/Documentation/4.0/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/storage/.docs.json
@@ -1,31 +1,37 @@
 [
-  {
-    "Path": "storage-engine.markdown",
-    "Name": "Storage Engine",
-    "DiscussionId": "fc350b7c-f161-4259-b186-51ce1bbadbcb",
-    "Mappings": [
-      {
-        "Version": 3.0,
-        "Key": "server/configuration/storage-engines"
-      }
-    ]
-  },
-  {
-    "Path": "directory-structure.markdown",
-    "Name": "Directory Structure",
-    "DiscussionId": "50785e1e-435a-42e2-8e6f-43ad2bda686c",
-    "Mappings": []
-  },
-  {
-    "Path": "customizing-raven-data-files-locations.markdown",
-    "Name": "Customizing Data Files Locations",
-    "DiscussionId": "6f4d2198-4a11-42d0-8629-43ffb5251332",
-    "Mappings": []
-  },
-  {
-    "Path": "transaction-mode.markdown",
-    "Name": "Transaction Mode",
-    "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
-    "Mappings": []
-  }
+    {
+        "Path": "storage-engine.markdown",
+        "Name": "Storage Engine",
+        "DiscussionId": "fc350b7c-f161-4259-b186-51ce1bbadbcb",
+        "Mappings": [
+            {
+                "Version": 3.0,
+                "Key": "server/configuration/storage-engines"
+            }
+        ]
+    },
+    {
+        "Path": "directory-structure.markdown",
+        "Name": "Directory Structure",
+        "DiscussionId": "50785e1e-435a-42e2-8e6f-43ad2bda686c",
+        "Mappings": []
+    },
+    {
+        "Path": "customizing-raven-data-files-locations.markdown",
+        "Name": "Customizing Data Files Locations",
+        "DiscussionId": "6f4d2198-4a11-42d0-8629-43ffb5251332",
+        "Mappings": []
+    },
+    {
+        "Path": "transaction-mode.markdown",
+        "Name": "Transaction Mode",
+        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
+        "Mappings": [
+            {
+                "Version": 6.0,
+                "Key": "server/storage/storage-engine"
+            }
+        ],
+        "LastSupportedVersion": "5.4"
+    }
 ]

--- a/Documentation/4.0/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
@@ -88,7 +88,6 @@ ln -s ~/RavenDB/Server/RavenData/Databases/Northwind/Indexes /mnt/FastDrive/Data
 
 - [Directory Structure](directory-structure)
 - [Storage Engine](../../server/storage/storage-engine)
-- [Transaction Mode](../../server/storage/transaction-mode)
 
 ### Installation
 

--- a/Documentation/4.0/Raven.Documentation.Pages/server/storage/directory-structure.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/storage/directory-structure.markdown
@@ -101,4 +101,3 @@ __Raven.voron file__
 
 - [Customize Data Location](../../server/storage/customizing-raven-data-files-locations)
 - [Storage Engine](../../server/storage/storage-engine)
-- [Transaction Mode](../../server/storage/transaction-mode)

--- a/Documentation/4.0/Raven.Documentation.Pages/server/storage/storage-engine.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/storage/storage-engine.markdown
@@ -63,7 +63,6 @@ The storage hardware / file system must support:
 ### Storage
 
 - [Directory Structure](../../server/storage/directory-structure)
-- [Transaction Mode](../../server/storage/transaction-mode)
 
 ### Configuration
 

--- a/Documentation/4.0/Raven.Documentation.Pages/server/storage/transaction-mode.markdown
+++ b/Documentation/4.0/Raven.Documentation.Pages/server/storage/transaction-mode.markdown
@@ -1,6 +1,14 @@
 # Storage: Transaction Mode
+---
 
-Voron storage engine can work in one of the following transactions modes: _Safe_, _Lazy_ or _Danger_.
+{NOTE: }
+
+* The Voron storage engine can operate in one of the following transaction modes: _Safe_, _Lazy_, or _Danger_.
+
+* The _Lazy_ and _Danger_ modes are available only up to RavenDB **5.4**.  
+  Starting from version **6.0**, Voron will work in the default _Safe_ mode only.
+
+{NOTE/}
 
 ## Safe
 

--- a/Documentation/4.1/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/4.1/Raven.Documentation.Pages/server/storage/.docs.json
@@ -21,5 +21,11 @@
         "Name": "Customizing Data Files Locations",
         "DiscussionId": "6f4d2198-4a11-42d0-8629-43ffb5251332",
         "Mappings": []
+    },
+    {
+        "Path": "transaction-mode.markdown",
+        "Name": "Transaction Mode",
+        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
+        "Mappings": []
     }
 ]

--- a/Documentation/4.1/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
+++ b/Documentation/4.1/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
@@ -230,7 +230,6 @@ Add the script to the _settings.json_ file as follows:
 
 - [Directory Structure](directory-structure)
 - [Storage Engine](../../server/storage/storage-engine)
-- [Transaction Mode](../../server/storage/transaction-mode)
 
 ### Installation
 

--- a/Documentation/4.2/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/4.2/Raven.Documentation.Pages/server/storage/.docs.json
@@ -21,5 +21,11 @@
         "Name": "Customizing Data Files Locations",
         "DiscussionId": "6f4d2198-4a11-42d0-8629-43ffb5251332",
         "Mappings": []
+    },
+    {
+        "Path": "transaction-mode.markdown",
+        "Name": "Transaction Mode",
+        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
+        "Mappings": []
     }
 ]

--- a/Documentation/5.0/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/5.0/Raven.Documentation.Pages/server/storage/.docs.json
@@ -27,5 +27,11 @@
         "Name": "Documents Compression",
         "DiscussionId": "ba60259c-2f0f-4bac-a99d-e5c136612311",
         "Mappings": []
+    },
+    {
+        "Path": "transaction-mode.markdown",
+        "Name": "Transaction Mode",
+        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
+        "Mappings": []
     }
 ]

--- a/Documentation/5.1/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/5.1/Raven.Documentation.Pages/server/storage/.docs.json
@@ -21,5 +21,17 @@
         "Name": "Customizing Data Files Locations",
         "DiscussionId": "6f4d2198-4a11-42d0-8629-43ffb5251332",
         "Mappings": []
+    },
+    {
+        "Path": "documents-compression.markdown",
+        "Name": "Documents Compression",
+        "DiscussionId": "ba60259c-2f0f-4bac-a99d-e5c136612311",
+        "Mappings": []
+    },
+    {
+        "Path": "transaction-mode.markdown",
+        "Name": "Transaction Mode",
+        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
+        "Mappings": []
     }
 ]

--- a/Documentation/5.2/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/server/storage/.docs.json
@@ -27,5 +27,11 @@
         "Name": "Documents Compression",
         "DiscussionId": "ba60259c-2f0f-4bac-a99d-e5c136612311",
         "Mappings": []
+    },
+    {
+        "Path": "transaction-mode.markdown",
+        "Name": "Transaction Mode",
+        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
+        "Mappings": []
     }
 ]

--- a/Documentation/5.4/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/storage/.docs.json
@@ -23,15 +23,15 @@
         "Mappings": []
     },
     {
-        "Path": "transaction-mode.markdown",
-        "Name": "Transaction Mode",
-        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
-        "Mappings": []
-    },
-    {
         "Path": "documents-compression.markdown",
         "Name": "Documents Compression",
         "DiscussionId": "ba60259c-2f0f-4bac-a99d-e5c136612311",
+        "Mappings": []
+    },
+    {
+        "Path": "transaction-mode.markdown",
+        "Name": "Transaction Mode",
+        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
         "Mappings": []
     }
 ]

--- a/Documentation/5.4/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/server/storage/customizing-raven-data-files-locations.markdown
@@ -249,7 +249,6 @@ Add the script to the _settings.json_ file as follows:
 
 - [Directory Structure](directory-structure)
 - [Storage Engine](../../server/storage/storage-engine)
-- [Transaction Mode](../../server/storage/transaction-mode)
 
 ### Installation
 

--- a/Documentation/6.0/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown
@@ -1,0 +1,159 @@
+# Configuration: Storage Options
+
+The following configuration options allow you configure [the storage engine](../../server/storage/storage-engine).
+
+{PANEL:Storage.TempPath}
+
+* Use this configuration option to customize the path for the temporary files of the following [directories](../../server/storage/directory-structure):
+  * `System`
+  * `Configuration` 
+  * `Databases/{database_name}`
+
+* By default, the temporary files are created under the `Temp` folder in those directories.
+
+* When the `Storage.TempPath` is configured:  
+
+  * The System temporary files will be written to `"<Storage.TempPath>/System"`.  
+  * The Databases temporary files will be written to `"<Storage.TempPath>/Databases/{database-name}"`.  
+  * The Configuration temporary files will be written to `"<Storage.TempPath>/Databases/{database-name}/Configuration"`.  
+
+* To specify a different path for the indexes temporary files go to [Indexing.TempPath](../../server/configuration/indexing-configuration#indexing.temppath).  
+
+* Learn more about RavenDB directory structure [here](../../server/storage/directory-structure).  
+
+---
+
+- **Type**: `string`
+- **Default**: `null`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.MaxConcurrentFlushes}
+
+Maximum concurrent flushes.
+
+- **Type**: `int`
+- **Default**: `10`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.TimeToSyncAfterFlushInSec}
+
+Time to sync after flush in seconds
+
+- **Type**: `int`
+- **Default**: `30`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.NumberOfConcurrentSyncsPerPhysicalDrive}
+
+Number of concurrent syncs per physical drive.
+
+- **Type**: `int`
+- **Default**: `3`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.CompressTxAboveSizeInKb}
+
+Compress transactions above size (value in KB)
+
+- **Type**: `int`
+- **Default**: `512`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.ForceUsing32BitsPager}
+
+Use the 32 bits memory mapped pager even when running on 64 bits.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+{PANEL:Storage.MaxScratchBufferSizeInMb}
+
+Maximum size of `.buffers` files
+
+- **Type**: `int`
+- **Default**: `256` when running on 64 bits, `32` when running on 32 bits or `Storage.ForceUsing32BitsPager` is set to `true`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+
+{PANEL:Storage.PrefetchBatchSizeInKb}
+
+Size of the batch in kilobytes that will be requested to the OS from disk when prefetching (value in powers of 2). Some OSs may not honor certain values. Experts only.
+
+- **Type**: `int`
+- **Default**: `1024`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.PrefetchResetThresholdInGb}
+
+How many gigabytes of memory should be prefetched before restarting the prefetch tracker table. Experts only.
+
+- **Type**: `int`
+- **Default**: `8`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.OnDirectoryInitialize.Exec}
+
+A command or executable to run when creating/opening a directory (storage environment). Experts only.  
+RavenDB will execute:  
+{CODE-BLOCK:plain}
+command [user-arg-1] ... [user-arg-n] <environment-type> <database-name> <data-dir-path> <temp-dir-path> <journal-dir-path>  
+{CODE-BLOCK/}
+
+- **Type**: `string`
+- **Default**: `null`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.OnDirectoryInitialize.Exec.Arguments}
+
+The optional user arguments for the 'Storage.OnDirectoryInitialize.Exec' command or executable. The arguments must be escaped for the command line. Experts only.  
+
+- **Type**: `string`
+- **Default**: `null`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.OnDirectoryInitialize.Exec.TimeoutInSec}
+
+The number of seconds to wait for the OnDirectoryInitialize executable to exit. Default: 30 seconds. Experts only.  
+
+- **Type**: `int`
+- **Default**: `30`
+- **Scope**: Server-wide or per database
+
+{PANEL/}
+
+{PANEL:Storage.EnablePrefetching}
+
+Enables memory prefetching mechanism if OS supports it.  
+
+- **Type**: `bool`
+- **Default**: `true`
+- **Scope**: Server-wide only
+
+{PANEL/}
+
+## Related Articles
+
+- [Storage Engine](../../server/storage/storage-engine)

--- a/Documentation/6.0/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/storage/.docs.json
@@ -23,12 +23,6 @@
         "Mappings": []
     },
     {
-        "Path": "transaction-mode.markdown",
-        "Name": "Transaction Mode",
-        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
-        "Mappings": []
-    },
-    {
         "Path": "documents-compression.markdown",
         "Name": "Documents Compression",
         "DiscussionId": "ba60259c-2f0f-4bac-a99d-e5c136612311",

--- a/Documentation/6.0/Raven.Documentation.Pages/server/storage/storage-engine.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/server/storage/storage-engine.markdown
@@ -1,0 +1,111 @@
+﻿# Storage Engine - Voron
+---
+
+{NOTE: }
+
+* RavenDB uses an in-house managed storage engine called Voron to persist your data (documents, indexes, and configuration).
+  It is a high performance storage engine designed and optimized for RavenDB's needs.
+
+* Voron employs the following structures to efficiently organize data on persistent storage:
+  * **B+Tree** - Supports variable-size keys and values.
+  * **Fixed Sized B+Tree** - Uses `Int64` keys and fixed-size values (defined at creation time).  
+    This structure enables various optimizations.
+  * **Raw Data Section** – Allows storage of raw data (e.g., document content) and provides an identifier for O(1) data access.
+  * **Table** – Combines Raw Data Sections with any number of indexes, which internally are implemented as regular or  
+    Fixed-Sized B+Trees.
+
+* In this page:
+  * [Transaction support](../../server/storage/storage-engine#transaction-support)
+  * [Single write model](../../server/storage/storage-engine#single-write-model)
+  * [Memory-mapped files](../../server/storage/storage-engine#memory-mapped-files)
+  * [Requirements](../../server/storage/storage-engine#requirements)
+  * [Limitations](../../server/storage/storage-engine#limitations)
+
+{NOTE/}
+
+---
+
+{PANEL: Transaction support}
+
+Voron is a fully transactional storage engine that ensures atomicity and durability using a Write-Ahead Journal (WAJ).
+All modifications made within a transaction are first written to a journal file (using unbuffered I/O and write-through) before being applied to the main data file and synced to disk.
+The journals act as a transaction log, preserving the durability property of ACID transactions.
+The application of the WAJ occurs in the background.
+
+In the event of an ungraceful server shutdown, the journals serve as the recovery source.  
+If a process stops unexpectedly, leaving modifications not yet applied to the data file, 
+Voron recovers the database state during the next database startup by replaying the transactions stored in the journal files. 
+
+Because journals are flushed and synced to disk before a transaction commit is completed, this guarantees that changes will survive process or system crashes. 
+Each transaction is written to the journal once it's committed, and a successful response is returned _only_ if the commit completes successfully.
+This ensures that transactions can be easily recovered if necessary.
+
+Multi-Version Concurrency Control (MVCC) is implemented using scratch files,
+which are temporary files that maintain concurrent versions of the data for active transactions.
+
+Each transaction operates on a snapshot of the database, ensuring that write transactions do not modify the data being accessed by other transactions.
+Snapshot isolation for concurrent transactions is maintained using Page Translation Tables.
+
+{PANEL/}
+
+{PANEL: Single write model}
+
+Voron supports only single write processes (but there can be multiple read processes).  
+Having only a single write transaction simplifies the handling of writes.
+
+To achieve high performance, RavenDB implements transaction merging on top of Voron's single write model.  
+This approach provides a tremendous performance boost, particularly in high-load scenarios.
+
+Additionally, Voron includes support for asynchronous transaction commits.
+These commits must meet specific requirements to seamlessly integrate with RavenDB's transaction merging mechanism. 
+The actual transaction lock handoff and early lock release are managed at a higher layer, where more detailed system information is available.
+
+{PANEL/}
+
+{PANEL: Memory-mapped files}
+
+Voron is based on memory mapped files.
+
+{INFO: Running on 32 bits}
+
+Since RavenDB 4.0, Voron has no limits when running in 32 bits mode. The issue of running out of address space when mapping files into memory 
+has been addressed by providing a dedicated pager (component responsible for mapping) for a 32 bits environments.
+
+Instead of mapping an entire file, it maps just the pages that are required and only for the duration of the transaction.
+
+{INFO/}
+
+{PANEL/}
+
+{PANEL: Requirements}
+
+The storage hardware / file system must support:
+
+* fsync
+* `[Windows]` UNBUFFERED_IO / WRITE_THROUGH
+* `[Windows]` [Hotfix for Windows 7 and Windows Server 2008 R2](https://support.microsoft.com/en-us/help/2731284/33-dos-error-code-when-memory-memory-mapped-files-are-cleaned-by-using)
+* `[Posix]` O_DIRECT
+
+{PANEL/}
+
+{PANEL: Limitations}
+
+- The key size must be less than 2025 bytes in UTF8
+
+{PANEL/}
+
+## Related Articles
+
+### Transactions
+
+- [Transaction Support in RavenDB](../../client-api/faq/transaction-support)
+
+### Storage
+
+- [Directory Structure](../../server/storage/directory-structure)
+
+### Configuration
+
+- [Storage](../../server/configuration/storage-configuration)
+
+

--- a/Documentation/6.2/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/6.2/Raven.Documentation.Pages/server/storage/.docs.json
@@ -23,12 +23,6 @@
         "Mappings": []
     },
     {
-        "Path": "transaction-mode.markdown",
-        "Name": "Transaction Mode",
-        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
-        "Mappings": []
-    },
-    {
         "Path": "documents-compression.markdown",
         "Name": "Documents Compression",
         "DiscussionId": "ba60259c-2f0f-4bac-a99d-e5c136612311",

--- a/Documentation/7.0/Raven.Documentation.Pages/server/storage/.docs.json
+++ b/Documentation/7.0/Raven.Documentation.Pages/server/storage/.docs.json
@@ -23,12 +23,6 @@
         "Mappings": []
     },
     {
-        "Path": "transaction-mode.markdown",
-        "Name": "Transaction Mode",
-        "DiscussionId": "e9b28886-1d69-4260-8d93-b1d3c4c178be",
-        "Mappings": []
-    },
-    {
         "Path": "documents-compression.markdown",
         "Name": "Documents Compression",
         "DiscussionId": "ba60259c-2f0f-4bac-a99d-e5c136612311",


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3155/Remove-Transaction-Modes

---

1. Removed the "modes" article from the 6.0 docs
2. Added a note in the existing "modes" 4.0 article about that
      ... The _Lazy_ and _Danger_ modes are available only up to RavenDB **5.4** ....
3.  Verified that all info written about the "Safe mode" is covered in the general "Storage configuration" 6.0 article
     `Documentation/6.0/Raven.Documentation.Pages/server/configuration/storage-configuration.markdown`
     and proofread and organized the text in that article. 


