### PR TITLE
Explain that sudo setcap is required when updating RavenDB

### DIFF
--- a/docs/server/security/authentication/certificate-management.mdx
+++ b/docs/server/security/authentication/certificate-management.mdx
@@ -295,7 +295,7 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
 
 ![Importing and Exporting Certificates](./assets/importing-and-exporting-certificate.png)
 
- 1. Click **Manage Server** and select **Certificates** to access the Studio - Certificates Management screen.  
+ 1. Click **Manage Server** and select **Certificates** to access Studio - Certificates Management screen.  
  2. Click **Server certificates** in the source server.  
    ![Server Certificates Button Options](./assets/server-certificates-button-options.png)
    * **Export server certificates**  
@@ -353,7 +353,7 @@ When uploading a `.pfx` file with multiple certificates, RavenDB will add all of
 and will allow access to all these certificates explicitly by their thumbprint.
 ### Generating Client Certificates Via Command Line Interface
 
-* RavenDB provides an intuitive certificates management GUI in the Studio.  
+* RavenDB provides an intuitive certificates management GUI in Studio.  
 
 * All of the operations which are described below are also available in Command Line Interface (CLI).  
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
@@ -385,7 +385,7 @@ and is explained here only to show how to view the full chain in Windows. The ri
 
 ![Figure 7. Client Certificate Chain](./assets/client-cert.png)
 
-Because client certificates are managed by RavenDB directly and not through any PKI infrastructure **this is perfectly acceptable**. 
+Because client certificates are managed by RavenDB directly and [not through any PKI infrastructure](../overview.mdx#important) **this is perfectly acceptable**. 
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
 

--- a/docs/server/security/overview.mdx
+++ b/docs/server/security/overview.mdx
@@ -31,10 +31,10 @@ Registering a certificate means one of the following:
 * The certificate was registered explicitly by an administrator. 
 * The certificate was registered implicitly for having the same [Public Key Pinning Hash](authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash) as a registered certificate. 
 
-In any case, it must appear in the certificates view in the studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
+In any case, it must appear in the certificates view in Studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
 </Admonition>
 
-In the Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
+In Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
 
 **Read more:**
 

--- a/docs/start/installation/setup-wizard/configure-node-addresses.mdx
+++ b/docs/start/installation/setup-wizard/configure-node-addresses.mdx
@@ -52,7 +52,20 @@ import Panel from '@site/src/components/Panel';
    Enter the private HTTPS port that the node will listen on (used by clients and browsers to connect to this server).  
    By default, this is set to `443`.    
    When using port 443, make sure it is not already used by other applications (such as IIS, Apache, Skype, etc.).  
+   <Admonition type="note" title="">
+
    On Linux, you might need to allow non-root processes to listen on port 443.  
+   Run the following command to grant the server permission to bind to privileged ports:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   <br />
+
+   Note that this must be re-applied after every upgrade, as Linux does not preserve file capabilities when a binary is replaced.
+
+   </Admonition>
    If you choose a different port, remember to include it in the URL when accessing the server  
    (for example, `https://a.yourdomainname.development.run:8443`).     
 3. **TCP port**:   

--- a/docs/start/installation/upgrading-to-new-version.mdx
+++ b/docs/start/installation/upgrading-to-new-version.mdx
@@ -36,7 +36,19 @@ Upgrading a RavenDB instance to a new version is very simple. To do so:
     * These steps are strictly necessary when updating to version 5.1.  
       To update to lower versions, overriding the old binaries may be sufficient - although removing them is recommended.  
 
-4. Copy the new binaries.  
+4. Copy the new binaries.
+
+   <Admonition type="note" title="">
+
+   On Linux, if the server uses a privileged port (below 1024, e.g. port `443`),
+   re-apply the `setcap` capability to the new binary.
+   Linux does not preserve file capabilities when a binary is replaced:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   </Admonition>
 
 5. Restart the server.  
 
@@ -53,7 +65,7 @@ However, sometimes our adjustments require changing the file format ("schema ver
 If RavenDB finds during startup that the stored database uses an old format, it 
 will automatically perform this kind of migration.  
 
-<Admonition type="warning" title="">
+<Admonition type="note" title="">
 Migrating data files is only one type of migration.  
 If you try to downgrade to an older RavenDB version after making any changes in data files 
 format, RavenDB will fail to start with a detailed error message.  

--- a/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
@@ -294,7 +294,7 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
 
 ![Importing and Exporting Certificates](./assets/importing-and-exporting-certificate.png)
 
- 1. Click **Manage Server** and select **Certificates** to access the Studio - Certificates Management screen.  
+ 1. Click **Manage Server** and select **Certificates** to access Studio - Certificates Management screen.  
  2. Click **Server certificates** in the source server.  
    ![Server Certificates Button Options](./assets/server-certificates-button-options.png)
    * **Export server certificates**  
@@ -352,7 +352,7 @@ When uploading a `.pfx` file with multiple certificates, RavenDB will add all of
 and will allow access to all these certificates explicitly by their thumbprint.
 ### Generating Client Certificates Via Command Line Interface
 
-* RavenDB provides an intuitive certificates management GUI in the Studio.  
+* RavenDB provides an intuitive certificates management GUI in Studio.  
 
 * All of the operations which are described below are also available in Command Line Interface (CLI).  
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
@@ -384,7 +384,7 @@ and is explained here only to show how to view the full chain in Windows. The ri
 
 ![Figure 7. Client Certificate Chain](./assets/client-cert.png)
 
-Because client certificates are managed by RavenDB directly and not through any PKI infrastructure **this is perfectly acceptable**. 
+Because client certificates are managed by RavenDB directly and [not through any PKI infrastructure](../overview.mdx#important) **this is perfectly acceptable**. 
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
 

--- a/versioned_docs/version-6.2/server/security/overview.mdx
+++ b/versioned_docs/version-6.2/server/security/overview.mdx
@@ -30,10 +30,10 @@ Registering a certificate means one of the following:
 * The certificate was registered explicitly by an administrator. 
 * The certificate was registered implicitly for having the same [Public Key Pinning Hash](authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash) as a registered certificate. 
 
-In any case, it must appear in the certificates view in the studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
+In any case, it must appear in the certificates view in Studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
 </Admonition>
 
-In the Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
+In Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
 
 **Read more:**
 

--- a/versioned_docs/version-6.2/start/installation/setup-wizard/configure-node-addresses.mdx
+++ b/versioned_docs/version-6.2/start/installation/setup-wizard/configure-node-addresses.mdx
@@ -51,7 +51,20 @@ import Panel from '@site/src/components/Panel';
    Enter the private HTTPS port that the node will listen on (used by clients and browsers to connect to this server).  
    By default, this is set to `443`.    
    When using port 443, make sure it is not already used by other applications (such as IIS, Apache, Skype, etc.).  
+   <Admonition type="note" title="">
+
    On Linux, you might need to allow non-root processes to listen on port 443.  
+   Run the following command to grant the server permission to bind to privileged ports:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   <br />
+
+   Note that this must be re-applied after every upgrade, as Linux does not preserve file capabilities when a binary is replaced.
+
+   </Admonition>
    If you choose a different port, remember to include it in the URL when accessing the server  
    (for example, `https://a.yourdomainname.development.run:8443`).     
 3. **TCP port**:   

--- a/versioned_docs/version-6.2/start/installation/upgrading-to-new-version.mdx
+++ b/versioned_docs/version-6.2/start/installation/upgrading-to-new-version.mdx
@@ -35,7 +35,19 @@ Upgrading a RavenDB instance to a new version is very simple. To do so:
     * These steps are strictly necessary when updating to version 5.1.  
       To update to lower versions, overriding the old binaries may be sufficient - although removing them is recommended.  
 
-4. Copy the new binaries.  
+4. Copy the new binaries.
+
+   <Admonition type="note" title="">
+
+   On Linux, if the server uses a privileged port (below 1024, e.g. port `443`),
+   re-apply the `setcap` capability to the new binary.
+   Linux does not preserve file capabilities when a binary is replaced:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   </Admonition>
 
 5. Restart the server.  
 
@@ -52,7 +64,7 @@ However, sometimes our adjustments require changing the file format ("schema ver
 If RavenDB finds during startup that the stored database uses an old format, it 
 will automatically perform this kind of migration.  
 
-<Admonition type="warning" title="">
+<Admonition type="note" title="">
 Migrating data files is only one type of migration.  
 If you try to downgrade to an older RavenDB version after making any changes in data files 
 format, RavenDB will fail to start with a detailed error message.  

--- a/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
@@ -294,7 +294,7 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
 
 ![Importing and Exporting Certificates](./assets/importing-and-exporting-certificate.png)
 
- 1. Click **Manage Server** and select **Certificates** to access the Studio - Certificates Management screen.  
+ 1. Click **Manage Server** and select **Certificates** to access Studio - Certificates Management screen.  
  2. Click **Server certificates** in the source server.  
    ![Server Certificates Button Options](./assets/server-certificates-button-options.png)
    * **Export server certificates**  
@@ -352,7 +352,7 @@ When uploading a `.pfx` file with multiple certificates, RavenDB will add all of
 and will allow access to all these certificates explicitly by their thumbprint.
 ### Generating Client Certificates Via Command Line Interface
 
-* RavenDB provides an intuitive certificates management GUI in the Studio.  
+* RavenDB provides an intuitive certificates management GUI in Studio.  
 
 * All of the operations which are described below are also available in Command Line Interface (CLI).  
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
@@ -384,7 +384,7 @@ and is explained here only to show how to view the full chain in Windows. The ri
 
 ![Figure 7. Client Certificate Chain](./assets/client-cert.png)
 
-Because client certificates are managed by RavenDB directly and not through any PKI infrastructure **this is perfectly acceptable**. 
+Because client certificates are managed by RavenDB directly and [not through any PKI infrastructure](../overview.mdx#important) **this is perfectly acceptable**. 
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
 

--- a/versioned_docs/version-7.0/server/security/overview.mdx
+++ b/versioned_docs/version-7.0/server/security/overview.mdx
@@ -30,10 +30,10 @@ Registering a certificate means one of the following:
 * The certificate was registered explicitly by an administrator. 
 * The certificate was registered implicitly for having the same [Public Key Pinning Hash](authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash) as a registered certificate. 
 
-In any case, it must appear in the certificates view in the studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
+In any case, it must appear in the certificates view in Studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
 </Admonition>
 
-In the Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
+In Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
 
 **Read more:**
 

--- a/versioned_docs/version-7.0/start/installation/setup-wizard/configure-node-addresses.mdx
+++ b/versioned_docs/version-7.0/start/installation/setup-wizard/configure-node-addresses.mdx
@@ -51,7 +51,20 @@ import Panel from '@site/src/components/Panel';
    Enter the private HTTPS port that the node will listen on (used by clients and browsers to connect to this server).  
    By default, this is set to `443`.    
    When using port 443, make sure it is not already used by other applications (such as IIS, Apache, Skype, etc.).  
+   <Admonition type="note" title="">
+
    On Linux, you might need to allow non-root processes to listen on port 443.  
+   Run the following command to grant the server permission to bind to privileged ports:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   <br />
+
+   Note that this must be re-applied after every upgrade, as Linux does not preserve file capabilities when a binary is replaced.
+
+   </Admonition>
    If you choose a different port, remember to include it in the URL when accessing the server  
    (for example, `https://a.yourdomainname.development.run:8443`).     
 3. **TCP port**:   

--- a/versioned_docs/version-7.0/start/installation/upgrading-to-new-version.mdx
+++ b/versioned_docs/version-7.0/start/installation/upgrading-to-new-version.mdx
@@ -35,7 +35,19 @@ Upgrading a RavenDB instance to a new version is very simple. To do so:
     * These steps are strictly necessary when updating to version 5.1.  
       To update to lower versions, overriding the old binaries may be sufficient - although removing them is recommended.  
 
-4. Copy the new binaries.  
+4. Copy the new binaries.
+
+   <Admonition type="note" title="">
+
+   On Linux, if the server uses a privileged port (below 1024, e.g. port `443`),
+   re-apply the `setcap` capability to the new binary.
+   Linux does not preserve file capabilities when a binary is replaced:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   </Admonition>
 
 5. Restart the server.  
 
@@ -52,7 +64,7 @@ However, sometimes our adjustments require changing the file format ("schema ver
 If RavenDB finds during startup that the stored database uses an old format, it 
 will automatically perform this kind of migration.  
 
-<Admonition type="warning" title="">
+<Admonition type="note" title="">
 Migrating data files is only one type of migration.  
 If you try to downgrade to an older RavenDB version after making any changes in data files 
 format, RavenDB will fail to start with a detailed error message.  

--- a/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
@@ -294,7 +294,7 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
 
 ![Importing and Exporting Certificates](./assets/importing-and-exporting-certificate.png)
 
- 1. Click **Manage Server** and select **Certificates** to access the Studio - Certificates Management screen.  
+ 1. Click **Manage Server** and select **Certificates** to access Studio - Certificates Management screen.  
  2. Click **Server certificates** in the source server.  
    ![Server Certificates Button Options](./assets/server-certificates-button-options.png)
    * **Export server certificates**  
@@ -352,7 +352,7 @@ When uploading a `.pfx` file with multiple certificates, RavenDB will add all of
 and will allow access to all these certificates explicitly by their thumbprint.
 ### Generating Client Certificates Via Command Line Interface
 
-* RavenDB provides an intuitive certificates management GUI in the Studio.  
+* RavenDB provides an intuitive certificates management GUI in Studio.  
 
 * All of the operations which are described below are also available in Command Line Interface (CLI).  
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
@@ -384,7 +384,7 @@ and is explained here only to show how to view the full chain in Windows. The ri
 
 ![Figure 7. Client Certificate Chain](./assets/client-cert.png)
 
-Because client certificates are managed by RavenDB directly and not through any PKI infrastructure **this is perfectly acceptable**. 
+Because client certificates are managed by RavenDB directly and [not through any PKI infrastructure](../overview.mdx#important) **this is perfectly acceptable**. 
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
 

--- a/versioned_docs/version-7.1/server/security/overview.mdx
+++ b/versioned_docs/version-7.1/server/security/overview.mdx
@@ -30,10 +30,10 @@ Registering a certificate means one of the following:
 * The certificate was registered explicitly by an administrator. 
 * The certificate was registered implicitly for having the same [Public Key Pinning Hash](authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash) as a registered certificate. 
 
-In any case, it must appear in the certificates view in the studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
+In any case, it must appear in the certificates view in Studio. Visit the [Certificate Management](authentication/certificate-management.mdx) section for more information.
 </Admonition>
 
-In the Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
+In Studio, administrators can use the [Certificates View](../../server/security/authentication/certificate-configuration.mdx) to easily manage their certificates. It can be used to generate client certificates, register existing client certificates, import and export server certificates, rename, assign permissions and more.
 
 **Read more:**
 

--- a/versioned_docs/version-7.1/start/installation/setup-wizard/configure-node-addresses.mdx
+++ b/versioned_docs/version-7.1/start/installation/setup-wizard/configure-node-addresses.mdx
@@ -51,7 +51,20 @@ import Panel from '@site/src/components/Panel';
    Enter the private HTTPS port that the node will listen on (used by clients and browsers to connect to this server).  
    By default, this is set to `443`.    
    When using port 443, make sure it is not already used by other applications (such as IIS, Apache, Skype, etc.).  
+   <Admonition type="note" title="">
+
    On Linux, you might need to allow non-root processes to listen on port 443.  
+   Run the following command to grant the server permission to bind to privileged ports:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   <br />
+
+   Note that this must be re-applied after every upgrade, as Linux does not preserve file capabilities when a binary is replaced.
+
+   </Admonition>
    If you choose a different port, remember to include it in the URL when accessing the server  
    (for example, `https://a.yourdomainname.development.run:8443`).     
 3. **TCP port**:   

--- a/versioned_docs/version-7.1/start/installation/upgrading-to-new-version.mdx
+++ b/versioned_docs/version-7.1/start/installation/upgrading-to-new-version.mdx
@@ -35,7 +35,19 @@ Upgrading a RavenDB instance to a new version is very simple. To do so:
     * These steps are strictly necessary when updating to version 5.1.  
       To update to lower versions, overriding the old binaries may be sufficient - although removing them is recommended.  
 
-4. Copy the new binaries.  
+4. Copy the new binaries.
+
+   <Admonition type="note" title="">
+
+   On Linux, if the server uses a privileged port (below 1024, e.g. port `443`),
+   re-apply the `setcap` capability to the new binary.
+   Linux does not preserve file capabilities when a binary is replaced:
+
+   ```bash
+   sudo setcap CAP_NET_BIND_SERVICE=+eip ./RavenDB/Server/Raven.Server
+   ```
+
+   </Admonition>
 
 5. Restart the server.  
 
@@ -52,7 +64,7 @@ However, sometimes our adjustments require changing the file format ("schema ver
 If RavenDB finds during startup that the stored database uses an old format, it 
 will automatically perform this kind of migration.  
 
-<Admonition type="warning" title="">
+<Admonition type="note" title="">
 Migrating data files is only one type of migration.  
 If you try to downgrade to an older RavenDB version after making any changes in data files 
 format, RavenDB will fail to start with a detailed error message.  


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-1234 - Explain that sudo setcap is required when updating RavenDB
https://issues.hibernatingrhinos.com/issue/RDoc-1705 - Emphasize that we dont use PKI when validating *client* certificates

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

