### PR TITLE
RDoc-3859 Fix "Edit on GitHub" link for language-variant pages

### DIFF
--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -16,7 +16,7 @@ const getEditUrlWithLanguage = (url: string, language: DocsLanguage, supportedLa
     const path = url.substring(0, lastSlashIndex + 1);
     const filename = url.substring(lastSlashIndex + 1).replace(".mdx", "");
 
-    return `${path}_${filename}-${language}.mdx`;
+    return `${path}content/_${filename}-${language}.mdx`;
 };
 
 export default function DocItemFooter(): ReactNode {


### PR DESCRIPTION
### Issue link
[RDoc-3859](https://issues.hibernatingrhinos.com/issue/RDoc-3859) "Edit on GitHub" link generation doesn't work for language-variant pages

### Additional description


### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

