### PR TITLE
RDoc-3798 Fix Admonition styling

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -466,6 +466,11 @@ code {
     @apply mb-0;
 }
 
+/* Scale down hash link for admonition headings */
+.theme-admonition .hash-link {
+    transform: scale(0.9);
+}
+
 /* Frames for documentation content */
 .content-frame {
     @apply rounded-md border border-black/10 dark:border-white/10 p-4;

--- a/src/theme/Admonition/Layout/index.tsx
+++ b/src/theme/Admonition/Layout/index.tsx
@@ -25,10 +25,11 @@ function AdmonitionContainer({
 
 function AdmonitionHeading({ title, id, href }: Pick<Props, "title" | "id" | "href">) {
     return (
-        <div>
-            <a id={id} href={href}>
+        <div className="inline-flex">
+            <h4 className="!mb-0 !leading-[24px]" id={id}>
                 {title}
-            </a>
+            </h4>
+            <a href={href} className="hash-link" aria-labelledby={id} />
         </div>
     );
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3798

### Additional description
Fixed heading styling; added anchor for better sharing experience

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [x] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [ ] No changes in UX/UI
- [x] Changes in UX/UI (include screenshots and description)
<img width="1115" height="397" alt="image" src="https://github.com/user-attachments/assets/91bdd938-8e5b-45c5-b6bf-3b4860df5ccc" />
