### PR TITLE
RDoc-3815 - update the replace-license page let's encrypt renewal section

### DIFF
--- a/docs/licensing/replace-license.mdx
+++ b/docs/licensing/replace-license.mdx
@@ -28,7 +28,6 @@ import ContentFrame from "@site/src/components/ContentFrame";
 * In this article:
     * [Replace your license using a configuration key](../licensing/replace-license.mdx#replace-your-license-using-a-configuration-key)  
     * [Replace your license via Studio](../licensing/replace-license.mdx#replace-your-license-via-studio)  
-    * [Let's Encrypt certificate renewal after a license replacement](../licensing/replace-license.mdx#let-s-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a license older than 6.x](../licensing/replace-license.mdx#upgrade-a-license-older-than-6-x)
 
 </Admonition>
@@ -61,20 +60,6 @@ To replace your existing license with a new one, open the **About** view and cli
 2. **Replace**  
    Click to paste and submit your new license.  
    ![Paste and Submit](./assets/register-license-form.png)
-
-</Panel>
-
-<Panel heading="Let's Encrypt certificate renewal after a license replacement">
-
-When you replace your license on a server that was set up using the [Setup Wizard](../start/installation/setup-wizard/overview.mdx) 
-with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
-Certificate auto-renewal will continue to work without any manual steps.  
-
-<Admonition type="note" title="">
-
-If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
-
-</Admonition>
 
 </Panel>
 

--- a/docs/licensing/replace-license.mdx
+++ b/docs/licensing/replace-license.mdx
@@ -70,6 +70,12 @@ When you replace your license on a server that was set up using the [Setup Wizar
 with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
 Certificate auto-renewal will continue to work without any manual steps.  
 
+<Admonition type="note" title="">
+
+If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Upgrade a license older than 6.x">

--- a/docs/licensing/replace-license.mdx
+++ b/docs/licensing/replace-license.mdx
@@ -28,7 +28,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
 * In this article:
     * [Replace your license using a configuration key](../licensing/replace-license.mdx#replace-your-license-using-a-configuration-key)  
     * [Replace your license via Studio](../licensing/replace-license.mdx#replace-your-license-via-studio)  
-    * [Maintain auto-renewal of Let's Encrypt certificates](../licensing/replace-license.mdx#maintain-auto-renewal-of-let-s-encrypt-certificates)  
+    * [Let's Encrypt certificate renewal after a license replacement](../licensing/replace-license.mdx#let-s-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a license older than 6.x](../licensing/replace-license.mdx#upgrade-a-license-older-than-6-x)
 
 </Admonition>
@@ -64,10 +64,11 @@ To replace your existing license with a new one, open the **About** view and cli
 
 </Panel>
 
-<Panel heading="Maintain auto-renewal of Let's Encrypt certificates">
+<Panel heading="Let's Encrypt certificate renewal after a license replacement">
 
-* If you installed RavenDB using the [Setup Wizard](../start/installation/setup-wizard/overview.mdx) and applied a Let's Encrypt certificate, contact [customer support](https://ravendb.net/contact) before replacing your license to keep automatic certificate renewal working.  
-* Otherwise, the change in your license ID will cause a mismatch between your new ID and the ID that Let's Encrypt expects during certificate renewal.  
+When you replace your license on a server that was set up using the [Setup Wizard](../start/installation/setup-wizard/overview.mdx) 
+with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
+Certificate auto-renewal will continue to work without any manual steps.  
 
 </Panel>
 

--- a/versioned_docs/version-6.2/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-6.2/start/licensing/replace-license.mdx
@@ -52,6 +52,12 @@ When you replace your license on a server that was set up using the [Setup Wizar
 with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
 Certificate auto-renewal will continue to work without any manual steps.  
 
+<Admonition type="note" title="">
+
+If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
+
+</Admonition>
+
 
 
 ## Upgrade a License Key For RavenDB 6.x

--- a/versioned_docs/version-6.2/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-6.2/start/licensing/replace-license.mdx
@@ -26,7 +26,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
     * [Replace license from Studio](../../start/licensing/replace-license.mdx#replace-license-from-studio)  
-    * [Let's Encrypt certificate renewal after a license replacement](../../start/licensing/replace-license.mdx#lets-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a License Key For RavenDB 6.x](../../start/licensing/replace-license.mdx#upgrade-a-license-key-for-ravendb-6x)  
 
 </Admonition>
@@ -43,20 +42,6 @@ Replace the existing license with the new one from the Studio:
    Click the _Replace License_ button
 
 ![Paste and Submit](./assets/replace-license_paste-and-submit.png)
-
-
-
-## Let's Encrypt certificate renewal after a license replacement
-
-When you replace your license on a server that was set up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
-with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
-Certificate auto-renewal will continue to work without any manual steps.  
-
-<Admonition type="note" title="">
-
-If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
-
-</Admonition>
 
 
 

--- a/versioned_docs/version-6.2/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-6.2/start/licensing/replace-license.mdx
@@ -26,7 +26,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
     * [Replace license from Studio](../../start/licensing/replace-license.mdx#replace-license-from-studio)  
-    * [Maintain auto-renewal of Let's Encrypt certificates](../../start/licensing/replace-license.mdx#maintain-auto-renewal-of-let)  
+    * [Let's Encrypt certificate renewal after a license replacement](../../start/licensing/replace-license.mdx#lets-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a License Key For RavenDB 6.x](../../start/licensing/replace-license.mdx#upgrade-a-license-key-for-ravendb-6x)  
 
 </Admonition>
@@ -46,13 +46,11 @@ Replace the existing license with the new one from the Studio:
 
 
 
-## Maintain auto-renewal of Let's Encrypt certificates 
+## Let's Encrypt certificate renewal after a license replacement
 
-* If you set RavenDB up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
-  and used a Let's Encrypt certificate,  contact [customer support](https://ravendb.net/contact) 
-  when changing your license to maintain auto-renewals of certificates.  
-* Otherwise, changing your license ID will cause a mismatch between the new 
-  license ID and the ID that Let's Encrypt expects when renewing the certificate.  
+When you replace your license on a server that was set up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
+with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
+Certificate auto-renewal will continue to work without any manual steps.  
 
 
 

--- a/versioned_docs/version-7.0/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-7.0/start/licensing/replace-license.mdx
@@ -52,6 +52,12 @@ When you replace your license on a server that was set up using the [Setup Wizar
 with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
 Certificate auto-renewal will continue to work without any manual steps.  
 
+<Admonition type="note" title="">
+
+If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
+
+</Admonition>
+
 
 
 ## Upgrade a License Key For RavenDB 6.x

--- a/versioned_docs/version-7.0/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-7.0/start/licensing/replace-license.mdx
@@ -26,7 +26,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
     * [Replace license from Studio](../../start/licensing/replace-license.mdx#replace-license-from-studio)  
-    * [Let's Encrypt certificate renewal after a license replacement](../../start/licensing/replace-license.mdx#lets-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a License Key For RavenDB 6.x](../../start/licensing/replace-license.mdx#upgrade-a-license-key-for-ravendb-6x)  
 
 </Admonition>
@@ -43,20 +42,6 @@ Replace the existing license with the new one from the Studio:
    Click the _Replace License_ button
 
 ![Paste and Submit](./assets/replace-license_paste-and-submit.png)
-
-
-
-## Let's Encrypt certificate renewal after a license replacement
-
-When you replace your license on a server that was set up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
-with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
-Certificate auto-renewal will continue to work without any manual steps.  
-
-<Admonition type="note" title="">
-
-If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
-
-</Admonition>
 
 
 

--- a/versioned_docs/version-7.0/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-7.0/start/licensing/replace-license.mdx
@@ -26,7 +26,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
     * [Replace license from Studio](../../start/licensing/replace-license.mdx#replace-license-from-studio)  
-    * [Maintain auto-renewal of Let's Encrypt certificates](../../start/licensing/replace-license.mdx#maintain-auto-renewal-of-let)  
+    * [Let's Encrypt certificate renewal after a license replacement](../../start/licensing/replace-license.mdx#lets-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a License Key For RavenDB 6.x](../../start/licensing/replace-license.mdx#upgrade-a-license-key-for-ravendb-6x)  
 
 </Admonition>
@@ -46,13 +46,11 @@ Replace the existing license with the new one from the Studio:
 
 
 
-## Maintain auto-renewal of Let's Encrypt certificates 
+## Let's Encrypt certificate renewal after a license replacement
 
-* If you set RavenDB up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
-  and used a Let's Encrypt certificate,  contact [customer support](https://ravendb.net/contact) 
-  when changing your license to maintain auto-renewals of certificates.  
-* Otherwise, changing your license ID will cause a mismatch between the new 
-  license ID and the ID that Let's Encrypt expects when renewing the certificate.  
+When you replace your license on a server that was set up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
+with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
+Certificate auto-renewal will continue to work without any manual steps.  
 
 
 

--- a/versioned_docs/version-7.1/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-7.1/start/licensing/replace-license.mdx
@@ -52,6 +52,12 @@ When you replace your license on a server that was set up using the [Setup Wizar
 with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
 Certificate auto-renewal will continue to work without any manual steps.  
 
+<Admonition type="note" title="">
+
+If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
+
+</Admonition>
+
 
 
 ## Upgrade a License Key For RavenDB 6.x

--- a/versioned_docs/version-7.1/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-7.1/start/licensing/replace-license.mdx
@@ -26,7 +26,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
     * [Replace license from Studio](../../start/licensing/replace-license.mdx#replace-license-from-studio)  
-    * [Let's Encrypt certificate renewal after a license replacement](../../start/licensing/replace-license.mdx#lets-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a License Key For RavenDB 6.x](../../start/licensing/replace-license.mdx#upgrade-a-license-key-for-ravendb-6x)  
 
 </Admonition>
@@ -43,20 +42,6 @@ Replace the existing license with the new one from the Studio:
    Click the _Replace License_ button
 
 ![Paste and Submit](./assets/replace-license_paste-and-submit.png)
-
-
-
-## Let's Encrypt certificate renewal after a license replacement
-
-When you replace your license on a server that was set up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
-with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
-Certificate auto-renewal will continue to work without any manual steps.  
-
-<Admonition type="note" title="">
-
-If you migrated from an older RavenDB version, note that this transfer is now handled automatically and no longer requires contacting customer support.
-
-</Admonition>
 
 
 

--- a/versioned_docs/version-7.1/start/licensing/replace-license.mdx
+++ b/versioned_docs/version-7.1/start/licensing/replace-license.mdx
@@ -26,7 +26,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
     * [Replace license from Studio](../../start/licensing/replace-license.mdx#replace-license-from-studio)  
-    * [Maintain auto-renewal of Let's Encrypt certificates](../../start/licensing/replace-license.mdx#maintain-auto-renewal-of-let)  
+    * [Let's Encrypt certificate renewal after a license replacement](../../start/licensing/replace-license.mdx#lets-encrypt-certificate-renewal-after-a-license-replacement)  
     * [Upgrade a License Key For RavenDB 6.x](../../start/licensing/replace-license.mdx#upgrade-a-license-key-for-ravendb-6x)  
 
 </Admonition>
@@ -46,13 +46,11 @@ Replace the existing license with the new one from the Studio:
 
 
 
-## Maintain auto-renewal of Let's Encrypt certificates 
+## Let's Encrypt certificate renewal after a license replacement
 
-* If you set RavenDB up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
-  and used a Let's Encrypt certificate,  contact [customer support](https://ravendb.net/contact) 
-  when changing your license to maintain auto-renewals of certificates.  
-* Otherwise, changing your license ID will cause a mismatch between the new 
-  license ID and the ID that Let's Encrypt expects when renewing the certificate.  
+When you replace your license on a server that was set up using the [Setup Wizard](../../start/installation/setup-wizard/overview.mdx) 
+with a Let's Encrypt certificate, RavenDB automatically updates its records to associate your domain with the new license before activating it.  
+Certificate auto-renewal will continue to work without any manual steps.  
 
 
 


### PR DESCRIPTION
### Issue link
[RDoc-3815](https://issues.hibernatingrhinos.com/issue/RDoc-3815) Document Let's encrypt cert renewal change

### Additional description
Update the replace-license page let's encrypt renewal section: contacting support is no longer needed to renew license.

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

