### PR TITLE
RDoc-3304 Update PutClientCertificateOperation (null is not allowed)

### DIFF
--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.dotnet.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.dotnet.markdown
@@ -1,29 +1,47 @@
-# Operations: Server: How to Put a Client Certificate
+# Put Client Certificate Operation
+---
 
-You can register an existing client certificate using **PutClientCertificateOperation**. 
+{NOTE: }
 
-## Syntax
+* Use `PutClientCertificateOperation` to register an existing client certificate.
 
-{CODE cert_put_1@ClientApi\Operations\Server\ClientCertificate.cs /}
+* To register an existing client certificate from the Studio,
+  see [Upload an existing client certificate](../../../../studio/server/certificates/server-management-certificates-view#upload-an-existing-client-certificate).
+
+* In this article:
+  * [Put client certificate example](../../../../client-api/operations/server-wide/certificates/put-client-certificate#put-client-certificate-example)
+  * [Syntax](../../../../client-api/operations/server-wide/certificates/put-client-certificate#syntax)
+
+{NOTE/}
+
+---
+
+{PANEL: Put client certificate example}
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync put_client_certificate@ClientApi\Operations\Server\ClientCertificate.cs /}
+{CODE-TAB:csharp:Async put_client_certificate_async@ClientApi\Operations\Server\ClientCertificate.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE put_syntax@ClientApi\Operations\Server\ClientCertificate.cs /}
+
+| Parameter       | Type                                 | Description                                                                                         |
+|-----------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|
+| **name**        | `string`                             | A name for the certificate.                                                                         |
+| **certificate** | `X509Certificate2`                   | The certificate to register.                                                                        |
+| **permissions** | `Dictionary<string, DatabaseAccess>` | A dictionary mapping database name to access level.<br>Relevant only when clearance is `ValidUser`. |
+| **clearance**   | `SecurityClearance`                  | Access level (role) assigned to the certificate.                                                    |
 
 {CODE cert_1_2@ClientApi\Operations\Server\ClientCertificate.cs /}
-
 {CODE cert_1_3@ClientApi\Operations\Server\ClientCertificate.cs /}
 
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **name** | string | Name of a certificate |
-| **certificate** | X509Certificate2 | Certificate to register |
-| **permissions** | Dictionary&lt;string, DatabaseAccess&gt; | Dictionary mapping databases to access level |
-| **clearance** | SecurityClearance | Access level |
-
-## Example
-
-{CODE cert_put_2@ClientApi\Operations\Server\ClientCertificate.cs /}
+{PANEL/}
 
 ## Related Articles
 
-- [How to **delete** client certificate?](../../../../client-api/operations/server-wide/certificates/delete-certificate) 
-- [How to **generate** client certificate?](../../../../client-api/operations/server-wide/certificates/create-client-certificate) 
-
+- [Delete client certificate](../../../../client-api/operations/server-wide/certificates/delete-certificate) 
+- [Generate client certificate](../../../../client-api/operations/server-wide/certificates/create-client-certificate)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.java.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.java.markdown
@@ -1,29 +1,44 @@
-# Operations: Server: How to Put a Client Certificate
+# Put Client Certificate Operation
+---
 
-You can register an existing client certificate using **PutClientCertificateOperation**. 
+{NOTE: }
 
-## Syntax
+* Use `PutClientCertificateOperation` to register an existing client certificate.
 
-{CODE:java cert_put_1@ClientApi\Operations\Server\ClientCertificate.java /}
+* To register an existing client certificate from the Studio,
+  see [Upload an existing client certificate](../../../../studio/server/certificates/server-management-certificates-view#upload-an-existing-client-certificate).
 
-{CODE:java cert_1_2@ClientApi\Operations\Server\ClientCertificate.java /}
+* In this article:
+    * [Put client certificate example](../../../../client-api/operations/server-wide/certificates/put-client-certificate#put-client-certificate-example)
+    * [Syntax](../../../../client-api/operations/server-wide/certificates/put-client-certificate#syntax)
 
-{CODE:java cert_1_3@ClientApi\Operations\Server\ClientCertificate.java /}
+{NOTE/}
 
+---
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **name** | String | Name of a certificate |
-| **certificate** | String | Certificate to register |
-| **permissions** | Map&lt;String, DatabaseAccess&gt; | Map with database to access level mapping |
-| **clearance** | SecurityClearance | Access level |
-
-## Example
+{PANEL: Put client certificate example}
 
 {CODE:java cert_put_2@ClientApi\Operations\Server\ClientCertificate.java /}
 
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:java cert_put_1@ClientApi\Operations\Server\ClientCertificate.java /}
+
+| Parameter       | Type                          | Description                                                                                          |
+|-----------------|-------------------------------|------------------------------------------------------------------------------------------------------|
+| **name**        | `String`                      | A name for the certificate.                                                                          |
+| **certificate** | `String`                      | The certificate to register.                                                                         |
+| **permissions** | `Map<String, DatabaseAccess>` | A dictionary mapping database name to access level.<br>Relevant only when clearance is `VALID_USER`. |
+| **clearance**   | `SecurityClearance`           | Access level (role) assigned to the certificate.                                                     |
+
+{CODE:java cert_1_2@ClientApi\Operations\Server\ClientCertificate.java /}
+{CODE:java cert_1_3@ClientApi\Operations\Server\ClientCertificate.java /}
+
+{PANEL/}
+
 ## Related Articles
 
-- [How to **delete** client certificate?](../../../../client-api/operations/server-wide/certificates/delete-certificate) 
-- [How to **generate** client certificate?](../../../../client-api/operations/server-wide/certificates/create-client-certificate) 
-
+- [Delete client certificate](../../../../client-api/operations/server-wide/certificates/delete-certificate)
+- [Generate client certificate](../../../../client-api/operations/server-wide/certificates/create-client-certificate)

--- a/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.js.markdown
+++ b/Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.js.markdown
@@ -1,37 +1,52 @@
-# Operations: Server: How to Put a Client Certificate
+# Put Client Certificate Operation
+---
 
-You can register an existing client certificate using **PutClientCertificateOperation**. 
+{NOTE: }
 
-## Usage
+* Use `PutClientCertificateOperation` to register an existing client certificate.
 
-{CODE:nodejs cert_put_1@ClientApi\Operations\Server\ClientCertificate.js /}
+* To register an existing client certificate from the Studio,
+  see [Upload an existing client certificate](../../../../studio/server/certificates/server-management-certificates-view#upload-an-existing-client-certificate).
 
-`SecurityClearance` options:
+* In this article:
+    * [Put client certificate example](../../../../client-api/operations/server-wide/certificates/put-client-certificate#put-client-certificate-example)
+    * [Syntax](../../../../client-api/operations/server-wide/certificates/put-client-certificate#syntax)
 
-* `UnauthenticatedClients`  
-* `ClusterAdmin`  
-* `ClusterNode`  
-* `Operator`  
-* `ValidUser`  
+{NOTE/}
 
-`DatabaseAccess ` options:
+---
 
-* `ReadWrite`  
-* `Admin`  
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **name** | string | Name of a certificate |
-| **certificate** | string | Certificate to register |
-| **permissions** | Record<string, DatabaseAccess> | Dictionary mapping databases to access level |
-| **clearance** | SecurityClearance | Access level |
-
-## Example
+{PANEL: Put client certificate example}
 
 {CODE:nodejs cert_put_2@ClientApi\Operations\Server\ClientCertificate.js /}
 
+{PANEL/}
+
+{PANEL: Syntax}
+
+{CODE:nodejs syntax@ClientApi\Operations\Server\ClientCertificate.js /}
+
+| Parameter       | Type                             | Description                                                                                         |
+|-----------------|----------------------------------|-----------------------------------------------------------------------------------------------------|
+| **name**        | `string`                         | A name for the certificate.                                                                         |
+| **certificate** | `string`                         | The certificate to register.                                                                        |
+| **permissions** | `Record<string, DatabaseAccess>` | A dictionary mapping database name to access level.<br>Relevant only when clearance is `ValidUser`. |
+| **clearance**   | `SecurityClearance`              | Access level (role) assigned to the certificate.                                                    |
+
+* `SecurityClearance` options:
+  * `ClusterAdmin`  
+  * `ClusterNode`  
+  * `Operator`  
+  * `ValidUser`  
+
+* `DatabaseAccess ` options:
+  * `Read`
+  * `ReadWrite`  
+  * `Admin`
+
+{PANEL/}
+
 ## Related Articles
 
-- [How to **delete** client certificate?](../../../../client-api/operations/server-wide/certificates/delete-certificate) 
-- [How to **generate** client certificate?](../../../../client-api/operations/server-wide/certificates/create-client-certificate) 
-
+- [Delete client certificate](../../../../client-api/operations/server-wide/certificates/delete-certificate)
+- [Generate client certificate](../../../../client-api/operations/server-wide/certificates/create-client-certificate)

--- a/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ClientCertificate.cs
+++ b/Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ClientCertificate.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
-using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
 
 namespace Raven.Documentation.Samples.ClientApi.Operations.Server
 {
-
     public class ClientCertificate
     {
         private interface IFoo
@@ -27,7 +26,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
             public GetCertificatesOperation(int start, int pageSize)
             #endregion
 
-            #region cert_put_1
+            #region put_syntax
             public PutClientCertificateOperation(
                 string name, 
                 X509Certificate2 certificate, 
@@ -40,6 +39,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
         private class Foo
         {
             #region cert_1_2
+            // The role assigned to the certificate:
             public enum SecurityClearance
             {
                 ClusterAdmin,
@@ -50,6 +50,7 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
             #endregion
 
             #region cert_1_3
+            // The access level for a 'ValidUser' security clearance:
             public enum DatabaseAccess
             {
                 Read,
@@ -105,14 +106,43 @@ namespace Raven.Documentation.Samples.ClientApi.Operations.Server
                         store.Maintenance.Server.Send(new GetCertificatesOperation(0, 20));
                     #endregion
                 }
+            }
+        }
+        
+        public async Task PutClientCertificate()
+        {
+            using (var store = new DocumentStore())
+            {
+                {
+                    #region put_client_certificate
+                    X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
+
+                    // Define the put client certificate operation 
+                    var putClientCertificateOp = new PutClientCertificateOperation(
+                        "certificateName",
+                        certificate, 
+                        new Dictionary<string, DatabaseAccess>(),
+                        SecurityClearance.ClusterAdmin);
+
+                    // Execute the operation by passing it to Maintenance.Server.Send
+                    store.Maintenance.Server.Send(putClientCertificateOp);
+                    #endregion
+                }
 
                 {
+                    #region put_client_certificate_async
 
-                    #region cert_put_2
                     X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
-                    store.Maintenance.Server.Send(
-                        new PutClientCertificateOperation(
-                            "cert1", certificate, null, SecurityClearance.ClusterAdmin));
+
+                    // Define the put client certificate operation 
+                    var putClientCertificateOp = new PutClientCertificateOperation(
+                        "certificateName",
+                        certificate, 
+                        new Dictionary<string, DatabaseAccess>(),
+                        SecurityClearance.ClusterAdmin);
+
+                    // Execute the operation by passing it to Maintenance.Server.SendAsync
+                    await store.Maintenance.Server.SendAsync(putClientCertificateOp);
                     #endregion
                 }
             }

--- a/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Server/ClientCertificate.java
+++ b/Documentation/5.2/Samples/java/src/test/java/net/ravendb/ClientApi/Operations/Server/ClientCertificate.java
@@ -52,7 +52,6 @@ public class ClientCertificate {
     private static class Foo {
         //region cert_1_2
         public enum SecurityClearance {
-            UNAUTHENTICATED_CLIENTS,
             CLUSTER_ADMIN,
             CLUSTER_NODE,
             OPERATOR,
@@ -118,14 +117,14 @@ public class ClientCertificate {
 
             try {
                 //region cert_put_2
-                Certificate certificate = keyStore.getCertificate("clientCert");
-                String certificateAsBase64 = Base64.encodeBase64String(certificate.getEncoded());
+                byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
+                String certificateAsBase64 = Base64.getEncoder().encodeToString(rawCert);                
 
                 store.maintenance().server().send(
                     new PutClientCertificateOperation(
-                        "cert1",
+                        "certificateName",
                         certificateAsBase64,
-                        null,
+                        new HashMap<>(),
                         SecurityClearance.CLUSTER_ADMIN));
                 //endregion
             } catch (Exception e) {

--- a/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/ClientCertificate.js
+++ b/Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/ClientCertificate.js
@@ -4,7 +4,9 @@ import {
     DocumentStore,
     PutClientCertificateOperation
 } from 'ravendb';
+
 let urls, database, authOptions,permissions,clearance,password,certificate,publicKey,thumbprint;
+
 {
     //document_store_creation
     const store = new DocumentStore(["http://localhost:8080"], "Northwind2");
@@ -16,10 +18,7 @@ let urls, database, authOptions,permissions,clearance,password,certificate,publi
         new CreateClientCertificateOperation([name], [permissions], [clearance], [password]));
     //endregion
 
-
-
     async function foo1() {
-
 
         //region cert_1_4
         // With user role set to Cluster Administrator or Operator the user of this certificate
@@ -40,19 +39,27 @@ let urls, database, authOptions,permissions,clearance,password,certificate,publi
     const clientCertificateOperation = await store.maintenance.server.send(
         new CreateClientCertificateOperation("user1", clearance, "ValidUser", "myPassword"));
     const certificateRawData = clientCertificateOperation.rawData;
-
     //endregion
 
     async function foo2() {
-        //region cert_put_1
-        const putOperation = new PutClientCertificateOperation([name], [certificate], [permissions], [clearance]);
+        //region syntax
+        const putOperation = 
+            new PutClientCertificateOperation(name, certificate, permissions, clearance);
         //endregion
     }
 
     async function foo3() {
         //region cert_put_2
-        const putOperation = new PutClientCertificateOperation("cert1", publicKey, {}, "ClusterAdmin");
-        await store.maintenance.server.send(putOperation);
+        const rawCert = fs.readFileSync("<path-to-certificate.crt>");
+        const certificateAsBase64 = rawCert.toString("base64");
+        
+        const putClientCertificateOp = new PutClientCertificateOperation(
+            "certificateName",
+            certificateAsBase64,
+            {},
+            "ClusterAdmin");
+        
+        await store.maintenance.server.send(putClientCertificateOp);
         //endregion
 
         //region delete_cert_1

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.dotnet.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.dotnet.markdown
@@ -4,7 +4,7 @@
 
 {NOTE: }
 
-* Use The `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
+* Use the `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
   that still occupy space after deletes.  
   You can choose whether to compact _documents_ and/or _selected indexes_.  
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.js.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.js.markdown
@@ -4,7 +4,7 @@
 
 {NOTE: }
 
-* Use The `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
+* Use the `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
   that still occupy space after deletes.  
   You can choose whether to compact _documents_ and/or _selected indexes_.  
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.php.markdown
@@ -4,7 +4,7 @@
 
 {NOTE: }
 
-* Use The `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
+* Use the `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
   that still occupy space after deletes.  
   You can choose whether to compact _documents_ and/or _selected indexes_.  
 

--- a/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.python.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/client-api/operations/server-wide/compact-database.python.markdown
@@ -4,7 +4,7 @@
 
 {NOTE: }
 
-* Use The `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
+* Use the `CompactDatabaseOperation` compaction operation to **removes empty gaps on disk** 
   that still occupy space after deletes.  
   You can choose whether to compact _documents_ and/or _selected indexes_.  
 

--- a/Documentation/5.4/Raven.Documentation.Pages/studio/server/certificates/server-management-certificates-view.markdown
+++ b/Documentation/5.4/Raven.Documentation.Pages/studio/server/certificates/server-management-certificates-view.markdown
@@ -5,20 +5,20 @@
 
 * Use the **Certificates** view to create, customize, import and export certificates.  
 
-* In this page:
+* In this article:
    * [The certificates view](../../../studio/server/certificates/server-management-certificates-view#the-certificates-view)  
-   * [View and Edit certificates](../../../studio/server/certificates/server-management-certificates-view#view-and-edit-certificates)  
+   * [View and edit certificates](../../../studio/server/certificates/server-management-certificates-view#view-and-edit-certificates)  
    * [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view#generate-a-client-certificate)  
    * [Enable communication between secure servers](../../../studio/server/certificates/server-management-certificates-view#enable-communication-between-secure-servers)  
-      * [Upload an Existing Certificate](../../../studio/server/certificates/server-management-certificates-view#upload-an-existing-certificate)
-      * [Export Server Certificates](../../../studio/server/certificates/server-management-certificates-view#export-server-certificates)
-   * [Certificate Collections](../../../studio/server/certificates/server-management-certificates-view#certificate-collections)
+      * [Upload an existing client certificate](../../../studio/server/certificates/server-management-certificates-view#upload-an-existing-client-certificate)
+      * [Export server certificates](../../../studio/server/certificates/server-management-certificates-view#export-server-certificates)
+   * [Certificate collections](../../../studio/server/certificates/server-management-certificates-view#certificate-collections)
 
 {NOTE/}
 
 ---
 
-{PANEL: The Certificates View}
+{PANEL: The certificates view}
 
 ![Studio Certificates Management View](images/studio-certificates-overview.png "Studio Certificates Management View")
 
@@ -40,7 +40,7 @@ the permissions entirely using this view.
 
 {PANEL/}
 
-{PANEL: View and Edit Certificates}
+{PANEL: View and edit certificates}
 
 In the image below, the client certificates (`sampledom.client.certificate` and `Booking`) have different 
 **security clearance** and **database permissions** configurations.  
@@ -126,7 +126,9 @@ To enable communication between two secure databases, you need to:
    the `.pfx` certificate from the destination cluster.  
 2. **Upload** (import) the downloaded certificate into the source server.  
 
-## Upload client certificate
+---
+
+### Upload an existing client certificate
 
 Use this option to upload an existing client certificate.  
 Uploaded certificates will be added to the list of registered certificates.  
@@ -140,7 +142,9 @@ While uploading the client certificate you can modify its settings.
 See the [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view#generate-a-client-certificate) 
 section to learn about the available settings.  
 
-## Export Server Certificates
+---
+
+### Export server certificates
 
 ![Export Server Certificates](images/export-server-certificates.png "Export Server Certificates")
 
@@ -151,7 +155,7 @@ will be exported.
 
 {PANEL/}
 
-{PANEL: Certificate Collections} 
+{PANEL: Certificate collections} 
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 

--- a/Documentation/7.0/Raven.Documentation.Pages/studio/server/certificates/server-management-certificates-view.markdown
+++ b/Documentation/7.0/Raven.Documentation.Pages/studio/server/certificates/server-management-certificates-view.markdown
@@ -5,20 +5,20 @@
 
 * Use the **Certificates** view to create, customize, import and export certificates.  
 
-* In this page:
-   * [The certificates view](../../../studio/server/certificates/server-management-certificates-view#the-certificates-view)  
-   * [View and Edit certificates](../../../studio/server/certificates/server-management-certificates-view#view-and-edit-certificates)  
-   * [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view#generate-a-client-certificate)  
-   * [Enable communication between secure servers](../../../studio/server/certificates/server-management-certificates-view#enable-communication-between-secure-servers)  
-      * [Upload an Existing Certificate](../../../studio/server/certificates/server-management-certificates-view#upload-an-existing-certificate)
-      * [Export Server Certificates](../../../studio/server/certificates/server-management-certificates-view#export-server-certificates)
-   * [Certificate Collections](../../../studio/server/certificates/server-management-certificates-view#certificate-collections)
+* In this article:
+   * [The certificates view](../../../studio/server/certificates/server-management-certificates-view#the-certificates-view)
+   * [View and edit certificates](../../../studio/server/certificates/server-management-certificates-view#view-and-edit-certificates)
+   * [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view#generate-a-client-certificate)
+   * [Enable communication between secure servers](../../../studio/server/certificates/server-management-certificates-view#enable-communication-between-secure-servers)
+      * [Upload an existing client certificate](../../../studio/server/certificates/server-management-certificates-view#upload-an-existing-client-certificate)
+      * [Export server certificates](../../../studio/server/certificates/server-management-certificates-view#export-server-certificates)
+   * [Certificate collections](../../../studio/server/certificates/server-management-certificates-view#certificate-collections)
 
 {NOTE/}
 
 ---
 
-{PANEL: The Certificates View}
+{PANEL: The Certificates view}
 
 ![Studio Certificates Management View](images/studio-certificates-overview.png "Studio Certificates Management View")
 
@@ -40,7 +40,7 @@ the permissions entirely using this view.
 
 {PANEL/}
 
-{PANEL: View and Edit Certificates}
+{PANEL: View and edit certificates}
 
 In the image below, the client certificates (`sampledom7.client.certificate` and `Booking`) have different 
 **security clearance** and **database permissions** configurations.  
@@ -128,7 +128,9 @@ To enable communication between two secure databases, you need to:
    the `.pfx` certificate from the destination cluster.  
 2. **Upload** (import) the downloaded certificate into the source server.  
 
-## Upload client certificate
+---
+
+### Upload an existing client certificate
 
 Use this option to upload an existing client certificate.  
 Uploaded certificates will be added to the list of registered certificates.  
@@ -142,7 +144,9 @@ While uploading the client certificate you can modify its settings.
 See the [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view#generate-a-client-certificate) 
 section to learn about the available settings.  
 
-## Export Server Certificates
+---
+
+## Export server certificates
 
 ![Export Server Certificates](images/export-server-certificates.png "Export Server Certificates")
 
@@ -153,7 +157,7 @@ will be exported.
 
 {PANEL/}
 
-{PANEL: Certificate Collections} 
+{PANEL: Certificate collections} 
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3304/Update-PutClientCertificateOperation-Example-null-for-permissions-is-not-allowed

---

C# @haludi 
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.dotnet.markdown
Documentation/5.2/Samples/csharp/Raven.Documentation.Samples/ClientApi/Operations/Server/ClientCertificate.cs
```

Node.js @M4xymm 
```
Documentation/5.2/Raven.Documentation.Pages/client-api/operations/server-wide/certificates/put-client-certificate.js.markdown
Documentation/5.2/Samples/nodejs/ClientApi/Operations/Server/ClientCertificate.js
```