### PR TITLE
RDoc-3818 - Document responsible-node and grace-period behavior for backup tasks

### DIFF
--- a/docs/backup/configuration.mdx
+++ b/docs/backup/configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Backup configuration options"
 sidebar_label: "Configuration options"
+description: "Server-wide configuration keys that control backup behavior: paths, allowed destinations, concurrency, low-memory delays, and the responsible-node grace period."
 sidebar_position: 85
 ---
 
@@ -29,6 +30,7 @@ Learn how to apply these keys in the [Configuration Overview](../server/configur
     * [Backup.MaxNumberOfConcurrentBackups](../backup/configuration#backupmaxnumberofconcurrentbackups)  
     * [Backup.ConcurrentBackupsDelayInSec](../backup/configuration#backupconcurrentbackupsdelayinsec)  
     * [Backup.LowMemoryBackupDelayInMin](../backup/configuration#backuplowmemorybackupdelayinmin)  
+    * [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../backup/configuration#backupmovetonewresponsiblenodegraceperiodinmin)  
     * [Server.CpuCredits.ExhaustionBackupDelayInMin](../backup/configuration#servercpucreditsexhaustionbackupdelayinmin)
 
 </Admonition>
@@ -152,6 +154,26 @@ Number of minutes to delay the backup if the server enters a low-memory state.
 - **Type**: `TimeSetting`  
 - **TimeUnit**: `TimeUnit.Minutes`  
 - **Default**: `10`  
+- **Scope**: Server-wide only  
+
+</ContentFrame>
+
+<ContentFrame>
+
+### Backup.MoveToNewResponsibleNodeGracePeriodInMin
+
+Number of minutes the [cluster observer](../server/clustering/distribution/cluster-observer.mdx) waits
+before reassigning a backup task to a new responsible node,
+when the current responsible node has entered the
+[Rehab state](../server/clustering/distribution/distributed-database.mdx#database-topology).  
+
+During this grace period, the task remains assigned to its current responsible node.  
+This gives the node a chance to recover, and prevents a duplicate backup
+from starting elsewhere in the cluster.  
+
+- **Type**: `TimeSetting`  
+- **TimeUnit**: `TimeUnit.Minutes`  
+- **Default**: `30`  
 - **Scope**: Server-wide only  
 
 </ContentFrame>

--- a/docs/backup/faq.mdx
+++ b/docs/backup/faq.mdx
@@ -162,18 +162,30 @@ to another database-group member.
 The grace period gives the original node a chance to recover,
 and prevents the same backup from running on two nodes at once.  
 
-When you create a backup task, you can pick the responsible node yourself,
-or leave it for the cluster to decide.  
-The choice (yours or the cluster's) is persisted cluster-wide,
-so all nodes agree on a single responsible node for the task.  
+* **Who picks the responsible node:**  
+  When you create a backup task, you can pick the responsible node yourself,
+  or leave it for the cluster to decide.  
+  The choice (yours or the cluster's) is persisted cluster-wide,
+  so all nodes agree on a single responsible node for the task.  
 
-If the current responsible node is in Rehab due to resource constraints on the host machine,
-the cluster observer will leave the backup task on the same node rather than reassign it.  
-The backup will run on that node once it recovers,
-or be reassigned to another node if this one is eventually removed from the database group.  
+* **If the node is in Rehab due to resource constraints on the host machine:**  
+  The cluster observer will leave the backup task on the same node rather than reassign it.  
+  The backup will run on that node once it recovers,
+  or be reassigned to another node if this one is eventually removed from the database group.  
 
 The grace period is configurable via
 [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../backup/configuration#backupmovetonewresponsiblenodegraceperiodinmin).
+
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to the behavior described above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves to another node when its pinned node is removed from the database group.  
+See [Pinning a Task](../server/clustering/distribution/highly-available-tasks.mdx#pinning-a-task) for the full behavior.
+
+</Admonition>
 
 </ContentFrame>
 

--- a/docs/backup/faq.mdx
+++ b/docs/backup/faq.mdx
@@ -1,6 +1,7 @@
 ---
 title: "FAQ"
 sidebar_label: "FAQ"
+description: "Frequently asked questions about backup and restore in RavenDB: one-time backups, server-wide backups, retention, failure handling, and behavior in a cluster."
 sidebar_position: 90
 ---
 
@@ -152,7 +153,27 @@ For example, you can set a backup task to keep backups locally as well as send t
 
 ### What happens if the node responsible for a backup task is down?
 
-When the responsible node is down during the scheduled time, another node from the database group will assume ownership of the task, so there will be no gaps in the backup schedule.
+When the responsible node enters the
+[Rehab state](../server/clustering/distribution/distributed-database.mdx#database-topology),
+the [cluster observer](../server/clustering/distribution/cluster-observer.mdx)
+does not move the backup task immediately.  
+Instead, it waits a grace period (30 minutes by default) before reassigning the task
+to another database-group member.  
+The grace period gives the original node a chance to recover,
+and prevents the same backup from running on two nodes at once.  
+
+When you create a backup task, you can pick the responsible node yourself,
+or leave it for the cluster to decide.  
+The choice (yours or the cluster's) is persisted cluster-wide,
+so all nodes agree on a single responsible node for the task.  
+
+If the current responsible node is in Rehab due to resource constraints on the host machine,
+the cluster observer will leave the backup task on the same node rather than reassign it.  
+The backup will run on that node once it recovers,
+or be reassigned to another node if this one is eventually removed from the database group.  
+
+The grace period is configurable via
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../backup/configuration#backupmovetonewresponsiblenodegraceperiodinmin).
 
 </ContentFrame>
 

--- a/docs/server/clustering/distribution/highly-available-tasks.mdx
+++ b/docs/server/clustering/distribution/highly-available-tasks.mdx
@@ -104,6 +104,17 @@ The grace period is set by
 
 </Admonition>
 
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to all of the above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves when its pinned node is removed from the database group.  
+See [Pinning a Task](#pinning-a-task) below for the full behavior.
+
+</Admonition>
+
 
 
 ## Tasks Relocation
@@ -152,6 +163,12 @@ The failover of a task to another responsible node can be prevented by **pinning
   [cluster.timebeforeaddingreplicainsec](../../../server/configuration/cluster-configuration.mdx#clustertimebeforeaddingreplicainsec), 
   the cluster observer will attempt to select an available node to replace it in the database group 
   and redistribute the fallen node's tasks, including pinned ones, among database group members.  
+* A pinned **backup task** is also not subject to the
+  [grace period](../../../backup/configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin)
+  that the cluster observer otherwise applies before reassigning a backup task.  
+  The pinned backup stays on its node even while the node is in Rehab,
+  and only moves when the cluster eventually replaces the node as described above.  
+
 A task can be pinned to a selected node via Studio or using code.  
 
 #### Pinning via Studio

--- a/docs/server/clustering/distribution/highly-available-tasks.mdx
+++ b/docs/server/clustering/distribution/highly-available-tasks.mdx
@@ -84,6 +84,26 @@ Learn more [here](../../../server/clustering/distribution/distributed-database.m
 about database nodes' relations and states. 
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Backup tasks are an exception** to the local-decision model described above.  
+
+For backup tasks, the responsible node is either picked when the task is created
+(via the **Set responsible node** option in Studio, or `MentorNode` via the API),
+or chosen by the [cluster observer](../../../server/clustering/distribution/cluster-observer.mdx)
+when no explicit choice was made.  
+Either way, the choice is persisted cluster-wide,
+so all nodes agree on a single responsible node.  
+
+When the current responsible node enters the `Rehab` state,
+the cluster observer waits a configurable grace period (30 minutes by default)
+before moving the task to another node.  
+This prevents the same backup from running on two nodes at once.  
+The grace period is set by
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../backup/configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
+
+</Admonition>
+
 
 
 ## Tasks Relocation

--- a/versioned_docs/version-6.2/client-api/operations/maintenance/backup/faq.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/maintenance/backup/faq.mdx
@@ -23,6 +23,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
   * [Does RavenDB automatically delete old backups?](../../../../client-api/operations/maintenance/backup/faq.mdx#does-ravendb-automatically-delete-old-backups)  
   * [Are there any locations that backup files should NOT be stored at?](../../../../client-api/operations/maintenance/backup/faq.mdx#are-there-any-locations-that-backup-files-should-not-be-stored-at)  
   * [What happens when a backup process fails before it is completed?](../../../../client-api/operations/maintenance/backup/faq.mdx#what-happens-when-a-backup-process-fails-before-completion)  
+  * [What happens if the node responsible for a backup task is down?](../../../../client-api/operations/maintenance/backup/faq.mdx#what-happens-if-the-node-responsible-for-a-backup-task-is-down)  
 
 </Admonition>
 ## FAQ
@@ -107,6 +108,30 @@ While in progress, the backup content is written to an **.in-progress* file on d
   This file will not be used in any future Restore processes.  
   If the failed process was an incremental-backup task, any future incremental backups will 
   continue from the correct place before the file was created so that the backup is consistent with the source.  
+
+### What happens if the node responsible for a backup task is down?
+
+When the responsible node enters the
+[Rehab state](../../../../server/clustering/distribution/distributed-database.mdx#database-topology),
+the [cluster observer](../../../../server/clustering/distribution/cluster-observer.mdx)
+does not move the backup task immediately.  
+Instead, it waits a grace period (30 minutes by default) before reassigning the task
+to another database-group member.  
+The grace period gives the original node a chance to recover,
+and prevents the same backup from running on two nodes at once.  
+
+When you create a backup task, you can pick the responsible node yourself,
+or leave it for the cluster to decide.  
+The choice (yours or the cluster's) is persisted cluster-wide,
+so all nodes agree on a single responsible node for the task.  
+
+If the current responsible node is in Rehab due to resource constraints on the host machine,
+the cluster observer will leave the backup task on the same node rather than reassign it.  
+The backup will run on that node once it recovers,
+or be reassigned to another node if this one is eventually removed from the database group.  
+
+The grace period is configurable via
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
 
 
 

--- a/versioned_docs/version-6.2/client-api/operations/maintenance/backup/faq.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/maintenance/backup/faq.mdx
@@ -120,18 +120,30 @@ to another database-group member.
 The grace period gives the original node a chance to recover,
 and prevents the same backup from running on two nodes at once.  
 
-When you create a backup task, you can pick the responsible node yourself,
-or leave it for the cluster to decide.  
-The choice (yours or the cluster's) is persisted cluster-wide,
-so all nodes agree on a single responsible node for the task.  
+* **Who picks the responsible node:**  
+  When you create a backup task, you can pick the responsible node yourself,
+  or leave it for the cluster to decide.  
+  The choice (yours or the cluster's) is persisted cluster-wide,
+  so all nodes agree on a single responsible node for the task.  
 
-If the current responsible node is in Rehab due to resource constraints on the host machine,
-the cluster observer will leave the backup task on the same node rather than reassign it.  
-The backup will run on that node once it recovers,
-or be reassigned to another node if this one is eventually removed from the database group.  
+* **If the node is in Rehab due to resource constraints on the host machine:**  
+  The cluster observer will leave the backup task on the same node rather than reassign it.  
+  The backup will run on that node once it recovers,
+  or be reassigned to another node if this one is eventually removed from the database group.  
 
 The grace period is configurable via
 [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
+
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to the behavior described above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves to another node when its pinned node is removed from the database group.  
+See [Pinning a Task](../../../../server/clustering/distribution/highly-available-tasks.mdx#pinning-a-task) for the full behavior.
+
+</Admonition>
 
 
 

--- a/versioned_docs/version-6.2/server/clustering/distribution/highly-available-tasks.mdx
+++ b/versioned_docs/version-6.2/server/clustering/distribution/highly-available-tasks.mdx
@@ -103,6 +103,17 @@ The grace period is set by
 
 </Admonition>
 
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to all of the above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves when its pinned node is removed from the database group.  
+See [Pinning a Task](#pinning-a-task) below for the full behavior.
+
+</Admonition>
+
 
 
 ## Tasks Relocation
@@ -151,6 +162,12 @@ The failover of a task to another responsible node can be prevented by **pinning
   [cluster.timebeforeaddingreplicainsec](../../../server/configuration/cluster-configuration.mdx#clustertimebeforeaddingreplicainsec), 
   the cluster observer will attempt to select an available node to replace it in the database group 
   and redistribute the fallen node's tasks, including pinned ones, among database group members.  
+* A pinned **backup task** is also not subject to the
+  [grace period](../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin)
+  that the cluster observer otherwise applies before reassigning a backup task.  
+  The pinned backup stays on its node even while the node is in Rehab,
+  and only moves when the cluster eventually replaces the node as described above.  
+
 A task can be pinned to a selected node via Studio or using code.  
 
 #### Pinning via Studio

--- a/versioned_docs/version-6.2/server/clustering/distribution/highly-available-tasks.mdx
+++ b/versioned_docs/version-6.2/server/clustering/distribution/highly-available-tasks.mdx
@@ -83,6 +83,26 @@ Learn more [here](../../../server/clustering/distribution/distributed-database.m
 about database nodes' relations and states. 
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Backup tasks are an exception** to the local-decision model described above.  
+
+For backup tasks, the responsible node is either picked when the task is created
+(via the **Set responsible node** option in Studio, or `MentorNode` via the API),
+or chosen by the [cluster observer](../../../server/clustering/distribution/cluster-observer.mdx)
+when no explicit choice was made.  
+Either way, the choice is persisted cluster-wide,
+so all nodes agree on a single responsible node.  
+
+When the current responsible node enters the `Rehab` state,
+the cluster observer waits a configurable grace period (30 minutes by default)
+before moving the task to another node.  
+This prevents the same backup from running on two nodes at once.  
+The grace period is set by
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
+
+</Admonition>
+
 
 
 ## Tasks Relocation

--- a/versioned_docs/version-6.2/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-6.2/server/configuration/backup-configuration.mdx
@@ -26,6 +26,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
     * [Backup.MaxNumberOfConcurrentBackups](../../server/configuration/backup-configuration.mdx#backupmaxnumberofconcurrentbackups)  
     * [Backup.ConcurrentBackupsDelayInSec](../../server/configuration/backup-configuration.mdx#backupconcurrentbackupsdelayinsec)  
     * [Backup.LowMemoryBackupDelayInMin](../../server/configuration/backup-configuration.mdx#backuplowmemorybackupdelayinmin)  
+    * [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin)  
 
 </Admonition>
 ## Backup.TempPath
@@ -108,6 +109,24 @@ Number of minutes to delay the backup if the server enters a low memory state.
 - **Type**: `TimeSetting`  
 - **TimeUnit**: `TimeUnit.Minutes`  
 - **Default**: `10`  
+- **Scope**: Server-wide only  
+
+
+
+## Backup.MoveToNewResponsibleNodeGracePeriodInMin
+
+Number of minutes the [cluster observer](../../server/clustering/distribution/cluster-observer.mdx) waits
+before reassigning a backup task to a new responsible node,
+when the current responsible node has entered the
+[Rehab state](../../server/clustering/distribution/distributed-database.mdx#database-topology).  
+
+During this grace period, the task remains assigned to its current responsible node.  
+This gives the node a chance to recover, and prevents a duplicate backup
+from starting elsewhere in the cluster.  
+
+- **Type**: `TimeSetting`  
+- **TimeUnit**: `TimeUnit.Minutes`  
+- **Default**: `30`  
 - **Scope**: Server-wide only  
 
 

--- a/versioned_docs/version-7.0/client-api/operations/maintenance/backup/faq.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/maintenance/backup/faq.mdx
@@ -23,6 +23,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
   * [Does RavenDB automatically delete old backups?](../../../../client-api/operations/maintenance/backup/faq.mdx#does-ravendb-automatically-delete-old-backups)  
   * [Are there any locations that backup files should NOT be stored at?](../../../../client-api/operations/maintenance/backup/faq.mdx#are-there-any-locations-that-backup-files-should-not-be-stored-at)  
   * [What happens when a backup process fails before it is completed?](../../../../client-api/operations/maintenance/backup/faq.mdx#what-happens-when-a-backup-process-fails-before-completion)  
+  * [What happens if the node responsible for a backup task is down?](../../../../client-api/operations/maintenance/backup/faq.mdx#what-happens-if-the-node-responsible-for-a-backup-task-is-down)  
 
 </Admonition>
 ## FAQ
@@ -107,6 +108,30 @@ While in progress, the backup content is written to an **.in-progress* file on d
   This file will not be used in any future Restore processes.  
   If the failed process was an incremental-backup task, any future incremental backups will 
   continue from the correct place before the file was created so that the backup is consistent with the source.  
+
+### What happens if the node responsible for a backup task is down?
+
+When the responsible node enters the
+[Rehab state](../../../../server/clustering/distribution/distributed-database.mdx#database-topology),
+the [cluster observer](../../../../server/clustering/distribution/cluster-observer.mdx)
+does not move the backup task immediately.  
+Instead, it waits a grace period (30 minutes by default) before reassigning the task
+to another database-group member.  
+The grace period gives the original node a chance to recover,
+and prevents the same backup from running on two nodes at once.  
+
+When you create a backup task, you can pick the responsible node yourself,
+or leave it for the cluster to decide.  
+The choice (yours or the cluster's) is persisted cluster-wide,
+so all nodes agree on a single responsible node for the task.  
+
+If the current responsible node is in Rehab due to resource constraints on the host machine,
+the cluster observer will leave the backup task on the same node rather than reassign it.  
+The backup will run on that node once it recovers,
+or be reassigned to another node if this one is eventually removed from the database group.  
+
+The grace period is configurable via
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
 
 
 

--- a/versioned_docs/version-7.0/client-api/operations/maintenance/backup/faq.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/maintenance/backup/faq.mdx
@@ -120,18 +120,30 @@ to another database-group member.
 The grace period gives the original node a chance to recover,
 and prevents the same backup from running on two nodes at once.  
 
-When you create a backup task, you can pick the responsible node yourself,
-or leave it for the cluster to decide.  
-The choice (yours or the cluster's) is persisted cluster-wide,
-so all nodes agree on a single responsible node for the task.  
+* **Who picks the responsible node:**  
+  When you create a backup task, you can pick the responsible node yourself,
+  or leave it for the cluster to decide.  
+  The choice (yours or the cluster's) is persisted cluster-wide,
+  so all nodes agree on a single responsible node for the task.  
 
-If the current responsible node is in Rehab due to resource constraints on the host machine,
-the cluster observer will leave the backup task on the same node rather than reassign it.  
-The backup will run on that node once it recovers,
-or be reassigned to another node if this one is eventually removed from the database group.  
+* **If the node is in Rehab due to resource constraints on the host machine:**  
+  The cluster observer will leave the backup task on the same node rather than reassign it.  
+  The backup will run on that node once it recovers,
+  or be reassigned to another node if this one is eventually removed from the database group.  
 
 The grace period is configurable via
 [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
+
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to the behavior described above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves to another node when its pinned node is removed from the database group.  
+See [Pinning a Task](../../../../server/clustering/distribution/highly-available-tasks.mdx#pinning-a-task) for the full behavior.
+
+</Admonition>
 
 
 

--- a/versioned_docs/version-7.0/server/clustering/distribution/highly-available-tasks.mdx
+++ b/versioned_docs/version-7.0/server/clustering/distribution/highly-available-tasks.mdx
@@ -103,6 +103,17 @@ The grace period is set by
 
 </Admonition>
 
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to all of the above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves when its pinned node is removed from the database group.  
+See [Pinning a Task](#pinning-a-task) below for the full behavior.
+
+</Admonition>
+
 
 
 ## Tasks Relocation
@@ -151,6 +162,12 @@ The failover of a task to another responsible node can be prevented by **pinning
   [cluster.timebeforeaddingreplicainsec](../../../server/configuration/cluster-configuration.mdx#clustertimebeforeaddingreplicainsec), 
   the cluster observer will attempt to select an available node to replace it in the database group 
   and redistribute the fallen node's tasks, including pinned ones, among database group members.  
+* A pinned **backup task** is also not subject to the
+  [grace period](../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin)
+  that the cluster observer otherwise applies before reassigning a backup task.  
+  The pinned backup stays on its node even while the node is in Rehab,
+  and only moves when the cluster eventually replaces the node as described above.  
+
 A task can be pinned to a selected node via Studio or using code.  
 
 #### Pinning via Studio

--- a/versioned_docs/version-7.0/server/clustering/distribution/highly-available-tasks.mdx
+++ b/versioned_docs/version-7.0/server/clustering/distribution/highly-available-tasks.mdx
@@ -83,6 +83,26 @@ Learn more [here](../../../server/clustering/distribution/distributed-database.m
 about database nodes' relations and states. 
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Backup tasks are an exception** to the local-decision model described above.  
+
+For backup tasks, the responsible node is either picked when the task is created
+(via the **Set responsible node** option in Studio, or `MentorNode` via the API),
+or chosen by the [cluster observer](../../../server/clustering/distribution/cluster-observer.mdx)
+when no explicit choice was made.  
+Either way, the choice is persisted cluster-wide,
+so all nodes agree on a single responsible node.  
+
+When the current responsible node enters the `Rehab` state,
+the cluster observer waits a configurable grace period (30 minutes by default)
+before moving the task to another node.  
+This prevents the same backup from running on two nodes at once.  
+The grace period is set by
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
+
+</Admonition>
+
 
 
 ## Tasks Relocation

--- a/versioned_docs/version-7.0/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-7.0/server/configuration/backup-configuration.mdx
@@ -26,6 +26,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
     * [Backup.MaxNumberOfConcurrentBackups](../../server/configuration/backup-configuration.mdx#backupmaxnumberofconcurrentbackups)  
     * [Backup.ConcurrentBackupsDelayInSec](../../server/configuration/backup-configuration.mdx#backupconcurrentbackupsdelayinsec)  
     * [Backup.LowMemoryBackupDelayInMin](../../server/configuration/backup-configuration.mdx#backuplowmemorybackupdelayinmin)  
+    * [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin)  
 
 </Admonition>
 ## Backup.TempPath
@@ -108,6 +109,24 @@ Number of minutes to delay the backup if the server enters a low memory state.
 - **Type**: `TimeSetting`  
 - **TimeUnit**: `TimeUnit.Minutes`  
 - **Default**: `10`  
+- **Scope**: Server-wide only  
+
+
+
+## Backup.MoveToNewResponsibleNodeGracePeriodInMin
+
+Number of minutes the [cluster observer](../../server/clustering/distribution/cluster-observer.mdx) waits
+before reassigning a backup task to a new responsible node,
+when the current responsible node has entered the
+[Rehab state](../../server/clustering/distribution/distributed-database.mdx#database-topology).  
+
+During this grace period, the task remains assigned to its current responsible node.  
+This gives the node a chance to recover, and prevents a duplicate backup
+from starting elsewhere in the cluster.  
+
+- **Type**: `TimeSetting`  
+- **TimeUnit**: `TimeUnit.Minutes`  
+- **Default**: `30`  
 - **Scope**: Server-wide only  
 
 

--- a/versioned_docs/version-7.1/client-api/operations/maintenance/backup/faq.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/maintenance/backup/faq.mdx
@@ -23,6 +23,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
   * [Does RavenDB automatically delete old backups?](../../../../client-api/operations/maintenance/backup/faq.mdx#does-ravendb-automatically-delete-old-backups)  
   * [Are there any locations that backup files should NOT be stored at?](../../../../client-api/operations/maintenance/backup/faq.mdx#are-there-any-locations-that-backup-files-should-not-be-stored-at)  
   * [What happens when a backup process fails before it is completed?](../../../../client-api/operations/maintenance/backup/faq.mdx#what-happens-when-a-backup-process-fails-before-completion)  
+  * [What happens if the node responsible for a backup task is down?](../../../../client-api/operations/maintenance/backup/faq.mdx#what-happens-if-the-node-responsible-for-a-backup-task-is-down)  
 
 </Admonition>
 ## FAQ
@@ -107,6 +108,30 @@ While in progress, the backup content is written to an **.in-progress* file on d
   This file will not be used in any future Restore processes.  
   If the failed process was an incremental-backup task, any future incremental backups will 
   continue from the correct place before the file was created so that the backup is consistent with the source.  
+
+### What happens if the node responsible for a backup task is down?
+
+When the responsible node enters the
+[Rehab state](../../../../server/clustering/distribution/distributed-database.mdx#database-topology),
+the [cluster observer](../../../../server/clustering/distribution/cluster-observer.mdx)
+does not move the backup task immediately.  
+Instead, it waits a grace period (30 minutes by default) before reassigning the task
+to another database-group member.  
+The grace period gives the original node a chance to recover,
+and prevents the same backup from running on two nodes at once.  
+
+When you create a backup task, you can pick the responsible node yourself,
+or leave it for the cluster to decide.  
+The choice (yours or the cluster's) is persisted cluster-wide,
+so all nodes agree on a single responsible node for the task.  
+
+If the current responsible node is in Rehab due to resource constraints on the host machine,
+the cluster observer will leave the backup task on the same node rather than reassign it.  
+The backup will run on that node once it recovers,
+or be reassigned to another node if this one is eventually removed from the database group.  
+
+The grace period is configurable via
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
 
 
 

--- a/versioned_docs/version-7.1/client-api/operations/maintenance/backup/faq.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/maintenance/backup/faq.mdx
@@ -120,18 +120,30 @@ to another database-group member.
 The grace period gives the original node a chance to recover,
 and prevents the same backup from running on two nodes at once.  
 
-When you create a backup task, you can pick the responsible node yourself,
-or leave it for the cluster to decide.  
-The choice (yours or the cluster's) is persisted cluster-wide,
-so all nodes agree on a single responsible node for the task.  
+* **Who picks the responsible node:**  
+  When you create a backup task, you can pick the responsible node yourself,
+  or leave it for the cluster to decide.  
+  The choice (yours or the cluster's) is persisted cluster-wide,
+  so all nodes agree on a single responsible node for the task.  
 
-If the current responsible node is in Rehab due to resource constraints on the host machine,
-the cluster observer will leave the backup task on the same node rather than reassign it.  
-The backup will run on that node once it recovers,
-or be reassigned to another node if this one is eventually removed from the database group.  
+* **If the node is in Rehab due to resource constraints on the host machine:**  
+  The cluster observer will leave the backup task on the same node rather than reassign it.  
+  The backup will run on that node once it recovers,
+  or be reassigned to another node if this one is eventually removed from the database group.  
 
 The grace period is configurable via
 [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
+
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to the behavior described above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves to another node when its pinned node is removed from the database group.  
+See [Pinning a Task](../../../../server/clustering/distribution/highly-available-tasks.mdx#pinning-a-task) for the full behavior.
+
+</Admonition>
 
 
 

--- a/versioned_docs/version-7.1/server/clustering/distribution/highly-available-tasks.mdx
+++ b/versioned_docs/version-7.1/server/clustering/distribution/highly-available-tasks.mdx
@@ -103,6 +103,17 @@ The grace period is set by
 
 </Admonition>
 
+<Admonition type="note" title="">
+
+A backup task that is **pinned** to its mentor node (via `PinToMentorNode`)
+is an exception to all of the above.  
+A pinned task is not subject to the grace period.  
+It stays on its node even while the node is in Rehab,
+and only moves when its pinned node is removed from the database group.  
+See [Pinning a Task](#pinning-a-task) below for the full behavior.
+
+</Admonition>
+
 
 
 ## Tasks Relocation
@@ -151,6 +162,12 @@ The failover of a task to another responsible node can be prevented by **pinning
   [cluster.timebeforeaddingreplicainsec](../../../server/configuration/cluster-configuration.mdx#clustertimebeforeaddingreplicainsec), 
   the cluster observer will attempt to select an available node to replace it in the database group 
   and redistribute the fallen node's tasks, including pinned ones, among database group members.  
+* A pinned **backup task** is also not subject to the
+  [grace period](../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin)
+  that the cluster observer otherwise applies before reassigning a backup task.  
+  The pinned backup stays on its node even while the node is in Rehab,
+  and only moves when the cluster eventually replaces the node as described above.  
+
 A task can be pinned to a selected node via Studio or using code.  
 
 #### Pinning via Studio

--- a/versioned_docs/version-7.1/server/clustering/distribution/highly-available-tasks.mdx
+++ b/versioned_docs/version-7.1/server/clustering/distribution/highly-available-tasks.mdx
@@ -83,6 +83,26 @@ Learn more [here](../../../server/clustering/distribution/distributed-database.m
 about database nodes' relations and states. 
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Backup tasks are an exception** to the local-decision model described above.  
+
+For backup tasks, the responsible node is either picked when the task is created
+(via the **Set responsible node** option in Studio, or `MentorNode` via the API),
+or chosen by the [cluster observer](../../../server/clustering/distribution/cluster-observer.mdx)
+when no explicit choice was made.  
+Either way, the choice is persisted cluster-wide,
+so all nodes agree on a single responsible node.  
+
+When the current responsible node enters the `Rehab` state,
+the cluster observer waits a configurable grace period (30 minutes by default)
+before moving the task to another node.  
+This prevents the same backup from running on two nodes at once.  
+The grace period is set by
+[Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin).
+
+</Admonition>
+
 
 
 ## Tasks Relocation

--- a/versioned_docs/version-7.1/server/configuration/backup-configuration.mdx
+++ b/versioned_docs/version-7.1/server/configuration/backup-configuration.mdx
@@ -26,6 +26,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
     * [Backup.MaxNumberOfConcurrentBackups](../../server/configuration/backup-configuration.mdx#backupmaxnumberofconcurrentbackups)  
     * [Backup.ConcurrentBackupsDelayInSec](../../server/configuration/backup-configuration.mdx#backupconcurrentbackupsdelayinsec)  
     * [Backup.LowMemoryBackupDelayInMin](../../server/configuration/backup-configuration.mdx#backuplowmemorybackupdelayinmin)  
+    * [Backup.MoveToNewResponsibleNodeGracePeriodInMin](../../server/configuration/backup-configuration.mdx#backupmovetonewresponsiblenodegraceperiodinmin)  
 
 </Admonition>
 ## Backup.TempPath
@@ -108,6 +109,24 @@ Number of minutes to delay the backup if the server enters a low memory state.
 - **Type**: `TimeSetting`  
 - **TimeUnit**: `TimeUnit.Minutes`  
 - **Default**: `10`  
+- **Scope**: Server-wide only  
+
+
+
+## Backup.MoveToNewResponsibleNodeGracePeriodInMin
+
+Number of minutes the [cluster observer](../../server/clustering/distribution/cluster-observer.mdx) waits
+before reassigning a backup task to a new responsible node,
+when the current responsible node has entered the
+[Rehab state](../../server/clustering/distribution/distributed-database.mdx#database-topology).  
+
+During this grace period, the task remains assigned to its current responsible node.  
+This gives the node a chance to recover, and prevents a duplicate backup
+from starting elsewhere in the cluster.  
+
+- **Type**: `TimeSetting`  
+- **TimeUnit**: `TimeUnit.Minutes`  
+- **Default**: `30`  
 - **Scope**: Server-wide only  
 
 


### PR DESCRIPTION
### Issue link
[RDoc-3818](https://issues.hibernatingrhinos.com/issue/RDoc-3818)

### Additional description
Document backup behavior: cluster node can start backup while another cluster node already runs backup

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

