### PR TITLE
RDoc-3839 - Document local temp-file behavior during remote-source restore

### DIFF
--- a/docs/backup/configuration.mdx
+++ b/docs/backup/configuration.mdx
@@ -46,6 +46,10 @@ Use this key to specify the local path where temporary backup files are stored.
 - By default, temporary backup files are stored under the server Database directory (or under [Storage.TempPath](../server/configuration/storage-configuration.mdx) if set).  
 - If `Backup.TempPath` is set, temporary backup files will be stored under the path it specifies.  
 - If a backup task is configured to store backups in a local folder, `Backup.TempPath` will be ignored and temporary files will be stored alongside the backups.  
+- `Backup.TempPath` is also used when restoring a database from a remote destination
+  (Amazon S3, Azure Blob Storage, or Google Cloud Storage): the backup file is first
+  downloaded to `Backup.TempPath` and then read from there.  
+  [Learn about restoring from a remote destination.](../backup/restore.mdx#restorebackupconfiguration---backup-location-settings)
 </Admonition>
 
 - **Type**: `string`

--- a/docs/backup/configuration.mdx
+++ b/docs/backup/configuration.mdx
@@ -46,9 +46,10 @@ Use this key to specify the local path where temporary backup files are stored.
 - By default, temporary backup files are stored under the server Database directory (or under [Storage.TempPath](../server/configuration/storage-configuration.mdx) if set).  
 - If `Backup.TempPath` is set, temporary backup files will be stored under the path it specifies.  
 - If a backup task is configured to store backups in a local folder, `Backup.TempPath` will be ignored and temporary files will be stored alongside the backups.  
-- `Backup.TempPath` is also used when restoring a database from a remote destination
-  (Amazon S3, Azure Blob Storage, or Google Cloud Storage): the backup file is first
-  downloaded to `Backup.TempPath` and then read from there.  
+- `Backup.TempPath` is also used when restoring a snapshot from a remote destination
+  (Amazon S3, Azure Blob Storage, or Google Cloud Storage): the snapshot file is first
+  downloaded to `Backup.TempPath` and then read from there. Full and incremental backups
+  are streamed directly from the destination and do not use this path.  
   [Learn about restoring from a remote destination.](../backup/restore.mdx#restorebackupconfiguration---backup-location-settings)
 </Admonition>
 

--- a/docs/backup/configuration.mdx
+++ b/docs/backup/configuration.mdx
@@ -46,10 +46,12 @@ Use this key to specify the local path where temporary backup files are stored.
 - By default, temporary backup files are stored under the server Database directory (or under [Storage.TempPath](../server/configuration/storage-configuration.mdx) if set).  
 - If `Backup.TempPath` is set, temporary backup files will be stored under the path it specifies.  
 - If a backup task is configured to store backups in a local folder, `Backup.TempPath` will be ignored and temporary files will be stored alongside the backups.  
-- `Backup.TempPath` is also used when restoring a snapshot from a remote destination
-  (Amazon S3, Azure Blob Storage, or Google Cloud Storage): the snapshot file is first
-  downloaded to `Backup.TempPath` and then read from there. Full and incremental backups
-  are streamed directly from the destination and do not use this path.  
+- `Backup.TempPath` is also used when restoring a [snapshot](../backup/overview.mdx#snapshot-image)
+  from a remote destination (Amazon S3, Azure Blob Storage, or Google Cloud Storage):
+  the snapshot file is first downloaded to `Backup.TempPath` and then read from there.  
+  [Logical backups](../backup/overview.mdx#logical-backup) are streamed directly from
+  the destination and do not use this path.
+
   [Learn about restoring from a remote destination.](../backup/restore.mdx#restorebackupconfiguration---backup-location-settings)
 </Admonition>
 

--- a/docs/backup/restore.mdx
+++ b/docs/backup/restore.mdx
@@ -190,8 +190,9 @@ Choose where to restore the backup from by using a restore configuration that ma
 
 <Admonition type="note" title="">
 
-When restoring from a remote destination (Amazon S3, Azure Blob Storage, or Google Cloud
-Storage), RavenDB downloads the backup file to local disk before reading the file.  
+When restoring a snapshot from a remote destination (Amazon S3, Azure Blob Storage, or
+Google Cloud Storage), RavenDB downloads the snapshot file to local disk before reading
+the file.  
 The first defined path in this list is used for the download:
 
 - [`Backup.TempPath`](../backup/configuration.mdx#backuptemppath)
@@ -200,6 +201,9 @@ The first defined path in this list is used for the download:
 
 Before the download starts, RavenDB checks that the chosen path has enough free space.  
 If there is not enough space, the restore fails with a `DiskFullException`.
+
+Full and incremental backups are streamed directly from the destination during restore
+and do not use this temp path.
 
 </Admonition>
 

--- a/docs/backup/restore.mdx
+++ b/docs/backup/restore.mdx
@@ -190,9 +190,9 @@ Choose where to restore the backup from by using a restore configuration that ma
 
 <Admonition type="note" title="">
 
-When restoring a snapshot from a remote destination (Amazon S3, Azure Blob Storage, or
-Google Cloud Storage), RavenDB downloads the snapshot file to local disk before reading
-the file.  
+When restoring a [snapshot](../backup/overview.mdx#snapshot-image) from a remote destination
+(Amazon S3, Azure Blob Storage, or Google Cloud Storage), RavenDB downloads the snapshot
+file to local disk before reading the file.  
 The first defined path in this list is used for the download:
 
 - [`Backup.TempPath`](../backup/configuration.mdx#backuptemppath)
@@ -202,8 +202,8 @@ The first defined path in this list is used for the download:
 Before the download starts, RavenDB checks that the chosen path has enough free space.  
 If there is not enough space, the restore fails with a `DiskFullException`.
 
-Full and incremental backups are streamed directly from the destination during restore
-and do not use this temp path.
+[Logical backups](../backup/overview.mdx#logical-backup) are streamed directly from the
+destination during restore and do not use this temp path.
 
 </Admonition>
 

--- a/docs/backup/restore.mdx
+++ b/docs/backup/restore.mdx
@@ -188,6 +188,21 @@ Choose where to restore the backup from by using a restore configuration that ma
 
 [See details in the syntax section.](../backup/restore#restore-configuration-classes)
 
+<Admonition type="note" title="">
+
+When restoring from a remote destination (Amazon S3, Azure Blob Storage, or Google Cloud
+Storage), RavenDB downloads the backup file to local disk before reading the file.  
+The first defined path in this list is used for the download:
+
+- [`Backup.TempPath`](../backup/configuration.mdx#backuptemppath)
+- [`Storage.TempPath`](../server/configuration/storage-configuration.mdx#storagetemppath)
+- The database directory
+
+Before the download starts, RavenDB checks that the chosen path has enough free space.  
+If there is not enough space, the restore fails with a `DiskFullException`.
+
+</Admonition>
+
 **Example: Restore from S3**
 ```csharp
 var restoreConfigS3 = new RestoreFromS3Configuration


### PR DESCRIPTION
### Issue link
[RDoc-3839](https://issues.hibernatingrhinos.com/issue/RDoc-3839)

### Additional description
added notes to `/backup/restore` and `/backup/configuration` to explain how temp path is used and disk-space is checked when restoring.

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

