### PR TITLE
Trim trailing slash on CloudFront via 301 redirect

### DIFF
--- a/scripts/handle_redirects.js
+++ b/scripts/handle_redirects.js
@@ -38,59 +38,63 @@ function compareVersions(v1, v2) {
     }
 }
 
+function redirect(targetUrl) {
+    return {
+        statusCode: 301,
+        statusDescription: "Moved Permanently",
+        headers: {
+            location: { value: targetUrl },
+        },
+    };
+}
+
 async function handler(event) {
     const request = event.request;
     const uri = request.uri;
+
     if (staticAssetRegex.test(uri)) {
         return request;
     }
 
-    if (uri !== "/" && uri.endsWith("/")) {
-        return {
-            statusCode: 301,
-            statusDescription: "Moved Permanently",
-            headers: {
-                location: { value: uri.slice(0, -1) },
-            },
-        };
-    }
+    const hasTrailingSlash = uri !== "/" && uri.endsWith("/");
+    const normalizedUri = hasTrailingSlash ? uri.slice(0, -1) : uri;
 
-    request.uri = uri + "/index.html";
-
-    if (uri.startsWith("/templates")) {
+    if (normalizedUri.startsWith("/templates")) {
+        if (hasTrailingSlash) {
+            return redirect(normalizedUri);
+        }
+        request.uri = uri + "/index.html";
         return request;
     }
 
-    if (uri.startsWith("/guides") || uri.startsWith("/cloud")) {
+    if (normalizedUri.startsWith("/guides") || normalizedUri.startsWith("/cloud")) {
         try {
-            const redirectData = await kvsHandle.get(uri);
+            const redirectData = await kvsHandle.get(normalizedUri);
             const redirectJsonValue = JSON.parse(redirectData);
             if (redirectJsonValue.targetUrl) {
-                return {
-                    statusCode: 301,
-                    statusDescription: "Moved Permanently",
-                    headers: {
-                        location: { value: redirectJsonValue.targetUrl },
-                    },
-                };
+                return redirect(redirectJsonValue.targetUrl);
             }
         } catch (_) {
-            // No redirect rule found — pass through as-is
+            // No redirect rule found
         }
+        if (hasTrailingSlash) {
+            return redirect(normalizedUri);
+        }
+        request.uri = uri + "/index.html";
         return request;
     }
 
-    const versionMatch = uri.match(versionRegex);
+    const versionMatch = normalizedUri.match(versionRegex);
 
     let version, versionlessUri, targetUri;
-    let redirectRequired = false;
+    let redirectRequired = hasTrailingSlash;
 
     if (versionMatch) {
         version = versionMatch[1];
         versionlessUri = versionMatch[2] || "";
     } else {
         version = defaultVersion;
-        versionlessUri = uri === "/" ? "" : uri;
+        versionlessUri = normalizedUri === "/" ? "" : normalizedUri;
         redirectRequired = true;
     }
 
@@ -113,14 +117,9 @@ async function handler(event) {
     }
 
     if (redirectRequired) {
-        return {
-            statusCode: 301,
-            statusDescription: "Moved Permanently",
-            headers: {
-                location: { value: targetUri },
-            },
-        };
+        return redirect(targetUri);
     }
 
+    request.uri = normalizedUri + "/index.html";
     return request;
 }

--- a/scripts/handle_redirects.js
+++ b/scripts/handle_redirects.js
@@ -9,10 +9,6 @@ const staticAssetRegex =
 
 const versionRegex = /^\/(\d+\.\d+)(\/.*)?/;
 
-function stripTrailingSlash(uri) {
-    return uri.endsWith("/") ? uri.slice(0, -1) : uri;
-}
-
 function compareVersions(v1, v2) {
     const parts1 = v1.split(".");
     const parts2 = v2.split(".");
@@ -45,21 +41,29 @@ function compareVersions(v1, v2) {
 async function handler(event) {
     const request = event.request;
     const uri = request.uri;
-    const normalizedUri = stripTrailingSlash(uri);
-
     if (staticAssetRegex.test(uri)) {
         return request;
     }
 
-    request.uri = normalizedUri + "/index.html";
+    if (uri !== "/" && uri.endsWith("/")) {
+        return {
+            statusCode: 301,
+            statusDescription: "Moved Permanently",
+            headers: {
+                location: { value: uri.slice(0, -1) },
+            },
+        };
+    }
 
-    if (normalizedUri.startsWith("/templates")) {
+    request.uri = uri + "/index.html";
+
+    if (uri.startsWith("/templates")) {
         return request;
     }
 
-    if (normalizedUri.startsWith("/guides") || normalizedUri.startsWith("/cloud")) {
+    if (uri.startsWith("/guides") || uri.startsWith("/cloud")) {
         try {
-            const redirectData = await kvsHandle.get(normalizedUri);
+            const redirectData = await kvsHandle.get(uri);
             const redirectJsonValue = JSON.parse(redirectData);
             if (redirectJsonValue.targetUrl) {
                 return {
@@ -76,17 +80,17 @@ async function handler(event) {
         return request;
     }
 
-    const versionMatch = normalizedUri.match(versionRegex);
+    const versionMatch = uri.match(versionRegex);
 
     let version, versionlessUri, targetUri;
     let redirectRequired = false;
 
     if (versionMatch) {
         version = versionMatch[1];
-        versionlessUri = versionMatch[2] || "/";
+        versionlessUri = versionMatch[2] || "";
     } else {
         version = defaultVersion;
-        versionlessUri = normalizedUri;
+        versionlessUri = uri === "/" ? "" : uri;
         redirectRequired = true;
     }
 


### PR DESCRIPTION
### Additional description
Force non-trailing-slash URLs by redirecting trailing-slash-ending requests with 301.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [x] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

