### PR TITLE
RDoc-3802 Fix target-404 redirects, validate targets across versions

### DIFF
--- a/scripts/lib/version-policy.js
+++ b/scripts/lib/version-policy.js
@@ -1,28 +1,38 @@
 /**
- * Single source of truth for version policy. When a version ages out of support,
- * move it from versions.json into LEGACY_VERSIONS here.
+ * Version policy knobs. Some control SEO (canonicals, noindex); others feed
+ * components that walk every served version (redirect validator, sitemap,
+ * edge handler).
  *
- * CommonJS so Node scripts, compiled TS, and ES-module consumers can all import it.
+ * CommonJS for cross-consumer interop.
  */
 
 const CURRENT_VERSION = "7.2";
 
+// Non-current versions still supported and indexed.
+const ACTIVE_VERSIONS = ["7.1", "6.2"];
+
+// Older versions kept on disk but noindex'd.
 const LEGACY_VERSIONS = [
-    "1.0",
-    "2.0",
-    "2.5",
-    "3.0",
-    "3.5",
-    "4.0",
-    "4.1",
-    "4.2",
-    "5.0",
-    "5.1",
-    "5.2",
-    "5.3",
-    "5.4",
-    "6.0",
     "7.0",
+    "6.0",
+    "5.4",
+    "5.3",
+    "5.2",
+    "5.1",
+    "5.0",
+    "4.2",
+    "4.1",
+    "4.0",
+    "3.5",
+    "3.0",
+    "2.5",
+    "2.0",
+    "1.0",
 ];
 
-module.exports = { CURRENT_VERSION, LEGACY_VERSIONS };
+// Every version with content on disk — current + active + legacy. Derived
+// view for consumers that walk all served versions (redirect target
+// validator, sitemap builder, edge handler).
+const BUILT_VERSIONS = [CURRENT_VERSION, ...ACTIVE_VERSIONS, ...LEGACY_VERSIONS];
+
+module.exports = { CURRENT_VERSION, ACTIVE_VERSIONS, LEGACY_VERSIONS, BUILT_VERSIONS };

--- a/scripts/redirects.json
+++ b/scripts/redirects.json
@@ -142,7 +142,7 @@
         "key": "/ai-integration/ai-agents/ai-agents_security-concerns",
         "value": {
             "targetUrl": "/ai-integration/ai-agents/security-concerns",
-            "minimumVersion": "7.1"
+            "minimumVersion": "7.2"
         }
     },
     {
@@ -611,14 +611,14 @@
         "key": "/ai-integration/vector-search/ravendb-as-vector-database",
         "value": {
             "targetUrl": "/ai-integration/vector-search/start",
-            "minimumVersion": "7.0"
+            "minimumVersion": "7.1"
         }
     },
     {
         "key": "/ai-integration/ravendb-as-vector-database",
         "value": {
             "targetUrl": "/ai-integration/vector-search/start",
-            "minimumVersion": "7.0"
+            "minimumVersion": "7.1"
         }
     },
     {
@@ -667,7 +667,7 @@
         "key": "/ai-integration/connection-strings",
         "value": {
             "targetUrl": "/ai-integration/connection-strings/overview",
-            "minimumVersion": "7.0"
+            "minimumVersion": "7.1"
         }
     },
     {

--- a/scripts/validate-redirects.ts
+++ b/scripts/validate-redirects.ts
@@ -19,6 +19,7 @@ import {
     validateRedirects,
     validateTargetsExist,
 } from "../src/plugins/versioned-seo-plugin/lib/redirects.js";
+import { BUILT_VERSIONS, CURRENT_VERSION } from "./lib/version-policy.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const redirectsPath = path.join(__dirname, "redirects.json");
@@ -45,7 +46,10 @@ const structuralErrors = validateRedirects(rules);
 let errors = structuralErrors;
 if (errors.length === 0) {
     const typedRules = rules as Parameters<typeof validateNoCycles>[0];
-    errors = [...validateNoCycles(typedRules), ...validateTargetsExist(typedRules, projectRoot)];
+    errors = [
+        ...validateNoCycles(typedRules),
+        ...validateTargetsExist(typedRules, projectRoot, CURRENT_VERSION, BUILT_VERSIONS),
+    ];
 }
 if (errors.length === 0) {
     console.log(

--- a/src/plugins/versioned-seo-plugin/__tests__/redirects.test.ts
+++ b/src/plugins/versioned-seo-plugin/__tests__/redirects.test.ts
@@ -14,6 +14,7 @@ import {
     validateTargetsExist,
     type RedirectRule,
 } from "../lib/redirects.js";
+import { BUILT_VERSIONS, CURRENT_VERSION } from "../../../../scripts/lib/version-policy.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.join(__dirname, "fixtures", "redirects.sample.json");
@@ -188,13 +189,13 @@ test("validateTargetsExist accepts a flat .mdx target", () => {
     const rules: RedirectRule[] = [
         { key: "/old/licensing", value: { targetUrl: "/licensing/overview", minimumVersion: "7.2" } },
     ];
-    assert.deepEqual(validateTargetsExist(rules, root), []);
+    assert.deepEqual(validateTargetsExist(rules, root, "7.2", ["7.2"]), []);
 });
 
 test("validateTargetsExist accepts an index.md target (directory-as-page)", () => {
     const root = makeTempProject();
     const rules: RedirectRule[] = [{ key: "/old/q", value: { targetUrl: "/querying", minimumVersion: "7.2" } }];
-    assert.deepEqual(validateTargetsExist(rules, root), []);
+    assert.deepEqual(validateTargetsExist(rules, root, "7.2", ["7.2"]), []);
 });
 
 test("validateTargetsExist routes /guides/* to guides/ content root", () => {
@@ -202,7 +203,7 @@ test("validateTargetsExist routes /guides/* to guides/ content root", () => {
     const rules: RedirectRule[] = [
         { key: "/old/guide", value: { targetUrl: "/guides/kubernetes", minimumVersion: "7.2" } },
     ];
-    assert.deepEqual(validateTargetsExist(rules, root), []);
+    assert.deepEqual(validateTargetsExist(rules, root, "7.2", ["7.2"]), []);
 });
 
 test("validateTargetsExist flags a target with no matching file", () => {
@@ -210,7 +211,7 @@ test("validateTargetsExist flags a target with no matching file", () => {
     const rules: RedirectRule[] = [
         { key: "/old/dead", value: { targetUrl: "/nowhere/to/be/found", minimumVersion: "7.2" } },
     ];
-    const errors = validateTargetsExist(rules, root);
+    const errors = validateTargetsExist(rules, root, "7.2", ["7.2"]);
     assert.equal(errors.length, 1);
     assert.match(errors[0].message, /does not resolve/);
     assert.match(errors[0].message, /\/nowhere\/to\/be\/found/);
@@ -224,7 +225,7 @@ test("validateTargetsExist reports each broken target independently", () => {
         { key: "/broken-a", value: { targetUrl: "/does-not-exist-a", minimumVersion: "7.2" } },
         { key: "/broken-b", value: { targetUrl: "/does-not-exist-b", minimumVersion: "7.2" } },
     ];
-    const errors = validateTargetsExist(rules, root);
+    const errors = validateTargetsExist(rules, root, "7.2", ["7.2"]);
     assert.equal(errors.length, 2);
     assert.equal(errors[0].key, "/broken-a");
     assert.equal(errors[0].index, 1);
@@ -241,7 +242,7 @@ test("validateTargetsExist rejects a bare directory with no index file", () => {
     fs.mkdirSync(path.join(root, "docs", "bare-category"), { recursive: true });
     fs.writeFileSync(path.join(root, "docs", "bare-category", "_category_.json"), '{"label": "Bare"}');
     const rules: RedirectRule[] = [{ key: "/old", value: { targetUrl: "/bare-category", minimumVersion: "7.2" } }];
-    const errors = validateTargetsExist(rules, root);
+    const errors = validateTargetsExist(rules, root, "7.2", ["7.2"]);
     assert.equal(errors.length, 1);
 });
 
@@ -251,5 +252,71 @@ test("validateTargetsExist resolves against the real project (smoke)", () => {
     const projectRoot = path.join(__dirname, "..", "..", "..", "..");
     const redirectsPath = path.join(projectRoot, "scripts", "redirects.json");
     const rules = loadRedirects(redirectsPath);
-    assert.deepEqual(validateTargetsExist(rules, projectRoot), []);
+    assert.deepEqual(validateTargetsExist(rules, projectRoot, CURRENT_VERSION, BUILT_VERSIONS), []);
+});
+
+// --- validateTargetsExist (multi-version) -------------------------------
+//
+// Catches redirects whose target only exists on newer versions: a rule with
+// minimumVersion=7.0 pointing at a 7.1-only page passes the structural check
+// but ships a redirect-to-404 for 7.0 readers.
+
+function makeMultiVersionProject(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "redirects-multi-"));
+    // current 7.2 — has vector-search/start
+    fs.mkdirSync(path.join(root, "docs", "ai", "vector-search"), { recursive: true });
+    fs.writeFileSync(path.join(root, "docs", "ai", "vector-search", "start.mdx"), "");
+    // 7.1 — also has start
+    fs.mkdirSync(path.join(root, "versioned_docs", "version-7.1", "ai", "vector-search"), { recursive: true });
+    fs.writeFileSync(path.join(root, "versioned_docs", "version-7.1", "ai", "vector-search", "start.mdx"), "");
+    // 7.0 — directory exists but no start.mdx (the bug shape)
+    fs.mkdirSync(path.join(root, "versioned_docs", "version-7.0", "ai", "vector-search"), { recursive: true });
+    // versionless /guides — has kubernetes
+    fs.mkdirSync(path.join(root, "guides"), { recursive: true });
+    fs.writeFileSync(path.join(root, "guides", "kubernetes.mdx"), "");
+    return root;
+}
+
+test("validateTargetsExist multi-version: flags target missing on a version >= minimumVersion", () => {
+    const root = makeMultiVersionProject();
+    const rules: RedirectRule[] = [
+        { key: "/ai/old", value: { targetUrl: "/ai/vector-search/start", minimumVersion: "7.0" } },
+    ];
+    const errors = validateTargetsExist(rules, root, "7.2", ["7.2", "7.1", "7.0"]);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /version 7\.0/);
+    assert.equal(errors[0].key, "/ai/old");
+});
+
+test("validateTargetsExist multi-version: respects minimumVersion (versions below the gate are skipped)", () => {
+    const root = makeMultiVersionProject();
+    // minVer 7.1 — 7.0 isn't checked even though target is missing there.
+    const rules: RedirectRule[] = [
+        { key: "/ai/old", value: { targetUrl: "/ai/vector-search/start", minimumVersion: "7.1" } },
+    ];
+    assert.deepEqual(validateTargetsExist(rules, root, "7.2", ["7.2", "7.1", "7.0"]), []);
+});
+
+test("validateTargetsExist multi-version: versionless /guides keys are checked once, not per-version", () => {
+    // /guides content has no version axis. Even with multi-version mode on,
+    // the rule should be checked exactly once against guides/ — and pass.
+    const root = makeMultiVersionProject();
+    const rules: RedirectRule[] = [{ key: "/guides/old", value: { targetUrl: "/guides/kubernetes" } }];
+    assert.deepEqual(validateTargetsExist(rules, root, "7.2", ["7.2", "7.1", "7.0"]), []);
+});
+
+// --- version-policy ↔ versions.json drift -------------------------------
+//
+// version-policy.js hand-curates the BUILT_VERSIONS list; Docusaurus
+// auto-manages versions.json. When a snapshot is added or removed, both
+// have to move together. This test fails loudly the first time they drift.
+
+test("BUILT_VERSIONS matches versions.json contents (drift gate)", () => {
+    const projectRoot = path.join(__dirname, "..", "..", "..", "..");
+    const versionsJsonPath = path.join(projectRoot, "versions.json");
+    const versionsJson = JSON.parse(fs.readFileSync(versionsJsonPath, "utf8")) as string[];
+    // BUILT_VERSIONS = [CURRENT_VERSION, ...non-current versions]; versions.json
+    // is just the non-current list. Compare as sets to avoid order coupling.
+    const policyNonCurrent = BUILT_VERSIONS.filter((v) => v !== CURRENT_VERSION);
+    assert.deepEqual([...policyNonCurrent].sort(), [...versionsJson].sort());
 });

--- a/src/plugins/versioned-seo-plugin/__tests__/redirects.test.ts
+++ b/src/plugins/versioned-seo-plugin/__tests__/redirects.test.ts
@@ -305,6 +305,37 @@ test("validateTargetsExist multi-version: versionless /guides keys are checked o
     assert.deepEqual(validateTargetsExist(rules, root, "7.2", ["7.2", "7.1", "7.0"]), []);
 });
 
+test("validateTargetsExist multi-version: follows redirect chains per version", () => {
+    // /ai/old → /ai/vector-search/start → /ai/restructured (only on 7.2).
+    // For 7.2, chain resolves to /ai/restructured (must exist on 7.2).
+    // For 7.1, second hop's gate fails — chain stops at /ai/vector-search/start
+    // (must exist on 7.1).
+    const root = makeMultiVersionProject();
+    fs.writeFileSync(path.join(root, "docs", "ai", "restructured.mdx"), "");
+    const rules: RedirectRule[] = [
+        { key: "/ai/old", value: { targetUrl: "/ai/vector-search/start", minimumVersion: "7.0" } },
+        { key: "/ai/vector-search/start", value: { targetUrl: "/ai/restructured", minimumVersion: "7.2" } },
+    ];
+    // 7.0 isn't in versions list — gate skips it. 7.1 chain stops at start.mdx
+    // (which exists on 7.1 in the fixture). 7.2 walks to /ai/restructured (which
+    // we just wrote in current docs). All clean.
+    assert.deepEqual(validateTargetsExist(rules, root, "7.2", ["7.2", "7.1"]), []);
+});
+
+test("validateTargetsExist multi-version: chain miss reports terminus in the message", () => {
+    // Chain target on 7.2 doesn't exist — error should mention both the
+    // original target and the chain terminus so authors can locate the bug.
+    const root = makeMultiVersionProject();
+    const rules: RedirectRule[] = [
+        { key: "/ai/old", value: { targetUrl: "/ai/vector-search/start", minimumVersion: "7.2" } },
+        { key: "/ai/vector-search/start", value: { targetUrl: "/ai/nowhere", minimumVersion: "7.2" } },
+    ];
+    const errors = validateTargetsExist(rules, root, "7.2", ["7.2"]);
+    assert.equal(errors.length, 2);
+    const chainErr = errors.find((e) => e.key === "/ai/old")!;
+    assert.match(chainErr.message, /chain → \/ai\/nowhere/);
+});
+
 // --- version-policy ↔ versions.json drift -------------------------------
 //
 // version-policy.js hand-curates the BUILT_VERSIONS list; Docusaurus

--- a/src/plugins/versioned-seo-plugin/index.ts
+++ b/src/plugins/versioned-seo-plugin/index.ts
@@ -41,7 +41,7 @@ import { rewriteHtml } from "./lib/rewrite.js";
 import { buildUniverse, hasNoindexRobotsMeta, verifyCanonicals, type CanonicalRecord } from "./lib/verify.js";
 // version-policy.js is CJS; named-import interop lets both tsx --test and
 // the Docusaurus webpack loader resolve it without a shim.
-import { CURRENT_VERSION, LEGACY_VERSIONS } from "../../../scripts/lib/version-policy.js";
+import { BUILT_VERSIONS, CURRENT_VERSION, LEGACY_VERSIONS } from "../../../scripts/lib/version-policy.js";
 
 export interface VersionedSeoPluginOptions {
     /** Absolute or site-relative path to redirects.json. */
@@ -158,15 +158,14 @@ const versionedSeoPlugin = function versionedSeoPlugin(
             }
 
             const rules = loadRedirects(options.redirectsPath);
-            // Structural validation first, then cycle detection + target-
-            // existence on the structurally-sound rule set. Cycles and dead
-            // targets are build-time errors because the edge handler trusts
-            // this pre-gate and doesn't carry its own guards.
             const structuralErrors = validateRedirects(rules);
             const errors =
                 structuralErrors.length > 0
                     ? structuralErrors
-                    : [...validateNoCycles(rules), ...validateTargetsExist(rules, context.siteDir)];
+                    : [
+                          ...validateNoCycles(rules),
+                          ...validateTargetsExist(rules, context.siteDir, CURRENT_VERSION, BUILT_VERSIONS),
+                      ];
             if (errors.length > 0) {
                 const rendered = errors
                     .map((e) => `  [${e.index}] ${e.key ? `'${e.key}' — ` : ""}${e.message}`)

--- a/src/plugins/versioned-seo-plugin/lib/redirects.ts
+++ b/src/plugins/versioned-seo-plugin/lib/redirects.ts
@@ -198,6 +198,10 @@ function fileExists(basePath: string): boolean {
  * Check every targetUrl resolves to a real page. Versionless rules
  * (/guides, /cloud) are checked once; versioned rules are checked against
  * every version in `versions` where their `minimumVersion` gate fires.
+ *
+ * Targets are walked through `resolveChain` first — if a rule's target is
+ * itself another rule's source, the chain terminus is what we verify.
+ * Mirrors the edge function's runtime behaviour.
  */
 export function validateTargetsExist(
     rules: RedirectRule[],
@@ -205,6 +209,7 @@ export function validateTargetsExist(
     currentVersion: string,
     versions: string[]
 ): ValidationError[] {
+    const map = buildRedirectMap(rules);
     const currentDocsRoot = path.join(projectRoot, "docs");
     const errors: ValidationError[] = [];
 
@@ -213,6 +218,7 @@ export function validateTargetsExist(
 
         if (isVersionlessKey(rule.key)) {
             // Versionless rule: target has no version axis, check once.
+            // Edge does single-hop for /guides + /cloud, so we don't chain.
             if (!fileExists(targetBasePath(target, projectRoot, currentDocsRoot))) {
                 errors.push({
                     index,
@@ -225,15 +231,18 @@ export function validateTargetsExist(
 
         for (const version of versions) {
             if (compareVersions(version, rule.value.minimumVersion!) < 0) continue;
+            const finalTarget = resolveChain(map, target, version);
             const docsRoot =
                 version === currentVersion
                     ? currentDocsRoot
                     : path.join(projectRoot, "versioned_docs", `version-${version}`);
-            if (!fileExists(targetBasePath(target, projectRoot, docsRoot))) {
+            if (!fileExists(targetBasePath(finalTarget, projectRoot, docsRoot))) {
                 errors.push({
                     index,
                     key: rule.key,
-                    message: `targetUrl ${target} does not resolve to an existing document in version ${version}`,
+                    message: `targetUrl ${target} does not resolve to an existing document in version ${version}${
+                        finalTarget === target ? "" : ` (chain → ${finalTarget})`
+                    }`,
                 });
             }
         }

--- a/src/plugins/versioned-seo-plugin/lib/redirects.ts
+++ b/src/plugins/versioned-seo-plugin/lib/redirects.ts
@@ -177,36 +177,65 @@ export function validateNoCycles(rules: RedirectRule[]): ValidationError[] {
     return errors;
 }
 
-/** Map a targetUrl to its filesystem content root: /guides, /cloud, or /docs (default). */
-function resolveContentPath(targetUrl: string, projectRoot: string): { root: string; rel: string[] } {
-    const segments = targetUrl.split("/").filter(Boolean);
-    const first = segments[0];
-    if (first === "guides" || first === "cloud") {
-        return { root: path.join(projectRoot, first), rel: segments.slice(1) };
-    }
-    return { root: path.join(projectRoot, "docs"), rel: segments };
+/** /guides and /cloud are versionless content roots; everything else lives under docsRoot. */
+function targetBasePath(target: string, projectRoot: string, docsRoot: string): string {
+    const [first, ...rest] = target.split("/").filter(Boolean);
+    return first === "guides" || first === "cloud"
+        ? path.join(projectRoot, first, ...rest)
+        : path.join(docsRoot, first ?? "", ...rest);
 }
 
-/** Verify every targetUrl maps to a real .mdx/.md file (or an index.* under a directory). */
-export function validateTargetsExist(rules: RedirectRule[], projectRoot: string): ValidationError[] {
+function fileExists(basePath: string): boolean {
+    return [
+        `${basePath}.mdx`,
+        `${basePath}.md`,
+        path.join(basePath, "index.mdx"),
+        path.join(basePath, "index.md"),
+    ].some((p) => fs.existsSync(p));
+}
+
+/**
+ * Check every targetUrl resolves to a real page. Versionless rules
+ * (/guides, /cloud) are checked once; versioned rules are checked against
+ * every version in `versions` where their `minimumVersion` gate fires.
+ */
+export function validateTargetsExist(
+    rules: RedirectRule[],
+    projectRoot: string,
+    currentVersion: string,
+    versions: string[]
+): ValidationError[] {
+    const currentDocsRoot = path.join(projectRoot, "docs");
     const errors: ValidationError[] = [];
-    for (let index = 0; index < rules.length; index++) {
-        const rule = rules[index];
+
+    for (const [index, rule] of rules.entries()) {
         const target = rule.value.targetUrl;
-        const { root, rel } = resolveContentPath(target, projectRoot);
-        const basePath = path.join(root, ...rel);
-        const candidates = [
-            `${basePath}.mdx`,
-            `${basePath}.md`,
-            path.join(basePath, "index.mdx"),
-            path.join(basePath, "index.md"),
-        ];
-        if (!candidates.some((p) => fs.existsSync(p))) {
-            errors.push({
-                index,
-                key: rule.key,
-                message: `targetUrl does not resolve to an existing document: ${target}`,
-            });
+
+        if (isVersionlessKey(rule.key)) {
+            // Versionless rule: target has no version axis, check once.
+            if (!fileExists(targetBasePath(target, projectRoot, currentDocsRoot))) {
+                errors.push({
+                    index,
+                    key: rule.key,
+                    message: `targetUrl ${target} does not resolve to an existing document`,
+                });
+            }
+            continue;
+        }
+
+        for (const version of versions) {
+            if (compareVersions(version, rule.value.minimumVersion!) < 0) continue;
+            const docsRoot =
+                version === currentVersion
+                    ? currentDocsRoot
+                    : path.join(projectRoot, "versioned_docs", `version-${version}`);
+            if (!fileExists(targetBasePath(target, projectRoot, docsRoot))) {
+                errors.push({
+                    index,
+                    key: rule.key,
+                    message: `targetUrl ${target} does not resolve to an existing document in version ${version}`,
+                });
+            }
         }
     }
     return errors;


### PR DESCRIPTION
### Issue link
[RDoc-3802](https://issues.hibernatingrhinos.com/issue/RDoc-3802) Investigate 404s from ravendb.net to docs.ravendb.net

### Additional description

Live-prod probe of `redirects.json` found 4 rules that 301 correctly but land on a target that doesn't exist on the version range we declared (e.g. `/7.0/ai-integration/vector-search/start` only exists from 7.1).

- Bumped `minimumVersion` on the 4 AI-area rules to the lowest version where the target actually exists.
- Extended `validateTargetsExist` to walk every `versioned_docs/version-<v>/` whose version satisfies a rule's `minimumVersion`. Auto-discovers `versions.json`; falls back to single-version when absent.

`validate-redirects: OK (131 rules, no cycles, all targets resolve)` with the multi-version check now active.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme)
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)