### PR TITLE
RDoc-3804 RavenDB ETL: Default request timeout

### DIFF
--- a/docs/server/configuration/etl-configuration.mdx
+++ b/docs/server/configuration/etl-configuration.mdx
@@ -11,11 +11,12 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
-# Configuration: ETL Options
 <Admonition type="note" title="">
 
-* In this page:  
+* In this article:  
     * [ETL.ExtractAndTransformTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlextractandtransformtimeoutinsec)
     * [ETL.MaxBatchSizeInMb](../../server/configuration/etl-configuration.mdx#etlmaxbatchsizeinmb)
     * [ETL.MaxFallbackTimeInSec](../../server/configuration/etl-configuration.mdx#etlmaxfallbacktimeinsec)
@@ -25,9 +26,13 @@ import LanguageContent from "@site/src/components/LanguageContent";
     * [ETL.Queue.AzureQueueStorage.TimeToLiveInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragetimetoliveinsec)
     * [ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragevisibilitytimeoutinsec)
     * [ETL.Queue.Kafka.InitTransactionsTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueuekafkainittransactionstimeoutinsec)
+    * [ETL.Raven.LoadRequestTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec)
     * [ETL.SQL.CommandTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlsqlcommandtimeoutinsec)
 
 </Admonition>
+
+<ContentFrame>
+    
 ## ETL.ExtractAndTransformTimeoutInSec
 
 Number of seconds after which extraction and transformation will end and loading will start.
@@ -36,49 +41,66 @@ Number of seconds after which extraction and transformation will end and loading
 - **Default**: `30`
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>
+<ContentFrame>
 
 ## ETL.MaxNumberOfExtractedDocuments
 
 * Max number of extracted documents in an ETL batch.
 * If value is not set, or set to null, the number of extracted documents fallbacks to `ETL.MaxNumberOfExtractedItems` value.
+
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxBatchSizeInMb
 
 * Maximum size in megabytes of a batch of data (documents and attachments) that will be sent to the destination as a single batch after transformation.
 * If value is not set, or set to null, the size of the batch isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `Size`
 - **Size Unit**: `Megabytes`
 - **Default**: `64`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxFallbackTimeInSec
 
 * Maximum number of seconds the ETL process will be in a fallback mode after a load connection failure to a destination.
 * The fallback mode means suspending the process.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `900`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxNumberOfExtractedItems
 
 * Max number of extracted items (documents, counters, etc) in an ETL batch.
 * If value is not set, or set to null, the number of extracted items isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.OLAP.MaxNumberOfExtractedDocuments
 
 Max number of extracted documents in OLAP ETL batch.
@@ -87,8 +109,9 @@ Max number of extracted documents in OLAP ETL batch.
 - **Default**: `64 * 1024`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.TimeToLiveInSec
 
 Lifespan of a message in the queue.
@@ -97,8 +120,9 @@ Lifespan of a message in the queue.
 - **Default**: `604800` (7 days)
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec
 
 How long a message is hidden after being retrieved but not deleted.
@@ -107,8 +131,9 @@ How long a message is hidden after being retrieved but not deleted.
 - **Default**: `0`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.Kafka.InitTransactionsTimeoutInSec
 
 Timeout to initialize transactions for the Kafka producer.
@@ -117,14 +142,33 @@ Timeout to initialize transactions for the Kafka producer.
 - **Default**: `60`
 - **Scope**: Server-wide or per database
 
+</ContentFrame>
+<ContentFrame>
+    
+## ETL.Raven.LoadRequestTimeoutInSec
 
-
-## ETL.SQL.CommandTimeoutInSec
-
-Number of seconds after which the SQL command will timeout.
+* Number of seconds after which the Raven ETL load request will time out.  
+* Can be overridden per task by setting the `LoadRequestTimeoutInSec` property in the [Raven ETL configuration](../../server/ongoing-tasks/etl/raven.mdx), 
+  or via [Studio](../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx#ravendb-etl-task-definition).
+    
+---    
 
 - **Type**: `int`
+- **Default**: `300`
+- **Scope**: Server-wide or per database
+
+</ContentFrame>    
+<ContentFrame>
+    
+## ETL.SQL.CommandTimeoutInSec
+
+* Number of seconds after which the SQL command will time out.  
+* Can be overridden by setting the `CommandTimeout` property in the SQL ETL configuration.
+    
+---    
+
+- **Type**: `int?`
 - **Default**: `null` (use provider default)
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>    

--- a/docs/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
+++ b/docs/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
@@ -62,10 +62,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
     
 5. **HTTP Request Timeout** (Optional)  
    * Sets the maximum time in seconds that the source server will wait for the destination server to process and acknowledge a batch of documents during the Load stage.
-     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.
-   * If not set, no per-request timeout is enforced,  
-     the global HTTP client timeout of 12 hours applies as the only backstop.  
-   * Consider setting this if the destination server is slow or under heavy load,  
+     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.    
+   * Default: `300` seconds.  
+     This is the global default, set by the [ETL.Raven.LoadRequestTimeoutInSec](../../../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec) configuration key.  
+     You can override it for a specific ETL task in the Studio, or in the client API by setting the `LoadRequestTimeoutInSec` property in the Raven ETL configuration.    
+   * Consider increasing this value if the destination server is slow or under heavy load,  
      or if batches are large and take a long time to process.
 
 </Panel>

--- a/versioned_docs/version-6.2/server/configuration/etl-configuration.mdx
+++ b/versioned_docs/version-6.2/server/configuration/etl-configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Configuration: ETL Options"
 sidebar_label: ETL Configuration
+description: "Tune RavenDB ETL task configuration with batch size limits, extraction intervals, and memory usage thresholds for data transformations."
 sidebar_position: 8
 ---
 
@@ -10,11 +11,12 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
-# Configuration: ETL Options
 <Admonition type="note" title="">
 
-* In this page:  
+* In this article:  
     * [ETL.ExtractAndTransformTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlextractandtransformtimeoutinsec)
     * [ETL.MaxBatchSizeInMb](../../server/configuration/etl-configuration.mdx#etlmaxbatchsizeinmb)
     * [ETL.MaxFallbackTimeInSec](../../server/configuration/etl-configuration.mdx#etlmaxfallbacktimeinsec)
@@ -24,9 +26,13 @@ import LanguageContent from "@site/src/components/LanguageContent";
     * [ETL.Queue.AzureQueueStorage.TimeToLiveInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragetimetoliveinsec)
     * [ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragevisibilitytimeoutinsec)
     * [ETL.Queue.Kafka.InitTransactionsTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueuekafkainittransactionstimeoutinsec)
+    * [ETL.Raven.LoadRequestTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec)
     * [ETL.SQL.CommandTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlsqlcommandtimeoutinsec)
 
 </Admonition>
+
+<ContentFrame>
+    
 ## ETL.ExtractAndTransformTimeoutInSec
 
 Number of seconds after which extraction and transformation will end and loading will start.
@@ -35,49 +41,66 @@ Number of seconds after which extraction and transformation will end and loading
 - **Default**: `30`
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>
+<ContentFrame>
 
 ## ETL.MaxNumberOfExtractedDocuments
 
 * Max number of extracted documents in an ETL batch.
 * If value is not set, or set to null, the number of extracted documents fallbacks to `ETL.MaxNumberOfExtractedItems` value.
+
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxBatchSizeInMb
 
 * Maximum size in megabytes of a batch of data (documents and attachments) that will be sent to the destination as a single batch after transformation.
 * If value is not set, or set to null, the size of the batch isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `Size`
 - **Size Unit**: `Megabytes`
 - **Default**: `64`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxFallbackTimeInSec
 
 * Maximum number of seconds the ETL process will be in a fallback mode after a load connection failure to a destination.
 * The fallback mode means suspending the process.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `900`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxNumberOfExtractedItems
 
 * Max number of extracted items (documents, counters, etc) in an ETL batch.
 * If value is not set, or set to null, the number of extracted items isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.OLAP.MaxNumberOfExtractedDocuments
 
 Max number of extracted documents in OLAP ETL batch.
@@ -86,8 +109,9 @@ Max number of extracted documents in OLAP ETL batch.
 - **Default**: `64 * 1024`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.TimeToLiveInSec
 
 Lifespan of a message in the queue.
@@ -96,8 +120,9 @@ Lifespan of a message in the queue.
 - **Default**: `604800` (7 days)
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec
 
 How long a message is hidden after being retrieved but not deleted.
@@ -106,8 +131,9 @@ How long a message is hidden after being retrieved but not deleted.
 - **Default**: `0`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.Kafka.InitTransactionsTimeoutInSec
 
 Timeout to initialize transactions for the Kafka producer.
@@ -116,14 +142,33 @@ Timeout to initialize transactions for the Kafka producer.
 - **Default**: `60`
 - **Scope**: Server-wide or per database
 
+</ContentFrame>
+<ContentFrame>
+    
+## ETL.Raven.LoadRequestTimeoutInSec
 
-
-## ETL.SQL.CommandTimeoutInSec
-
-Number of seconds after which the SQL command will timeout.
+* Number of seconds after which the Raven ETL load request will time out.  
+* Can be overridden per task by setting the `LoadRequestTimeoutInSec` property in the [Raven ETL configuration](../../server/ongoing-tasks/etl/raven.mdx),  
+  or via [Studio](../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx#ravendb-etl-task-definition).
+    
+---    
 
 - **Type**: `int`
+- **Default**: `300`
+- **Scope**: Server-wide or per database
+
+</ContentFrame>    
+<ContentFrame>
+    
+## ETL.SQL.CommandTimeoutInSec
+
+* Number of seconds after which the SQL command will time out.  
+* Can be overridden by setting the `CommandTimeout` property in the SQL ETL configuration.
+    
+---    
+
+- **Type**: `int?`
 - **Default**: `null` (use provider default)
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>    

--- a/versioned_docs/version-6.2/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
+++ b/versioned_docs/version-6.2/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
@@ -61,10 +61,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
     
 5. **HTTP Request Timeout** (Optional)  
    * Sets the maximum time in seconds that the source server will wait for the destination server to process and acknowledge a batch of documents during the Load stage.
-     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.
-   * If not set, no per-request timeout is enforced,  
-     the global HTTP client timeout of 12 hours applies as the only backstop.  
-   * Consider setting this if the destination server is slow or under heavy load,  
+     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.    
+   * Default: `300` seconds.  
+     This is the global default, set by the [ETL.Raven.LoadRequestTimeoutInSec](../../../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec) configuration key.  
+     You can override it for a specific ETL task in the Studio, or in the client API by setting the `LoadRequestTimeoutInSec` property in the Raven ETL configuration.    
+   * Consider increasing this value if the destination server is slow or under heavy load,  
      or if batches are large and take a long time to process.
 
 </Panel>

--- a/versioned_docs/version-7.0/server/configuration/etl-configuration.mdx
+++ b/versioned_docs/version-7.0/server/configuration/etl-configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Configuration: ETL Options"
 sidebar_label: ETL Configuration
+description: "Tune RavenDB ETL task configuration with batch size limits, extraction intervals, and memory usage thresholds for data transformations."
 sidebar_position: 8
 ---
 
@@ -10,11 +11,12 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
-# Configuration: ETL Options
 <Admonition type="note" title="">
 
-* In this page:  
+* In this article:  
     * [ETL.ExtractAndTransformTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlextractandtransformtimeoutinsec)
     * [ETL.MaxBatchSizeInMb](../../server/configuration/etl-configuration.mdx#etlmaxbatchsizeinmb)
     * [ETL.MaxFallbackTimeInSec](../../server/configuration/etl-configuration.mdx#etlmaxfallbacktimeinsec)
@@ -24,9 +26,13 @@ import LanguageContent from "@site/src/components/LanguageContent";
     * [ETL.Queue.AzureQueueStorage.TimeToLiveInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragetimetoliveinsec)
     * [ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragevisibilitytimeoutinsec)
     * [ETL.Queue.Kafka.InitTransactionsTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueuekafkainittransactionstimeoutinsec)
+    * [ETL.Raven.LoadRequestTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec)
     * [ETL.SQL.CommandTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlsqlcommandtimeoutinsec)
 
 </Admonition>
+
+<ContentFrame>
+    
 ## ETL.ExtractAndTransformTimeoutInSec
 
 Number of seconds after which extraction and transformation will end and loading will start.
@@ -35,49 +41,66 @@ Number of seconds after which extraction and transformation will end and loading
 - **Default**: `30`
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>
+<ContentFrame>
 
 ## ETL.MaxNumberOfExtractedDocuments
 
 * Max number of extracted documents in an ETL batch.
 * If value is not set, or set to null, the number of extracted documents fallbacks to `ETL.MaxNumberOfExtractedItems` value.
+
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxBatchSizeInMb
 
 * Maximum size in megabytes of a batch of data (documents and attachments) that will be sent to the destination as a single batch after transformation.
 * If value is not set, or set to null, the size of the batch isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `Size`
 - **Size Unit**: `Megabytes`
 - **Default**: `64`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxFallbackTimeInSec
 
 * Maximum number of seconds the ETL process will be in a fallback mode after a load connection failure to a destination.
 * The fallback mode means suspending the process.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `900`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxNumberOfExtractedItems
 
 * Max number of extracted items (documents, counters, etc) in an ETL batch.
 * If value is not set, or set to null, the number of extracted items isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.OLAP.MaxNumberOfExtractedDocuments
 
 Max number of extracted documents in OLAP ETL batch.
@@ -86,8 +109,9 @@ Max number of extracted documents in OLAP ETL batch.
 - **Default**: `64 * 1024`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.TimeToLiveInSec
 
 Lifespan of a message in the queue.
@@ -96,8 +120,9 @@ Lifespan of a message in the queue.
 - **Default**: `604800` (7 days)
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec
 
 How long a message is hidden after being retrieved but not deleted.
@@ -106,8 +131,9 @@ How long a message is hidden after being retrieved but not deleted.
 - **Default**: `0`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.Kafka.InitTransactionsTimeoutInSec
 
 Timeout to initialize transactions for the Kafka producer.
@@ -116,14 +142,33 @@ Timeout to initialize transactions for the Kafka producer.
 - **Default**: `60`
 - **Scope**: Server-wide or per database
 
+</ContentFrame>
+<ContentFrame>
+    
+## ETL.Raven.LoadRequestTimeoutInSec
 
-
-## ETL.SQL.CommandTimeoutInSec
-
-Number of seconds after which the SQL command will timeout.
+* Number of seconds after which the Raven ETL load request will time out.  
+* Can be overridden per task by setting the `LoadRequestTimeoutInSec` property in the [Raven ETL configuration](../../server/ongoing-tasks/etl/raven.mdx),  
+  or via [Studio](../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx#ravendb-etl-task-definition).
+    
+---    
 
 - **Type**: `int`
+- **Default**: `300`
+- **Scope**: Server-wide or per database
+
+</ContentFrame>    
+<ContentFrame>
+    
+## ETL.SQL.CommandTimeoutInSec
+
+* Number of seconds after which the SQL command will time out.  
+* Can be overridden by setting the `CommandTimeout` property in the SQL ETL configuration.
+    
+---    
+
+- **Type**: `int?`
 - **Default**: `null` (use provider default)
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>    

--- a/versioned_docs/version-7.0/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
+++ b/versioned_docs/version-7.0/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
@@ -61,10 +61,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
     
 5. **HTTP Request Timeout** (Optional)  
    * Sets the maximum time in seconds that the source server will wait for the destination server to process and acknowledge a batch of documents during the Load stage.
-     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.
-   * If not set, no per-request timeout is enforced,  
-     the global HTTP client timeout of 12 hours applies as the only backstop.  
-   * Consider setting this if the destination server is slow or under heavy load,  
+     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.    
+   * Default: `300` seconds.  
+     This is the global default, set by the [ETL.Raven.LoadRequestTimeoutInSec](../../../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec) configuration key.  
+     You can override it for a specific ETL task in the Studio, or in the client API by setting the `LoadRequestTimeoutInSec` property in the Raven ETL configuration.    
+   * Consider increasing this value if the destination server is slow or under heavy load,  
      or if batches are large and take a long time to process.
 
 </Panel>

--- a/versioned_docs/version-7.1/server/configuration/etl-configuration.mdx
+++ b/versioned_docs/version-7.1/server/configuration/etl-configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Configuration: ETL Options"
 sidebar_label: ETL Configuration
+description: "Tune RavenDB ETL task configuration with batch size limits, extraction intervals, and memory usage thresholds for data transformations."
 sidebar_position: 8
 ---
 
@@ -10,11 +11,12 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
-# Configuration: ETL Options
 <Admonition type="note" title="">
 
-* In this page:  
+* In this article:  
     * [ETL.ExtractAndTransformTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlextractandtransformtimeoutinsec)
     * [ETL.MaxBatchSizeInMb](../../server/configuration/etl-configuration.mdx#etlmaxbatchsizeinmb)
     * [ETL.MaxFallbackTimeInSec](../../server/configuration/etl-configuration.mdx#etlmaxfallbacktimeinsec)
@@ -24,9 +26,13 @@ import LanguageContent from "@site/src/components/LanguageContent";
     * [ETL.Queue.AzureQueueStorage.TimeToLiveInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragetimetoliveinsec)
     * [ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueueazurequeuestoragevisibilitytimeoutinsec)
     * [ETL.Queue.Kafka.InitTransactionsTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlqueuekafkainittransactionstimeoutinsec)
+    * [ETL.Raven.LoadRequestTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec)
     * [ETL.SQL.CommandTimeoutInSec](../../server/configuration/etl-configuration.mdx#etlsqlcommandtimeoutinsec)
 
 </Admonition>
+
+<ContentFrame>
+    
 ## ETL.ExtractAndTransformTimeoutInSec
 
 Number of seconds after which extraction and transformation will end and loading will start.
@@ -35,49 +41,66 @@ Number of seconds after which extraction and transformation will end and loading
 - **Default**: `30`
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>
+<ContentFrame>
 
 ## ETL.MaxNumberOfExtractedDocuments
 
 * Max number of extracted documents in an ETL batch.
 * If value is not set, or set to null, the number of extracted documents fallbacks to `ETL.MaxNumberOfExtractedItems` value.
+
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxBatchSizeInMb
 
 * Maximum size in megabytes of a batch of data (documents and attachments) that will be sent to the destination as a single batch after transformation.
 * If value is not set, or set to null, the size of the batch isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `Size`
 - **Size Unit**: `Megabytes`
 - **Default**: `64`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxFallbackTimeInSec
 
 * Maximum number of seconds the ETL process will be in a fallback mode after a load connection failure to a destination.
 * The fallback mode means suspending the process.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `900`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.MaxNumberOfExtractedItems
 
 * Max number of extracted items (documents, counters, etc) in an ETL batch.
 * If value is not set, or set to null, the number of extracted items isn't limited in the processed ETL batch.
+    
+---
+    
 - **Type**: `int`
 - **Default**: `8192`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.OLAP.MaxNumberOfExtractedDocuments
 
 Max number of extracted documents in OLAP ETL batch.
@@ -86,8 +109,9 @@ Max number of extracted documents in OLAP ETL batch.
 - **Default**: `64 * 1024`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.TimeToLiveInSec
 
 Lifespan of a message in the queue.
@@ -96,8 +120,9 @@ Lifespan of a message in the queue.
 - **Default**: `604800` (7 days)
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec
 
 How long a message is hidden after being retrieved but not deleted.
@@ -106,8 +131,9 @@ How long a message is hidden after being retrieved but not deleted.
 - **Default**: `0`
 - **Scope**: Server-wide or per database
 
-
-
+</ContentFrame>
+<ContentFrame>
+    
 ## ETL.Queue.Kafka.InitTransactionsTimeoutInSec
 
 Timeout to initialize transactions for the Kafka producer.
@@ -116,14 +142,33 @@ Timeout to initialize transactions for the Kafka producer.
 - **Default**: `60`
 - **Scope**: Server-wide or per database
 
+</ContentFrame>
+<ContentFrame>
+    
+## ETL.Raven.LoadRequestTimeoutInSec
 
-
-## ETL.SQL.CommandTimeoutInSec
-
-Number of seconds after which the SQL command will timeout.
+* Number of seconds after which the Raven ETL load request will time out.  
+* Can be overridden per task by setting the `LoadRequestTimeoutInSec` property in the [Raven ETL configuration](../../server/ongoing-tasks/etl/raven.mdx),  
+  or via [Studio](../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx#ravendb-etl-task-definition).
+    
+---    
 
 - **Type**: `int`
+- **Default**: `300`
+- **Scope**: Server-wide or per database
+
+</ContentFrame>    
+<ContentFrame>
+    
+## ETL.SQL.CommandTimeoutInSec
+
+* Number of seconds after which the SQL command will time out.  
+* Can be overridden by setting the `CommandTimeout` property in the SQL ETL configuration.
+    
+---    
+
+- **Type**: `int?`
 - **Default**: `null` (use provider default)
 - **Scope**: Server-wide or per database
 
-
+</ContentFrame>    

--- a/versioned_docs/version-7.1/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
+++ b/versioned_docs/version-7.1/studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx
@@ -61,10 +61,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
     
 5. **HTTP Request Timeout** (Optional)  
    * Sets the maximum time in seconds that the source server will wait for the destination server to process and acknowledge a batch of documents during the Load stage.
-     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.
-   * If not set, no per-request timeout is enforced,  
-     the global HTTP client timeout of 12 hours applies as the only backstop.  
-   * Consider setting this if the destination server is slow or under heavy load,  
+     If the destination does not respond within this time, the request is canceled and the ETL task enters fallback mode and retries.    
+   * Default: `300` seconds.  
+     This is the global default, set by the [ETL.Raven.LoadRequestTimeoutInSec](../../../../server/configuration/etl-configuration.mdx#etlravenloadrequesttimeoutinsec) configuration key.  
+     You can override it for a specific ETL task in the Studio, or in the client API by setting the `LoadRequestTimeoutInSec` property in the Raven ETL configuration.    
+   * Consider increasing this value if the destination server is slow or under heavy load,  
      or if batches are large and take a long time to process.
 
 </Panel>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3804/RavenDB-ETL-Default-request-timeout

### Additional description

* Add the new server configuration: ETL.Raven.LoadRequestTimeoutInSec in:
`../server/configuration/etl-configuration`
* Update point 5 in section:
`../studio/database/tasks/ongoing-tasks/ravendb-etl-task#ravendb-etl-task-definition`

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

