### PR TITLE
RDoc-3486 Fix links in indexes-overview

### DIFF
--- a/docs/studio/database/indexes/indexes-overview.mdx
+++ b/docs/studio/database/indexes/indexes-overview.mdx
@@ -13,6 +13,7 @@ import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
 # Indexes Overview
+
 <Admonition type="note" title="">
 
 * RavenDB uses __indexes__ to satisfy queries, allowing for fast query results.  
@@ -32,9 +33,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 * In this page:  
    * [Indexes - The General Concept](../../../studio/database/indexes/indexes-overview.mdx#indexes---the-general-concept)  
    * [Indexes - The Moving Parts](../../../studio/database/indexes/indexes-overview.mdx#indexes---the-moving-parts) : 
-      * [Index Definition](../../../studio/database/indexes/indexes-overview.mdx#index-definition)  
-      * [Indexing Process](../../../studio/database/indexes/indexes-overview.mdx#indexing-process)  
-      * [Indexed Data](../../../studio/database/indexes/indexes-overview.mdx#indexed-data)  
+      * [Index Definition](../../../studio/database/indexes/indexes-overview#1-index-definition)  
+      * [Indexing Process](../../../studio/database/indexes/indexes-overview#2-indexing-process)  
+      * [Indexed Data](../../../studio/database/indexes/indexes-overview#3-indexed-data)  
    * [Index Types](../../../studio/database/indexes/indexes-overview.mdx#index-types) : 
       * [Auto Indexes -vs- Static Indexes](../../../studio/database/indexes/indexes-overview.mdx#auto-indexes--vs--static-indexes)  
       * [Map Indexes -vs- Map-Reduce Indexes](../../../studio/database/indexes/indexes-overview.mdx#map-indexes--vs--map-reduce-indexes)  
@@ -43,7 +44,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
    * [Modifying Index Definition](../../../studio/database/indexes/indexes-overview.mdx#modifying-index-definition)
    * [Indexes in the Cluster](../../../studio/database/indexes/indexes-overview.mdx#indexes-in-the-cluster)
    * [Indexing Errors](../../../studio/database/indexes/indexes-overview.mdx#indexing-errors)
+
 </Admonition>
+
 ## Indexes - The General Concept
 
 * Once defined, the index iterates over the documents,  


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-3486/Links-to-headers-fail-new-platform-adds-numbering-to-anchors