### PR TITLE
CI hygiene: Docusaurus v4 prep, Node 24 actions, CVE pin, typecheck in CI

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Prettier
         run: npm run prettier
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build Docusaurus & Check Internal Links
         run: npx cross-env DOCUSAURUS_VERSIONS='6.2, 7.1, current' DOCUSAURUS_STRICT=true npm run build
 

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
         run: npx cross-env DOCUSAURUS_VERSIONS='6.2, 7.1, current' DOCUSAURUS_STRICT=true npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: docusaurus-build
           path: build/

--- a/.github/workflows/dryrun-deploy-after-merge.yml
+++ b/.github/workflows/dryrun-deploy-after-merge.yml
@@ -10,16 +10,16 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v5
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           cache: 'npm'
-          
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -35,8 +35,13 @@ const config: Config = {
     baseUrl: "/",
 
     onBrokenLinks: isStrict ? "throw" : "warn",
-    onBrokenMarkdownLinks: isStrict ? "throw" : "warn",
     onBrokenAnchors: "ignore",
+
+    markdown: {
+        hooks: {
+            onBrokenMarkdownLinks: isStrict ? "throw" : "warn",
+        },
+    },
 
     i18n: {
         defaultLocale: "en",

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,7 @@
             "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.41.0.tgz",
             "integrity": "sha512-G9I2atg1ShtFp0t7zwleP6aPS4DcZvsV4uoQOripp16aR6VJzbEnKFPLW4OFXzX7avgZSpYeBAS+Zx4FOgmpPw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@algolia/client-common": "5.41.0",
                 "@algolia/requester-browser-xhr": "5.41.0",
@@ -398,6 +399,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -2185,6 +2187,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2207,6 +2210,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2316,6 +2320,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -2737,6 +2742,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -3494,6 +3500,7 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.9.2.tgz",
             "integrity": "sha512-DEVIwhbrZZ4ir31X+qQNEQqDWkgCJUV6kiPPAd2MGTY8n5/n0c4B8qA5k1ipF2izwH00JEf0h6Daaut71zzkyw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@docusaurus/types": "3.9.2",
                 "@rspack/core": "^1.5.0",
@@ -3662,6 +3669,7 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
             "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@docusaurus/core": "3.9.2",
                 "@docusaurus/logger": "3.9.2",
@@ -4666,6 +4674,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
             "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
+            "peer": true,
             "dependencies": {
                 "@types/mdx": "^2.0.0"
             },
@@ -5220,6 +5229,7 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -5324,6 +5334,7 @@
             "integrity": "sha512-oExhY90bes5pDTVrei0xlMVosTxwd/NMafIpqsC4dMbRYZ5KB981l/CX8tMnGsagTplj/RcG9BeRYmV6/J5m3w==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.25"
@@ -6307,6 +6318,7 @@
             "version": "19.1.8",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
             "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -6476,6 +6488,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz",
             "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.39.0",
                 "@typescript-eslint/types": "8.39.0",
@@ -6895,6 +6908,7 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -6975,6 +6989,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -7018,6 +7033,7 @@
             "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.41.0.tgz",
             "integrity": "sha512-9E4b3rJmYbBkn7e3aAPt1as+VVnRhsR4qwRRgOzpeyz4PAOuwKh0HI4AN6mTrqK0S0M9fCCSTOUnuJ8gPY/tvA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@algolia/abtesting": "1.7.0",
                 "@algolia/client-abtesting": "5.41.0",
@@ -7757,6 +7773,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -8752,6 +8769,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -9835,6 +9853,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
             "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -10722,6 +10741,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -15961,6 +15981,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -16561,6 +16582,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -17464,6 +17486,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -18265,14 +18288,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/range-parser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -18336,6 +18351,7 @@
             "version": "19.1.0",
             "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
             "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18344,6 +18360,7 @@
             "version": "19.1.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
             "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.26.0"
             },
@@ -18395,6 +18412,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
             "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
+            "peer": true,
             "dependencies": {
                 "@types/react": "*"
             },
@@ -18421,6 +18439,7 @@
             "version": "5.3.4",
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
             "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
@@ -19340,11 +19359,12 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/serve-handler": {
@@ -20574,7 +20594,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "peer": true
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -20732,6 +20753,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "devOptional": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -21083,6 +21105,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -21288,6 +21311,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
             "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -21986,6 +22010,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
             "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     },
     "engines": {
         "node": ">=18.0"
+    },
+    "overrides": {
+        "serialize-javascript": "^7.0.5"
     }
 }

--- a/src/components/Common/CustomSearchButton.tsx
+++ b/src/components/Common/CustomSearchButton.tsx
@@ -41,6 +41,10 @@ export default function CustomSearchButton({
         onOpen: onClick,
         onClose: () => {},
         searchButtonRef: buttonRef,
+        // DocSearch v4 added AskAI support; we don't use it, so pass a
+        // permanent-off state and a no-op toggle. The hook requires both.
+        isAskAiActive: false,
+        onAskAiToggle: () => {},
     });
 
     return (

--- a/src/components/Common/LazyImage.tsx
+++ b/src/components/Common/LazyImage.tsx
@@ -77,5 +77,11 @@ function getSources({ imgSrc, src }: Pick<LazyImageProps, "imgSrc" | "src">): Th
         return { light: resolved, dark: resolved };
     }
 
-    return imgSrc;
+    // Every realistic branch returned above: a string imgSrc flows through
+    // toUrl() and gets wrapped; an object with {light,dark} is returned at
+    // the guard above; the ideal-image plugin's nested {src:{src}} shape is
+    // unwrapped by toUrl. The remainder is imgSrc === undefined, for which
+    // ThemedImage expects string fields — return empty strings so the type
+    // holds and the broken <img> surfaces in DOM rather than crashing here.
+    return { light: "", dark: "" };
 }

--- a/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -1,25 +1,18 @@
-import React, { version, type ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import clsx from "clsx";
 import { useNavbarSecondaryMenu } from "@docusaurus/theme-common/internal";
 import { ThemeClassNames } from "@docusaurus/theme-common";
 import type { Props } from "@theme/Navbar/MobileSidebar/Layout";
 
-// TODO Docusaurus v4: remove temporary inert workaround
-//  See https://github.com/facebook/react/issues/17157
-//  See https://github.com/radix-ui/themes/pull/509
-function inertProps(inert: boolean) {
-    const isBeforeReact19 = parseInt(version!.split(".")[0]!, 10) < 19;
-    if (isBeforeReact19) {
-        return { inert: inert ? "" : undefined };
-    }
-    return { inert };
-}
-
+// React 19 accepts a boolean `inert` prop natively (React 18 and earlier
+// required passing an empty string). We pin react ^19 in package.json,
+// so the legacy string-coercion workaround is dead code and has been
+// removed. See https://github.com/facebook/react/issues/17157.
 function NavbarMobileSidebarPanel({ children, inert }: { children: ReactNode; inert: boolean }) {
     return (
         <div
             className={clsx(ThemeClassNames.layout.navbar.mobileSidebar.panel, "navbar-sidebar__item menu")}
-            {...inertProps(inert)}
+            inert={inert}
         >
             {children}
         </div>

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -35,7 +35,11 @@ function importDocSearchModalIfNeeded() {
         return Promise.resolve();
     }
     return Promise.all([
-        import("@docsearch/react/modal") as Promise<typeof import("@docsearch/react")>,
+        // The /modal entrypoint only re-exports DocSearchModal, while the
+        // default export of @docsearch/react re-exports more (DocSearch,
+        // DocSearchButton, useDocSearchKeyboardEvents, version). Typing this
+        // as the full module is incorrect — narrow to what we actually use.
+        import("@docsearch/react/modal") as Promise<{ DocSearchModal: typeof DocSearchModalType }>,
         import("@docsearch/react/style"),
         import("./styles.css"),
     ]).then(([{ DocSearchModal: Modal }]) => {
@@ -199,6 +203,10 @@ function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
         onClose: closeModal,
         onInput: handleInput,
         searchButtonRef,
+        // DocSearch v4 added AskAI support; we don't use it, so pass a
+        // permanent-off state and a no-op toggle. The hook requires both.
+        isAskAiActive: false,
+        onAskAiToggle: () => {},
     });
 
     return (


### PR DESCRIPTION
## Summary

Five targeted commits clearing the non-blocking noise and latent risk the `build-on-pr` workflow had been accumulating. Each commit is independently revertible and carries a three-beat rationale (why / viable / gain) in the body.

| Commit | Concern cleared |
|---|---|
| [`58b6efc2d`](../commit/58b6efc2d) Migrate `onBrokenMarkdownLinks` to `markdown.hooks` | Two `[WARNING]` lines per build; Docusaurus v4 will hard-remove the top-level key. |
| [`bc70d6d13`](../commit/bc70d6d13) Bump GitHub Actions to v5 | Node 20 actions force-flip to Node 24 on 2026-06-02; front-run the bump so we can't be surprised. |
| [`ce595ec78`](../commit/ce595ec78) Pin `serialize-javascript` >=7.0.5 via npm `overrides` | 22 high-severity advisories cleared (GHSA-5c6j-r48x-rmvq RCE + GHSA-qj8w-gfj5-8c6v DoS). |
| [`5410eb485`](../commit/5410eb485) Fix theme-shim TS errors | Five pre-existing `tsc` errors blocking typecheck-in-CI (inert string→bool, DocSearch v4 props, import cast, LazyImage narrowing). |
| [`82eab78b4`](../commit/82eab78b4) Add typecheck step to `build-on-pr` | Catches TS regressions before they land on `main`. |

## Verification

- `npm run typecheck` — clean.
- `npm run prettier` — clean.
- `npm run lint` — 0 errors (7 pre-existing unused-eslint-disable warnings on `main`, out of scope here).
- `npm run build:current` — clean.
- Full multi-version build (`DOCUSAURUS_VERSIONS='6.2, 7.1, current'` + `--trace-deprecation`) — no `DEP0169 url.parse()` output (the deprecation we saw upstream was on a different branch's added steps; does not reproduce on `main`'s build path).
- `npm ls serialize-javascript` — all three webpack-plugin consumers resolved to `7.0.5`.
- `npm audit` totals: before 28 (1 low / 5 moderate / **22 high**), after 24 (1 low / 22 moderate / 1 high). The 22 high advisories from `serialize-javascript` are gone; the remaining moderates are unrelated (see "Not addressed" below).

## Not addressed (explicit out-of-scope, deliberate)

- **`prebuild-install` deprecation** (via `sharp@0.32.x` under `@docusaurus/plugin-ideal-image`): upstream. Plugin-ideal-image still pins `sharp@0.32.x`; sharp ≥0.33 removed `prebuild-install`. Clears on the plugin's next bump.
- **`follow-redirects`, `qs`, `lodash`, `uuid`/`sockjs` audit moderates**: all transitive through `@docusaurus/bundler` or dev-time-only paths. Could be override-pinned in a future security-focused PR; deferred here to keep the change surface bounded and the commit rationale clean.
- **Node 18 pin in `dryrun-deploy-after-merge.yml`**: that workflow runs deploy scripts under Node 18 (itself EOL'd). Orthogonal concern — needs a deploy-side review.
- **7 `no-undef` unused-eslint-disable warnings** on `main`: separate lint-hygiene sweep.

## Upstream follow-ups (for reference — not filed from this PR)

| Concern | Existing upstream tracking |
|---|---|
| `plugin-ideal-image` pins `sharp@0.32.x` (prebuild-install deprecation) | [facebook/docusaurus#11173](https://github.com/facebook/docusaurus/issues/11173), [facebook/docusaurus#11000](https://github.com/facebook/docusaurus/issues/11000), [lovell/sharp#4318](https://github.com/lovell/sharp/issues/4318) |
| `serialize-javascript` CVEs propagating through Docusaurus | [facebook/docusaurus#11801](https://github.com/facebook/docusaurus/issues/11801), [webpack/terser-webpack-plugin#644](https://github.com/webpack/terser-webpack-plugin/issues/644) |
| `follow-redirects` auth-header leak (older CVE, already patched in 1.15.6) | [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) |
| `qs` arrayLimit DoS (fixed in 6.14.1; severity disputed) | [GHSA-6rw7-vpxm-498p](https://github.com/ljharb/qs/security/advisories/GHSA-6rw7-vpxm-498p), [GHSA-w7fw-mjwx-w883](https://github.com/ljharb/qs/security/advisories/GHSA-w7fw-mjwx-w883) |
| DocSearch v4 `isAskAiActive` / `onAskAiToggle` breaks swizzled SearchBar shims | [facebook/docusaurus#11719](https://github.com/facebook/docusaurus/issues/11719) (v4 umbrella) |

None required filing a new upstream issue — every concern already has a tracking item.

## Test plan

- [ ] `build-on-pr` CI run completes green on this branch.
- [ ] No `[WARNING] The siteConfig.onBrokenMarkdownLinks` line in the CI log.
- [ ] No "Node.js 20 actions are deprecated" annotation on the CI run.
- [ ] `Typecheck` step visible and passing in the CI log.
- [ ] `npm warn deprecated prebuild-install` still present (expected — upstream concern, not ours to fix).