### PR TITLE
RDoc-3808 Enable reo.dev

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -227,6 +227,11 @@ const config: Config = {
                 },
             }),
         },
+        {
+            tagName: "script",
+            attributes: { type: "text/javascript" },
+            innerHTML: `!function(){if(location.hostname!=="docs.ravendb.net")return;var e,t,n;e="151dc5b0493a177",t=function(){Reo.init({clientID:"151dc5b0493a177"})},n=document.createElement("script"),n.src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();`,
+        },
     ],
     themeConfig: {
         docs: {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3808/Enable-reo.dev-for-the-new-documentation

### Additional description
Installs the [reo.dev](https://reo.dev/) tracking snippet on the docs site.
The snippet is added directly to docusaurus.config.ts headTags (rather than going through GTM) so it loads in <head> before page hydration. The snippet is wrapped in `if (location.hostname !== "docs.ravendb.net") return;`. The Docusaurus url is hardcoded to `https://docs.ravendb.net/` and the staging deploy uses the same build artifact, so without a runtime gate, internal browsing of staging would pollute the reo dashboard. The guard ensures `static.reo.dev/<id>/reo.js` is only ever requested on production.

**Once merged, needs CSP bump**

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [x] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

