### PR TITLE
RDoc-3852: Document backup tier requirements and failure disclaimer

### DIFF
--- a/cloud/cloud-backup-and-restore.mdx
+++ b/cloud/cloud-backup-and-restore.mdx
@@ -86,9 +86,11 @@ RavenDB is **not liable** for backup failures caused by a product tier that is i
 the size of the databases it hosts. It is the **customer's responsibility** to ensure the selected
 tier can sustain backup operations given their data volume.
 
-If the portal surfaces a **"Last successful backup is over a day old"** alert, the most common
-cause on small tiers is that the instance ran out of resources during the backup run. Upgrade your
-product tier to resolve the issue.
+Monitor backup health via the **RavenDB Studio notification center** and the available
+monitoring facilities ([SNMP](../docs/server/administration/snmp/snmp-overview.mdx),
+[OpenTelemetry](../docs/server/administration/monitoring/open-telemetry.mdx), and others).
+If backups stop completing on small tiers, the most common cause is the instance running out
+of resources during the backup run. Upgrade your product tier to resolve the issue.
 
 </Admonition>
 

--- a/cloud/cloud-backup-and-restore.mdx
+++ b/cloud/cloud-backup-and-restore.mdx
@@ -25,6 +25,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:  
   * [The Mandatory-Backup Routine](../cloud/cloud-backup-and-restore.mdx#the-mandatory-backup-routine)  
+    * [Tier Requirements and Failure Disclaimer](../cloud/cloud-backup-and-restore.mdx#tier-requirements-and-failure-disclaimer)  
   * [Backup storage](../cloud/cloud-backup-and-restore.mdx#backup-storage)  
   * [Charging For Backup storage](../cloud/cloud-backup-and-restore.mdx#charging-for-backup-storage)  
   * [Backup Encryption](../cloud/cloud-backup-and-restore.mdx#backup-encryption)  
@@ -55,6 +56,44 @@ To view or activate the mandatory backup task, open your product's management st
 * Click the "Server Wide Backup" task.  
 
 !["Backup Task"](./assets/backup-and-restore-001-backup-task.png)  
+
+#### Tier Requirements and Failure Disclaimer
+
+Backups in RavenDB Cloud run **on the instance itself**, using the product's own compute, memory,
+and disk resources. Your selected tier must be sufficient to handle a full backup of every database
+hosted on that product.
+
+<Admonition type="warning" title="Ensure your tier can sustain backup operations">
+
+Key constraints to keep in mind:
+
+- The instance needs enough **free disk space** to stage the backup.
+- The backup process places **additional I/O and memory pressure** on the instance on top of
+  existing workloads during its run.
+- On undersized tiers the backup job may time out, be terminated due to memory exhaustion,
+  or fail mid-run — leaving you without a usable recovery point.
+
+**Example:** A product running on a **PS10** (entry-level Performance tier) that hosts a
+**500 GB database** will reliably fail to complete backups. The instance does not have enough
+resources — disk IOPS, memory, or both — to snapshot a database of that size. Customers in this
+situation must upgrade to a higher tier before backups can succeed.
+
+</Admonition>
+
+<Admonition type="warning" title="Liability disclaimer">
+
+RavenDB is **not liable** for backup failures caused by a product tier that is insufficient for
+the size of the databases it hosts. It is the **customer's responsibility** to ensure the selected
+tier can sustain backup operations given their data volume.
+
+If the portal surfaces a **"Last successful backup is over a day old"** alert, the most common
+cause on small tiers is that the instance ran out of resources during the backup run. Upgrade your
+product tier to resolve the issue.
+
+</Admonition>
+
+See [Tiers and Instances](../cloud/cloud-instances.mdx) for a full comparison of available tiers
+and their resource allocations.
 
 
 ## Backup storage

--- a/cloud/cloud-instances.mdx
+++ b/cloud/cloud-instances.mdx
@@ -127,6 +127,14 @@ The production tier offers three instance levels:
 1. [Basic](../cloud/cloud-instances.mdx#1-basic-grade-production-cluster)  
 2. [Standard](../cloud/cloud-instances.mdx#2-standard-grade-production-cluster)  
 3. [Performance](../cloud/cloud-instances.mdx#3-performance-grade-production-cluster)  
+
+<Admonition type="note" title="">
+The tier you select must have sufficient compute, memory, and disk resources to run backups on top
+of your normal workload. Undersized tiers can cause backup jobs to fail.  
+See [Tier Requirements and Failure Disclaimer](../cloud/cloud-backup-and-restore.mdx#tier-requirements-and-failure-disclaimer)
+for details.
+</Admonition>
+
 #### 1. Basic-grade Production Cluster
 Basic production clusters are [burstable](../cloud/cloud-overview.mdx#burstable-instances).  
 While suitable for low to medium workloads, they trade-off peak efficiency for lower costs.  

--- a/cloud/cloud-instances.mdx
+++ b/cloud/cloud-instances.mdx
@@ -128,7 +128,7 @@ The production tier offers three instance levels:
 2. [Standard](../cloud/cloud-instances.mdx#2-standard-grade-production-cluster)  
 3. [Performance](../cloud/cloud-instances.mdx#3-performance-grade-production-cluster)  
 
-<Admonition type="note" title="">
+<Admonition type="note" title="Backup resource requirements">
 The tier you select must have sufficient compute, memory, and disk resources to run backups on top
 of your normal workload. Undersized tiers can cause backup jobs to fail.  
 See [Tier Requirements and Failure Disclaimer](../cloud/cloud-backup-and-restore.mdx#tier-requirements-and-failure-disclaimer)


### PR DESCRIPTION
## Summary

- Adds a **Tier Requirements and Failure Disclaimer** subsection under _The Mandatory-Backup Routine_ in `cloud/cloud-backup-and-restore.mdx`
- Explains that mandatory backups run on the instance itself and require sufficient compute, memory, and disk — on top of existing workloads
- Includes a concrete failure example (PS10 + 500 GB database) and an explicit liability disclaimer
- Adds a cross-reference note to `cloud/cloud-instances.mdx` (Production tier section) pointing readers to the new disclaimer

## Related

- Closes [RDoc-3852](https://issues.hibernatingrhinos.com/issue/RDoc-3852)
- Related to [RDBCL-5269](https://issues.hibernatingrhinos.com/issue/RDBCL-5269) (portal "Last successful backup is over a day old" alert)

## Test plan

- [ ] Dev server renders the new warning boxes correctly in `cloud/cloud-backup-and-restore`
- [ ] Anchor link `#tier-requirements-and-failure-disclaimer` resolves
- [ ] Cross-reference note on `cloud/cloud-instances` links to the new section