### PR TITLE
Added missing GoogleCloud option, Update download links, Document ImportIncrementalAsync, Fix description for certificate view

### DIFF
--- a/docs/backup/restore.mdx
+++ b/docs/backup/restore.mdx
@@ -23,6 +23,8 @@ import ContentFrame from "@site/src/components/ContentFrame";
 
 * If your backup consists of full and incremental backup files, you can restore the database up to a specific point in time by selecting the last incremental backup file to restore.  
 
+* To import backup files into an **existing** database instead of creating a new one, see [Importing into an existing database](../backup/restore#importing-into-an-existing-database).  
+
 * On a [sharded](../sharding/overview.mdx) database, restore is performed per shard, using the backups created by the shards.  
   [Learn to restore a sharded database.](../sharding/backup-and-restore/restore.mdx)  
 
@@ -40,6 +42,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
      * [Restoring to a single node and replicating to additional nodes](../backup/restore#restoring-to-a-single-node-and-replicating-to-additional-nodes)
      * [Restoring to multiple nodes simultaneously](../backup/restore#restoring-to-multiple-nodes-simultaneously)
   * [Restoring from server-wide backups](../backup/restore#restoring-from-server-wide-backups)
+  * [Importing into an existing database](../backup/restore#importing-into-an-existing-database)
 
 </Admonition>
 
@@ -876,5 +879,16 @@ Restoring databases backed up by a server-wide backup task **is identical** to r
 - Though a server-wide task creates backups for multiple databases, the backup for each database is restored separately into a new database.  
 - Note that each backup is stored in the backup location within its own folder, named after the database it belongs to.  
   When restoring, make sure the correct backup folder is selected.
+
+</Panel>
+
+<Panel heading="Importing into an existing database">
+
+The restore operation described on this page always creates a **new** database.  
+If you need to import backup files from a backup folder into an **existing** database instead, use `store.Smuggler.ImportIncrementalAsync`.
+
+This method accepts the path to a backup folder, finds all backup files it contains, orders them chronologically, and imports them in sequence — without creating a new database.
+
+[Learn about `ImportIncrementalAsync` in the Smuggler documentation.](../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
 
 </Panel>

--- a/docs/backup/restore.mdx
+++ b/docs/backup/restore.mdx
@@ -23,6 +23,8 @@ import ContentFrame from "@site/src/components/ContentFrame";
 
 * If your backup consists of full and incremental backup files, you can restore the database up to a specific point in time by selecting the last incremental backup file to restore.  
 
+* To import backup files into an **existing** database instead of creating a new one, see [Importing into an existing database](../backup/restore.mdx#importing-into-an-existing-database).  
+
 * On a [sharded](../sharding/overview.mdx) database, restore is performed per shard, using the backups created by the shards.  
   [Learn to restore a sharded database.](../sharding/backup-and-restore/restore.mdx)  
 
@@ -40,6 +42,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
      * [Restoring to a single node and replicating to additional nodes](../backup/restore.mdx#restoring-to-a-single-node-and-replicating-to-additional-nodes)
      * [Restoring to multiple nodes simultaneously](../backup/restore.mdx#restoring-to-multiple-nodes-simultaneously)
   * [Restoring from server-wide backups](../backup/restore.mdx#restoring-from-server-wide-backups)
+  * [Importing into an existing database](../backup/restore.mdx#importing-into-an-existing-database)
 
 </Admonition>
 
@@ -895,5 +898,16 @@ Restoring databases backed up by a server-wide backup task **is identical** to r
 - Though a server-wide task creates backups for multiple databases, the backup for each database is restored separately into a new database.  
 - Note that each backup is stored in the backup location within its own folder, named after the database it belongs to.  
   When restoring, make sure the correct backup folder is selected.
+
+</Panel>
+
+<Panel heading="Importing into an existing database">
+
+The restore operation described in this article always creates a **new** database.  
+If you need to import backup files from a backup folder into an **existing** database instead, use `store.Smuggler.ImportIncrementalAsync`.
+
+This method accepts the path to a backup folder, finds all logical-backup files it contains, orders them chronologically, and imports them in sequence, without creating a new database.
+
+[Learn about `ImportIncrementalAsync` in the Smuggler documentation.](../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
 
 </Panel>

--- a/docs/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/docs/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -2,34 +2,44 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from '@site/src/components/Panel';
+import ContentFrame from '@site/src/components/ContentFrame';
+
+<Admonition type="note" title="">
 
 Smuggler gives you the ability to export or import data from or to a database using JSON format.  
 It is exposed via the `DocumentStore.Smuggler` property.
 
-## ForDatabase
+* In this page:
+   * [ForDatabase](../../../client-api/smuggler/what-is-smuggler.mdx#fordatabase)
+   * [Export](../../../client-api/smuggler/what-is-smuggler.mdx#export)
+      * [DatabaseSmugglerExportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions)
+   * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
+      * [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
+   * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
 
-By default, the `DocumentStore.Smuggler` works on the default document store database from the `DocumentStore.Database` property. 
+</Admonition>
 
-In order to switch it to a different database use the `.ForDatabase` method.
+<Panel heading="ForDatabase">
 
-<TabItem value="for_database" label="for_database">
-<CodeBlock language="csharp">
-{`var northwindSmuggler = store
-    .Smuggler
-    .ForDatabase("Northwind");
-`}
-</CodeBlock>
-</TabItem>
+By default, `DocumentStore.Smuggler` works against the default database from the `DocumentStore.Database` property.  
+To target a different database, use `ForDatabase`:
 
+```csharp
+var northwindSmuggler = store.Smuggler.ForDatabase("Northwind");
+```
 
+</Panel>
 
-## Export
+<Panel heading="Export">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="export_syntax" label="export_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ExportAsync(
+```csharp
+Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     DatabaseSmuggler toDatabase,
     CancellationToken token = default(CancellationToken));
@@ -38,65 +48,77 @@ Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     string toFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions). |
-| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
-| **toFile** | `string` | Path to a file where exported data will be written |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination. |
+| **toFile** | `string` | Path to a file where exported data will be written. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerExportOptions
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be exported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be exported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be exported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be exported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be exported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be exported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="export_example" label="export_example">
-<CodeBlock language="csharp">
-{`// export only Indexes and Documents to a given file
+```csharp
+// Export only Indexes and Documents to a given file
 var exportOperation = await store
     .Smuggler
     .ExportAsync(
         new DatabaseSmugglerExportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Indexes
                              | DatabaseItemType.Documents
-        \},
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await exportOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## Import
+<Panel heading="Import">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="import_syntax" label="import_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ImportAsync(
+```csharp
+Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     Stream stream,
     CancellationToken token = default(CancellationToken));
@@ -105,75 +127,137 @@ Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
-| **stream** | `Stream` | Stream with data to import |
-| **fromFile** | `string` | Path to a file from which data will be imported |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **stream** | `Stream` | Stream with data to import. |
+| **fromFile** | `string` | Path to a file from which data will be imported. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerImportOptions
 
-| Parameters | | |
-| - | - | - |
-| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be imported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be imported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be imported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be imported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="import_example" label="import_example">
-<CodeBlock language="csharp">
-{`// import only Documents from a given file
+```csharp
+// Import only Documents from a given file
 var importOperation = await store
     .Smuggler
     .ImportAsync(
         new DatabaseSmugglerImportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Documents
-        \},
-        // import the .ravendbdump file that you exported (i.e. in the export example above)
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await importOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## TransformScript
+<Panel heading="ImportIncrementalAsync">
 
-`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+A RavenDB backup folder contains one full backup file and any incremental backup files accumulated since the last full backup.  
+Use `ImportIncrementalAsync` to import all backup files from such a folder into an existing database in a single call,  
+instead of importing each file individually.
 
-Underneath the JavaScript engine is exactly the same as used for [patching operations](../../../client-api/operations/patching/single-document.mdx) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+The method finds all backup files in the specified directory, orders them chronologically, and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
 
-<TabItem value="javascript" label="javascript">
-<CodeBlock language="javascript">
-{`var id = this['@metadata']['@id'];
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports into an **existing** database.  
+To create a **new** database from backup files, use [`RestoreBackupOperation`](../../../backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Syntax
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+| --- | --- |
+| `Task` | Completes when all backup files in the folder have been imported. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="TransformScript">
+
+`TransformScript` exposes the ability to modify or filter documents during the import and export process using JavaScript.
+
+The JavaScript engine is the same one used for [patching operations](../../../client-api/operations/patching/single-document.mdx),  
+with the same syntax and capabilities, plus the ability to filter out documents by throwing a `'skip'` exception.
+
+```javascript
+var id = this['@metadata']['@id'];
 if (id === 'orders/999-A')
-    throw 'skip'; // filter-out
+    throw 'skip'; // filter out this document
 
 this.Freight = 15.3;
-`}
-</CodeBlock>
-</TabItem>
+```
 
-
-
-
+</Panel>

--- a/docs/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/docs/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -24,6 +24,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
       * [Export specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#export-specific-collections)
    * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
       * [Import specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#import-specific-collections)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
    * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
    * [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax)
       * [Methods](../../../client-api/smuggler/what-is-smuggler.mdx#methods)
@@ -97,7 +98,9 @@ await exportOperation.WaitForCompletionAsync();
 
 <br />
 
-See [ExportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and [DatabaseSmugglerExportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions) in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
+See [ExportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods)
+and [DatabaseSmugglerExportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions)
+in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
 
 </Panel>
 
@@ -154,7 +157,45 @@ await importOperation.WaitForCompletionAsync();
 
 <br />
 
-See [ImportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions) in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
+See [ImportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
+[DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
+
+</Panel>
+
+<Panel heading="ImportIncrementalAsync">
+
+A RavenDB backup folder contains one full backup file and any number of incremental backup files accumulated since
+the last full backup.  
+Use `ImportIncrementalAsync` to import all [logical-backup](../../../backup/overview.mdx#logical-backup) files
+from a backup folder into an existing database in a single call, instead of importing each file individually.
+
+After finding all backup files in the specified folder, the method orders them chronologically and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
+
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports your backup into an **existing** database.  
+To create a **new** database from backup, use [`RestoreBackupOperation`](../../../backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+<br />
+
+See [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
+[DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
 
 </Panel>
 
@@ -162,7 +203,8 @@ See [ImportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
 
 `TransformScript` lets you modify or filter out each document during an export or import, using JavaScript that you provide.  
 
-The JavaScript engine is the same one used for [patching operations](../../../documents/patching-documents/patch-a-single-document/api-overview.mdx), so you have identical syntax and capabilities, plus the ability to filter out a document by throwing a `skip` exception.  
+The JavaScript engine is the same one used for [patching operations](../../../documents/patching-documents/patch-a-single-document/api-overview.mdx),
+so you have identical syntax and capabilities, plus the ability to filter out a document by throwing a `skip` exception.  
 
 ```javascript
 var id = this['@metadata']['@id'];
@@ -262,7 +304,7 @@ Imports data from a file or a stream into the database.
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
-    CancellationToken token = default);
+    CancellationToken cancellationToken = default);
 
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
@@ -285,11 +327,44 @@ var importOperation = await store.Smuggler.ImportAsync(options, fromFile, token)
 | **options** | `DatabaseSmugglerImportOptions` | Options used during the import. See [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
 | **fromFile** | `string` | Path to the file the data is imported from. |
 | **stream** | `Stream` | Stream with the data to import. |
-| **token** | `CancellationToken` | Token used to cancel the operation. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a file. |
+| **token** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a stream. |
 
 | Return value | |
 |-----------|-------------|
 | `Operation` | An `Operation` instance you can use to wait for completion and subscribe to progress events. |
+
+</TabItem>
+<TabItem value="ImportIncrementalAsync" label="ImportIncrementalAsync">
+
+Imports the logical-backup files found in a backup folder, in chronological order.
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+await store.Smuggler.ImportIncrementalAsync(options, fromDirectory, token);
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+|-----------|-------------|
+| `Task` | Completes when all backup files in the folder have been imported. |
 
 </TabItem>
 </Tabs>

--- a/docs/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/docs/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -26,13 +26,13 @@ You can also ignore these limits and replace the certificates immediately but be
 
 To manually replace the server certificate you can either edit [settings.json](../../configuration/configuration-options.mdx#json) with a new certificate path and restart the server or you can overwrite the existing certificate file and the server will pick it up within one hour without requiring a restart.
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -48,9 +48,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/docs/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/docs/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -28,13 +28,13 @@ To manually replace the server certificate you can either edit [settings.json](.
 
 If the server certificate has already expired and Studio can no longer be reached, see [recover from an expired certificate](../../../server/security/authentication/recover-from-expired-certificate.mdx).
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -50,9 +50,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/docs/start/getting-started.mdx
+++ b/docs/start/getting-started.mdx
@@ -53,10 +53,14 @@ RavenDB is written in `.NET` so it requires the same set of prerequisites as `.N
 
 <Admonition type="note" title="Windows" id="windows" href="#windows">
 
-Please install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) before launching the RavenDB server.  
+Please install the **Microsoft Visual C++ Redistributable Package 2019 or later** before launching the RavenDB server on Windows.
+
+Download the latest supported Microsoft Visual C++ v14 Redistributable package for your Windows architecture:  
+[x64](https://aka.ms/vc14/vc_redist.x64.exe) | [x86](https://aka.ms/vc14/vc_redist.x86.exe).  
 This package should be the sole requirement for the 'Windows' platforms.  
+
 If you're experiencing difficulties, please check the 
-prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).  
+prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).
 
 </Admonition>
 

--- a/docs/start/installation/setup-examples/aws-windows-vm.mdx
+++ b/docs/start/installation/setup-examples/aws-windows-vm.mdx
@@ -95,9 +95,10 @@ Dowload Chrome. You will need to allow it in the Internet Explorer firewall.
 ![20](./assets/20.png)
 ![21](./assets/21.png)
 
-Install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
+---
 
-![19](./assets/19.png)
+Install the **Microsoft Visual C++ Redistributable Package 2019 or later**.  
+For the Windows Server x64 VM used in this walkthrough, use the [x64 installer](https://aka.ms/vc14/vc_redist.x64.exe). If you are running a 32-bit Windows installation, use the [x86 installer](https://aka.ms/vc14/vc_redist.x86.exe).
 
 ## Run the RavenDB Setup Wizard
 

--- a/versioned_docs/version-6.2/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -2,34 +2,44 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from '@site/src/components/Panel';
+import ContentFrame from '@site/src/components/ContentFrame';
+
+<Admonition type="note" title="">
 
 Smuggler gives you the ability to export or import data from or to a database using JSON format.  
 It is exposed via the `DocumentStore.Smuggler` property.
 
-## ForDatabase
+* In this page:
+   * [ForDatabase](../../../client-api/smuggler/what-is-smuggler.mdx#fordatabase)
+   * [Export](../../../client-api/smuggler/what-is-smuggler.mdx#export)
+      * [DatabaseSmugglerExportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions)
+   * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
+      * [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
+   * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
 
-By default, the `DocumentStore.Smuggler` works on the default document store database from the `DocumentStore.Database` property. 
+</Admonition>
 
-In order to switch it to a different database use the `.ForDatabase` method.
+<Panel heading="ForDatabase">
 
-<TabItem value="for_database" label="for_database">
-<CodeBlock language="csharp">
-{`var northwindSmuggler = store
-    .Smuggler
-    .ForDatabase("Northwind");
-`}
-</CodeBlock>
-</TabItem>
+By default, `DocumentStore.Smuggler` works against the default database from the `DocumentStore.Database` property.  
+To target a different database, use `ForDatabase`:
 
+```csharp
+var northwindSmuggler = store.Smuggler.ForDatabase("Northwind");
+```
 
+</Panel>
 
-## Export
+<Panel heading="Export">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="export_syntax" label="export_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ExportAsync(
+```csharp
+Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     DatabaseSmuggler toDatabase,
     CancellationToken token = default(CancellationToken));
@@ -38,65 +48,77 @@ Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     string toFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions). |
-| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
-| **toFile** | `string` | Path to a file where exported data will be written |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination. |
+| **toFile** | `string` | Path to a file where exported data will be written. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerExportOptions
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be exported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be exported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be exported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be exported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be exported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be exported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="export_example" label="export_example">
-<CodeBlock language="csharp">
-{`// export only Indexes and Documents to a given file
+```csharp
+// Export only Indexes and Documents to a given file
 var exportOperation = await store
     .Smuggler
     .ExportAsync(
         new DatabaseSmugglerExportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Indexes
                              | DatabaseItemType.Documents
-        \},
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await exportOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## Import
+<Panel heading="Import">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="import_syntax" label="import_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ImportAsync(
+```csharp
+Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     Stream stream,
     CancellationToken token = default(CancellationToken));
@@ -105,75 +127,137 @@ Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
-| **stream** | `Stream` | Stream with data to import |
-| **fromFile** | `string` | Path to a file from which data will be imported |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **stream** | `Stream` | Stream with data to import. |
+| **fromFile** | `string` | Path to a file from which data will be imported. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerImportOptions
 
-| Parameters | | |
-| - | - | - |
-| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be imported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be imported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be imported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be imported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="import_example" label="import_example">
-<CodeBlock language="csharp">
-{`// import only Documents from a given file
+```csharp
+// Import only Documents from a given file
 var importOperation = await store
     .Smuggler
     .ImportAsync(
         new DatabaseSmugglerImportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Documents
-        \},
-        // import the .ravendbdump file that you exported (i.e. in the export example above)
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await importOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## TransformScript
+<Panel heading="ImportIncrementalAsync">
 
-`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+A RavenDB backup folder contains one full backup file and any incremental backup files accumulated since the last full backup.  
+Use `ImportIncrementalAsync` to import all backup files from such a folder into an existing database in a single call,  
+instead of importing each file individually.
 
-Underneath the JavaScript engine is exactly the same as used for [patching operations](../../../client-api/operations/patching/single-document.mdx) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+The method finds all backup files in the specified directory, orders them chronologically, and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
 
-<TabItem value="javascript" label="javascript">
-<CodeBlock language="javascript">
-{`var id = this['@metadata']['@id'];
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports into an **existing** database.  
+To create a **new** database from backup files, use [`RestoreBackupOperation`](../../../backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Syntax
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+| --- | --- |
+| `Task` | Completes when all backup files in the folder have been imported. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="TransformScript">
+
+`TransformScript` exposes the ability to modify or filter documents during the import and export process using JavaScript.
+
+The JavaScript engine is the same one used for [patching operations](../../../client-api/operations/patching/single-document.mdx),  
+with the same syntax and capabilities, plus the ability to filter out documents by throwing a `'skip'` exception.
+
+```javascript
+var id = this['@metadata']['@id'];
 if (id === 'orders/999-A')
-    throw 'skip'; // filter-out
+    throw 'skip'; // filter out this document
 
 this.Freight = 15.3;
-`}
-</CodeBlock>
-</TabItem>
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-6.2/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -24,6 +24,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
       * [Export specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#export-specific-collections)
    * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
       * [Import specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#import-specific-collections)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
    * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
    * [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax)
       * [Methods](../../../client-api/smuggler/what-is-smuggler.mdx#methods)
@@ -158,6 +159,42 @@ See [ImportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
 
 </Panel>
 
+<Panel heading="ImportIncrementalAsync">
+
+A RavenDB backup folder contains one full backup file and any number of incremental backup files accumulated since
+the last full backup.  
+Use `ImportIncrementalAsync` to import all [logical-backup](../../../client-api/operations/maintenance/backup/backup-overview.mdx#logical-backup) files
+from a backup folder into an existing database in a single call, instead of importing each file individually.
+
+After finding all backup files in the specified folder, the method orders them chronologically and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
+
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports your backup into an **existing** database.  
+To create a **new** database from backup, use [`RestoreBackupOperation`](../../../client-api/operations/maintenance/backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+<br />
+
+See [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
+[DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
+
+</Panel>
+
 <Panel heading="TransformScript">
 
 `TransformScript` lets you modify or filter out each document during an export or import, using JavaScript that you provide.  
@@ -262,7 +299,7 @@ Imports data from a file or a stream into the database.
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
-    CancellationToken token = default);
+    CancellationToken cancellationToken = default);
 
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
@@ -285,11 +322,44 @@ var importOperation = await store.Smuggler.ImportAsync(options, fromFile, token)
 | **options** | `DatabaseSmugglerImportOptions` | Options used during the import. See [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
 | **fromFile** | `string` | Path to the file the data is imported from. |
 | **stream** | `Stream` | Stream with the data to import. |
-| **token** | `CancellationToken` | Token used to cancel the operation. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a file. |
+| **token** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a stream. |
 
 | Return value | |
 |-----------|-------------|
 | `Operation` | An `Operation` instance you can use to wait for completion and subscribe to progress events. |
+
+</TabItem>
+<TabItem value="ImportIncrementalAsync" label="ImportIncrementalAsync">
+
+Imports the logical-backup files found in a backup folder, in chronological order.
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+await store.Smuggler.ImportIncrementalAsync(options, fromDirectory, token);
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+|-----------|-------------|
+| `Task` | Completes when all backup files in the folder have been imported. |
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-6.2/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-6.2/server/configuration/backup-configuration.mdx
@@ -65,6 +65,7 @@ Possible values:
 - `Azure`  
 - `AmazonGlacier`  
 - `AmazonS3`  
+- `GoogleCloud`  
 - `FTP`  
 
 

--- a/versioned_docs/version-6.2/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-6.2/server/configuration/backup-configuration.mdx
@@ -66,6 +66,7 @@ Possible values:
 - `Azure`  
 - `AmazonGlacier`  
 - `AmazonS3`  
+- `GoogleCloud`  
 - `FTP`  
 
 

--- a/versioned_docs/version-6.2/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/versioned_docs/version-6.2/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -25,13 +25,13 @@ You can also ignore these limits and replace the certificates immediately but be
 
 To manually replace the server certificate you can either edit [settings.json](../../configuration/configuration-options.mdx#json) with a new certificate path and restart the server or you can overwrite the existing certificate file and the server will pick it up within one hour without requiring a restart.
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -47,9 +47,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/versioned_docs/version-6.2/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/versioned_docs/version-6.2/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -27,13 +27,13 @@ To manually replace the server certificate you can either edit [settings.json](.
 
 If the server certificate has already expired and Studio can no longer be reached, see [recover from an expired certificate](../../../server/security/authentication/recover-from-expired-certificate.mdx).
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -49,9 +49,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/versioned_docs/version-7.0/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -2,34 +2,44 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from '@site/src/components/Panel';
+import ContentFrame from '@site/src/components/ContentFrame';
+
+<Admonition type="note" title="">
 
 Smuggler gives you the ability to export or import data from or to a database using JSON format.  
 It is exposed via the `DocumentStore.Smuggler` property.
 
-## ForDatabase
+* In this page:
+   * [ForDatabase](../../../client-api/smuggler/what-is-smuggler.mdx#fordatabase)
+   * [Export](../../../client-api/smuggler/what-is-smuggler.mdx#export)
+      * [DatabaseSmugglerExportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions)
+   * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
+      * [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
+   * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
 
-By default, the `DocumentStore.Smuggler` works on the default document store database from the `DocumentStore.Database` property. 
+</Admonition>
 
-In order to switch it to a different database use the `.ForDatabase` method.
+<Panel heading="ForDatabase">
 
-<TabItem value="for_database" label="for_database">
-<CodeBlock language="csharp">
-{`var northwindSmuggler = store
-    .Smuggler
-    .ForDatabase("Northwind");
-`}
-</CodeBlock>
-</TabItem>
+By default, `DocumentStore.Smuggler` works against the default database from the `DocumentStore.Database` property.  
+To target a different database, use `ForDatabase`:
 
+```csharp
+var northwindSmuggler = store.Smuggler.ForDatabase("Northwind");
+```
 
+</Panel>
 
-## Export
+<Panel heading="Export">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="export_syntax" label="export_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ExportAsync(
+```csharp
+Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     DatabaseSmuggler toDatabase,
     CancellationToken token = default(CancellationToken));
@@ -38,65 +48,77 @@ Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     string toFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions). |
-| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
-| **toFile** | `string` | Path to a file where exported data will be written |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination. |
+| **toFile** | `string` | Path to a file where exported data will be written. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerExportOptions
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be exported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be exported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be exported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be exported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be exported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be exported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="export_example" label="export_example">
-<CodeBlock language="csharp">
-{`// export only Indexes and Documents to a given file
+```csharp
+// Export only Indexes and Documents to a given file
 var exportOperation = await store
     .Smuggler
     .ExportAsync(
         new DatabaseSmugglerExportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Indexes
                              | DatabaseItemType.Documents
-        \},
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await exportOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## Import
+<Panel heading="Import">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="import_syntax" label="import_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ImportAsync(
+```csharp
+Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     Stream stream,
     CancellationToken token = default(CancellationToken));
@@ -105,75 +127,137 @@ Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
-| **stream** | `Stream` | Stream with data to import |
-| **fromFile** | `string` | Path to a file from which data will be imported |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **stream** | `Stream` | Stream with data to import. |
+| **fromFile** | `string` | Path to a file from which data will be imported. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerImportOptions
 
-| Parameters | | |
-| - | - | - |
-| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be imported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be imported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be imported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be imported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="import_example" label="import_example">
-<CodeBlock language="csharp">
-{`// import only Documents from a given file
+```csharp
+// Import only Documents from a given file
 var importOperation = await store
     .Smuggler
     .ImportAsync(
         new DatabaseSmugglerImportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Documents
-        \},
-        // import the .ravendbdump file that you exported (i.e. in the export example above)
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await importOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## TransformScript
+<Panel heading="ImportIncrementalAsync">
 
-`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+A RavenDB backup folder contains one full backup file and any incremental backup files accumulated since the last full backup.  
+Use `ImportIncrementalAsync` to import all backup files from such a folder into an existing database in a single call,  
+instead of importing each file individually.
 
-Underneath the JavaScript engine is exactly the same as used for [patching operations](../../../client-api/operations/patching/single-document.mdx) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+The method finds all backup files in the specified directory, orders them chronologically, and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
 
-<TabItem value="javascript" label="javascript">
-<CodeBlock language="javascript">
-{`var id = this['@metadata']['@id'];
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports into an **existing** database.  
+To create a **new** database from backup files, use [`RestoreBackupOperation`](../../../backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Syntax
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+| --- | --- |
+| `Task` | Completes when all backup files in the folder have been imported. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="TransformScript">
+
+`TransformScript` exposes the ability to modify or filter documents during the import and export process using JavaScript.
+
+The JavaScript engine is the same one used for [patching operations](../../../client-api/operations/patching/single-document.mdx),  
+with the same syntax and capabilities, plus the ability to filter out documents by throwing a `'skip'` exception.
+
+```javascript
+var id = this['@metadata']['@id'];
 if (id === 'orders/999-A')
-    throw 'skip'; // filter-out
+    throw 'skip'; // filter out this document
 
 this.Freight = 15.3;
-`}
-</CodeBlock>
-</TabItem>
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.0/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -24,6 +24,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
       * [Export specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#export-specific-collections)
    * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
       * [Import specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#import-specific-collections)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
    * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
    * [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax)
       * [Methods](../../../client-api/smuggler/what-is-smuggler.mdx#methods)
@@ -158,6 +159,42 @@ See [ImportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
 
 </Panel>
 
+<Panel heading="ImportIncrementalAsync">
+
+A RavenDB backup folder contains one full backup file and any number of incremental backup files accumulated since
+the last full backup.  
+Use `ImportIncrementalAsync` to import all [logical-backup](../../../client-api/operations/maintenance/backup/backup-overview.mdx#logical-backup) files
+from a backup folder into an existing database in a single call, instead of importing each file individually.
+
+After finding all backup files in the specified folder, the method orders them chronologically and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
+
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports your backup into an **existing** database.  
+To create a **new** database from backup, use [`RestoreBackupOperation`](../../../client-api/operations/maintenance/backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+<br />
+
+See [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
+[DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
+
+</Panel>
+
 <Panel heading="TransformScript">
 
 `TransformScript` lets you modify or filter out each document during an export or import, using JavaScript that you provide.  
@@ -262,7 +299,7 @@ Imports data from a file or a stream into the database.
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
-    CancellationToken token = default);
+    CancellationToken cancellationToken = default);
 
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
@@ -285,11 +322,44 @@ var importOperation = await store.Smuggler.ImportAsync(options, fromFile, token)
 | **options** | `DatabaseSmugglerImportOptions` | Options used during the import. See [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
 | **fromFile** | `string` | Path to the file the data is imported from. |
 | **stream** | `Stream` | Stream with the data to import. |
-| **token** | `CancellationToken` | Token used to cancel the operation. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a file. |
+| **token** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a stream. |
 
 | Return value | |
 |-----------|-------------|
 | `Operation` | An `Operation` instance you can use to wait for completion and subscribe to progress events. |
+
+</TabItem>
+<TabItem value="ImportIncrementalAsync" label="ImportIncrementalAsync">
+
+Imports the logical-backup files found in a backup folder, in chronological order.
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+await store.Smuggler.ImportIncrementalAsync(options, fromDirectory, token);
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+|-----------|-------------|
+| `Task` | Completes when all backup files in the folder have been imported. |
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-7.0/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-7.0/server/configuration/backup-configuration.mdx
@@ -65,6 +65,7 @@ Possible values:
 - `Azure`  
 - `AmazonGlacier`  
 - `AmazonS3`  
+- `GoogleCloud`  
 - `FTP`  
 
 

--- a/versioned_docs/version-7.0/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-7.0/server/configuration/backup-configuration.mdx
@@ -66,6 +66,7 @@ Possible values:
 - `Azure`  
 - `AmazonGlacier`  
 - `AmazonS3`  
+- `GoogleCloud`  
 - `FTP`  
 
 

--- a/versioned_docs/version-7.0/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/versioned_docs/version-7.0/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -25,13 +25,13 @@ You can also ignore these limits and replace the certificates immediately but be
 
 To manually replace the server certificate you can either edit [settings.json](../../configuration/configuration-options.mdx#json) with a new certificate path and restart the server or you can overwrite the existing certificate file and the server will pick it up within one hour without requiring a restart.
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -47,9 +47,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/versioned_docs/version-7.0/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/versioned_docs/version-7.0/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -27,13 +27,13 @@ To manually replace the server certificate you can either edit [settings.json](.
 
 If the server certificate has already expired and Studio can no longer be reached, see [recover from an expired certificate](../../../server/security/authentication/recover-from-expired-certificate.mdx).
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -49,9 +49,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/versioned_docs/version-7.0/start/getting-started.mdx
+++ b/versioned_docs/version-7.0/start/getting-started.mdx
@@ -52,11 +52,14 @@ RavenDB is written in `.NET` so it requires the same set of prerequisites as `.N
 
 <Admonition type="note" title="Windows" id="windows" href="#windows">
 
-Please install [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) 
-(or newer) before launching the RavenDB server.  
+Please install the **Microsoft Visual C++ Redistributable Package 2019 or later** before launching the RavenDB server on Windows.
+
+Download the latest supported Microsoft Visual C++ v14 Redistributable package for your Windows architecture:  
+[x64](https://aka.ms/vc14/vc_redist.x64.exe) | [x86](https://aka.ms/vc14/vc_redist.x86.exe).  
 This package should be the sole requirement for the 'Windows' platforms.  
+
 If you're experiencing difficulties, please check the 
-prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).  
+prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).
 
 </Admonition>
 

--- a/versioned_docs/version-7.0/start/installation/setup-examples/aws-windows-vm.mdx
+++ b/versioned_docs/version-7.0/start/installation/setup-examples/aws-windows-vm.mdx
@@ -94,9 +94,10 @@ Dowload Chrome. You will need to allow it in the Internet Explorer firewall.
 ![20](./assets/20.png)
 ![21](./assets/21.png)
 
-Install the [Visual C++ 2015 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) (or newer).
+---
 
-![19](./assets/19.png)
+Install the **Microsoft Visual C++ Redistributable Package 2019 or later**.  
+For the Windows Server x64 VM used in this walkthrough, use the [x64 installer](https://aka.ms/vc14/vc_redist.x64.exe). If you are running a 32-bit Windows installation, use the [x86 installer](https://aka.ms/vc14/vc_redist.x86.exe).
 
 ## Run the RavenDB Setup Wizard
 

--- a/versioned_docs/version-7.1/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -2,34 +2,44 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from '@site/src/components/Panel';
+import ContentFrame from '@site/src/components/ContentFrame';
+
+<Admonition type="note" title="">
 
 Smuggler gives you the ability to export or import data from or to a database using JSON format.  
 It is exposed via the `DocumentStore.Smuggler` property.
 
-## ForDatabase
+* In this page:
+   * [ForDatabase](../../../client-api/smuggler/what-is-smuggler.mdx#fordatabase)
+   * [Export](../../../client-api/smuggler/what-is-smuggler.mdx#export)
+      * [DatabaseSmugglerExportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions)
+   * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
+      * [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
+   * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
 
-By default, the `DocumentStore.Smuggler` works on the default document store database from the `DocumentStore.Database` property. 
+</Admonition>
 
-In order to switch it to a different database use the `.ForDatabase` method.
+<Panel heading="ForDatabase">
 
-<TabItem value="for_database" label="for_database">
-<CodeBlock language="csharp">
-{`var northwindSmuggler = store
-    .Smuggler
-    .ForDatabase("Northwind");
-`}
-</CodeBlock>
-</TabItem>
+By default, `DocumentStore.Smuggler` works against the default database from the `DocumentStore.Database` property.  
+To target a different database, use `ForDatabase`:
 
+```csharp
+var northwindSmuggler = store.Smuggler.ForDatabase("Northwind");
+```
 
+</Panel>
 
-## Export
+<Panel heading="Export">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="export_syntax" label="export_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ExportAsync(
+```csharp
+Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     DatabaseSmuggler toDatabase,
     CancellationToken token = default(CancellationToken));
@@ -38,65 +48,77 @@ Task<Operation> ExportAsync(
     DatabaseSmugglerExportOptions options,
     string toFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerExportOptions` | Options that will be used during the export. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerexportoptions). |
-| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination |
-| **toFile** | `string` | Path to a file where exported data will be written |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **toDatabase** | `DatabaseSmuggler` | `DatabaseSmuggler` instance used as a destination. |
+| **toFile** | `string` | Path to a file where exported data will be written. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerExportOptions
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be exported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be exported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be exported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to export. If empty, then all collections will be exported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be exported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be exported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be exported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be exported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be exported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every exported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="export_example" label="export_example">
-<CodeBlock language="csharp">
-{`// export only Indexes and Documents to a given file
+```csharp
+// Export only Indexes and Documents to a given file
 var exportOperation = await store
     .Smuggler
     .ExportAsync(
         new DatabaseSmugglerExportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Indexes
                              | DatabaseItemType.Documents
-        \},
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await exportOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## Import
+<Panel heading="Import">
+
+<ContentFrame>
 
 ### Syntax
 
-<TabItem value="import_syntax" label="import_syntax">
-<CodeBlock language="csharp">
-{`Task<Operation> ImportAsync(
+```csharp
+Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     Stream stream,
     CancellationToken token = default(CancellationToken));
@@ -105,75 +127,137 @@ Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
-</TabItem>
+```
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
 | **options** | `DatabaseSmugglerImportOptions` | Options that will be used during the import. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
-| **stream** | `Stream` | Stream with data to import |
-| **fromFile** | `string` | Path to a file from which data will be imported |
-| **token** | `CancellationToken` | Token used to cancel the operation |
+| **stream** | `Stream` | Stream with data to import. |
+| **fromFile** | `string` | Path to a file from which data will be imported. |
+| **token** | `CancellationToken` | Token used to cancel the operation. |
 
-| Return Value | | 
-| ------------- | ----- |
-| `Operation` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events |
+| Return value | |
+| --- | --- |
+| `Task<Operation>` | Instance of Operation-class which gives you an ability to wait for the operation to complete and subscribe to operation progress events. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### DatabaseSmugglerImportOptions
 
-| Parameters | | |
-| - | - | - |
-| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. <br/> Default: `empty` |
-| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. <br/> Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
-| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. <br/> Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
-| **IncludeExpired** | `bool` | Should expired documents be imported. <br/> Default: `true` |
-| **IncludeArtificial** | `bool` | Should artificial documents be imported. <br/> Default: `false` |
-| **IncludeArchived** | `bool` | Should archived documents be imported. <br/> Default: `true` |
-| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. <br/> Default: `false` |
+| Property | Type | Description |
+| --- | --- | --- |
+| **Collections** | `List<string>` | List of specific collections to import. If empty, then all collections will be imported. Default: `empty` |
+| **OperateOnTypes** | `DatabaseItemType` | Indicates what should be imported. Default: `Indexes`, `Documents`, `RevisionDocuments`, `Conflicts`, `DatabaseRecord`, `ReplicationHubCertificates`, `Identities`, `CompareExchange`, `Attachments`, `CounterGroups`, `Subscriptions`, `TimeSeries` |
+| **OperateOnDatabaseRecordTypes** | `DatabaseRecordItemType` | Indicates what should be imported from database record. Default: `Client`, `ConflictSolverConfig`, `Expiration`, `ExternalReplications`, `PeriodicBackups`, `RavenConnectionStrings`, `RavenEtls`, `Revisions`, `Settings`, `SqlConnectionStrings`, `Sorters`, `SqlEtls`, `HubPullReplications`, `SinkPullReplications`, `TimeSeries`, `DocumentsCompression`, `Analyzers`, `LockMode`, `OlapConnectionStrings`, `OlapEtls`, `ElasticSearchConnectionStrings`, `ElasticSearchEtls`, `PostgreSQLIntegration`, `QueueConnectionStrings`, `QueueEtls`, `IndexesHistory`, `Refresh`, `DataArchival` |
+| **IncludeExpired** | `bool` | Should expired documents be imported. Default: `true` |
+| **IncludeArtificial** | `bool` | Should artificial documents be imported. Default: `false` |
+| **IncludeArchived** | `bool` | Should archived documents be imported. Default: `true` |
+| **RemoveAnalyzers** | `bool` | Should analyzers be removed from Indexes. Default: `false` |
 | **TransformScript** | `string` | JavaScript-based script applied to every imported document. Read more [here](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript). |
-| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. <br/> Default: **10000** |
+| **MaxStepsForTransformScript** | `int` | Maximum number of steps that the transform script can process before failing. Default: `10000` |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
-<TabItem value="import_example" label="import_example">
-<CodeBlock language="csharp">
-{`// import only Documents from a given file
+```csharp
+// Import only Documents from a given file
 var importOperation = await store
     .Smuggler
     .ImportAsync(
         new DatabaseSmugglerImportOptions
-        \{
+        {
             OperateOnTypes = DatabaseItemType.Documents
-        \},
-        // import the .ravendbdump file that you exported (i.e. in the export example above)
-        @"C:\\ravendb-exports\\Northwind.ravendbdump",
+        },
+        @"C:\ravendb-exports\Northwind.ravendbdump",
         token);
 
 await importOperation.WaitForCompletionAsync();
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</ContentFrame>
 
+</Panel>
 
-## TransformScript
+<Panel heading="ImportIncrementalAsync">
 
-`TransformScript` exposes the ability to modify or even filter-out the document during the import and export process using the provided JavaScript. 
+A RavenDB backup folder contains one full backup file and any incremental backup files accumulated since the last full backup.  
+Use `ImportIncrementalAsync` to import all backup files from such a folder into an existing database in a single call,  
+instead of importing each file individually.
 
-Underneath the JavaScript engine is exactly the same as used for [patching operations](../../../client-api/operations/patching/single-document.mdx) giving you identical syntax and capabilities with additional **ability to filter out documents by throwing a 'skip' exception**.
+The method finds all backup files in the specified directory, orders them chronologically, and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
 
-<TabItem value="javascript" label="javascript">
-<CodeBlock language="javascript">
-{`var id = this['@metadata']['@id'];
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports into an **existing** database.  
+To create a **new** database from backup files, use [`RestoreBackupOperation`](../../../backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Syntax
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+| --- | --- |
+| `Task` | Completes when all backup files in the folder have been imported. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="TransformScript">
+
+`TransformScript` exposes the ability to modify or filter documents during the import and export process using JavaScript.
+
+The JavaScript engine is the same one used for [patching operations](../../../client-api/operations/patching/single-document.mdx),  
+with the same syntax and capabilities, plus the ability to filter out documents by throwing a `'skip'` exception.
+
+```javascript
+var id = this['@metadata']['@id'];
 if (id === 'orders/999-A')
-    throw 'skip'; // filter-out
+    throw 'skip'; // filter out this document
 
 this.Freight = 15.3;
-`}
-</CodeBlock>
-</TabItem>
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.1/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/smuggler/content/_what-is-smuggler-csharp.mdx
@@ -24,6 +24,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
       * [Export specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#export-specific-collections)
    * [Import](../../../client-api/smuggler/what-is-smuggler.mdx#import)
       * [Import specific collections](../../../client-api/smuggler/what-is-smuggler.mdx#import-specific-collections)
+   * [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#importincrementalasync)
    * [TransformScript](../../../client-api/smuggler/what-is-smuggler.mdx#transformscript)
    * [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax)
       * [Methods](../../../client-api/smuggler/what-is-smuggler.mdx#methods)
@@ -158,6 +159,42 @@ See [ImportAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
 
 </Panel>
 
+<Panel heading="ImportIncrementalAsync">
+
+A RavenDB backup folder contains one full backup file and any number of incremental backup files accumulated since
+the last full backup.  
+Use `ImportIncrementalAsync` to import all [logical-backup](../../../client-api/operations/maintenance/backup/backup-overview.mdx#logical-backup) files
+from a backup folder into an existing database in a single call, instead of importing each file individually.
+
+After finding all backup files in the specified folder, the method orders them chronologically and imports them in sequence.  
+Indexes and Subscriptions are excluded from all files except the last, ensuring only their most recent state is applied.
+
+<Admonition type="note" title="">
+`ImportIncrementalAsync` imports your backup into an **existing** database.  
+To create a **new** database from backup, use [`RestoreBackupOperation`](../../../client-api/operations/maintenance/backup/restore.mdx).
+</Admonition>
+
+<ContentFrame>
+
+### Example
+
+```csharp
+// Import all backup files from a backup folder into an existing database
+await store.Smuggler.ImportIncrementalAsync(
+    new DatabaseSmugglerImportOptions(),
+    @"C:\RavenDB\Backups\Northwind.2024-01-15T12-00-00");
+```
+
+</ContentFrame>
+
+<br />
+
+See [ImportIncrementalAsync](../../../client-api/smuggler/what-is-smuggler.mdx#methods) and
+[DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions)
+in the [Syntax](../../../client-api/smuggler/what-is-smuggler.mdx#syntax) section.  
+
+</Panel>
+
 <Panel heading="TransformScript">
 
 `TransformScript` lets you modify or filter out each document during an export or import, using JavaScript that you provide.  
@@ -262,7 +299,7 @@ Imports data from a file or a stream into the database.
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
     string fromFile,
-    CancellationToken token = default);
+    CancellationToken cancellationToken = default);
 
 Task<Operation> ImportAsync(
     DatabaseSmugglerImportOptions options,
@@ -285,11 +322,44 @@ var importOperation = await store.Smuggler.ImportAsync(options, fromFile, token)
 | **options** | `DatabaseSmugglerImportOptions` | Options used during the import. See [DatabaseSmugglerImportOptions](../../../client-api/smuggler/what-is-smuggler.mdx#databasesmugglerimportoptions). |
 | **fromFile** | `string` | Path to the file the data is imported from. |
 | **stream** | `Stream` | Stream with the data to import. |
-| **token** | `CancellationToken` | Token used to cancel the operation. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a file. |
+| **token** | `CancellationToken` | Token used to cancel the operation, in the overload that imports from a stream. |
 
 | Return value | |
 |-----------|-------------|
 | `Operation` | An `Operation` instance you can use to wait for completion and subscribe to progress events. |
+
+</TabItem>
+<TabItem value="ImportIncrementalAsync" label="ImportIncrementalAsync">
+
+Imports the logical-backup files found in a backup folder, in chronological order.
+
+```csharp
+Task ImportIncrementalAsync(
+    DatabaseSmugglerImportOptions options,
+    string fromDirectory,
+    CancellationToken cancellationToken = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+await store.Smuggler.ImportIncrementalAsync(options, fromDirectory, token);
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `DatabaseSmugglerImportOptions` | Options applied to each file imported from the directory. `Tombstones` and `CompareExchangeTombstones` are added automatically. |
+| **fromDirectory** | `string` | Path to the backup folder containing the backup files to import. |
+| **cancellationToken** | `CancellationToken` | Token used to cancel the operation. |
+
+| Return value | |
+|-----------|-------------|
+| `Task` | Completes when all backup files in the folder have been imported. |
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-7.1/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-7.1/server/configuration/backup-configuration.mdx
@@ -65,6 +65,7 @@ Possible values:
 - `Azure`  
 - `AmazonGlacier`  
 - `AmazonS3`  
+- `GoogleCloud`  
 - `FTP`  
 
 

--- a/versioned_docs/version-7.1/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-7.1/server/configuration/backup-configuration.mdx
@@ -66,6 +66,7 @@ Possible values:
 - `Azure`  
 - `AmazonGlacier`  
 - `AmazonS3`  
+- `GoogleCloud`  
 - `FTP`  
 
 

--- a/versioned_docs/version-7.1/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/versioned_docs/version-7.1/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -25,13 +25,13 @@ You can also ignore these limits and replace the certificates immediately but be
 
 To manually replace the server certificate you can either edit [settings.json](../../configuration/configuration-options.mdx#json) with a new certificate path and restart the server or you can overwrite the existing certificate file and the server will pick it up within one hour without requiring a restart.
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -47,9 +47,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/versioned_docs/version-7.1/server/security/authentication/certificate-renewal-and-rotation.mdx
+++ b/versioned_docs/version-7.1/server/security/authentication/certificate-renewal-and-rotation.mdx
@@ -27,13 +27,13 @@ To manually replace the server certificate you can either edit [settings.json](.
 
 If the server certificate has already expired and Studio can no longer be reached, see [recover from an expired certificate](../../../server/security/authentication/recover-from-expired-certificate.mdx).
 
-<Admonition type="danger" title="">
+<Admonition type="warning" title="">
 The new certificate must contain all of the cluster domain names in the CN or ASN properties of the certificate. Otherwise you will get an authentication error because SSL/TLS requires the domain in the certificate to match with the actual domain being used.
 </Admonition>
 
-## Replace the Cluster Certificate Using the Studio
+## Replace the Server Certificate Using Studio
 
-Access the certificate view, click on `Cluster certificate` -&gt; `Replace cluster certificate` and upload the new certificate PFX file.
+Access the [certificate view](../../../studio/server/certificates/server-management-certificates-view.mdx), click on `Server certificate` -&gt; `Replace server certificate` and upload the new certificate PFX file.
 
 This will start the certificate replacement process.
 
@@ -49,9 +49,9 @@ If a node is not responding during the replacement, the operation will not compl
 
 * `Replace immediately` is chosen. In this case, the cluster will complete the operation without the node which is down. When bringing that node up, the certificate must be replaced manually.
 
-During the process you will receive alerts in the studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
+During the process you will receive alerts in Studio and in the logs indicating the status of the operation and any errors if they occur. The alerts are displayed for each node independently.
 
-## Replace the Cluster Certificate Using Powershell
+## Replace the Server Certificate Using Powershell
 
 Here is a little example of using the REST API directly with powershell to replace the cluster certificate:  
 

--- a/versioned_docs/version-7.1/start/getting-started.mdx
+++ b/versioned_docs/version-7.1/start/getting-started.mdx
@@ -52,10 +52,14 @@ RavenDB is written in `.NET` so it requires the same set of prerequisites as `.N
 
 <Admonition type="note" title="Windows" id="windows" href="#windows">
 
-Please install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) before launching the RavenDB server.  
+Please install the **Microsoft Visual C++ Redistributable Package 2019 or later** before launching the RavenDB server on Windows.
+
+Download the latest supported Microsoft Visual C++ v14 Redistributable package for your Windows architecture:  
+[x64](https://aka.ms/vc14/vc_redist.x64.exe) | [x86](https://aka.ms/vc14/vc_redist.x86.exe).  
 This package should be the sole requirement for the 'Windows' platforms.  
+
 If you're experiencing difficulties, please check the 
-prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).  
+prerequisites for .NET on Windows in this [Microsoft article](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#dependencies).
 
 </Admonition>
 

--- a/versioned_docs/version-7.1/start/installation/setup-examples/aws-windows-vm.mdx
+++ b/versioned_docs/version-7.1/start/installation/setup-examples/aws-windows-vm.mdx
@@ -94,9 +94,10 @@ Dowload Chrome. You will need to allow it in the Internet Explorer firewall.
 ![20](./assets/20.png)
 ![21](./assets/21.png)
 
-Install the [Visual C++ Redistributable Package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
+---
 
-![19](./assets/19.png)
+Install the **Microsoft Visual C++ Redistributable Package 2019 or later**.  
+For the Windows Server x64 VM used in this walkthrough, use the [x64 installer](https://aka.ms/vc14/vc_redist.x64.exe). If you are running a 32-bit Windows installation, use the [x86 installer](https://aka.ms/vc14/vc_redist.x86.exe).
 
 ## Run the RavenDB Setup Wizard
 


### PR DESCRIPTION
### Issue link
[RDoc-1655](https://issues.hibernatingrhinos.com/issue/RDoc-1655) GoogleCloud's option missing on /server/configuration/backup-configuration#server.alloweddestinations
[RDoc-2310](https://issues.hibernatingrhinos.com/issue/RDoc-2310) Fix description for certificate view
[RDoc-3344](https://issues.hibernatingrhinos.com/issue/RDoc-3344) Update the download link of the Visual C++ Redistributable Package
[RDoc-2387](https://issues.hibernatingrhinos.com/issue/RDoc-2387) Document ImportIncrementalAsync

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

