### PR TITLE
RDoc-3310 Using 'Include' in a NoTracking session will throw

### DIFF
--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
@@ -1,0 +1,145 @@
+# Disable Entity Tracking
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `SaveChanges` is called.  
+
+* Tracking can be disabled at various scopes:  
+  for a specific entity, for entities returned by a query, for all entities in a session, or globally using conventions.
+
+* In this article:
+  * [Disable tracking changes for a specific entity](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-changes-for-a-specific-entity)
+  * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+  * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+  * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+  * [Using 'Include' in a NoTracking session will throw](../../../client-api/session/configuration/how-to-disable-tracking#using-)
+
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking changes for a specific entity}
+
+* You can prevent the session from persisting changes made to a specific entity by using `IgnoreChangesFor`.
+* Once changes are ignored for the entity:
+  * Any modifications made to the entity will be ignored by `SaveChanges`.
+  * The session will still keep a reference to the entity to avoid repeated server requests.  
+    Performing another `Load` for the same entity will Not generate another call to the server.
+
+**Example**
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_1_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+**Syntax**
+
+{CODE syntax_1@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+| Parameter  | Type     | Description                                          |
+|------------|----------|------------------------------------------------------|
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking all entities in session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `Store` will Not be available (an exception will be thrown if used).
+  * Calling `Load` or `Query` will generate a call to the server and create new entities instances.  
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_2_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Disable tracking query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE-TABS}
+{CODE-TAB:csharp:Query-Sync disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Query-Async disable_tracking_3_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:DocumentQuery-Sync disable_tracking_3_documentQuery@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:DocumentQuery-Async disable_tracking_3_documentQuery_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+
+**Example**
+
+{CODE:csharp disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+// todo .. async...
+
+**Syntax**
+
+{CODE syntax_2@ClientApi\Session\Configuration\DisableTracking.cs /}
+
+| Parameter                           | Description                                      |
+|-------------------------------------|--------------------------------------------------|
+| `InMemoryDocumentSessionOperations` | The session for which tracking is to be disabled |
+| `object`                            | The entity for which tracking is to be disabled  |
+| `string`                            | The entity's document ID                         |
+
+| Return Type  | Description                                                             |
+|--------------|-------------------------------------------------------------------------|
+| `bool`       | `true` - Entity will Not be tracked<br>`false` - Entity will be tracked |
+
+{PANEL/}
+
+{PANEL: Using 'Include' in a NoTracking session will throw}
+ 
+* Attempting to use `Include` in a `NoTracking` session will throw an exception.
+
+* Like other entities in a _NoTracking_ session, 
+  the included items are not tracked and will not prevent additional server requests during subsequent _Load_ operations for the same data.
+  To avoid confusion, _Include_ operations are disallowed during non-tracking session actions such as `Load` or `Query`. 
+
+* This applies to all items that can be included -  
+  e.g., documents, compare-exchange items, counters, revisions, and time series.
+
+---
+
+**Include when loading**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_5@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_5_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+**Include when querying**:
+
+{CODE-TABS}
+{CODE-TAB:csharp:Sync disable_tracking_6@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TAB:csharp:Async disable_tracking_6_async@ClientApi\Session\Configuration\DisableTracking.cs /}
+{CODE-TABS/}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
@@ -1,0 +1,126 @@
+# Disable Entity Tracking
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `saveChanges` is called.  
+
+* Tracking can be disabled at various scopes:  
+  for a specific entity, for entities returned by a query, for all entities in a session, or globally using conventions.
+
+* In this article:
+  * [Disable tracking changes for a specific entity](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-changes-for-a-specific-entity)
+  * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+  * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+  * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+  * [Using 'Include' in a NoTracking session will throw](../../../client-api/session/configuration/how-to-disable-tracking#using-)
+
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking changes for a specific entity}
+
+* You can prevent the session from persisting changes made to a specific entity by using `ignoreChangesFor`.
+* Once changes are ignored for the entity:
+    * Any modifications made to the entity will be ignored by `saveChanges`.
+    * The session will still keep a reference to the entity to avoid repeated server requests.  
+      Performing another `load` for the same entity will Not generate another call to the server.
+  
+**Example**
+
+{CODE:nodejs disable_tracking_1@client-api\session\Configuration\disableTracking.js /}
+
+**Syntax**
+
+{CODE:nodejs syntax_1@client-api\session\Configuration\disableTracking.js /}
+
+| Parameter  | Type     | Description                                          |
+|------------|----------|------------------------------------------------------|
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking all entities in session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `store` will Not be available (an exception will be thrown if used).
+  * Calling `load` or `query` will generate a call to the server and create new entities instances.
+
+{CODE:nodejs disable_tracking_2@client-api\session\Configuration\disableTracking.js /}
+
+{PANEL/}
+
+{PANEL: Disable tracking query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE:nodejs disable_tracking_3@client-api\session\Configuration\disableTracking.js /}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `shouldIgnoreEntityChanges` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+
+**Example**
+
+{CODE:nodejs disable_tracking_4@client-api\session\Configuration\disableTracking.js /}
+
+**Syntax**
+
+{CODE:nodejs syntax_2@client-api\session\Configuration\disableTracking.js /}
+
+| Parameter         | Type                                | Description                                      |
+|-------------------|-------------------------------------|--------------------------------------------------|
+| sessionOperations | `InMemoryDocumentSessionOperations` | The session for which tracking is to be disabled |
+| entity            | `object`                            | The entity for which tracking is to be disabled  |
+| documentId        | `string`                            | The entity's document ID                         |
+
+| Return Type   | Description                                                             |
+|---------------|-------------------------------------------------------------------------|
+| `boolean`     | `true` - Entity will Not be tracked<br>`false` - Entity will be tracked |
+
+{PANEL/}
+
+{PANEL: Using 'include' in a noTracking session will throw}
+
+* Attempting to use `include` in a `noTracking` session will throw an exception.
+
+* Like other entities in a _noTracking_ session,
+  the included items are not tracked and will not prevent additional server requests during subsequent _load_ operations for the same data.
+  To avoid confusion, _include_ operations are disallowed during non-tracking session actions such as `load` or `query`.
+
+* This applies to all items that can be included -  
+  e.g., documents, compare-exchange items, counters, revisions, and time series.
+
+---
+
+**Include when loading**:
+
+{CODE:nodejs disable_tracking_5@client-api\session\Configuration\disableTracking.js /}
+
+**Include when querying**:
+
+{CODE:nodejs disable_tracking_6@client-api\session\Configuration\disableTracking.js /}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.php.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.php.markdown
@@ -1,0 +1,84 @@
+# Disable Entity Tracking
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `saveChanges` is called.  
+
+* Tracking can be disabled at various scopes:  
+  for a specific entity, for entities returned by a query, for all entities in a session, or globally using conventions.
+
+* In this article:
+    * [Disable tracking changes for a specific entity](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-changes-for-a-specific-entity)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking changes for a specific entity}
+
+* You can prevent the session from persisting changes made to a specific entity by using `ignoreChangesFor`.
+* Once changes are ignored for the entity:
+    * Any modifications made to the entity will be ignored by `saveChanges`.
+    * The session will still keep a reference to the entity to avoid repeated server requests.  
+      Performing another `load` for the same entity will Not generate another call to the server.
+  
+**Example**
+
+{CODE:php disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.php /}
+
+{PANEL/}
+
+{PANEL: Disable tracking for all entities in a session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `store` will Not be available (an exception will be thrown if used).
+  * Calling `load` or `query` will generate a call to the server and create new entities instances.  
+
+{CODE:php disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.php /}
+
+{PANEL/}
+
+{PANEL: Disable tracking for query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE-TABS}
+{CODE-TAB:php:query disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.php /}
+{CODE-TAB:php:documentQuery disable_tracking_3_documentQuery@ClientApi\Session\Configuration\DisableTracking.php /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `ShouldIgnoreEntityChanges` convention method on the document store.
+* This customization will apply to all sessions opened for this document store.
+* Use the `setShouldIgnoreEntityChanges` method to do so.  
+
+#### Example:
+
+{CODE:php disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.php /}
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.python.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.python.markdown
@@ -1,0 +1,105 @@
+# Disable Entity Tracking
+---
+
+{NOTE: }
+
+* By default, each session tracks changes to all entities it has either stored, loaded, or queried for.  
+  All changes are then persisted when `save_changes` is called.  
+
+* Tracking can be disabled at various scopes:  
+  for a specific entity, for entities returned by a query, for all entities in a session, or globally using conventions.
+
+* In this article:
+    * [Disable tracking changes for a specific entity](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-changes-for-a-specific-entity)
+    * [Disable tracking all entities in session](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-all-entities-in-session)
+    * [Disable tracking query results](../../../client-api/session/configuration/how-to-disable-tracking#disable-tracking-query-results)
+    * [Customize tracking in conventions](../../../client-api/session/configuration/how-to-disable-tracking#customize-tracking-in-conventions)
+
+{NOTE/}
+
+---
+
+{PANEL: Disable tracking changes for a specific entity}
+
+* You can prevent the session from persisting changes made to a specific entity by using `ignore_changes_for`.
+* Once changes are ignored for the entity:
+    * Any modifications made to the entity will be ignored by `save_changes`.
+    * The session will still keep a reference to the entity to avoid repeated server requests.  
+      Performing another `load` for the same entity will Not generate another call to the server.
+  
+**Example**
+
+{CODE:python disable_tracking_1@ClientApi\Session\Configuration\DisableTracking.py /}
+
+**Syntax**
+
+{CODE:python syntax_1@ClientApi\Session\Configuration\DisableTracking.py /}
+
+| Parameter  | Type     | Description                                          |
+|------------|----------|------------------------------------------------------|
+| **entity** | `object` | Instance of entity for which changes will be ignored |
+
+{PANEL/}
+
+{PANEL: Disable tracking for all entities in a session}
+
+* Tracking can be disabled for all entities in the session's options.  
+* When tracking is disabled for the session:  
+  * Method `store` will Not be available (an exception will be thrown if used).
+  * Calling `load` or `query` will generate a call to the server and create new entities instances.  
+
+{CODE:python disable_tracking_2@ClientApi\Session\Configuration\DisableTracking.py /}
+
+{PANEL/}
+
+{PANEL: Disable tracking for query results}
+
+* Tracking can be disabled for all entities resulting from a query.
+
+{CODE-TABS}
+{CODE-TAB:python disable_tracking_3@ClientApi\Session\Configuration\DisableTracking.py /}
+{CODE-TABS/}
+
+{PANEL/}
+
+{PANEL: Customize tracking in conventions}
+
+* You can further customize and fine-tune which entities will not be tracked  
+  by configuring the `should_ignore_entity_changes` convention method on the document store.
+* This customization rule will apply to all sessions opened for this document store.
+* Implement rules under your [ShouldIgnoreEntityChanges](../../../client-api/session/configuration/how-to-disable-tracking#syntax) subclass.  
+  Apply the class's `check` method to control the ignore flow.
+
+**Example**:
+
+{CODE:python disable_tracking_4@ClientApi\Session\Configuration\DisableTracking.py /}
+
+**Syntax**:
+
+{CODE:python syntax_2@ClientApi\Session\Configuration\DisableTracking.py /}
+
+| Parameter   | Type     | Description                                     |
+|-------------|----------|-------------------------------------------------|
+| entity      | `object` | The entity for which tracking is to be disabled |
+| document_id | `str`    | The entity's document ID                        |
+
+| Return Type   | Description                                                             |
+|---------------|-------------------------------------------------------------------------|
+| `bool`        | `True` - Entity will Not be tracked<br>`False` - Entity will be tracked |
+
+{PANEL/}
+
+## Related Articles
+
+### Client API
+
+- [Document Store Conventions](../../../client-api/configuration/conventions)
+
+### Session
+
+- [How to Ignore Entity Changes](../../../client-api/session/how-to/ignore-entity-changes)
+- [What is a Session and How Does it Work](../../../client-api/session/what-is-a-session-and-how-does-it-work) 
+- [Opening a Session](../../../client-api/session/opening-a-session)
+- [Storing Entities](../../../client-api/session/storing-entities)
+- [Loading Entities](../../../client-api/session/loading-entities)
+- [Saving Changes](../../../client-api/session/saving-changes)

--- a/Documentation/6.0/Raven.Documentation.Pages/migration/client-api/client-breaking-changes.markdown
+++ b/Documentation/6.0/Raven.Documentation.Pages/migration/client-api/client-breaking-changes.markdown
@@ -5,7 +5,7 @@
 The features listed on this page were available in former RavenDB versions and are unavailable in RavenDB `6.x`,  
 or their behavior is inconsistent with their behavior in previous versions.  
 
-* In this page:
+* In this article:
    * [Breaking changes](../../migration/client-api/client-breaking-changes#breaking-changes)  
    * [Breaking changes in a sharded database](../../migration/client-api/client-breaking-changes#breaking-changes-in-a-sharded-database)  
    * [Additional breaking changes](../../migration/client-api/client-breaking-changes#additional-breaking-changes)  
@@ -14,14 +14,12 @@ or their behavior is inconsistent with their behavior in previous versions.
 
 {PANEL: Breaking changes}
 
-* **Include from a Non-tracking session**  
-  A non-tracking session will now throw the following exception if an 'Include' operation is used in it,  
-  to indicate that the operation is forbidden in a non-tracking session and to warn about its expected results.
-
-        "This session does not track any entities, because of that registering includes is forbidden
-        to avoid false expectations when later load operations are performed on those and no requests
-        are being sent to the server.
-        Please avoid any 'Include' operations during non-tracking session actions like load or query."
+* **Include from a non-tracking session**  
+  * A non-tracking session will now throw an exception if an `Include` operation is used in it.
+  * Like other entities in a `NoTracking` session,
+    included items are not tracked and will not prevent additional server requests during subsequent _Load_ operations for the same data.
+    To avoid confusion, _Include_ operations are disallowed during non-tracking session actions such as _Load_ or _Query_.
+  * Learn more in [Using 'Include' in a NoTracking session will throw](../../client-api/session/configuration/how-to-disable-tracking#using-).
   
 * **Type changes**  
   Many methods related to paging information (Skip, Take, PageSize, TotalResults, etc.) that used the `int` type in former RavenDB versions now use `long`, 

--- a/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
+++ b/Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
@@ -1,0 +1,308 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.Loaders;
+using Raven.Documentation.Samples.Orders;
+using Xunit;
+
+namespace Raven.Documentation.Samples.ClientApi.Session.Configuration
+{
+    public class DisableTracking
+    {
+        private interface IgnoreChangesEntity
+        {
+            #region syntax_1
+            void IgnoreChangesFor(object entity);
+            #endregion
+        }
+
+        private abstract class IgnoreChangesConvention
+        {
+            #region syntax_2
+            public Func<InMemoryDocumentSessionOperations, object, string, bool> ShouldIgnoreEntityChanges;
+            #endregion
+        }
+
+        public async Task DisableTrackingSamples()
+        {
+            using (var store = new DocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    #region disable_tracking_1
+                    // Load a product entity - the session will track the entity by default
+                    Product product = session.Load<Product>("products/1-A");
+                    
+                    // Call 'IgnoreChangesFor' to instruct the session to ignore changes made to this entity
+                    session.Advanced.IgnoreChangesFor(product);
+                    
+                    // The following change will be ignored by SaveChanges - it will not be persisted
+                    product.UnitsInStock += 1;
+                    
+                    session.SaveChanges();
+                    #endregion
+                }
+                
+                using (var asyncSession = store.OpenAsyncSession())
+                {
+                    #region disable_tracking_1_async
+                    // Load a product entity - the session will track the entity by default
+                    Product product = await asyncSession.LoadAsync<Product>("products/1-A");
+                    
+                    // Call 'IgnoreChangesFor' to instruct the session to ignore changes made to this entity
+                    asyncSession.Advanced.IgnoreChangesFor(product);
+                    
+                    // The following change will be ignored by SaveChanges - it will not be persisted
+                    product.UnitsInStock += 1;
+                    
+                    await asyncSession.SaveChangesAsync();
+                    #endregion
+                }
+                
+                #region disable_tracking_2
+                using (IDocumentSession session = store.OpenSession(new SessionOptions
+                {
+                    // Disable tracking for all entities in the session's options
+                    NoTracking = true
+                }))
+                {
+                    // Load any entity, it will Not be tracked by the session
+                    Employee employee1 = session.Load<Employee>("employees/1-A");
+                    
+                    // Loading again from same document will result in a new entity instance
+                    Employee employee2 = session.Load<Employee>("employees/1-A");
+                    
+                    // Entities instances are not the same
+                    Assert.NotEqual(employee1, employee2);
+                }
+                #endregion
+
+                #region disable_tracking_2_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession(new SessionOptions
+                {
+                    // Disable tracking for all entities in the session's options
+                    NoTracking = true
+                }))
+                {
+                    // Load any entity, it will Not be tracked by the session
+                    Employee employee1 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+                    
+                    // Loading again from same document will result in a new entity instance
+                    Employee employee2 = await asyncSession.LoadAsync<Employee>("employees/1-A");
+
+                    // Entities instances are not the same
+                    Assert.NotEqual(employee1, employee2);
+                }
+                #endregion
+                
+                #region disable_tracking_3
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = session.Query<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    session.SaveChanges();
+                }
+                #endregion
+
+                #region disable_tracking_3_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = asyncSession.Query<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .Customize(x => x.NoTracking())
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    await asyncSession.SaveChangesAsync();
+                }
+                #endregion
+                
+                #region disable_tracking_3_documentQuery
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = session.Advanced.DocumentQuery<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .NoTracking()
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    session.SaveChanges();
+                }
+                #endregion
+                
+                #region disable_tracking_3_documentQuery_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession())
+                {
+                    // Define a query
+                    List<Employee> employeesResults = asyncSession.Advanced.AsyncDocumentQuery<Employee>()
+                        // Set NoTracking, all resulting entities will not be tracked
+                        .NoTracking()
+                        .Where(x => x.FirstName == "Robert")
+                        .ToList();
+
+                    // The following modification will not be tracked for SaveChanges
+                    Employee firstEmployee = employeesResults[0];
+                    firstEmployee.LastName = "NewName";
+                    
+                    // Change to 'firstEmployee' will not be persisted
+                    await asyncSession.SaveChangesAsync();
+                }
+                #endregion
+            }
+
+            #region disable_tracking_4
+            using (var store = new DocumentStore()
+            {
+                // Define the 'ignore' convention on your document store
+                Conventions =
+                {
+                    ShouldIgnoreEntityChanges =
+                        // Define for which entities tracking should be disabled 
+                        // Tracking will be disabled ONLY for entities of type Employee whose FirstName is Bob
+                        (session, entity, id) => (entity is Employee e) &&
+                                                 (e.FirstName == "Bob")
+                }
+            }.Initialize())
+            {
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    var employee1 = new Employee { Id = "employees/1", FirstName = "Alice" };
+                    var employee2 = new Employee { Id = "employees/2", FirstName = "Bob" };
+
+                    session.Store(employee1);      // This entity will be tracked
+                    session.Store(employee2);      // Changes to this entity will be ignored
+
+                    session.SaveChanges();         // Only employee1 will be persisted
+
+                    employee1.FirstName = "Bob";   // Changes to this entity will now be ignored
+                    employee2.FirstName = "Alice"; // This entity will now be tracked
+
+                    session.SaveChanges();         // Only employee2 is persisted
+                }
+            }
+            #endregion
+           
+            using (var store = new DocumentStore())
+            {
+                #region disable_tracking_5
+                using (IDocumentSession session = store.OpenSession(new SessionOptions
+                {
+                    // Working with a non-tracking session
+                    NoTracking = true
+                }))
+                {
+                    try
+                    {
+                        // Trying to include a related document when loading a document will throw:
+                        Product product1 = session
+                            .Include<Product>(x => x.Supplier)
+                            .Load<Product>("products/1-A");
+                        
+                        // The same applies when using the builder syntax:
+                        Product product2 = session.Load<Product>("products/1-A",
+                            builder => builder.IncludeDocuments(product => product.Supplier));
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        // An InvalidOperationException is expected here
+                    }
+                }
+                #endregion
+                
+                #region disable_tracking_5_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession(new SessionOptions
+                       {
+                           // Working with a non-tracking session
+                           NoTracking = true
+                       }))
+                {
+                    try
+                    {
+                        // Trying to include a related document when loading a document will throw:
+                        Product product = await asyncSession
+                            .Include<Product>(x => x.Supplier)
+                            .LoadAsync<Product>("products/1-A");
+                        
+                        // The same applies when using the builder syntax:
+                        Product product2 = await asyncSession.LoadAsync<Product>("products/1-A",
+                            builder => builder.IncludeDocuments(product => product.Supplier));
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        // An InvalidOperationException is expected here
+                    }
+                }
+                #endregion
+                
+                #region disable_tracking_6
+                using (IDocumentSession session = store.OpenSession(new SessionOptions
+                       {
+                           // Working with a non-tracking session
+                           NoTracking = true
+                       }))
+                {
+                    try
+                    {
+                        // Trying to include related documents in a query will throw
+                        var products = session
+                            .Query<Product>()
+                            .Include(x => x.Supplier)
+                            .ToList();
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        // An InvalidOperationException is expected here
+                    }
+                }
+                #endregion
+                
+                #region disable_tracking_6_async
+                using (IAsyncDocumentSession asyncSession = store.OpenAsyncSession(new SessionOptions
+                       {
+                           // Working with a non-tracking session
+                           NoTracking = true
+                       }))
+                {
+                    try
+                    {
+                        // Trying to include related documents when making a query will throw
+                        var products = await asyncSession
+                            .Query<Product>()
+                            .Include(x => x.Supplier)
+                            .ToListAsync();
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        // An InvalidOperationException is expected here
+                    }
+                }
+                #endregion
+            }
+        }
+    }
+}

--- a/Documentation/6.0/Samples/nodejs/client-api/session/configuration/disableTracking.js
+++ b/Documentation/6.0/Samples/nodejs/client-api/session/configuration/disableTracking.js
@@ -1,0 +1,150 @@
+import { DocumentStore } from "ravendb";
+import assert from "assert";
+
+async function whatIsSessionUsingAwait() {
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_1
+        const session = documentStore.openSession();        
+
+        // Load a product entity - the session will track the entity by default
+        const product = await session.load("products/1-A");
+
+        // Call 'ignoreChangesFor' to instruct the session to ignore changes made to this entity
+        session.advanded.ignoreChangesFor(product);
+
+        // The following change will be ignored by SaveChanges - it will not be persisted
+        product.unitsInStock += 1;
+        
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_2
+        const session = documentStore.openSession({
+            // Disable tracking for all entities in the session's options
+            noTracking: true
+        });
+
+        // Load any entity, it will Not be tracked by the session
+        const employee1 = await session.load("employees/1-A");
+
+        // Loading again from same document will result in a new entity instance
+        const employee2 = await session.load("employees/1-A");
+
+        // Entities instances are not the same
+        assert.notStrictEqual(company1, company2);
+        
+        // Calling saveChanges will throw an exception
+        await session.saveChanges();
+        //endregion
+    }
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_3
+        const session = documentStore.openSession();
+
+        // Define a query
+        const employeesResults = await session.query({ collection: "employees" })
+            .whereEquals("FirstName", "Robert")
+             // Set noTracking, all resulting entities will not be tracked
+            .noTracking()
+            .all();
+
+        // The following modification will not be tracked for saveChanges
+        const firstEmployee = employeesResults[0];
+        firstEmployee.lastName = "NewName";
+
+        // Change to 'firstEmployee' will not be persisted
+        session.saveChanges();
+        //endregion
+    }
+    {
+        //region disable_tracking_4
+        const customStore = new DocumentStore();
+        
+        // Define the 'ignore' convention on your document store
+        customStore.conventions.shouldIgnoreEntityChanges =
+            (sessionOperations, entity, documentId) => {
+                // Define for which entities tracking should be disabled 
+                // Tracking will be disabled ONLY for entities of type Employee whose firstName is Bob
+                return entity instanceof Employee && entity.firstName === "Bob";
+            };
+        customStore.initialize();
+
+        const session = customStore.openSession();
+
+        const employee1 = new Employee();
+        employee1.firstName = "Alice";
+
+        const employee2 = new Employee();
+        employee2.firstName = "Bob";
+
+        await session.store(employee1, "employees/1-A"); // This entity will be tracked
+        await session.store(employee2, "employees/2-A"); // Changes to this entity will be ignored
+
+        await session.saveChanges();   // Only employee1 will be persisted
+
+        employee1.firstName = "Bob";   // Changes to this entity will now be ignored
+        employee2.firstName = "Alice"; // This entity will now be tracked
+
+        session.saveChanges();         // Only employee2 is persisted
+        //endregion
+    }
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_5
+        const session = documentStore.openSession({
+            // Working with a non-tracking session
+            noTracking: true
+        });
+
+        try {
+            // Trying to include a related document when loading a document will throw
+            const product = await session
+                .include("supplier")
+                .load("products/1-A");
+        }
+        catch (error) {
+            // An exception is expected here
+        }
+        //endregion
+    }
+    {
+        const documentStore = new DocumentStore();
+        //region disable_tracking_6
+        const session = documentStore.openSession({
+            // Working with a non-tracking session
+            noTracking: true
+        });
+
+        try {
+            // Trying to include related documents in a query will throw
+            const products = await session
+                .query({ collection: 'products' })
+                .include("supplier")
+                .all();
+        }
+        catch (error) {
+            // An exception is expected here
+        }
+        //endregion
+    }
+    {
+        //region syntax_1
+        session.advanced.ignoreChangesFor(entity);
+        //endregion
+    }
+    {
+        //region syntax_2
+        store.conventions.shouldIgnoreEntityChanges = (sessionOperations, entity, documentId) => {
+            // Write your logic
+            // return value:
+            //     true - entity will not be tracked 
+            //     false - entity will be tracked
+        }
+        //endregion
+    }
+}
+

--- a/Documentation/6.0/Samples/php/ClientApi/Session/Configuration/DisableTracking.php
+++ b/Documentation/6.0/Samples/php/ClientApi/Session/Configuration/DisableTracking.php
@@ -1,0 +1,147 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use RavenDB\Documents\Conventions\DocumentConventions;
+use RavenDB\Documents\DocumentStore;
+use RavenDB\Documents\Session\SessionOptions;
+use RavenDB\Samples\Infrastructure\Orders\Product;
+
+class DisableTracking extends TestCase
+{
+    public function example(): void
+    {
+        $store = new DocumentStore();
+
+        try {
+            $session = $store->openSession();
+            try {
+                # region disable_tracking_1
+                // Load a product entity - the session will track the entity by default
+                /** @var Product $product */
+                $product = $session->load(Product::class, "products/1-A");
+
+                // Call 'ignoreChangesFor' to instruct the session to ignore changes made to this entity
+                $session->advanced()->ignoreChangesFor($product);
+
+                // The following change will be ignored by saveChanges - it will not be persisted
+                $product->setUnitsInStock($product->getUnitsInStock() + 1);
+
+                $session->saveChanges();
+                # endregion
+            } finally {
+                $session->close();
+            }
+
+            # region disable_tracking_2
+            $sessionOptions = new SessionOptions();
+            // Disable tracking for all entities in the session's options
+            $sessionOptions->setNoTracking(true);
+
+            $session = $store->openSession($sessionOptions);
+            try {
+                // Load any entity, it will Not be tracked by the session
+                /** @var Employee $employee1 */
+                $employee1 = $session->load(Employee::class, "employees/1-A");
+
+                // Loading again from same document will result in a new entity instance
+                $employee2 = $session->load(Employee::class, "employees/1-A");
+
+                // Entities instances are not the same
+                $this->assertNotEquals($employee1, $employee2);
+            } finally {
+                $session->close();
+            }
+            # endregion
+
+            # region disable_tracking_3
+            $session = $store->openSession();
+            try {
+                // Define a query
+                /** @var array<Employee> $employeesResults */
+                $employeesResults = $session->query(Employee::class)
+                    // Set NoTracking, all resulting entities will not be tracked
+                    ->noTracking()
+                    ->whereEquals("FirstName", "Robert")
+                    ->toList();
+
+                // The following modification will not be tracked for SaveChanges
+                $firstEmployee = $employeesResults[0];
+                $firstEmployee->setLastName("NewName");
+
+                // Change to 'firstEmployee' will not be persisted
+                $session->saveChanges();
+            } finally {
+                $session->close();
+            }
+            # endregion
+
+            # region disable_tracking_3_documentQuery
+            $session = $store->openSession();
+            try {
+                // Define a query
+                /** @var array<Employee> $employeesResults */
+                $employeesResults = $session->advanced()->documentQuery(Employee::class)
+                    // Set NoTracking, all resulting entities will not be tracked
+                    ->noTracking()
+                    ->whereEquals("FirstName", "Robert")
+                    ->toList();
+
+                // The following modification will not be tracked for SaveChanges
+                $firstEmployee = $employeesResults[0];
+                $firstEmployee->setLastName("NewName");
+
+                // Change to 'firstEmployee' will not be persisted
+                $session->saveChanges();
+            } finally {
+                $session->close();
+            }
+            # endregion
+        } finally {
+            $store->close();
+        }
+
+
+        # region disable_tracking_4
+        // Define the 'ignore' convention on your document store
+        $conventions = new DocumentConventions();
+        $conventions->setShouldIgnoreEntityChanges(
+        // Define for which entities tracking should be disabled
+        // Tracking will be disabled ONLY for entities of type Employee whose FirstName is Bob
+            function ($session, $entity, $id) {
+                return $entity instanceof Employee && $entity->getFirstName() == "Bob";
+            }
+        );
+
+        $store = new DocumentStore();
+        $store->setConventions($conventions);
+        $store->initialize();
+        try {
+            $session = $store->openSession();
+            try {
+                $employee1 = new Employee();
+                $employee1->setId("employees/1");
+                $employee1->setFirstName("Alice");
+
+                $employee2 = new Employee();
+                $employee2->setId("employees/2");
+                $employee2->setFirstName("Bob");
+
+                $session->store($employee1);      // This entity will be tracked
+                $session->store($employee2);      // Changes to this entity will be ignored
+
+                $session->saveChanges();          // Only employee1 will be persisted
+
+                $employee1->setFirstName("Bob");  // Changes to this entity will now be ignored
+                $employee2->setFirstName("Alice");// This entity will now be tracked
+
+                $session->saveChanges();          // Only employee2 is persisted
+            } finally {
+                $session->close();
+            }
+        } finally {
+            $store->close();
+        }
+        # endregion
+
+    }
+}

--- a/Documentation/6.0/Samples/python/ClientApi/Session/Configuration/DisableTracking.py
+++ b/Documentation/6.0/Samples/python/ClientApi/Session/Configuration/DisableTracking.py
@@ -1,0 +1,119 @@
+from abc import ABC, abstractmethod
+
+from ravendb import InMemoryDocumentSessionOperations, SessionOptions, DocumentStore, DocumentSession
+from ravendb.documents.conventions import ShouldIgnoreEntityChanges
+
+from examples_base import ExampleBase, Product, Employee
+
+
+class DisableTracking(ExampleBase):
+    def setUp(self):
+        super().setUp()
+
+    class IgnoreChangesEntity:
+        # region syntax_1
+        def ignore_changes_for(self, entity: object) -> None: ...
+
+        # endregion
+
+    class IgnoreChangesConvention:
+        should_ignore_entity_changes = None
+
+        # region syntax_2
+        @should_ignore_entity_changes.setter
+        def should_ignore_entity_changes(self, value: ShouldIgnoreEntityChanges) -> None: ...
+
+        class ShouldIgnoreEntityChanges(ABC):
+            @abstractmethod
+            def check(
+                self,
+                session_operations: "InMemoryDocumentSessionOperations",
+                entity: object,
+                document_id: str,
+            ) -> bool:
+                pass
+
+        # endregion
+
+    def test_disable_tracking(self):
+        with self.embedded_server.get_document_store("DisableTracking") as store:
+            with store.open_session() as session:
+                # region disable_tracking_1
+                # Load a product entity - the session will track the entity by default
+                product = session.load("products/1-A", Product)
+
+                # Call 'ignore_changes_for' to instruct the session to ignore changes made to this entity
+                session.ignore_changes_for(product)
+
+                # The following change will be ignored by SaveChanges - it will not be persisted
+                product.units_in_stock += 1
+                session.save_changes()
+                # endregion
+
+            # region disable_tracking_2
+            with store.open_session(
+                SessionOptions(
+                    # Disable tracking for all entities in the session's options
+                    no_tracking=True
+                )
+            ):
+                # Load any entity, it will Not be tracked by the session
+                employee1 = session.load("employees/1-A", Employee)
+
+                # Loading again from same document will result in a new entity instance
+                employee2 = session.load("employees/1-A", Employee)
+
+                # Entities instances are not the same
+                self.assertNotEqual(employee1, employee2)
+
+            # endregion
+
+            # region disable_tracking_3
+            with store.open_session() as session:
+                # Define a query
+                employees_results = list(
+                    session.advanced.document_query(object_type=Employee)
+                    # Set no_tracking, all resulting entities will not ne tracked
+                    .no_tracking().where_equals("FirstName", "Robert")
+                )
+
+                # The following modification will not be tracked for save_changes
+                first_employee = employees_results[0]
+                first_employee.last_name = "NewName"
+
+                # Change to 'first_employee' will not be persisted
+                session.save_changes()
+            # endregion
+
+            # region disable_tracking_4
+            with DocumentStore() as store:
+                # Define the 'ignore' convention on your document store:
+
+                # Create a class that implements 'ravendb.documents.conventions.ShouldIgnoreEntityChanges'
+                # and implement 'check' method - it's going to be called to check if entity should be ignored
+
+                class MyCustomShouldIgnoreEntityChanges(ShouldIgnoreEntityChanges):
+                    def check(self, session_operations: DocumentSession, entity: object, document_id: str) -> bool:
+                        # Define for which entities tracking should be disabled
+                        # Tracking will be disabled ONLY for entities of type Employee whose FirstName is Bob
+                        return isinstance(entity, Employee) and entity.first_name == "Bob"
+
+                store.conventions.should_ignore_entity_changes = MyCustomShouldIgnoreEntityChanges
+
+                store.initialize()
+
+                with store.open_session() as session:
+                    employee1 = Employee(first_name="Alice", Id="employees/1")
+                    employee2 = Employee(first_name="Bob", Id="employees/2")
+
+                    session.store(employee1)  # This entity will be tracked
+                    session.store(employee2)  # Changes to this entity will be ignored
+
+                    session.save_changes()
+
+                    employee1.first_name = "Bob"  # Changes to this entity will now be ignored
+                    employee2.first_name = "Alice"  # This entity will now be tracked
+
+                    session.save_changes()
+
+            # endregion


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3310/Using-Include-in-a-NoTracking-session-will-throw

---
* Fixed description of section "Disable tracking changes for a specific entity (all clients)"
* Added a new section about using include in a non-tracking session
---

**C#** @maciejaszyk 
```
Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.dotnet.markdown
Documentation/6.0/Samples/csharp/Raven.Documentation.Samples/ClientApi/Session/Configuration/DisableTracking.cs
and also:
Documentation/6.0/Raven.Documentation.Pages/migration/client-api/client-breaking-changes.markdown
```

**Node.js** @M4xymm 
```
Documentation/6.0/Raven.Documentation.Pages/client-api/session/configuration/how-to-disable-tracking.js.markdown
Documentation/6.0/Samples/nodejs/client-api/session/configuration/disableTracking.js
```

**PHP & Python**
The feature is not yet implemented in these clients.
Files were copied from an earlier version for visibility.
