### PR TITLE
RDoc-1627 + RDoc-3295 Indexing Metadata + Indexing ALL fields for FTS

### DIFF
--- a/Documentation/3.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/3.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -141,10 +141,15 @@
     "Path": "converting-to-json-and-accessing-metadata.markdown",
     "Name": "Converting to JSON and accessing Metadata",
     "DiscussionId": "4566869a-8fa4-49a0-8875-0b82ddb45ed7",
+    "LastSupportedVersion": "5.4",
     "Mappings": [
       {
-        "Version": 2.0,
+        "Version": 2.5,
         "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
+      },
+      {
+        "Version": 6.0,
+        "Key": "indexes/indexing-metadata"
       }
     ]
   },

--- a/Documentation/3.5/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/3.5/Raven.Documentation.Pages/indexes/.docs.json
@@ -141,11 +141,12 @@
     "Path": "converting-to-json-and-accessing-metadata.markdown",
     "Name": "Converting to JSON and accessing Metadata",
     "DiscussionId": "08f5aae9-5159-419c-9ec2-bbd5b459097a",
+    "LastSupportedVersion": "5.4",
     "Mappings": [
-      {
-        "Version": 2.0,
-        "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-      }
+        {
+            "Version": 6.0,
+            "Key": "indexes/indexing-metadata"
+        }
     ]
   },
   {

--- a/Documentation/4.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/4.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -151,11 +151,12 @@
     "Path": "converting-to-json-and-accessing-metadata.markdown",
     "Name": "Converting to JSON and Accessing Metadata",
     "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
+    "LastSupportedVersion": "5.4",
     "Mappings": [
-      {
-        "Version": 2.0,
-        "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-      }
+        {
+            "Version": 6.0,
+            "Key": "indexes/indexing-metadata"
+        }
     ]
   },
   {

--- a/Documentation/4.1/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/4.1/Raven.Documentation.Pages/indexes/.docs.json
@@ -169,12 +169,8 @@
     "Path": "converting-to-json-and-accessing-metadata.markdown",
     "Name": "Converting to JSON and Accessing Metadata",
     "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
-    "Mappings": [
-      {
-        "Version": 2.0,
-        "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-      }
-    ]
+    "LastSupportedVersion": "5.4",
+    "Mappings": []
   },
   {
     "Path": "boosting.markdown",

--- a/Documentation/4.2/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/4.2/Raven.Documentation.Pages/indexes/.docs.json
@@ -169,12 +169,8 @@
     "Path": "converting-to-json-and-accessing-metadata.markdown",
     "Name": "Converting to JSON and Accessing Metadata",
     "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
-    "Mappings": [
-      {
-        "Version": 2.0,
-        "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-      }
-    ]
+    "LastSupportedVersion": "5.4",
+    "Mappings": []
   },
   {
     "Path": "boosting.markdown",

--- a/Documentation/5.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -181,12 +181,8 @@
         "Path": "converting-to-json-and-accessing-metadata.markdown",
         "Name": "Converting to JSON and Accessing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
-        "Mappings": [
-            {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-            }
-        ]
+        "LastSupportedVersion": "5.4",
+        "Mappings": []
     },
     {
         "Path": "boosting.markdown",

--- a/Documentation/5.1/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.1/Raven.Documentation.Pages/indexes/.docs.json
@@ -181,10 +181,11 @@
         "Path": "converting-to-json-and-accessing-metadata.markdown",
         "Name": "Converting to JSON and Accessing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
+        "LastSupportedVersion": "5.4",
         "Mappings": [
             {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
+                "Version": 6.0,
+                "Key": "indexes/indexing-metadata"
             }
         ]
     },

--- a/Documentation/5.2/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.2/Raven.Documentation.Pages/indexes/.docs.json
@@ -191,12 +191,8 @@
         "Path": "converting-to-json-and-accessing-metadata.markdown",
         "Name": "Converting to JSON and Accessing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
-        "Mappings": [
-            {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-            }
-        ]
+        "LastSupportedVersion": "5.4",
+        "Mappings": []
     },
     {
         "Path": "rolling-index-deployment.markdown",

--- a/Documentation/5.3/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.3/Raven.Documentation.Pages/indexes/.docs.json
@@ -181,12 +181,8 @@
         "Path": "converting-to-json-and-accessing-metadata.markdown",
         "Name": "Converting to JSON and Accessing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
-        "Mappings": [
-            {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-            }
-        ]
+        "LastSupportedVersion": "5.4",
+        "Mappings": []
     },
     {
         "Path": "rolling-index-deployment.markdown",

--- a/Documentation/5.4/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/5.4/Raven.Documentation.Pages/indexes/.docs.json
@@ -181,10 +181,11 @@
         "Path": "converting-to-json-and-accessing-metadata.markdown",
         "Name": "Converting to JSON and Accessing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
+        "LastSupportedVersion": "5.4",
         "Mappings": [
             {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
+                "Version": 6.0,
+                "Key": "indexes/indexing-metadata"
             }
         ]
     },

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -178,13 +178,13 @@
         "Mappings": []
     },
     {
-        "Path": "converting-to-json-and-accessing-metadata.markdown",
-        "Name": "Converting to JSON and Accessing Metadata",
+        "Path": "indexing-metadata.markdown",
+        "Name": "Indexing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
         "Mappings": [
             {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
+                "Version": 3.0,
+                "Key": "indexes/converting-to-json-and-accessing-metadata"
             }
         ]
     },

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.dotnet.markdown
@@ -31,13 +31,14 @@
 * Use the `MetadataFor` method to access a document's metadata within the index definition,  
   as shown in the example below.
 
-* You can retrieve metadata values using one of two syntaxes: a generic method or an indexer.
+* You can retrieve metadata values using one of two syntaxes:
 
-  * **Access using the generic `Value<T>()` method** - returns the metadata value cast to the specified type.  
-    This approach ensures type safety and is recommended when you know the expected type (e.g., _DateTime_).
-
-  * **Access using the indexer syntax with a string key** - returns the raw object.  
-    You can cast the value manually if needed.
+    * **Generic method syntax**  
+      Use `Value<T>()` to retrieve and cast the metadata value to the expected type.  
+      This is type-safe and preferred when the type is known (e.g., _DateTime_).  
+    * **Indexer syntax**  
+      Use `metadata["key"]` to retrieve the raw object.  
+      You can cast it manually if needed.  
 
 ---
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.dotnet.markdown
@@ -1,0 +1,112 @@
+# Indexing Metadata
+---
+
+{NOTE: }
+
+* Each document in the database includes a metadata section, stored in a special JSON object under the `@metadata` property.
+
+* This metadata is not part of the document's content but holds internal system information (used by RavenDB),
+  such as the document ID, collection name, change vector, last modified timestamp, and more,  
+  as well as optional user-defined entries.
+
+* To learn how to access (get and modify) the metadata from your client code,  
+  see [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata).
+
+* Content from metadata properties can be extracted and **indexed** within a static index, alongside content from the document fields.
+  This allows you to query for documents based on values stored in the metadata.  
+  See the examples below.
+
+---
+
+* In this article:  
+   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)  
+   * [Metadata properties that can be indexed](../indexes/indexing-metadata#metadata-properties-that-can-be-indexed)  
+
+{NOTE/}
+
+---
+
+{PANEL: Indexing metadata properties}
+
+* Use the `MetadataFor` method to access a document's metadata within the index definition,  
+  as shown in the example below.
+
+* You can retrieve metadata values using one of two syntaxes: a generic method or an indexer.
+
+  * **Access using the generic `Value<T>()` method** - returns the metadata value cast to the specified type.  
+    This approach ensures type safety and is recommended when you know the expected type (e.g., _DateTime_).
+
+  * **Access using the indexer syntax with a string key** - returns the raw object.  
+    You can cast the value manually if needed.
+
+---
+
+* The following index definition indexes content from the `@last-modified` and `@counters` metadata properties.
+
+{CODE-TABS}
+{CODE-TAB:csharp:LINQ_index_accessMetadataViaValue index_1@Indexes/Metadata.cs /}
+{CODE-TAB:csharp:LINQ_index_accessMetadataViaIndexer index_2@Indexes/Metadata.cs /}
+{CODE-TAB:csharp:JS_index index_3@Indexes/Metadata.cs /}
+{CODE-TABS/}
+
+* Query for documents based on metadata values:  
+  Retrieve documents that have counters and order them by their last modified timestamp.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query query_1@Indexes/Metadata.cs /}
+{CODE-TAB:csharp:Query_async query_1_async@Indexes/Metadata.cs /}
+{CODE-TAB:csharp:DocumentQuery query_2@Indexes/Metadata.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByMetadata/AccessViaValue"
+where HasCounters = false
+order by LastModified desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Metadata properties that can be indexed}
+
+* The table below lists **predefined metadata properties that can be indexed**.
+
+* Each property can be accessed using either a string literal (e.g. `"@last-modified"`) or the corresponding Client API constant (e.g. `Raven.Client.Constants.Documents.Metadata.LastModified`).  
+  Using the Client API constant is recommended for clarity and to avoid typos.
+
+* You can add custom metadata properties to any document as needed.  
+  These custom properties can be indexed just like the predefined ones.
+
+| String literal      | Client API Constant                                    |
+|---------------------|--------------------------------------------------------|
+| `@archive-at`       | Raven.Client.Constants.Documents.Metadata.ArchiveAt    |
+| `@attachments`      | Raven.Client.Constants.Documents.Metadata.Attachments  |
+| `@change-vector`    | Raven.Client.Constants.Documents.Metadata.ChangeVector |
+| `@collection`       | Raven.Client.Constants.Documents.Metadata.Collection   |
+| `@counters`         | Raven.Client.Constants.Documents.Metadata.Counters     |
+| `@etag`             | Raven.Client.Constants.Documents.Metadata.Etag         |
+| `@expires`          | Raven.Client.Constants.Documents.Metadata.Expires      |
+| `@id`               | Raven.Client.Constants.Documents.Metadata.Id           |
+| `@last-modified`    | Raven.Client.Constants.Documents.Metadata.LastModified |
+| `@refresh`          | Raven.Client.Constants.Documents.Metadata.Refresh      |
+| `@timeseries`       | Raven.Client.Constants.Documents.Metadata.TimeSeries   |
+| `Raven-Clr-Type`    | Raven.Client.Constants.Documents.Metadata.RavenClrType |
+
+{WARNING: }
+
+Note:  
+
+* The `@attachments` metadata property can only be indexed using a **Lucene** index.  
+* The **Corax** search engine does not support indexing complex JSON properties.  
+  Learn more in [Corax: Handling complex JSON objects](../indexes/search-engine/corax#handling-of-complex-json-objects).
+
+{WARNING/}
+{PANEL/}
+
+## Related articles
+
+### Indexes
+
+- [Indexing Basics](../indexes/indexing-basics)
+
+### Client API
+
+- [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.dotnet.markdown
@@ -58,7 +58,7 @@
 {CODE-TAB:csharp:DocumentQuery query_2@Indexes/Metadata.cs /}
 {CODE-TAB-BLOCK:sql:RQL}
 from index "Products/ByMetadata/AccessViaValue"
-where HasCounters = false
+where HasCounters == true
 order by LastModified desc
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.java.markdown
@@ -1,0 +1,44 @@
+# Indexing Metadata
+---
+
+{NOTE: }
+
+* Each document in the database includes a metadata section, stored in a special JSON object under the `@metadata` property.
+
+* This metadata is not part of the document's content but holds internal system information (used by RavenDB),
+  such as the document ID, collection name, change vector, last modified timestamp, and more,  
+  as well as optional user-defined entries.
+
+* To learn how to access (get and modify) the metadata from your client code,  
+  see [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata).
+
+* Content from metadata properties can be extracted and **indexed** within a static index, alongside content from the document fields.
+  This allows you to query for documents based on values stored in the metadata.  
+  See the examples below.
+
+---
+
+* In this article:  
+   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+
+{NOTE/}
+
+---
+
+{PANEL: Indexing metadata properties}
+
+{CODE:java index_1@Indexes/Metadata.java /}
+
+{CODE:java query_1@Indexes/Metadata.java /}
+
+{PANEL/}
+
+## Related articles
+
+### Indexes
+
+- [Indexing Basics](../indexes/indexing-basics)
+
+### Client API
+
+- [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.js.markdown
@@ -1,0 +1,44 @@
+# Indexing Metadata
+---
+
+{NOTE: }
+
+* Each document in the database includes a metadata section, stored in a special JSON object under the `@metadata` property.
+
+* This metadata is not part of the document's content but holds internal system information (used by RavenDB),
+  such as the document ID, collection name, change vector, last modified timestamp, and more,  
+  as well as optional user-defined entries.
+
+* To learn how to access (get and modify) the metadata from your client code,  
+  see [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata).
+
+* Content from metadata properties can be extracted and **indexed** within a static index, alongside content from the document fields.
+  This allows you to query for documents based on values stored in the metadata.  
+  See the examples below.
+
+---
+
+* In this article:  
+   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+
+{NOTE/}
+
+---
+
+{PANEL: Indexing metadata properties}
+
+{CODE:nodejs index_1@indexes/metadata.js /}
+
+{CODE:nodejs query_1@indexes/metadata.js /}
+
+{PANEL/}
+
+## Related articles
+
+### Indexes
+
+- [Indexing Basics](../indexes/indexing-basics)
+
+### Client API
+
+- [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.js.markdown
@@ -18,8 +18,9 @@
 
 ---
 
-* In this article:  
-   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+* In this article:
+    * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+    * [Metadata properties that can be indexed](../indexes/indexing-metadata#metadata-properties-that-can-be-indexed)
 
 {NOTE/}
 
@@ -27,10 +28,56 @@
 
 {PANEL: Indexing metadata properties}
 
+* Use the `getMetadata` method to access a document’s metadata, as shown in the example below.
+
+* The following index definition indexes content from the `@last-modified` and `@counters` metadata properties.
+
 {CODE:nodejs index_1@indexes/metadata.js /}
 
-{CODE:nodejs query_1@indexes/metadata.js /}
+* Query for documents based on metadata values:  
+  Retrieve documents that have counters and order them by their last modified timestamp.
 
+{CODE-TABS}
+{CODE-TAB:nodejs:Query query_1@indexes/metadata.js /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByMetadata"
+where HasCounters == true
+order by LastModified desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Metadata properties that can be indexed}
+
+* The following are the **predefined metadata properties that can be indexed**:
+    * `@archive-at`
+    * `@attachments`
+    * `@change-vector`
+    * `@collection`
+    * `@counters`
+    * `@etag`
+    * `@expires`
+    * `@id`
+    * `@last-modified`
+    * `@refresh`
+    * `@timeseries`
+    * `Raven-Clr-Type`
+
+* You can add custom metadata properties to any document as needed.  
+  These custom properties can be indexed just like the predefined ones.
+
+---
+
+{WARNING: }
+
+Note:
+
+* The `@attachments` metadata property can only be indexed using a **Lucene** index.
+* The **Corax** search engine does not support indexing complex JSON properties.  
+  Learn more in [Corax: Handling complex JSON objects](../indexes/search-engine/corax#handling-of-complex-json-objects).
+
+{WARNING/}
 {PANEL/}
 
 ## Related articles

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.php.markdown
@@ -29,7 +29,7 @@
 {PANEL: Indexing metadata properties}
 
 * To access a document's metadata, use the `MetadataFor` method, which is available in the **C# LINQ string**
-  that is assigned to the `$this->map` property in the PHP index class, as shown in the example below.
+  that is assigned to the `map` property in the PHP index class, as shown in the example below.
 
 * You can retrieve metadata values using one of two C# syntaxes:
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.php.markdown
@@ -1,0 +1,44 @@
+# Indexing Metadata
+---
+
+{NOTE: }
+
+* Each document in the database includes a metadata section, stored in a special JSON object under the `@metadata` property.
+
+* This metadata is not part of the document's content but holds internal system information (used by RavenDB),
+  such as the document ID, collection name, change vector, last modified timestamp, and more,  
+  as well as optional user-defined entries.
+
+* To learn how to access (get and modify) the metadata from your client code,  
+  see [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata).
+
+* Content from metadata properties can be extracted and **indexed** within a static index, alongside content from the document fields.
+  This allows you to query for documents based on values stored in the metadata.  
+  See the examples below.
+
+---
+
+* In this article:  
+   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+
+{NOTE/}
+
+---
+
+{PANEL: Indexing metadata properties}
+
+{CODE:php index_1@Indexes/Metadata.php /}
+
+{CODE:php query_1@Indexes/Metadata.php /}
+
+{PANEL/}
+
+## Related articles
+
+### Indexes
+
+- [Indexing Basics](../indexes/indexing-basics)
+
+### Client API
+
+- [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.php.markdown
@@ -18,8 +18,9 @@
 
 ---
 
-* In this article:  
-   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+* In this article:
+    * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+    * [Metadata properties that can be indexed](../indexes/indexing-metadata#metadata-properties-that-can-be-indexed)
 
 {NOTE/}
 
@@ -27,10 +28,71 @@
 
 {PANEL: Indexing metadata properties}
 
-{CODE:php index_1@Indexes/Metadata.php /}
+* To access a document's metadata, use the `MetadataFor` method, which is available in the **C# LINQ string**
+  that is assigned to the `$this->map` property in the PHP index class, as shown in the example below.
 
-{CODE:php query_1@Indexes/Metadata.php /}
+* You can retrieve metadata values using one of two C# syntaxes:
 
+    * **Generic method syntax**  
+      Use `Value<T>()` to retrieve and cast the metadata value to the expected type.  
+      This is type-safe and preferred when the type is known (e.g., _DateTime_).
+    * **Indexer syntax**  
+      Use `metadata["key"]` to retrieve the raw object.  
+      You can cast it manually if needed.
+
+---
+
+* The following index definition indexes content from the `@last-modified` and `@counters` metadata properties.
+
+{CODE-TABS}
+{CODE-TAB:php:Index_accessMetadataViaValue index_1@Indexes/Metadata.php /}
+{CODE-TAB:php:Index_accessMetadataViaIndexer index_2@Indexes/Metadata.php /}
+{CODE-TABS/}
+
+* Query for documents based on metadata values:  
+  Retrieve documents that have counters and order them by their last modified timestamp.
+
+{CODE-TABS}
+{CODE-TAB:php:Query query_1@Indexes/Metadata.php /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByMetadata/AccessViaValue"
+where hasCounters == true
+order by lastModified desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Metadata properties that can be indexed}
+
+* The following are the **predefined metadata properties that can be indexed**:
+    * `@archive-at`
+    * `@attachments`
+    * `@change-vector`
+    * `@collection`
+    * `@counters`
+    * `@etag`
+    * `@expires`
+    * `@id`
+    * `@last-modified`
+    * `@refresh`
+    * `@timeseries`
+    * `Raven-Clr-Type`
+
+* You can add custom metadata properties to any document as needed.  
+  These custom properties can be indexed just like the predefined ones.
+
+---
+
+{WARNING: }
+
+Note:
+
+* The `@attachments` metadata property can only be indexed using a **Lucene** index.
+* The **Corax** search engine does not support indexing complex JSON properties.  
+  Learn more in [Corax: Handling complex JSON objects](../indexes/search-engine/corax#handling-of-complex-json-objects).
+
+{WARNING/}
 {PANEL/}
 
 ## Related articles

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
@@ -22,31 +22,31 @@
     * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
     * [Metadata properties that can be indexed](../indexes/indexing-metadata#metadata-properties-that-can-be-indexed)
 
-
 {NOTE/}
 
 ---
 
 {PANEL: Indexing metadata properties}
 
-* Use the `MetadataFor` method to access a document's metadata within the index definition,  
-  as shown in the example below.
+* Use the `MetadataFor` method to access a document’s metadata **inside the C# LINQ string** that defines the index mapping
+  (the string assigned to `self.map` in the Python index class), as shown in the example below.
 
-* You can retrieve metadata values using one of two syntaxes: a generic method or an indexer.
+* You can retrieve metadata values using one of two C# syntaxes:
 
-    * **Access using the generic `Value<T>()` method** - returns the metadata value cast to the specified type.  
-      This approach ensures type safety and is recommended when you know the expected type (e.g., _DateTime_).
-
-    * **Access using the indexer syntax with a string key** - returns the raw object.  
-      You can cast the value manually if needed.
+  * **Generic method syntax**  
+    Use `Value<T>()` to retrieve and cast the metadata value to the expected type.  
+    This is type-safe and preferred when the type is known (e.g., _DateTime_).  
+  * **Indexer syntax**  
+    Use `metadata["key"]` to retrieve the raw object.  
+    You can cast it manually if needed.  
 
 ---
 
 * The following index definition indexes content from the `@last-modified` and `@counters` metadata properties.
 
 {CODE-TABS}
-{CODE-TAB:python:LINQ_Index_accessMetadataViaValue index_1@Indexes/Metadata.py /}
-{CODE-TAB:python:LINQ_Index_accessMetadataViaIndexer index_2@Indexes/Metadata.py /}
+{CODE-TAB:python:Index_accessMetadataViaValue index_1@Indexes/Metadata.py /}
+{CODE-TAB:python:Index_accessMetadataViaIndexer index_2@Indexes/Metadata.py /}
 {CODE-TABS/}
 
 * Query for documents based on metadata values:  

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
@@ -1,0 +1,44 @@
+# Indexing Metadata
+---
+
+{NOTE: }
+
+* Each document in the database includes a metadata section, stored in a special JSON object under the `@metadata` property.
+
+* This metadata is not part of the document's content but holds internal system information (used by RavenDB),
+  such as the document ID, collection name, change vector, last modified timestamp, and more,  
+  as well as optional user-defined entries.
+
+* To learn how to access (get and modify) the metadata from your client code,  
+  see [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata).
+
+* Content from metadata properties can be extracted and **indexed** within a static index, alongside content from the document fields.
+  This allows you to query for documents based on values stored in the metadata.  
+  See the examples below.
+
+---
+
+* In this article:  
+   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+
+{NOTE/}
+
+---
+
+{PANEL: Indexing metadata properties}
+
+{CODE:python index_1@Indexes/Metadata.py /}
+
+{CODE:python query_1@Indexes/Metadata.py /}
+
+{PANEL/}
+
+## Related articles
+
+### Indexes
+
+- [Indexing Basics](../indexes/indexing-basics)
+
+### Client API
+
+- [How to get and modify the metadata](../client-api/session/how-to/get-and-modify-entity-metadata)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
@@ -28,8 +28,8 @@
 
 {PANEL: Indexing metadata properties}
 
-* Use the `MetadataFor` method to access a document’s metadata **inside the C# LINQ string** that defines the index mapping
-  (the string assigned to `self.map` in the Python index class), as shown in the example below.
+* To access a document's metadata, use the `MetadataFor` method, which is available in the **C# LINQ string**
+  that is assigned to the `self->map` property in the PHP index class, as shown in the example below.
 
 * You can retrieve metadata values using one of two C# syntaxes:
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
@@ -29,7 +29,7 @@
 {PANEL: Indexing metadata properties}
 
 * To access a document's metadata, use the `MetadataFor` method, which is available in the **C# LINQ string**
-  that is assigned to the `self->map` property in the PHP index class, as shown in the example below.
+  that is assigned to the `map` property in the PHP index class, as shown in the example below.
 
 * You can retrieve metadata values using one of two C# syntaxes:
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
@@ -18,8 +18,10 @@
 
 ---
 
-* In this article:  
-   * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+* In this article:
+    * [Indexing metadata properties](../indexes/indexing-metadata#indexing-metadata-properties)
+    * [Metadata properties that can be indexed](../indexes/indexing-metadata#metadata-properties-that-can-be-indexed)
+
 
 {NOTE/}
 
@@ -27,10 +29,70 @@
 
 {PANEL: Indexing metadata properties}
 
-{CODE:python index_1@Indexes/Metadata.py /}
+* Use the `MetadataFor` method to access a document's metadata within the index definition,  
+  as shown in the example below.
 
-{CODE:python query_1@Indexes/Metadata.py /}
+* You can retrieve metadata values using one of two syntaxes: a generic method or an indexer.
 
+    * **Access using the generic `Value<T>()` method** - returns the metadata value cast to the specified type.  
+      This approach ensures type safety and is recommended when you know the expected type (e.g., _DateTime_).
+
+    * **Access using the indexer syntax with a string key** - returns the raw object.  
+      You can cast the value manually if needed.
+
+---
+
+* The following index definition indexes content from the `@last-modified` and `@counters` metadata properties.
+
+{CODE-TABS}
+{CODE-TAB:python:LINQ_Index_accessMetadataViaValue index_1@Indexes/Metadata.py /}
+{CODE-TAB:python:LINQ_Index_accessMetadataViaIndexer index_2@Indexes/Metadata.py /}
+{CODE-TABS/}
+
+* Query for documents based on metadata values:  
+  Retrieve documents that have counters and order them by their last modified timestamp.
+
+{CODE-TABS}
+{CODE-TAB:python:Query query_1@Indexes/Metadata.py /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByMetadata/AccessViaValue"
+where has_counters == true
+order by last_modified desc
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Metadata properties that can be indexed}
+
+* The following are the **predefined metadata properties that can be indexed**:  
+   * `@archive-at`  
+   * `@attachments`  
+   * `@change-vector`  
+   * `@collection`  
+   * `@counters`  
+   * `@etag`  
+   * `@expires`  
+   * `@id`  
+   * `@last-modified`  
+   * `@refresh`  
+   * `@timeseries`  
+   * `Raven-Clr-Type`  
+
+* You can add custom metadata properties to any document as needed.  
+  These custom properties can be indexed just like the predefined ones.
+
+---
+
+{WARNING: }
+
+Note:
+
+* The `@attachments` metadata property can only be indexed using a **Lucene** index.
+* The **Corax** search engine does not support indexing complex JSON properties.  
+  Learn more in [Corax: Handling complex JSON objects](../indexes/search-engine/corax#handling-of-complex-json-objects).
+
+{WARNING/}
 {PANEL/}
 
 ## Related articles

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.dotnet.markdown
@@ -18,9 +18,10 @@
 
 ---
 
-* In this page:
+* In this article:
   * [Indexing single field for FTS](../../indexes/querying/searching#indexing-single-field-for-fts)
   * [Indexing multiple fields for FTS](../../indexes/querying/searching#indexing-multiple-fields-for-fts)
+  * [Indexing all fields for FTS (using AsJson)](../../indexes/querying/searching#indexing-all-fields-for-fts-(using-asjson))
   * [Boosting search results](../../indexes/querying/searching#boosting-search-results)
   * [Searching with wildcards](../../indexes/querying/searching#searching-with-wildcards)
       * [When using RavenStandardAnalyzer or StandardAnalyzer or NGramAnalyzer](../../indexes/querying/searching#when-usingoror)
@@ -75,6 +76,42 @@ where search(EmployeeNotes, "French")
 {CODE-TAB-BLOCK:sql:RQL}
 from index "Employees/ByEmployeeData"
 where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish", and))
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Indexing all fields for FTS (using AsJson)}
+
+* To search across ALL fields in a document without defining each one explicitly,
+  use the `AsJson` method in the _Map_ function to extract all property values and index them in a single searchable field.
+
+* This approach makes the index robust to changes in the document schema.  
+  By calling `.Select(x => x.Value)` on the result of `AsJson(...)`, 
+  the index automatically includes values from ALL existing and newly added properties 
+  and there is no need to update the index when the document structure changes.
+
+* {INFO: }
+  This indexing method is supported only when using **Lucene** as the indexing engine.
+  {INFO/}
+
+---
+
+#### The index:
+
+{CODE:csharp index_6@Indexes\Querying\Searching.cs/}
+
+---
+
+#### Sample query:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query search_16@Indexes\Querying\Searching.cs /}
+{CODE-TAB:csharp:Query_async search_17@Indexes\Querying\Searching.cs /}
+{CODE-TAB:csharp:DocumentQuery search_18@Indexes\Querying\Searching.cs /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByAllValues"
+where search(AllValues, "tofu")
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.java.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.java.markdown
@@ -1,0 +1,194 @@
+# Querying: Searching
+
+When you need to do a more complex text searching, use the `search` method. This method allows you to pass a few search terms that will be used in the searching process for a particular field. Here is a sample code
+that uses the `search` method to get users with the name *John* or *Adam*:
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_3_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Users
+where search(Name, 'John Adam')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+Each of the search terms (separated by space character) will be checked independently. The result documents must match exactly one of the passed terms.
+
+In the same way, you can also look for users that have some hobby:
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_4_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Users
+where search(Name, 'looking for someone who likes sport books computers')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+The results will return users that are interested in *sport*, *books* or *computers*.
+
+## Multiple Fields
+
+By using the `search` method, you are also able to look for multiple indexed fields. In order to search using both `name` and `hobbies` properties, you need to issue the following query:
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_5_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Users
+where search(Name, 'Adam') or search(Hobbies, 'sport')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Boosting
+
+Indexing in RavenDB is built upon the Lucene engine that provides a boosting term mechanism. This feature introduces the relevance level of matching documents based on the terms found. 
+Each search term can be associated with a boost factor that influences the final search results. The higher the boost factor, the more relevant the term will be. 
+RavenDB also supports that, in order to improve your searching mechanism and provide the users with much more accurate results you can specify the boost argument. 
+
+For example:
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_6_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Users
+where boost(search(Hobbies, 'I love sport'), 10) or boost(search(Hobbies, 'but also like reading books'), 5)
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+This search will promote users who do sports before book readers and they will be placed at the top of the results list.
+
+## Search Options
+
+You can specify the logic of a search expression. It can be either:
+
+* or,
+* andAlso,
+* not.
+
+The following query:
+
+{CODE:java search_7_0@Indexes\Querying\Searching.java /}
+
+will be translated into
+
+{CODE-BLOCK:csharp}
+from Users
+where search(Hobbies, 'computers') or search(Name, 'James') and Age = 20
+{CODE-BLOCK/}
+
+You can also specify what exactly the query logic should be. The applied option will influence a query term where it was used. The query as follows:
+
+{CODE:java search_8_0@Indexes\Querying\Searching.java /}
+
+will result in the following RQL query:
+
+{CODE-BLOCK:csharp}
+from Users
+where search(Name, 'Adam') and search(Hobbies, 'sport')
+{CODE-BLOCK/}
+
+If you want to negate the term use `not`:
+
+{CODE:java search_9_0@Indexes\Querying\Searching.java /}
+
+According to RQL syntax it will be transformed into the query:
+
+{CODE-BLOCK:csharp}
+from Users
+where exists(Name) and not search(James, 'Adam')
+{CODE-BLOCK/}
+
+You can also combine search options:
+
+{CODE:java search_10_1@Indexes\Querying\Searching.java /}
+
+It will produce the following RQL query:
+
+{CODE-BLOCK:csharp}
+from Users
+where search(Name, 'Adam') and (exists(Hobbies) and not search(Hobbies, 'sport'))
+{CODE-BLOCK/}
+
+## Using Wildcards
+
+When the beginning or ending of a search term is unknown, wildcards can be used to add additional power to the searching feature. RavenDB supports both suffix and postfix wildcards.
+
+### Example I - Using Postfix Wildcards
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_11_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Users
+where search(Name, 'Jo* Ad*')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example II - Using Suffix and Postfix Wildcards
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_12_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from Users
+where search(Name, '*oh* *da*')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{WARNING:Warning}
+RavenDB allows you to search by using such queries, but you have to be aware that **leading wildcards drastically slow down searches**.
+
+Consider if you really need to find substrings. In most cases, looking for whole words is enough. There are also other alternatives for searching without expensive wildcard matches, e.g. indexing a reversed version of text field or creating a custom analyzer.
+{WARNING/}
+
+## Static Indexes
+
+All of the previous examples demonstrated searching capabilities by executing dynamic queries and were using auto indexes underneath. The same set of queries can be done when static indexes are used, and also those capabilities can be customized by changing the [analyzer](../using-analyzers) or setting up full text search on multiple fields.
+
+### Example I - Basics
+
+To be able to search you need to set `Indexing` to `Search` on a desired field.
+
+{CODE:java search_20_2@Indexes\Querying\Searching.java/}
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_20_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Users/ByName'
+where search(Name, 'John')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example II - FullTextSearch
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_21_0@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index 'Users/Search'
+where search(Query, 'John')
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+### Example III - Indexing all fields for FTS
+
+This indexing method is supported only when using **Lucene** as the indexing engine.
+
+{CODE:java index_all_fields@Indexes\Querying\Searching.java /}
+
+{CODE-TABS}
+{CODE-TAB:java:Query search_22@Indexes\Querying\Searching.java /}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByAllValues"
+where search(allValues, "tofu")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+## Related Articles
+
+### Indexes
+
+- [Boosting](../../indexes/boosting)
+
+### Querying
+
+- [Boosting](../../indexes/querying/boosting)
+
+### Client API
+
+- [How to Use Search](../../client-api/session/querying/how-to-use-search)

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.js.markdown
@@ -19,9 +19,10 @@
 
 ---
 
-* In this page:
+* In this article:
   * [Indexing single field for FTS](../../indexes/querying/searching#indexing-single-field-for-fts)
   * [Indexing multiple fields for FTS](../../indexes/querying/searching#indexing-multiple-fields-for-fts)
+  * [Indexing all fields for FTS (using AsJson)](../../indexes/querying/searching#indexing-all-fields-for-fts-(using-asjson))
   * [Boosting search results](../../indexes/querying/searching#boosting-search-results)
   * [Searching with wildcards](../../indexes/querying/searching#searching-with-wildcards)
       * [When using RavenStandardAnalyzer or StandardAnalyzer or NGramAnalyzer](../../indexes/querying/searching#when-usingoror)
@@ -72,6 +73,41 @@ where search(employeeNotes, "French")
 {CODE-TAB-BLOCK:sql:RQL}
 from index "Employees/ByEmployeeData"
 where (search(employeeData, "Manager") or search(employeeData, "French Spanish", and))
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Indexing all fields for FTS (using AsJson)}
+
+* To search across ALL fields in a document without defining each one explicitly, use the `AsJson` method, 
+  which is available when using **a C# LINQ string** that is assigned to the `this.map` property in the Node.js index class,
+  as shown in the example below.
+
+* This approach makes the index robust to changes in the document schema.  
+  By calling `.Select(x => x.Value)` on the result of `AsJson(...)`,
+  the index automatically includes values from ALL existing and newly added properties
+  and there is no need to update the index when the document structure changes.
+
+* {INFO: }
+  This indexing method is supported only when using **Lucene** as the indexing engine.
+  {INFO/}
+
+---
+
+#### The index:
+
+{CODE:nodejs index_6@Indexes\Querying\searching.js/}
+
+---
+
+#### Sample query:
+
+{CODE-TABS}
+{CODE-TAB:nodejs:Query search_6@Indexes\Querying\searching.js/}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByAllValues"
+where search(AllValues, "tofu")
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.js.markdown
@@ -81,7 +81,7 @@ where (search(employeeData, "Manager") or search(employeeData, "French Spanish",
 {PANEL: Indexing all fields for FTS (using AsJson)}
 
 * To search across ALL fields in a document without defining each one explicitly, use the `AsJson` method, 
-  which is available when using **a C# LINQ string** that is assigned to the `this.map` property in the Node.js index class,
+  which is available when using **a C# LINQ string** that is assigned to the `map` property in the Node.js index class,
   as shown in the example below.
 
 * This approach makes the index robust to changes in the document schema.  

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.php.markdown
@@ -19,9 +19,10 @@
 
 ---
 
-* In this page:
+* In this article:
   * [Indexing single field for FTS](../../indexes/querying/searching#indexing-single-field-for-fts)
   * [Indexing multiple fields for FTS](../../indexes/querying/searching#indexing-multiple-fields-for-fts)
+  * [Indexing all fields for FTS (using AsJson)](../../indexes/querying/searching#indexing-all-fields-for-fts-(using-asjson))
   * [Boosting search results](../../indexes/querying/searching#boosting-search-results)
 
 {NOTE/}
@@ -70,6 +71,41 @@ where search(EmployeeNotes, "French")
 {CODE-TAB-BLOCK:sql:RQL}
 from index "Employees/ByEmployeeData"
 where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish", and))
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Indexing all fields for FTS (using AsJson)}
+
+* To search across ALL fields in a document without defining each one explicitly,
+  use the `AsJson` method **inside the C# LINQ string** assigned to the `$this->map` property in the PHP index class.  
+  This method will extract all property values and index them in a single searchable field.
+
+* This approach makes the index robust to changes in the document schema.  
+  By calling `.Select(x => x.Value)` on the result of `AsJson(...)`,
+  the index automatically includes values from ALL existing and newly added properties
+  and there is no need to update the index when the document structure changes.
+
+* {INFO: }
+  This indexing method is supported only when using **Lucene** as the indexing engine.
+  {INFO/}
+
+---
+
+#### The index:
+
+{CODE:php index_3@Indexes\Querying\Searching.php/}
+
+---
+
+#### Sample query:
+
+{CODE-TABS}
+{CODE-TAB:php:Query search_7@Indexes\Querying\Searching.php/}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByAllValues"
+where search(allValues, "tofu")
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.php.markdown
@@ -78,9 +78,9 @@ where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish",
 
 {PANEL: Indexing all fields for FTS (using AsJson)}
 
-* To search across ALL fields in a document without defining each one explicitly,
-  use the `AsJson` method **inside the C# LINQ string** assigned to the `$this->map` property in the PHP index class.  
-  This method will extract all property values and index them in a single searchable field.
+* To search across ALL fields in a document without defining each one explicitly, use the `AsJson` method,
+  which is available in the **C# LINQ string** that is assigned to the `$this->map` property in the PHP index class,
+  as shown in the example below.
 
 * This approach makes the index robust to changes in the document schema.  
   By calling `.Select(x => x.Value)` on the result of `AsJson(...)`,

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.php.markdown
@@ -79,7 +79,7 @@ where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish",
 {PANEL: Indexing all fields for FTS (using AsJson)}
 
 * To search across ALL fields in a document without defining each one explicitly, use the `AsJson` method,
-  which is available in the **C# LINQ string** that is assigned to the `$this->map` property in the PHP index class,
+  which is available in the **C# LINQ string** that is assigned to the `map` property in the PHP index class,
   as shown in the example below.
 
 * This approach makes the index robust to changes in the document schema.  

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
@@ -97,7 +97,13 @@ where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish",
 
 #### Sample query:
 
-{CODE:python search_5@Indexes\Querying\Searching.py/}
+{CODE-TABS}
+{CODE-TAB:python:Query search_5@Indexes\Querying\Searching.py/}
+{CODE-TAB-BLOCK:sql:RQL}
+from index "Products/ByAllValues"
+where search(all_values, "tofu")
+{CODE-TAB-BLOCK/}
+{CODE-TABS/}
 
 {PANEL/}
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
@@ -76,9 +76,9 @@ where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish",
 
 {PANEL: Indexing all fields for FTS (using AsJson)}
 
-* To search across ALL fields in a document without defining each one explicitly,
-  use the `AsJson` method **inside the C# LINQ string** assigned to the `self.map` property in the Python index class.  
-  This method will extract all property values and index them in a single searchable field.
+* To search across ALL fields in a document without defining each one explicitly, use the `AsJson` method,
+  which is available in the **C# LINQ string** that is assigned to the `self.map` property in the Python index class,
+  as shown in the example below.
 
 * This approach makes the index robust to changes in the document schema.  
   By calling `.Select(x => x.Value)` on the result of `AsJson(...)`,
@@ -94,6 +94,8 @@ where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish",
 #### The index:
 
 {CODE:python index_3@Indexes\Querying\Searching.py/}
+
+---
 
 #### Sample query:
 

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
@@ -77,7 +77,7 @@ where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish",
 {PANEL: Indexing all fields for FTS (using AsJson)}
 
 * To search across ALL fields in a document without defining each one explicitly, use the `AsJson` method,
-  which is available in the **C# LINQ string** that is assigned to the `self.map` property in the Python index class,
+  which is available in the **C# LINQ string** that is assigned to the `map` property in the Python index class,
   as shown in the example below.
 
 * This approach makes the index robust to changes in the document schema.  

--- a/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
@@ -19,9 +19,10 @@
 
 ---
 
-* In this page:
+* In this article:
   * [Indexing single field for FTS](../../indexes/querying/searching#indexing-single-field-for-fts)
   * [Indexing multiple fields for FTS](../../indexes/querying/searching#indexing-multiple-fields-for-fts)
+  * [Indexing all fields for FTS (using AsJson)](../../indexes/querying/searching#indexing-all-fields-for-fts-(using-asjson))
   * [Boosting search results](../../indexes/querying/searching#boosting-search-results)
 
 {NOTE/}
@@ -70,6 +71,33 @@ from index "Employees/ByEmployeeData"
 where (search(EmployeeData, "Manager") or search(EmployeeData, "French Spanish", and))
 {CODE-TAB-BLOCK/}
 {CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Indexing all fields for FTS (using AsJson)}
+
+* To search across ALL fields in a document without defining each one explicitly,
+  use the `AsJson` method **inside the C# LINQ string** assigned to the `self.map` property in the Python index class.  
+  This method will extract all property values and index them in a single searchable field.
+
+* This approach makes the index robust to changes in the document schema.  
+  By calling `.Select(x => x.Value)` on the result of `AsJson(...)`,
+  the index automatically includes values from ALL existing and newly added properties
+  and there is no need to update the index when the document structure changes.
+
+* {INFO: }
+  This indexing method is supported only when using **Lucene** as the indexing engine.
+  {INFO/}
+
+---
+
+#### The index:
+
+{CODE:python index_3@Indexes\Querying\Searching.py/}
+
+#### Sample query:
+
+{CODE:python search_5@Indexes\Querying\Searching.py/}
 
 {PANEL/}
 

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Metadata.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Metadata.cs
@@ -29,9 +29,11 @@ namespace Raven.Documentation.Samples.Indexes
                     {
                         // Access metadata properties using generic method
                         LastModified = metadata.Value<DateTime>(
+                            // Specify the Client API Constant corresponding to '@last-modified'
                             Raven.Client.Constants.Documents.Metadata.LastModified),
                         
                         HasCounters =  metadata.Value<object>(
+                            // Specify the Client API Constant corresponding to '@counters'
                             Raven.Client.Constants.Documents.Metadata.Counters) != null
                     };
             }
@@ -57,10 +59,12 @@ namespace Raven.Documentation.Samples.Indexes
                     select new IndexEntry()
                     {
                         // Access metadata properties using indexer
-                        LastModified = 
+                        LastModified =
+                            // Specify the Client API Constant corresponding to '@last-modified'
                             (DateTime)metadata[Raven.Client.Constants.Documents.Metadata.LastModified],
 
                         HasCounters = 
+                            // Specify the Client API Constant corresponding to '@counters'
                             metadata[Raven.Client.Constants.Documents.Metadata.Counters] != null
                     };
             }

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Metadata.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Metadata.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Documentation.Samples.Orders;
+
+namespace Raven.Documentation.Samples.Indexes
+{
+    public class Metadata
+    {
+        #region index_1
+        public class Products_ByMetadata_AccessViaValue : AbstractIndexCreationTask<Product>
+        {
+            public class IndexEntry
+            {
+                public DateTime LastModified { get; set; }
+                public bool HasCounters { get; set; }
+            }
+
+            public Products_ByMetadata_AccessViaValue()
+            {
+                Map = products => from product in products
+                    // Use 'MetadataFor' to access the metadata object
+                    let metadata = MetadataFor(product)
+                    
+                    // Define the index fields
+                    select new IndexEntry()
+                    {
+                        // Access metadata properties using generic method
+                        LastModified = metadata.Value<DateTime>(
+                            Raven.Client.Constants.Documents.Metadata.LastModified),
+                        
+                        HasCounters =  metadata.Value<object>(
+                            Raven.Client.Constants.Documents.Metadata.Counters) != null
+                    };
+            }
+        }
+        #endregion
+        
+        #region index_2
+        public class Products_ByMetadata_AccessViaIndexer : AbstractIndexCreationTask<Product>
+        {
+            public class IndexEntry
+            {
+                public DateTime LastModified { get; set; }
+                public bool HasCounters { get; set; }
+            }
+
+            public Products_ByMetadata_AccessViaIndexer()
+            {
+                Map = products => from product in products
+                    // Use 'MetadataFor' to access the metadata object
+                    let metadata = MetadataFor(product)
+                    
+                    // Define the index fields
+                    select new IndexEntry()
+                    {
+                        // Access metadata properties using indexer
+                        LastModified = 
+                            (DateTime)metadata[Raven.Client.Constants.Documents.Metadata.LastModified],
+
+                        HasCounters = 
+                            metadata[Raven.Client.Constants.Documents.Metadata.Counters] != null
+                    };
+            }
+        }
+        #endregion
+        
+        #region index_3
+        public class Products_ByMetadata_JS : AbstractJavaScriptIndexCreationTask
+        {
+            public Products_ByMetadata_JS()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Products', function (product) {
+                        var metadata = metadataFor(product);
+
+                        return {
+                            LastModified: metadata['@last-modified'],
+                            HasCounters: !!metadata['@counters']
+                        };
+                    })"
+                };
+            }
+        }
+        #endregion
+
+        public Metadata()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region query_1
+                    List<Product> productsWithCounters = session
+                        .Query<Products_ByMetadata_AccessViaValue.IndexEntry,
+                            Products_ByMetadata_AccessViaValue>()
+                        .Where(x => x.HasCounters == true)
+                        .OrderByDescending(x => x.LastModified)
+                        .OfType<Product>()
+                        .ToList();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region query_1_async
+                    List<Product> productsWithCounters = await asyncSession
+                        .Query<Products_ByMetadata_AccessViaValue.IndexEntry,
+                            Products_ByMetadata_AccessViaValue>()
+                        .Where(x => x.HasCounters == true)
+                        .OrderByDescending(x => x.LastModified)
+                        .OfType<Product>()
+                        .ToListAsync();
+                    #endregion
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    #region query_2
+                    List<Product> productsWithCounters = session.Advanced.
+                        DocumentQuery<Products_ByMetadata_AccessViaValue.IndexEntry,
+                            Products_ByMetadata_AccessViaValue>()
+                        .WhereEquals(x => x.HasCounters, true)
+                        .OrderByDescending(x => x.LastModified)
+                        .OfType<Product>()
+                        .ToList();
+                    #endregion
+                }
+            }
+        }
+    }
+}

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Metadata.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Metadata.java
@@ -34,7 +34,7 @@ public class Metadata {
                 "    Product = Product, " +
                 "    Metadata = this.MetadataFor(product) " +
                 "}).Select(this0 => new { " +
-                "    LastModified = this0.metadata.Value<DateTime>(\"Last-Modified\") " +
+                "    LastModified = this0.metadata.Value<DateTime>(\"@last-modified\") " +
                 "})";
         }
     }

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Metadata.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Metadata.java
@@ -1,0 +1,56 @@
+package net.ravendb.Indexes;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.FieldIndexing;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.Date;
+import java.util.List;
+
+public class Metadata {
+
+    private static class Product {
+    
+    }
+
+    //region index_1
+    public static class Products_WithMetadata extends AbstractIndexCreationTask {
+        public static class Result {
+            private Date lastModified;
+
+            public Date getLastModified() {
+                return lastModified;
+            }
+
+            public void setLastModified(Date lastModified) {
+                this.lastModified = lastModified;
+            }
+        }
+
+        public Products_WithMetadata() {
+            map = "docs.Products.Select(product => new { " +
+                "    Product = Product, " +
+                "    Metadata = this.MetadataFor(product) " +
+                "}).Select(this0 => new { " +
+                "    LastModified = this0.metadata.Value<DateTime>(\"Last-Modified\") " +
+                "})";
+        }
+    }
+    //endregion
+
+    public Metadata() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region query_1
+                List<Product> results = session
+                    .query(Products_WithMetadata.Result.class, Products_WithMetadata.class)
+                    .orderByDescending("LastModified")
+                    .ofType(Product.class)
+                    .toList();
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Searching.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Searching.java
@@ -236,7 +236,7 @@ public class Searching {
                 //region search_22
                 List<Product> results = session
                     .query(Products_ByAllValues.IndexEntry.class, Products_ByAllValues.class)
-                    .whereEquals("allValues", "tofu")
+                    .search("allValues", "tofu")
                     .ofType(Product.class)
                     .toList();
                     

--- a/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Searching.java
+++ b/Documentation/6.0/Samples/java/src/test/java/net/ravendb/Indexes/Querying/Searching.java
@@ -1,0 +1,251 @@
+package net.ravendb.Indexes.Querying;
+
+import net.ravendb.client.documents.DocumentStore;
+import net.ravendb.client.documents.IDocumentStore;
+import net.ravendb.client.documents.indexes.AbstractIndexCreationTask;
+import net.ravendb.client.documents.indexes.FieldIndexing;
+import net.ravendb.client.documents.session.IDocumentSession;
+
+import java.util.List;
+
+public class Searching {
+
+    //region search_20_2
+    public static class Users_ByName extends AbstractIndexCreationTask {
+        public Users_ByName() {
+            map = "docs.Users.Select(user => new {" +
+                "    Name = user.Name" +
+                "})";
+
+            index("Name", FieldIndexing.SEARCH);
+        }
+    }
+    //endregion
+
+    //region search_21_2
+    public static class Users_Search extends AbstractIndexCreationTask {
+        public Users_Search() {
+            map = "docs.Users.Select(user => new {" +
+                "    Query = new object[] {" +
+                "        user.Name," +
+                "        user.Hobbies," +
+                "        user.Age" +
+                "    }" +
+                "}))";
+
+            index("Query", FieldIndexing.SEARCH);
+        }
+    }
+    //endregion
+    
+    //region index_all_fields
+    public static class Products_ByAllValues extends AbstractIndexCreationTask {
+        public static class IndexEntry {
+            private String allValues;
+
+            public String getAllValues() {
+                return allValues;
+            }
+
+            public void setAllValues(String allValues) {
+                this.allValues = allValues;
+            }
+        }
+
+        public Products_ByAllValues() {
+            map = "docs.Products.Select(product => new { " +
+                  // Use the 'AsJson' method to convert the document into a JSON-like structure
+                  // and call 'Select' to extract only the values of each property
+                  "    allValues = this.AsJson(product).Select(x => x.Value) " +
+                  "})";
+
+            // Configure the index-field for FTS:
+            // Set 'FieldIndexing.SEARCH' on index-field 'allValues'
+            index("allValues", FieldIndexing.SEARCH);
+            
+            // Set the search engine type to Lucene:
+            searchEngineType = SearchEngineType.LUCENE;
+        }
+    }
+    //endregion    
+
+    //region linq_extensions_search_user_class
+    public static class User {
+        private String id;
+        private String name;
+        private byte age;
+        private List<String> hobbies;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public byte getAge() {
+            return age;
+        }
+
+        public void setAge(byte age) {
+            this.age = age;
+        }
+
+        public List<String> getHobbies() {
+            return hobbies;
+        }
+
+        public void setHobbies(List<String> hobbies) {
+            this.hobbies = hobbies;
+        }
+    }
+    //endregion
+
+    public Searching() {
+        try (IDocumentStore store = new DocumentStore()) {
+            try (IDocumentSession session = store.openSession()) {
+                //region search_3_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Name", "John Adam")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_4_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Hobbies", "looking for someone who likes sport books computers")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_5_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Name", "Adam")
+                    .search("Hobbies", "sport")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_6_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Hobbies", "I love sport")
+                    .boost(10)
+                    .search("Hobbies", "but also like reading books")
+                    .boost(5)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_7_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Hobbies", "computers")
+                    .search("Name", "James")
+                    .whereEquals("Age", 20)
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_8_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Name", "Adam")
+                    .andAlso()
+                    .search("Hobbies", "sport")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_9_0
+                List<User> users = session
+                    .query(User.class)
+                    .not()
+                    .search("Name", "James")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_10_1
+                List<User> users = session
+                    .query(User.class)
+                    .search("Name", "Adam")
+                    .andAlso()
+                    .not()
+                    .search("Hobbies", "sport")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_11_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Name", "Jo* Ad*")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_12_0
+                List<User> users = session
+                    .query(User.class)
+                    .search("Name", "*oh* *da*")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_20_0
+                List<User> users = session
+                    .query(User.class, Users_ByName.class)
+                    .search("Name", "John")
+                    .toList();
+                //endregion
+            }
+
+            try (IDocumentSession session = store.openSession()) {
+                //region search_21_0
+                List<User> users = session
+                    .query(User.class, Users_Search.class)
+                    .search("Query", "John")
+                    .toList();
+                //endregion
+            }
+            
+            try (IDocumentSession session = store.openSession()) {
+                //region search_22
+                List<Product> results = session
+                    .query(Products_ByAllValues.IndexEntry.class, Products_ByAllValues.class)
+                    .whereEquals("allValues", "tofu")
+                    .ofType(Product.class)
+                    .toList();
+                    
+                // * Results will contain all Product documents that have 'tofu'
+                //   in ANY of their fields.
+                //
+                // * Search is case-insensitive since the default analyzer is used.
+                //endregion
+            }
+        }
+    }
+}

--- a/Documentation/6.0/Samples/nodejs/indexes/metadata.js
+++ b/Documentation/6.0/Samples/nodejs/indexes/metadata.js
@@ -14,7 +14,7 @@ class Products_ByMetadata extends AbstractJavaScriptIndexCreationTask {
 
         this.map("Products", product => {
             // Call 'getMetadata' to access the metadata object
-            var metadata = getMetadata(product);
+            const metadata = getMetadata(product);
 
             return {
                 // Define the index fields

--- a/Documentation/6.0/Samples/nodejs/indexes/metadata.js
+++ b/Documentation/6.0/Samples/nodejs/indexes/metadata.js
@@ -1,0 +1,37 @@
+import { 
+    DocumentStore,
+    AbstractIndexCreationTask
+} from "ravendb";
+
+const store = new DocumentStore();
+
+class Product { }
+class DateTime{}
+
+//region index_1
+class Products_WithMetadata extends AbstractIndexCreationTask {
+    constructor() {
+        super();
+        this.map = "docs.Products.Select(product => new {\n" +
+            "    Product = product,\n" +
+            "    Metadata = this.MetadataFor(product)\n" +
+            "}).Select(this_0 => new {\n" +
+            "       LastModified = this_0.Metadata.Value<DateTime>(\'Last-Modified'\)\n"+
+            "   })";
+    }
+}
+//endregion
+
+async function example() {
+    
+    const session = store.openSession();
+
+        //region query_1
+        const results = await session
+            .query({ indexName: "Products/WithMetadata" })
+            .orderByDescending("LastModified")
+            .ofType(Product)
+            .all();
+        //endregion
+}
+

--- a/Documentation/6.0/Samples/nodejs/indexes/querying/searching.js
+++ b/Documentation/6.0/Samples/nodejs/indexes/querying/searching.js
@@ -114,6 +114,30 @@ class Employees_ByFirstName_usingExactAnalyzer extends AbstractJavaScriptIndexCr
 }
 //endregion
 
+//region index_6
+// Extend the index class from 'AbstractCsharpIndexCreationTask':
+class Products_ByAllValues extends AbstractCsharpIndexCreationTask {
+    constructor () {
+        super();
+
+        // Using a C# LINQ string:  
+        this.map = `docs.Products.Select(product => new {
+                        AllValues = this.AsJson(product).Select(x => x.Value)
+                    })`;
+
+        // Configure the index-field for FTS:
+        // Set 'Search' on index-field 'AllValues'
+        this.index("AllValues", "Search");
+
+        // Note:
+        // Since no analyzer is set, the default 'RavenStandardAnalyzer' is used.
+
+        // Set the search engine type to Lucene:
+        this.searchEngineType = "Lucene";
+    }
+}
+//endregion
+
 async function searching() {
     const session = store.openSession();
     
@@ -235,6 +259,20 @@ async function searching() {
         
         assert.ok(explanation.includes(expectedVal),
             `'${explanation}' does not contain '${expectedVal}.'`);
+        //endregion
+    }
+
+    {
+        //region search_6
+        const products = await session
+            .query({ indexName: "Products/ByAllValues" })
+            .search("AllValues", "tofu")
+            .all();
+
+        // * Results will contain all Product documents that have 'tofu'
+        //   in ANY of their fields.
+        //
+        // * Search is case-insensitive since the default analyzer is used.        
         //endregion
     }
 

--- a/Documentation/6.0/Samples/php/Indexes/Metadata.php
+++ b/Documentation/6.0/Samples/php/Indexes/Metadata.php
@@ -34,7 +34,7 @@ class Products_WithMetadata extends AbstractIndexCreationTask
             "    Product = Product, " .
             "    Metadata = this.MetadataFor(product) " .
             "}).Select(this0 => new { " .
-            "    LastModified = this0.metadata.Value\<DateTime\>(\"Last-Modified\") " .
+            "    LastModified = this0.metadata.Value\<DateTime\>(\"@last-modified\") " .
             "})";
     }
 }

--- a/Documentation/6.0/Samples/php/Indexes/Metadata.php
+++ b/Documentation/6.0/Samples/php/Indexes/Metadata.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace RavenDB\Samples\Indexes;
+
+use DateTime;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Indexes\AbstractIndexCreationTask;
+use RavenDB\Documents\Indexes\FieldIndexing;
+use RavenDB\Samples\Infrastructure\Orders\Product;
+
+# region index_1
+class Products_WithMetadata_Result
+{
+    public ?DateTime $lastModified = null;
+
+    public function getLastModified(): ?DateTime
+    {
+        return $this->lastModified;
+    }
+
+    public function setLastModified(?DateTime $lastModified): void
+    {
+        $this->lastModified = $lastModified;
+    }
+}
+
+class Products_WithMetadata extends AbstractIndexCreationTask
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->map = "docs.Products.Select(product => new { " .
+            "    Product = Product, " .
+            "    Metadata = this.MetadataFor(product) " .
+            "}).Select(this0 => new { " .
+            "    LastModified = this0.metadata.Value\<DateTime\>(\"Last-Modified\") " .
+            "})";
+    }
+}
+# endregion
+
+class Metadata
+{
+    public function samples(): void
+    {
+        $store = new DocumentStore();
+        try {
+
+            $session = $store->openSession();
+            try {
+                # region query_1
+                $results = $session
+                    ->query(Products_WithMetadata_Result::class, Products_WithMetadata::class)
+                    ->orderByDescending("LastModified")
+                    ->ofType(Product::class)
+                    ->toList();
+                # endregion
+            } finally {
+                $session->close();
+            }
+
+        } finally {
+            $store->close();
+        }
+    }
+}

--- a/Documentation/6.0/Samples/php/Indexes/Querying/Searching.php
+++ b/Documentation/6.0/Samples/php/Indexes/Querying/Searching.php
@@ -115,7 +115,7 @@ class Searching
             try {
                 # region search_7
                 $results = $session->query(Products_ByAllValues_IndexEntry::class, Products_ByAllValues::class)
-                        ->whereEquals("allValues", "tofu")
+                        ->search("allValues", "tofu")
                         ->ofType(Product::class)
                         ->toList();
                         

--- a/Documentation/6.0/Samples/python/Indexes/Metadata.py
+++ b/Documentation/6.0/Samples/python/Indexes/Metadata.py
@@ -1,0 +1,38 @@
+import datetime
+
+from ravendb import AbstractIndexCreationTask
+from ravendb.documents.indexes.definitions import FieldIndexing
+
+from examples_base import ExampleBase, Product
+
+# region index_1
+class Products_WithMetadata(AbstractIndexCreationTask):
+    class Result:
+        def __init__(self, last_modified: datetime.datetime = None):
+            self.last_modified = last_modified
+
+    def __init__(self):
+        super().__init__()
+        self.map = """
+                   docs.Products.Select(product => new { 
+                       Product = Product, 
+                       Metadata = this.MetadataFor(product) 
+                   }).Select(this0 => new { 
+                       last_modified = this0.metadata.Value<DateTime>("Last-Modified") 
+                   })"""
+# endregion
+
+class Metadata(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_metadata(self):
+        with self.embedded_server.get_document_store("MetadataJSON") as store:
+            with store.open_session() as session:
+                # region query_1
+                results = list(
+                    session.query_index_type(Products_WithMetadata, Products_WithMetadata.Result)
+                    .order_by_descending("LastModified")
+                    .of_type(Product)
+                )
+                # endregion

--- a/Documentation/6.0/Samples/python/Indexes/Metadata.py
+++ b/Documentation/6.0/Samples/python/Indexes/Metadata.py
@@ -42,7 +42,7 @@ class Products_ByMetadata_AccessViaIndexer(AbstractIndexCreationTask):
                    {
                        last_modified = (DateTime)metadata["@last-modified"],
                        has_counters = metadata["@counters"] != null 
-                   }; 
+                   } 
                    """
 # endregion
 

--- a/Documentation/6.0/Samples/python/Indexes/Metadata.py
+++ b/Documentation/6.0/Samples/python/Indexes/Metadata.py
@@ -40,7 +40,7 @@ class Products_ByMetadata_AccessViaIndexer(AbstractIndexCreationTask):
                     
                    select new 
                    {
-                       last_modified = (DateTime)metadata["@last_modified"],
+                       last_modified = (DateTime)metadata["@last-modified"],
                        has_counters = metadata["@counters"] != null 
                    }; 
                    """

--- a/Documentation/6.0/Samples/python/Indexes/Querying/Searching.py
+++ b/Documentation/6.0/Samples/python/Indexes/Querying/Searching.py
@@ -133,7 +133,7 @@ class Searching(ExampleBase):
                 # region search_5
                 products = list(
                     session.query_index_type(Products_ByAllValues, Products_ByAllValues.IndexEntry)
-                    .where_equals("all_values", "tofu")
+                    .search("all_values", "tofu")
                     .of_type(Product)
                 )
                 

--- a/Documentation/6.2/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/6.2/Raven.Documentation.Pages/indexes/.docs.json
@@ -178,15 +178,10 @@
         "Mappings": []
     },
     {
-        "Path": "converting-to-json-and-accessing-metadata.markdown",
-        "Name": "Converting to JSON and Accessing Metadata",
+        "Path": "indexing-metadata.markdown",
+        "Name": "Indexing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
-        "Mappings": [
-            {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-            }
-        ]
+        "Mappings": []
     },
     {
         "Path": "rolling-index-deployment.markdown",

--- a/Documentation/7.0/Raven.Documentation.Pages/indexes/.docs.json
+++ b/Documentation/7.0/Raven.Documentation.Pages/indexes/.docs.json
@@ -178,15 +178,10 @@
         "Mappings": []
     },
     {
-        "Path": "converting-to-json-and-accessing-metadata.markdown",
-        "Name": "Converting to JSON and Accessing Metadata",
+        "Path": "indexing-metadata.markdown",
+        "Name": "Indexing Metadata",
         "DiscussionId": "2fe7313c-df13-478b-acd3-08c5b4d21a1d",
-        "Mappings": [
-            {
-                "Version": 2.0,
-                "Key": "client-api/querying/static-indexes/defining-static-index#using--and-"
-            }
-        ]
+        "Mappings": []
     },
     {
         "Path": "rolling-index-deployment.markdown",


### PR DESCRIPTION
**Related issues:**
https://issues.hibernatingrhinos.com/issue/RDoc-1627/Access-to-internal-properties-of-a-document
https://issues.hibernatingrhinos.com/issue/RDoc-3295/Index-all-fields-for-FTS-using-AsJson

---
To be reviewed:

**C# @Lwiel** 
```
Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.dotnet.markdown
Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.dotnet.markdown
Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Metadata.cs
Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/Indexes/Querying/Searching.cs
```

**Python @poissoncorp** 
```
Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.python.markdown
Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.python.markdown
Documentation/6.0/Samples/python/Indexes/Metadata.py
Documentation/6.0/Samples/python/Indexes/Querying/Searching.py
```

**PHP @alxsabo** 
```
Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.php.markdown
Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.php.markdown
Documentation/6.0/Samples/php/Indexes/Metadata.php
Documentation/6.0/Samples/php/Indexes/Querying/Searching.php
```

**Node.js @ml054 @M4xymm**  
```
Documentation/6.0/Raven.Documentation.Pages/indexes/indexing-metadata.js.markdown
Documentation/6.0/Raven.Documentation.Pages/indexes/querying/searching.js.markdown
Documentation/6.0/Samples/nodejs/indexes/metadata.js
Documentation/6.0/Samples/nodejs/indexes/querying/searching.js
```

**Java:**
As written in the related issues:
Need to open a new dedicated issue for Java to match text & examples to the C# articles.
