### PR TITLE
RDoc-3822 Chunk CloudFront KVS updates to clear per-request quota

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -110,28 +110,66 @@ function Prepare-RobotsTxt {
     Write-Host "robots.txt -> using '$srcName'" -ForegroundColor Cyan
 }
 
+# CloudFront KVS UpdateKeys is hard-capped at ~50 operations and ~3 KB body
+$KvsBatchSize = 25
+
+function Split-IntoBatches {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [object[]] $Items,
+        [Parameter(Mandatory)] [int]      $BatchSize
+    )
+    for ($i = 0; $i -lt $Items.Count; $i += $BatchSize) {
+        $end = [Math]::Min($i + $BatchSize - 1, $Items.Count - 1)
+        # Comma-prefix preserves the inner array as a single pipeline item.
+        ,@($Items[$i..$end])
+    }
+}
+
+function Push-KvsBatch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]   $KvsArn,
+        [Parameter(Mandatory)] [string]   $Etag,
+        [Parameter(Mandatory)] [object[]] $Batch
+    )
+
+    $payload = $Batch | ConvertTo-Json -Compress -Depth 5 -AsArray
+    $newEtag = aws cloudfront-keyvaluestore update-keys `
+        --kvs-arn $KvsArn --if-match $Etag --puts $payload `
+        --query 'ETag' --output text
+    if ($LASTEXITCODE -ne 0) {
+        throw "aws update-keys failed (exit $LASTEXITCODE)"
+    }
+    return $newEtag
+}
+
 function Update-CloudFrontKVS {
     $kvsArn = $env:KVS_ARN
-
     if (-not $kvsArn) {
         Write-Error "Environment variable KVS_ARN is not set."
         exit 1
     }
 
-    $redirectsData = Get-Content -Path $RedirectsFilePath | ConvertFrom-Json
-
-    $transformedRedirects = $redirectsData | ForEach-Object {
-        @{
-            Key   = $_.key
-            Value = ($_.value | ConvertTo-Json -Compress)
-        }
+    $redirects = Get-Content -Path $RedirectsFilePath | ConvertFrom-Json | ForEach-Object {
+        @{ Key = $_.key; Value = ($_.value | ConvertTo-Json -Compress) }
     }
 
-    $encodedPayload = $transformedRedirects | ConvertTo-Json -Compress
+    $batches = @(Split-IntoBatches -Items $redirects -BatchSize $KvsBatchSize)
+    $etag = aws cloudfront-keyvaluestore describe-key-value-store `
+        --kvs-arn $kvsArn --query 'ETag' --output text
 
-    $kvsEtag = aws cloudfront-keyvaluestore describe-key-value-store --kvs-arn $kvsArn --query 'ETag' --output text
+    Write-Host "Pushing $($redirects.Count) keys in $($batches.Count) batch(es) of up to $KvsBatchSize" -ForegroundColor Cyan
 
-    aws cloudfront-keyvaluestore update-keys --kvs-arn $kvsArn --if-match $kvsEtag --puts $encodedPayload
+    for ($i = 0; $i -lt $batches.Count; $i++) {
+        Write-Host "  batch $($i + 1)/$($batches.Count) ($($batches[$i].Count) keys)" -ForegroundColor Cyan
+        try {
+            $etag = Push-KvsBatch -KvsArn $kvsArn -Etag $etag -Batch $batches[$i]
+        } catch {
+            Write-Error "KVS batch $($i + 1)/$($batches.Count) failed: $_"
+            exit 1
+        }
+    }
 }
 
 Ensure-Dependencies


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3822/Chunk-CloudFront-KVS-updates-to-clear-per-request-quota

### Additional description
Fixes broken redirects kvs. 

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

