### PR TITLE
RDoc-3498 Fixed sidebar label for two linux docs

### DIFF
--- a/docs/server/kb/linux-setting-limits.mdx
+++ b/docs/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/docs/server/kb/linux-setting-memlock.mdx
+++ b/docs/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-4.1/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-4.1/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-4.1/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-4.1/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-4.2/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-4.2/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-4.2/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-4.2/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-5.0/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-5.0/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-5.0/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-5.0/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-5.1/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-5.1/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-5.1/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-5.1/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-5.2/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-5.2/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-5.2/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-5.2/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-5.3/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-5.3/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-5.3/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-5.3/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-5.4/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-5.4/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-5.4/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-5.4/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-6.0/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-6.0/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-6.0/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-6.0/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-6.2/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-6.2/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-6.2/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-6.2/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 

--- a/versioned_docs/version-7.0/server/kb/linux-setting-limits.mdx
+++ b/versioned_docs/version-7.0/server/kb/linux-setting-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting limits"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting limits
+sidebar_label: "Linux: Setting limits"
 sidebar_position: 3
 ---
 

--- a/versioned_docs/version-7.0/server/kb/linux-setting-memlock.mdx
+++ b/versioned_docs/version-7.0/server/kb/linux-setting-memlock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Linux: Setting memlock when using encrypted database"
 hide_table_of_contents: true
-sidebar_label: Linux"":"" Setting `memlock` when using encrypted database
+sidebar_label: "Linux: Setting `memlock` when using encrypted database"
 sidebar_position: 4
 ---
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDoc-3498/Doc-title-contains-excessive-number-of-characters