### PR TITLE
RDoc-3838 - clarify how to run a batch of commands cluster-wide in `how-to-send-multiple-commands-using-a-batch`.

### DIFF
--- a/docs/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
+++ b/docs/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.  
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `TransactionMode.ClusterWide` and call `SaveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/docs/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
+++ b/docs/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `transactionMode: "ClusterWide"` and call `saveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/docs/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
+++ b/docs/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
@@ -5,6 +5,10 @@ description: "Send multiple document commands in a single RavenDB batch request 
 sidebar_position: 0
 supported_languages: ["csharp", "java", "nodejs"]
 see_also:
+     - title: "Cluster Transaction - Overview"
+       link: "client-api/session/cluster-transaction/overview"
+       source: "docs"
+       path: "Client API > Session > Cluster Transaction"
      - title: "Transaction Support"
        link: "client-api/faq/transaction-support"
        source: "docs"

--- a/versioned_docs/version-6.2/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.  
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `TransactionMode.ClusterWide` and call `SaveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/versioned_docs/version-6.2/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
+++ b/versioned_docs/version-6.2/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `transactionMode: "ClusterWide"` and call `saveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/versioned_docs/version-6.2/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
+++ b/versioned_docs/version-6.2/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
@@ -4,6 +4,10 @@ sidebar_label: Send Multiple Commands
 sidebar_position: 0
 supported_languages: ["csharp", "java", "nodejs"]
 see_also:
+     - title: "Cluster Transaction - Overview"
+       link: "client-api/session/cluster-transaction/overview"
+       source: "docs"
+       path: "Client API > Session > Cluster Transaction"
      - title: "Transaction Support"
        link: "client-api/faq/transaction-support"
        source: "docs"

--- a/versioned_docs/version-7.0/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.  
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `TransactionMode.ClusterWide` and call `SaveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/versioned_docs/version-7.0/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
+++ b/versioned_docs/version-7.0/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `transactionMode: "ClusterWide"` and call `saveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/versioned_docs/version-7.0/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
+++ b/versioned_docs/version-7.0/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
@@ -4,6 +4,10 @@ sidebar_label: Send Multiple Commands
 sidebar_position: 0
 supported_languages: ["csharp", "java", "nodejs"]
 see_also:
+     - title: "Cluster Transaction - Overview"
+       link: "client-api/session/cluster-transaction/overview"
+       source: "docs"
+       path: "Client API > Session > Cluster Transaction"
      - title: "Transaction Support"
        link: "client-api/faq/transaction-support"
        source: "docs"

--- a/versioned_docs/version-7.1/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-csharp.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.  
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `TransactionMode.ClusterWide` and call `SaveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/versioned_docs/version-7.1/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
+++ b/versioned_docs/version-7.1/client-api/commands/batches/content/_how-to-send-multiple-commands-using-a-batch-nodejs.mdx
@@ -5,13 +5,17 @@ import CodeBlock from '@theme/CodeBlock';
 
 <Admonition type="note" title="">
 
-* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to the server.  
+* Use the low-level `SingleNodeBatchCommand` to send **multiple commands** in a **single request** to a cluster node.  
   This reduces the number of remote calls and allows several operations to share the same transaction.
 
-* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.
+* All the commands sent in the batch are executed as a **single transaction** on the node the client communicated with.  
   If any command fails, the entire batch is rolled back, ensuring data integrity.
 
 * The commands are replicated to other nodes in the cluster only AFTER the transaction is successfully completed on that node.
+
+* To run multiple commands as a **cluster-wide** transaction, do not use `SingleNodeBatchCommand`,
+  but open the session with `transactionMode: "ClusterWide"` and call `saveChanges`.  
+  See [Open a cluster-wide session](../../../../client-api/session/cluster-transaction/overview.mdx#open-a-cluster-transaction).
 
 * In this page:
     * [Examples](../../../../client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx#examples)

--- a/versioned_docs/version-7.1/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
+++ b/versioned_docs/version-7.1/client-api/commands/batches/how-to-send-multiple-commands-using-a-batch.mdx
@@ -4,6 +4,10 @@ sidebar_label: Send Multiple Commands
 sidebar_position: 0
 supported_languages: ["csharp", "java", "nodejs"]
 see_also:
+     - title: "Cluster Transaction - Overview"
+       link: "client-api/session/cluster-transaction/overview"
+       source: "docs"
+       path: "Client API > Session > Cluster Transaction"
      - title: "Transaction Support"
        link: "client-api/faq/transaction-support"
        source: "docs"


### PR DESCRIPTION
### Issue link
[RDoc-3838](https://issues.hibernatingrhinos.com/issue/RDoc-3838)

### Additional description
Added a clarification about running a batch of commands cluster-wide to `client-api/commands/batches/how-to-send-multiple-commands-using-a-batch` (and a "see also" reference to the wrapper). Updated C# and Node.js pages, v6.2 to v7.2. Java pages unchanged. Class-name migration to `SingleNodeBatchCommand` is already documented. 

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

