### PR TITLE
RDoc-3809 Add Python version of Setup Aggressive Caching page

### DIFF
--- a/docs/client-api/how-to/content/_setup-aggressive-caching-python.mdx
+++ b/docs/client-api/how-to/content/_setup-aggressive-caching-python.mdx
@@ -1,0 +1,432 @@
+import Admonition from '@theme/Admonition';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import Panel from '@site/src/components/Panel';
+import ContentFrame from '@site/src/components/ContentFrame';
+
+<Admonition type="note" title="">
+
+* By default, the RavenDB client caches every HTTP response and revalidates it with the server using ETags and `304 Not Modified` on every read.
+
+* Aggressive caching skips that revalidation round trip:  
+   inside an aggressive caching scope, the client serves the cached response straight from local memory without contacting the server.
+
+* Use aggressive caching where the same documents are read many times, where reference data changes rarely, and where end-to-end latency matters more than absolute freshness.
+
+* Cached entries are invalidated automatically through the [Changes API](../../../client-api/changes/what-is-changes-api.mdx).  
+   A short notification delay can briefly cause stale reads inside the scope.
+
+* Some requests bypass aggressive caching by design, including queries with `wait_for_non_stale_results()`, queries with `no_caching()`, and internal cluster traffic.
+
+---
+
+* In this article:  
+   * [Caching in RavenDB](../../../client-api/how-to/setup-aggressive-caching.mdx#caching-in-ravendb)  
+      * [Standard HTTP caching](../../../client-api/how-to/setup-aggressive-caching.mdx#standard-http-caching)  
+      * [Aggressive caching](../../../client-api/how-to/setup-aggressive-caching.mdx#aggressive-caching)  
+      * [How invalidation works](../../../client-api/how-to/setup-aggressive-caching.mdx#how-invalidation-works)  
+   * [Enable aggressive caching](../../../client-api/how-to/setup-aggressive-caching.mdx#enable-aggressive-caching)  
+      * [Enable for a scope](../../../client-api/how-to/setup-aggressive-caching.mdx#enable-for-a-scope)  
+      * [Apply to the entire application](../../../client-api/how-to/setup-aggressive-caching.mdx#apply-to-the-entire-application)  
+   * [Cache modes](../../../client-api/how-to/setup-aggressive-caching.mdx#cache-modes)  
+      * [TrackChanges](../../../client-api/how-to/setup-aggressive-caching.mdx#trackchanges)  
+      * [DoNotTrackChanges](../../../client-api/how-to/setup-aggressive-caching.mdx#donottrackchanges)  
+   * [More operations](../../../client-api/how-to/setup-aggressive-caching.mdx#more-operations)  
+      * [Opt out for a single call](../../../client-api/how-to/setup-aggressive-caching.mdx#opt-out-for-a-single-call)  
+      * [Requests that are never aggressively cached](../../../client-api/how-to/setup-aggressive-caching.mdx#requests-that-are-never-aggressively-cached)  
+      * [Common mistakes](../../../client-api/how-to/setup-aggressive-caching.mdx#common-mistakes)  
+   * [Syntax](../../../client-api/how-to/setup-aggressive-caching.mdx#syntax)  
+      * [Methods](../../../client-api/how-to/setup-aggressive-caching.mdx#methods)  
+      * [Classes](../../../client-api/how-to/setup-aggressive-caching.mdx#classes)
+
+</Admonition>
+
+<Panel heading="Caching in RavenDB">
+
+<ContentFrame>
+
+## Standard HTTP caching
+
+Reading a document from the server costs a network round trip.  
+When the same document is read repeatedly, that round trip dominates the cost of the call: the database itself can usually answer in microseconds, so cutting the round trip translates into lower latency in your application, less bandwidth use, and reduced load on the server.
+
+The RavenDB client caches every HTTP response it receives.  
+On the next read of the same data, the client sends only the cached ETag.  
+The server replies with `304 Not Modified` when nothing has changed, no payload crosses the network, and the client serves the cached value to your code as if a fresh response had arrived.  
+The total size of this cache is bounded by the [`MaxHttpCacheSize`](../../../client-api/configuration/conventions.mdx#maxhttpcachesize) convention; once the limit is reached, older entries are evicted.
+
+This standard cache is on by default and works without any setup.  
+The trade-off is that every read still costs one network round trip to confirm freshness.  
+For workloads that read the same documents over and over, that single round trip becomes the bottleneck.
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+## Aggressive caching
+
+Aggressive caching skips the round trip entirely.  
+While a request runs inside an aggressive caching scope, the client serves the cached response straight from local memory without contacting the server.  
+This is the right choice when the same documents are read many times, when reference data changes rarely, and when end-to-end latency matters more than absolute freshness.
+
+The trade-off is staleness.  
+Because the client does not revalidate on every read, a document that was modified on the server can briefly be served from the local cache until the change is propagated back to the client.  
+RavenDB narrows that window by listening for change notifications from the server and evicting matching cache entries as soon as they arrive.
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+## How invalidation works
+
+The first time aggressive caching is enabled for a database, the client opens a [Changes API](../../../client-api/changes/what-is-changes-api.mdx) subscription to that database.  
+The subscription stays open for as long as the document store is alive and is shared by every aggressive scope opened against the same database.
+
+When a document or index is modified on the server, the server publishes a change notification on that subscription.  
+The client treats that as a signal that the local cache may be stale and marks every aggressively-cached entry for revalidation.  
+The next read of each entry sends a single conditional request (`If-None-Match`) and is served from the cache as soon as the server confirms the entry is unchanged with `304 Not Modified`.  
+Entries that are not read again stay marked until they are.  
+No application code is required for any of this; the client wires up the listener for you.
+
+If the Changes API connection drops, the client invalidates the entire cache as a safety measure.  
+The next read of any aggressively cached entry is sent to the server for revalidation.
+
+<Admonition type="warning" title="">
+
+There is a short delay between the moment a document is modified on the server and the moment the change notification reaches the client.  
+A read that hits the aggressive cache during that window will return the previous value of the document.  
+Use aggressive caching only when this small staleness window is acceptable for the calling code.  
+For requests that must always see the most recent committed state, use the bypass options under [Opt out for a single call](../../../client-api/how-to/setup-aggressive-caching.mdx#opt-out-for-a-single-call) and [Requests that are never aggressively cached](../../../client-api/how-to/setup-aggressive-caching.mdx#requests-that-are-never-aggressively-cached).
+
+</Admonition>
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Enable aggressive caching">
+
+Aggressive caching is enabled for a scope that you define with a `with` block over the context manager returned by `aggressively_cache_for`.  
+The configuration applies to every request issued from inside that `with` block on the same thread.  
+When the `with` block exits, the previous configuration is restored automatically.
+
+<ContentFrame>
+
+## Enable for a scope
+
+Call `aggressively_cache_for` with a duration and wrap the code that should use the cache in a `with` block:
+
+```python
+from datetime import timedelta
+
+with document_store.aggressively_cache_for(timedelta(minutes=5)):
+    with document_store.open_session() as session:
+        # Reads in this scope are served from the local cache when the
+        # cached entry is younger than 5 minutes and has not been
+        # invalidated by a change notification from the server.
+        order = session.load("orders/1-A", Order)
+```
+
+<br />
+
+The `cache_duration` value is the maximum age allowed for a cached entry.  
+While the entry is younger than this value, the client serves it locally.  
+Once it ages past the value, or when a change notification invalidates it earlier, the client fetches a fresh copy from the server on the next read.
+
+The same rules apply to queries that run inside the scope.
+
+The right duration depends on how stale the calling code can tolerate the data being if the change notification is delayed or missed.  
+Reference data that changes rarely is a good fit for hours or days; hot reads where you still want some safety net work well at minutes; when the calling code must always see the latest committed value, do not use aggressive caching at all and rely on the standard 304 cache instead.
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+## Apply to the entire application
+
+If aggressive caching is the right policy for the whole application, open one scope at startup and exit it during shutdown by calling the context manager's `__exit__` (or by entering it under a long-lived `with` block):
+
+```python
+from datetime import timedelta
+
+aggressive_scope = document_store.aggressively_cache_for(timedelta(minutes=5))
+aggressive_scope.__enter__()
+
+# ... the application runs and serves requests ...
+
+aggressive_scope.__exit__(None, None, None)  # typically called when the application shuts down
+```
+
+<br />
+
+The mechanism is identical to a short-lived `with` block; only the moment of disposal differs.  
+There is no separate "global" mode on the document store.
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Cache modes">
+
+The `AggressiveCacheMode` enum controls whether the client subscribes to the Changes API to invalidate cached entries within an aggressive scope.
+
+<ContentFrame>
+
+## TrackChanges
+
+This is the default value.  
+The client opens a Changes API connection to the database and listens for notifications about modified documents and indexes.  
+A cache entry is evicted as soon as the matching notification arrives.  
+A request inside the aggressive scope serves a cached value only when the entry has not been flagged as modified.
+
+This is the right mode for most applications: aggressive caching skips the round trip on stable data, and changes still propagate to the client within the notification delay.
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+## DoNotTrackChanges
+
+The client does not open a Changes API connection.  
+Cached entries are served for the entire duration of the scope without any revalidation, no matter what happens on the server.
+
+Use this mode when you explicitly accept stale reads in exchange for not maintaining a Changes API connection.  
+For example, when the duration is short enough that staleness is bounded by it, or when the client is running in an environment where the Changes WebSocket is undesirable.
+
+```python
+from datetime import timedelta
+from ravendb.http.misc import AggressiveCacheMode
+
+with document_store.aggressively_cache_for(timedelta(minutes=5),
+                                           mode=AggressiveCacheMode.DO_NOT_TRACK_CHANGES):
+    # Reads here are served from the cache for up to 5 minutes
+    # and ignore any changes published by the server.
+    ...
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="More operations">
+
+<ContentFrame>
+
+## Opt out for a single call
+
+When your code runs inside an aggressive scope opened higher up the call stack and one specific read needs to reach the server anyway (for example, right after a write you just performed), wrap that read in a `with` block over `disable_aggressive_caching()`.  
+The context manager restores the enclosing aggressive configuration when the inner scope ends.
+
+```python
+from datetime import timedelta
+
+with document_store.aggressively_cache_for(timedelta(minutes=5)):
+    with document_store.open_session() as session:
+        cached = session.load("orders/1-A", Order)  # may be served from the cache
+
+        with document_store.disable_aggressive_caching():
+            fresh = session.load("orders/1-A", Order)  # forced server round trip
+```
+
+<br />
+
+`disable_aggressive_caching()` only suspends aggressive caching.  
+The standard 304-based HTTP cache still runs.  
+To disable HTTP caching as well, see [Disable Caching per Session](../../../client-api/session/configuration/how-to-disable-caching.mdx) and the [`MaxHttpCacheSize`](../../../client-api/configuration/conventions.mdx#maxhttpcachesize) convention.
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+## Requests that are never aggressively cached
+
+Some requests bypass aggressive caching regardless of the active scope:
+
+| Request | Aggressively cached? | Notes |
+|---|---|---|
+| `session.load`, `session.include`, etc. | Yes | Default behavior. |
+| Query without `wait_for_non_stale_results()` | Yes | Default behavior. |
+| Query with `wait_for_non_stale_results()` | No | Aggressive caching is suppressed because the caller explicitly asked for non-stale data. |
+| Query with `no_caching()` | No | Caching is disabled for the request entirely, both standard and aggressive. |
+| Lazy query, lazy suggestion query | Same rule as the non-lazy form | Lazy operations are bundled into a single MultiGet request. Aggressive caching can only short-circuit the batch when every operation in it is aggressively cacheable; if any one operation has `wait_for_non_stale_results()` or `no_caching()` set, the entire batch is sent to the server (individual operations can still be served from the standard 304 cache on the response path). See [Perform queries lazily](../../../client-api/session/how-to/perform-operations-lazily.mdx). |
+| Internal cluster bookkeeping | No | Topology and similar maintenance traffic is never aggressively cached. |
+
+A session opened with `SessionOptions(no_caching=True)` disables HTTP caching for every request that session issues, including aggressive caching.  
+See [Disable Caching per Session](../../../client-api/session/configuration/how-to-disable-caching.mdx).
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+## Common mistakes
+
+<Admonition type="warning" title="">
+
+* Forgetting to exit the returned context manager.  
+   The object returned by `aggressively_cache_for` controls the lifetime of the scope.  
+   Without a `with` block, or an explicit call to `__exit__`, the scope stays attached to the current thread (`threading.local`-based) and applies to whatever runs on that thread next, including subsequent requests in long-lived hosts where threads are recycled.
+
+* Expecting the scope to be tied to a specific session.  
+   The configuration lives on the request executor, not on the session.  
+   A session opened inside the `with` block uses the scope.  
+   A session opened outside the block does not.
+
+* Expecting the scope to cross threads.  
+   The scope is stored in `threading.local`, so it applies only to the thread that entered the `with` block.  
+   Code that hands work off to a worker thread or thread pool must re-enter an aggressive scope on that thread.
+
+* Expecting `wait_for_non_stale_results()` to honor the cache.  
+   Queries with `wait_for_non_stale_results()` always reach the server and never read from the aggressive cache.
+
+* Treating duration as a refresh interval.  
+   The `cache_duration` is the maximum age allowed for a cached entry.  
+   In `TRACK_CHANGES` mode, an entry can also be evicted earlier when the server publishes a change notification.
+
+</Admonition>
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Syntax">
+
+<ContentFrame>
+
+## Methods
+
+<Tabs groupId='aggressive-caching-methods'>
+<TabItem value="aggressively_cache_for" label="aggressively_cache_for">
+
+Open an aggressive caching scope for the calling code.
+
+```python
+def aggressively_cache_for(
+    self,
+    cache_duration: datetime.timedelta,
+    database: Optional[str] = None,
+    mode: Optional[AggressiveCacheMode] = None,
+): ...
+```
+
+<br />
+
+Usage:
+
+```python
+from datetime import timedelta
+from ravendb.http.misc import AggressiveCacheMode
+
+with document_store.aggressively_cache_for(timedelta(minutes=5),
+                                           mode=AggressiveCacheMode.TRACK_CHANGES):
+    with document_store.open_session() as session:
+        order = session.load("orders/1-A", Order)
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **cache_duration** | `datetime.timedelta` | Maximum age allowed for a cached entry to be served from the local cache without contacting the server. |
+| **database** | `Optional[str]` | The database the scope applies to. When `None`, the document store's default database is used. |
+| **mode** | `Optional[AggressiveCacheMode]` | Whether to track server-side changes for cache invalidation. When `None`, defaults to `AggressiveCacheMode.TRACK_CHANGES`. |
+
+| Return value | |
+|-----------|-------------|
+| Context manager | A context manager whose exit restores the previous aggressive caching configuration on the current thread. |
+
+</TabItem>
+<TabItem value="disable_aggressive_caching" label="disable_aggressive_caching">
+
+Suppress aggressive caching inside an enclosing scope. Standard HTTP caching is unaffected.
+
+```python
+def disable_aggressive_caching(self, database: Optional[str] = None): ...
+```
+
+<br />
+
+Usage:
+
+```python
+from datetime import timedelta
+
+with document_store.aggressively_cache_for(timedelta(minutes=5)):
+    with document_store.disable_aggressive_caching():
+        # Requests issued in this inner scope reach the server.
+        ...
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `Optional[str]` | The database the scope applies to. When `None`, the document store's default database is used. |
+
+| Return value | |
+|-----------|-------------|
+| Context manager | A context manager whose exit restores the enclosing aggressive caching configuration on the current thread. |
+
+</TabItem>
+</Tabs>
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+## Classes
+
+<Tabs groupId='aggressive-caching-classes'>
+<TabItem value="AggressiveCacheOptions" label="AggressiveCacheOptions">
+
+```python
+class AggressiveCacheOptions:
+    def __init__(self, duration: datetime.timedelta, mode: AggressiveCacheMode): ...
+
+    duration: datetime.timedelta
+    mode: AggressiveCacheMode
+```
+
+<br />
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| **duration** | `datetime.timedelta` | Maximum age allowed for a cached entry to be served without contacting the server. |
+| **mode** | `AggressiveCacheMode` | Whether the client tracks server-side changes for cache invalidation. |
+
+</TabItem>
+<TabItem value="AggressiveCacheMode" label="AggressiveCacheMode">
+
+```python
+class AggressiveCacheMode(Enum):
+    TRACK_CHANGES = "TrackChanges"
+    DO_NOT_TRACK_CHANGES = "DoNotTrackChanges"
+```
+
+<br />
+
+| Value | Description |
+|-----------|-------------|
+| **TRACK_CHANGES** | Default. The client subscribes to the Changes API and evicts cached entries as soon as a notification arrives. |
+| **DO_NOT_TRACK_CHANGES** | The client does not subscribe to the Changes API. Cached entries are served for the entire duration of the scope. |
+
+</TabItem>
+</Tabs>
+
+</ContentFrame>
+
+</Panel>

--- a/docs/client-api/how-to/setup-aggressive-caching.mdx
+++ b/docs/client-api/how-to/setup-aggressive-caching.mdx
@@ -3,7 +3,7 @@ title: "Client API: How to Setup Aggressive Caching"
 sidebar_label: ...setup aggressive caching
 description: "Enable aggressive caching in the RavenDB client to serve requests from local cache and reduce server round trips for read-heavy workloads."
 sidebar_position: 0
-supported_languages: ["csharp", "java"]
+supported_languages: ["csharp", "java", "python"]
 see_also:
      - title: "Conventions"
        link: "client-api/configuration/conventions"
@@ -24,6 +24,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import SetupAggressiveCachingCsharp from './content/_setup-aggressive-caching-csharp.mdx';
 import SetupAggressiveCachingJava from './content/_setup-aggressive-caching-java.mdx';
+import SetupAggressiveCachingPython from './content/_setup-aggressive-caching-python.mdx';
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
@@ -33,4 +34,8 @@ import SetupAggressiveCachingJava from './content/_setup-aggressive-caching-java
 
 <LanguageContent language="java">
    <SetupAggressiveCachingJava />
+</LanguageContent>
+
+<LanguageContent language="python">
+   <SetupAggressiveCachingPython />
 </LanguageContent>


### PR DESCRIPTION
### Issue link
[RDoc-3809](https://issues.hibernatingrhinos.com/issue/RDoc-3809) [Python] create a Python version for the aggressive caching page

### Additional description
adds python version of aggressive caching docs

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

