### PR TITLE
RDoc-3812 - queue ETL - explain which optional CloudEvents attributes can be specified

### DIFF
--- a/docs/server/ongoing-tasks/etl/queue-etl/overview.mdx
+++ b/docs/server/ongoing-tasks/etl/queue-etl/overview.mdx
@@ -112,12 +112,20 @@ The above ETL tasks:
     | **type**        | `string` | [Event type](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type)                      | "ravendb.etl.put"                                    |
     | **source**      | `string` | [Event context](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source-1)               | `<ravendb-node-url>/<database-name>/<etl-task-name>` |
 
-* The optional 'partitionkey' attribute can also be added.  
-  Currently, it is only implemented by [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx).  
+* The following [optional attributes](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#optional-attributes) can also be specified:  
 
-    | Optional Attribute   | Type       | Description                                                                                                                                  | Default Value    |
-    |----------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-    | **partitionkey**     | `string`   | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey) | The document ID  |
+    | Optional Attribute | Type        | Description                                                                                                                                          | Default Value   |
+    |--------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+    | **partitionkey**   | `string`    | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey)        | The document ID |
+    | **dataschema**     | `URI`       | [Identifies the schema that data adheres to](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema)                          | None            |
+    | **subject**        | `string`    | [Describes the subject of the event in the context of the event producer](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject) | None            |
+    | **time**           | `Timestamp` | [Timestamp of when the occurrence happened](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time)                                 | None            |
+
+<Admonition type="note" title="">
+The `partitionkey` attribute is a [CloudEvents partitioning extension](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md).  
+For [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx), it controls which partition the message is routed to.  
+For other queue brokers, it is included as message metadata but has no routing effect.  
+</Admonition>
 
 
 

--- a/versioned_docs/version-6.2/server/ongoing-tasks/etl/queue-etl/overview.mdx
+++ b/versioned_docs/version-6.2/server/ongoing-tasks/etl/queue-etl/overview.mdx
@@ -107,12 +107,20 @@ The above ETL tasks:
     | **type**        | `string` | [Event type](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type)                      | "ravendb.etl.put"                                    |
     | **source**      | `string` | [Event context](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source-1)               | `<ravendb-node-url>/<database-name>/<etl-task-name>` |
 
-* The optional 'partitionkey' attribute can also be added.  
-  Currently, it is only implemented by [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx).  
+* The following [optional attributes](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#optional-attributes) can also be specified:  
 
-    | Optional Attribute   | Type       | Description                                                                                                                                  | Default Value    |
-    |----------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-    | **partitionkey**     | `string`   | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey) | The document ID  |
+    | Optional Attribute | Type        | Description                                                                                                                                          | Default Value   |
+    |--------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+    | **partitionkey**   | `string`    | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey)        | The document ID |
+    | **dataschema**     | `URI`       | [Identifies the schema that data adheres to](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema)                          | None            |
+    | **subject**        | `string`    | [Describes the subject of the event in the context of the event producer](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject) | None            |
+    | **time**           | `Timestamp` | [Timestamp of when the occurrence happened](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time)                                 | None            |
+
+<Admonition type="note" title="">
+The `partitionkey` attribute is a [CloudEvents partitioning extension](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md).  
+For [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx), it controls which partition the message is routed to.  
+For other queue brokers, it is included as message metadata but has no routing effect.  
+</Admonition>
 
 
 

--- a/versioned_docs/version-7.0/server/ongoing-tasks/etl/queue-etl/overview.mdx
+++ b/versioned_docs/version-7.0/server/ongoing-tasks/etl/queue-etl/overview.mdx
@@ -111,12 +111,20 @@ The above ETL tasks:
     | **type**        | `string` | [Event type](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type)                      | "ravendb.etl.put"                                    |
     | **source**      | `string` | [Event context](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source-1)               | `<ravendb-node-url>/<database-name>/<etl-task-name>` |
 
-* The optional 'partitionkey' attribute can also be added.  
-  Currently, it is only implemented by [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx).  
+* The following [optional attributes](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#optional-attributes) can also be specified:  
 
-    | Optional Attribute   | Type       | Description                                                                                                                                  | Default Value    |
-    |----------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-    | **partitionkey**     | `string`   | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey) | The document ID  |
+    | Optional Attribute | Type        | Description                                                                                                                                          | Default Value   |
+    |--------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+    | **partitionkey**   | `string`    | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey)        | The document ID |
+    | **dataschema**     | `URI`       | [Identifies the schema that data adheres to](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema)                          | None            |
+    | **subject**        | `string`    | [Describes the subject of the event in the context of the event producer](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject) | None            |
+    | **time**           | `Timestamp` | [Timestamp of when the occurrence happened](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time)                                 | None            |
+
+<Admonition type="note" title="">
+The `partitionkey` attribute is a [CloudEvents partitioning extension](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md).  
+For [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx), it controls which partition the message is routed to.  
+For other queue brokers, it is included as message metadata but has no routing effect.  
+</Admonition>
 
 
 

--- a/versioned_docs/version-7.1/server/ongoing-tasks/etl/queue-etl/overview.mdx
+++ b/versioned_docs/version-7.1/server/ongoing-tasks/etl/queue-etl/overview.mdx
@@ -111,12 +111,20 @@ The above ETL tasks:
     | **type**        | `string` | [Event type](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type)                      | "ravendb.etl.put"                                    |
     | **source**      | `string` | [Event context](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source-1)               | `<ravendb-node-url>/<database-name>/<etl-task-name>` |
 
-* The optional 'partitionkey' attribute can also be added.  
-  Currently, it is only implemented by [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx).  
+* The following [optional attributes](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#optional-attributes) can also be specified:  
 
-    | Optional Attribute   | Type       | Description                                                                                                                                  | Default Value    |
-    |----------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-    | **partitionkey**     | `string`   | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey) | The document ID  |
+    | Optional Attribute | Type        | Description                                                                                                                                          | Default Value   |
+    |--------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+    | **partitionkey**   | `string`    | [Events relationship/grouping definition](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md#partitionkey)        | The document ID |
+    | **dataschema**     | `URI`       | [Identifies the schema that data adheres to](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema)                          | None            |
+    | **subject**        | `string`    | [Describes the subject of the event in the context of the event producer](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject) | None            |
+    | **time**           | `Timestamp` | [Timestamp of when the occurrence happened](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time)                                 | None            |
+
+<Admonition type="note" title="">
+The `partitionkey` attribute is a [CloudEvents partitioning extension](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/partitioning.md).  
+For [Kafka ETL](../../../../server/ongoing-tasks/etl/queue-etl/kafka.mdx), it controls which partition the message is routed to.  
+For other queue brokers, it is included as message metadata but has no routing effect.  
+</Admonition>
 
 
 


### PR DESCRIPTION
### Issue link
[RDoc-3812](https://issues.hibernatingrhinos.com/issue/RDoc-3812) Document Queue ETL behavior: allowing to define optional Cloud Event attributes

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

