### PR TITLE
RDoc-3770 RQL: Explain how to negate the 'in' operator (v6.2, v7.0, v7.1)

### DIFF
--- a/docs/querying/rql/what-is-rql.mdx
+++ b/docs/querying/rql/what-is-rql.mdx
@@ -358,9 +358,11 @@ where Lines[].ProductName in ("Chang", "Spegesild", "Unknown product name")
     
 ---
 
-**To negate an `in` condition**, use the `NOT` operator. In RQL, `NOT` cannot start a `where` clause; it must follow a **valid preceding expression.**
+**To negate an `in` condition**, use the `NOT` operator.  
+In RQL, `NOT` cannot start a `where` clause; it must follow a **valid preceding expression.**
 
-To ensure accuracy, especially when fields might be missing from some documents, use `exists(fieldName)` as the anchor:
+To ensure accuracy, especially when fields might be missing from some documents,  
+use `exists(fieldName)` as the anchor:
     
 <TabItem>
 ```csharp
@@ -369,8 +371,9 @@ where exists(Name) and NOT Name in ("The Big Cheese", "The Cracker Box")
 ```
 </TabItem>
 
-**Note:** Avoid using `where true` or an `exists()` check on a *different* field. If a document is missing the field you're 
-filtering on, these anchors may return unexpected results.     
+**Note:**  
+Avoid using `where true` or an `exists()` check on a *different* field.  
+If a document is missing the field you're filtering on, these anchors may return unexpected results.
 
 </ContentFrame>
     

--- a/versioned_docs/version-6.2/client-api/session/querying/what-is-rql.mdx
+++ b/versioned_docs/version-6.2/client-api/session/querying/what-is-rql.mdx
@@ -347,12 +347,13 @@ where PricePerUnit >= 10.5 and PricePerUnit <= 13.0 // Using >= and <=
 </TabItem>
 
 </Admonition>
+
 <Admonition type="note" title="">
 
 #### Operator: &nbsp;&nbsp; `in`
 
-The operator `in` is validating if a given field contains passed values.  
-It will return results if a given field matches **any** of the passed values.
+The `in` operator evaluates a field against a list of values.  
+It will return results if the field matches **any** of the items in that list.
 
 <TabItem value="csharp" label="csharp">
 <CodeBlock language="csharp">
@@ -369,8 +370,28 @@ where Lines[].ProductName in ("Chang", "Spegesild", "Unknown product name")
 `}
 </CodeBlock>
 </TabItem>
+    
+---
+
+**To negate an `in` condition**, use the `NOT` operator.  
+In RQL, `NOT` cannot start a `where` clause; it must follow a **valid preceding expression.**
+
+To ensure accuracy, especially when fields might be missing from some documents,  
+use `exists(fieldName)` as the anchor:
+    
+<TabItem>
+```csharp
+from "Companies" 
+where exists(Name) and NOT Name in ("The Big Cheese", "The Cracker Box")
+```
+</TabItem>
+
+**Note:**  
+Avoid using `where true` or an `exists()` check on a *different* field.  
+If a document is missing the field you're filtering on, these anchors may return unexpected results.
 
 </Admonition>
+
 <Admonition type="note" title="">
 
 #### Operator: &nbsp;&nbsp; `all in`

--- a/versioned_docs/version-7.0/client-api/session/querying/what-is-rql.mdx
+++ b/versioned_docs/version-7.0/client-api/session/querying/what-is-rql.mdx
@@ -348,12 +348,13 @@ where PricePerUnit >= 10.5 and PricePerUnit <= 13.0 // Using >= and <=
 </TabItem>
 
 </Admonition>
+
 <Admonition type="note" title="">
 
 #### Operator: &nbsp;&nbsp; `in`
 
-The operator `in` is validating if a given field contains passed values.  
-It will return results if a given field matches **any** of the passed values.
+The `in` operator evaluates a field against a list of values.  
+It will return results if the field matches **any** of the items in that list.
 
 <TabItem value="csharp" label="csharp">
 <CodeBlock language="csharp">
@@ -370,8 +371,28 @@ where Lines[].ProductName in ("Chang", "Spegesild", "Unknown product name")
 `}
 </CodeBlock>
 </TabItem>
+    
+---
+
+**To negate an `in` condition**, use the `NOT` operator.  
+In RQL, `NOT` cannot start a `where` clause; it must follow a **valid preceding expression.**
+
+To ensure accuracy, especially when fields might be missing from some documents,  
+use `exists(fieldName)` as the anchor:
+    
+<TabItem>
+```csharp
+from "Companies" 
+where exists(Name) and NOT Name in ("The Big Cheese", "The Cracker Box")
+```
+</TabItem>
+
+**Note:**  
+Avoid using `where true` or an `exists()` check on a *different* field.  
+If a document is missing the field you're filtering on, these anchors may return unexpected results.
 
 </Admonition>
+
 <Admonition type="note" title="">
 
 #### Operator: &nbsp;&nbsp; `all in`

--- a/versioned_docs/version-7.1/client-api/session/querying/what-is-rql.mdx
+++ b/versioned_docs/version-7.1/client-api/session/querying/what-is-rql.mdx
@@ -346,14 +346,15 @@ where PricePerUnit >= 10.5 and PricePerUnit <= 13.0 // Using >= and <=
 `}
 </CodeBlock>
 </TabItem>
-
+    
 </Admonition>
+
 <Admonition type="note" title="">
 
 #### Operator: &nbsp;&nbsp; `in`
 
-The operator `in` is validating if a given field contains passed values.  
-It will return results if a given field matches **any** of the passed values.
+The `in` operator evaluates a field against a list of values.  
+It will return results if the field matches **any** of the items in that list.
 
 <TabItem value="csharp" label="csharp">
 <CodeBlock language="csharp">
@@ -370,8 +371,28 @@ where Lines[].ProductName in ("Chang", "Spegesild", "Unknown product name")
 `}
 </CodeBlock>
 </TabItem>
+    
+---
+
+**To negate an `in` condition**, use the `NOT` operator.  
+In RQL, `NOT` cannot start a `where` clause; it must follow a **valid preceding expression.**
+
+To ensure accuracy, especially when fields might be missing from some documents,  
+use `exists(fieldName)` as the anchor:
+    
+<TabItem>
+```csharp
+from "Companies" 
+where exists(Name) and NOT Name in ("The Big Cheese", "The Cracker Box")
+```
+</TabItem>
+
+**Note:**  
+Avoid using `where true` or an `exists()` check on a *different* field.  
+If a document is missing the field you're filtering on, these anchors may return unexpected results.
 
 </Admonition>
+
 <Admonition type="note" title="">
 
 #### Operator: &nbsp;&nbsp; `all in`


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3770/RQL-Explain-how-to-negate-the-in-operator

### Additional description
Explain how to negate the in operator in the RQL article (v6.2, v7.0, v7.1)
Use the same explanation as in https://github.com/ravendb/docs/pull/2360

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

