### PR TITLE
RDoc-3835 Fix Visual C++ Redistributable Package links in docs

### DIFF
--- a/docs/start/getting-started.mdx
+++ b/docs/start/getting-started.mdx
@@ -53,8 +53,7 @@ RavenDB is written in `.NET` so it requires the same set of prerequisites as `.N
 
 <Admonition type="note" title="Windows" id="windows" href="#windows">
 
-Please install [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) 
-(or newer) before launching the RavenDB server.  
+Please install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) before launching the RavenDB server.  
 This package should be the sole requirement for the 'Windows' platforms.  
 If you're experiencing difficulties, please check the 
 prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).  

--- a/docs/start/installation/setup-examples/aws-windows-vm.mdx
+++ b/docs/start/installation/setup-examples/aws-windows-vm.mdx
@@ -95,7 +95,7 @@ Dowload Chrome. You will need to allow it in the Internet Explorer firewall.
 ![20](./assets/20.png)
 ![21](./assets/21.png)
 
-Install the [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) (or newer).
+Install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
 
 ![19](./assets/19.png)
 

--- a/versioned_docs/version-6.2/start/getting-started.mdx
+++ b/versioned_docs/version-6.2/start/getting-started.mdx
@@ -52,8 +52,7 @@ RavenDB is written in `.NET` so it requires the same set of prerequisites as `.N
 
 <Admonition type="note" title="Windows" id="windows" href="#windows">
 
-Please install [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) 
-(or newer) before launching the RavenDB server.  
+Please install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) before launching the RavenDB server.  
 This package should be the sole requirement for the 'Windows' platforms.  
 If you're experiencing difficulties, please check the 
 prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).  

--- a/versioned_docs/version-6.2/start/installation/setup-examples/aws-windows-vm.mdx
+++ b/versioned_docs/version-6.2/start/installation/setup-examples/aws-windows-vm.mdx
@@ -94,7 +94,7 @@ Dowload Chrome. You will need to allow it in the Internet Explorer firewall.
 ![20](./assets/20.png)
 ![21](./assets/21.png)
 
-Install the [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) (or newer).
+Install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
 
 ![19](./assets/19.png)
 

--- a/versioned_docs/version-7.1/start/getting-started.mdx
+++ b/versioned_docs/version-7.1/start/getting-started.mdx
@@ -52,8 +52,7 @@ RavenDB is written in `.NET` so it requires the same set of prerequisites as `.N
 
 <Admonition type="note" title="Windows" id="windows" href="#windows">
 
-Please install [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) 
-(or newer) before launching the RavenDB server.  
+Please install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) before launching the RavenDB server.  
 This package should be the sole requirement for the 'Windows' platforms.  
 If you're experiencing difficulties, please check the 
 prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).  

--- a/versioned_docs/version-7.1/start/installation/setup-examples/aws-windows-vm.mdx
+++ b/versioned_docs/version-7.1/start/installation/setup-examples/aws-windows-vm.mdx
@@ -94,7 +94,7 @@ Dowload Chrome. You will need to allow it in the Internet Explorer firewall.
 ![20](./assets/20.png)
 ![21](./assets/21.png)
 
-Install the [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) (or newer).
+Install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
 
 ![19](./assets/19.png)
 


### PR DESCRIPTION
### Issue link
[RDoc-3835](https://issues.hibernatingrhinos.com/issue/RDoc-3835) Fix Visual C++ Redistributable Package links in docs

### Additional description
Fixed obsolete 404 links

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

