### PR TITLE
RDoc-3855 - fix the clustering overview section that explains the license cores caps - per cluster & per node

### DIFF
--- a/docs/server/clustering/overview.mdx
+++ b/docs/server/clustering/overview.mdx
@@ -67,12 +67,16 @@ across a fault-tolerant, [High-Availability](https://en.wikipedia.org/wiki/High-
 
 * A cluster is limited in the maximum number of CPU cores that can be used by all of its nodes 
 at a given time.  
-* This limit is determined by the cluster's RavenDB license. For example, a Community licensed 
-cluster can have up to 3 cores. This means that when there is just one node in the cluster, it 
-can use 1-3 cores. If there are 3 nodes, each will use 1 core (since a server is allowed to be 
-assigned with at least 1 core).  
-* The number of assigned cores is divided evenly between all the nodes of a cluster.  
-* The maximum number of cores a node can use can be limited 
-  [using Studio](../../studio/cluster/cluster-view.mdx#reassign-cores).  
+* This limit is determined by the cluster's RavenDB license, which can cap both the total 
+cores used by the cluster and the cores used by any single node.  
+For example, a Community license allows up to 3 cores in the cluster, with no more than 
+2 cores on any single node:
+  * A single-node Community cluster can use up to 2 cores.  
+  * In a 3-node Community cluster each node can use only 1 core, since the cluster cap 
+    is 3 and every node must be assigned at least 1 core.  
+* By default each node uses all of its hardware cores, up to the per-node cap. To 
+lower a node's count (for example, to bring the cluster total within the cluster 
+cap), use [Reassign Cores](../../studio/cluster/cluster-view.mdx#reassign-cores) 
+in Studio.  
 </Admonition>
 

--- a/versioned_docs/version-6.2/server/clustering/overview.mdx
+++ b/versioned_docs/version-6.2/server/clustering/overview.mdx
@@ -66,12 +66,16 @@ across a fault-tolerant, [High-Availability](https://en.wikipedia.org/wiki/High-
 
 * A cluster is limited in the maximum number of CPU cores that can be used by all of its nodes 
 at a given time.  
-* This limit is determined by the cluster's RavenDB license. For example, a Community licensed 
-cluster can have up to 3 cores. This means that when there is just one node in the cluster, it 
-can use 1-3 cores. If there are 3 nodes, each will use 1 core (since a server is allowed to be 
-assigned with at least 1 core).  
-* The number of assigned cores is divided evenly between all the nodes of a cluster.  
-* The maximum number of cores a node can use can be limited 
-  [using Studio](../../studio/cluster/cluster-view.mdx#reassign-cores).  
+* This limit is determined by the cluster's RavenDB license, which can cap both the total 
+cores used by the cluster and the cores used by any single node.  
+For example, a Community license allows up to 3 cores in the cluster, with no more than 
+2 cores on any single node:
+  * A single-node Community cluster can use up to 2 cores.  
+  * In a 3-node Community cluster each node can use only 1 core, since the cluster cap 
+    is 3 and every node must be assigned at least 1 core.  
+* By default each node uses all of its hardware cores, up to the per-node cap. To 
+lower a node's count (for example, to bring the cluster total within the cluster 
+cap), use [Reassign Cores](../../studio/cluster/cluster-view.mdx#reassign-cores) 
+in Studio.  
 </Admonition>
 

--- a/versioned_docs/version-7.0/server/clustering/overview.mdx
+++ b/versioned_docs/version-7.0/server/clustering/overview.mdx
@@ -66,12 +66,16 @@ across a fault-tolerant, [High-Availability](https://en.wikipedia.org/wiki/High-
 
 * A cluster is limited in the maximum number of CPU cores that can be used by all of its nodes 
 at a given time.  
-* This limit is determined by the cluster's RavenDB license. For example, a Community licensed 
-cluster can have up to 3 cores. This means that when there is just one node in the cluster, it 
-can use 1-3 cores. If there are 3 nodes, each will use 1 core (since a server is allowed to be 
-assigned with at least 1 core).  
-* The number of assigned cores is divided evenly between all the nodes of a cluster.  
-* The maximum number of cores a node can use can be limited 
-  [using Studio](../../studio/cluster/cluster-view.mdx#reassign-cores).  
+* This limit is determined by the cluster's RavenDB license, which can cap both the total 
+cores used by the cluster and the cores used by any single node.  
+For example, a Community license allows up to 3 cores in the cluster, with no more than 
+2 cores on any single node:
+  * A single-node Community cluster can use up to 2 cores.  
+  * In a 3-node Community cluster each node can use only 1 core, since the cluster cap 
+    is 3 and every node must be assigned at least 1 core.  
+* By default each node uses all of its hardware cores, up to the per-node cap. To 
+lower a node's count (for example, to bring the cluster total within the cluster 
+cap), use [Reassign Cores](../../studio/cluster/cluster-view.mdx#reassign-cores) 
+in Studio.  
 </Admonition>
 

--- a/versioned_docs/version-7.1/server/clustering/overview.mdx
+++ b/versioned_docs/version-7.1/server/clustering/overview.mdx
@@ -66,12 +66,16 @@ across a fault-tolerant, [High-Availability](https://en.wikipedia.org/wiki/High-
 
 * A cluster is limited in the maximum number of CPU cores that can be used by all of its nodes 
 at a given time.  
-* This limit is determined by the cluster's RavenDB license. For example, a Community licensed 
-cluster can have up to 3 cores. This means that when there is just one node in the cluster, it 
-can use 1-3 cores. If there are 3 nodes, each will use 1 core (since a server is allowed to be 
-assigned with at least 1 core).  
-* The number of assigned cores is divided evenly between all the nodes of a cluster.  
-* The maximum number of cores a node can use can be limited 
-  [using Studio](../../studio/cluster/cluster-view.mdx#reassign-cores).  
+* This limit is determined by the cluster's RavenDB license, which can cap both the total 
+cores used by the cluster and the cores used by any single node.  
+For example, a Community license allows up to 3 cores in the cluster, with no more than 
+2 cores on any single node:
+  * A single-node Community cluster can use up to 2 cores.  
+  * In a 3-node Community cluster each node can use only 1 core, since the cluster cap 
+    is 3 and every node must be assigned at least 1 core.  
+* By default each node uses all of its hardware cores, up to the per-node cap. To 
+lower a node's count (for example, to bring the cluster total within the cluster 
+cap), use [Reassign Cores](../../studio/cluster/cluster-view.mdx#reassign-cores) 
+in Studio.  
 </Admonition>
 


### PR DESCRIPTION
### Issue link
[RDoc-3855](https://issues.hibernatingrhinos.com/issue/RDoc-3855)

### Additional description
fix the community-license example at the bottom of the clustering overview page

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

