### PR TITLE
RDoc-1617: Document the `ForceRevisionCreationStrategy` property in `PutCommandData` glossary

### DIFF
--- a/docs/glossary/content/_put-command-data-csharp.mdx
+++ b/docs/glossary/content/_put-command-data-csharp.mdx
@@ -11,6 +11,7 @@ import CodeBlock from '@theme/CodeBlock';
 | **ChangeVector** | string | Document change-vector |
 | **Document** | DynamicJsonValue | Document to put |
 | **Type** | CommandType | The Command Type (PUT) |
+| **ForceRevisionCreationStrategy** | `ForceRevisionStrategy` | Strategy for forcing a revision when the document is stored. `None` (default): no forced revision is created; `Before`: a forced revision is created from the document as it currently exists in the store, before applying changes. |
 
 ### Methods
 

--- a/versioned_docs/version-6.2/glossary/content/_put-command-data-csharp.mdx
+++ b/versioned_docs/version-6.2/glossary/content/_put-command-data-csharp.mdx
@@ -11,10 +11,4 @@ import CodeBlock from '@theme/CodeBlock';
 | **ChangeVector** | string | Document change-vector |
 | **Document** | DynamicJsonValue | Document to put |
 | **Type** | CommandType | The Command Type (PUT) |
-
-### Methods
-
-| Signature | Description |
-| ---------- | ----------- |
-| **DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)** | Translate this instance to Json. |
-
+| **ForceRevisionCreationStrategy** | `ForceRevisionStrategy` | Strategy for forcing a revision when the document is stored. `None` (default): no forced revision is created; `Before`: a forced revision 

--- a/versioned_docs/version-7.0/glossary/content/_put-command-data-csharp.mdx
+++ b/versioned_docs/version-7.0/glossary/content/_put-command-data-csharp.mdx
@@ -11,10 +11,4 @@ import CodeBlock from '@theme/CodeBlock';
 | **ChangeVector** | string | Document change-vector |
 | **Document** | DynamicJsonValue | Document to put |
 | **Type** | CommandType | The Command Type (PUT) |
-
-### Methods
-
-| Signature | Description |
-| ---------- | ----------- |
-| **DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)** | Translate this instance to Json. |
-
+| **ForceRevisionCreationStrategy** | `ForceRevisionStrategy` | Strategy for forcing a revision when the document is stored. `None` (default): no forced revision is created; `Before`: a forced revision 

--- a/versioned_docs/version-7.1/glossary/content/_put-command-data-csharp.mdx
+++ b/versioned_docs/version-7.1/glossary/content/_put-command-data-csharp.mdx
@@ -11,10 +11,4 @@ import CodeBlock from '@theme/CodeBlock';
 | **ChangeVector** | string | Document change-vector |
 | **Document** | DynamicJsonValue | Document to put |
 | **Type** | CommandType | The Command Type (PUT) |
-
-### Methods
-
-| Signature | Description |
-| ---------- | ----------- |
-| **DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)** | Translate this instance to Json. |
-
+| **ForceRevisionCreationStrategy** | `ForceRevisionStrategy` | Strategy for forcing a revision when the document is stored. `None` (default): no forced revision is created; `Before`: a forced revision 


### PR DESCRIPTION
### Issue link
[RDoc-1617](https://issues.hibernatingrhinos.com/issue/RDoc-1617) Document `ForceRevisionCreationStrategy`

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

