### PR TITLE
RDoc-3830 Add billing period and daily cost delay info

### DIFF
--- a/cloud/cloud-pricing-payment-billing.mdx
+++ b/cloud/cloud-pricing-payment-billing.mdx
@@ -28,6 +28,7 @@ details in any case). You can pay per minute without any commitment, or use one 
      - [Additional Expenses](../cloud/cloud-pricing-payment-billing.mdx#additional-expenses)  
   * [Payment](../cloud/cloud-pricing-payment-billing.mdx#payment)  
   * [Billing](../cloud/cloud-pricing-payment-billing.mdx#billing)  
+    - [Billing Period](../cloud/cloud-pricing-payment-billing.mdx#billing-period)  
     - [Charging Failures](../cloud/cloud-pricing-payment-billing.mdx#charging-failures)  
     - [Pay Now](../cloud/cloud-pricing-payment-billing.mdx#pay-now)  
 
@@ -146,6 +147,17 @@ Approach our Support personnel to use wire transfer or purchase order.
 Your Portal's [Billing & Costs tab](../cloud/portal/cloud-portal-billing-tab.mdx) summarizes your 
 outstanding charges and past invoices. Additional data you can see there includes Daily cost, Total 
 cost, and the expected charge at the end of this month.  
+#### Billing Period
+
+Each billing period runs from the **26th of one calendar month** to the **25th of the following month**.  
+Your account is charged on the **27th** — two days after the period closes.  
+For example, the April billing period covers April 26th through May 25th, and the charge is made on May 27th.
+
+<Admonition type="note" title="">
+Daily costs appear in your billing view with a **two-day delay**.  
+Usage incurred on a given day is processed and reflected approximately two days later.
+</Admonition>
+
 #### Charging failures  
 If we fail to charge your account using the payment method you provided, we'll notify
 you and retry for 5 days. Failure to pay after that period may result in account closure.


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3830

### Additional description
Added a new **Billing Period** subsection under the Billing section of the Pricing, Payment and Billing page.

Documents two previously undocumented behaviours:
- The standard billing period runs from the **26th of one calendar month** to the **25th of the following month**, with the charge made on the **27th**
- Daily costs are reflected in the billing view with a **two-day delay**

Also added the new section to the page's table-of-contents Admonition.

### Type of change

- [ ] Content - docs
- [x] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)