### PR TITLE
RDoc-2211: Explain why clusters and database groups need an odd number of nodes

### DIFF
--- a/docs/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/docs/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -33,7 +33,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/docs/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/docs/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -19,6 +19,28 @@ import CodeBlock from '@theme/CodeBlock';
    * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/docs/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/docs/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -32,7 +32,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/docs/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/docs/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -18,6 +18,28 @@ import CodeBlock from '@theme/CodeBlock';
     * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/docs/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/docs/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -17,6 +17,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
    * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
@@ -41,6 +42,25 @@ For ACID guarantees, a majority of the nodes must agree on every [cluster-wide t
 so having an odd number of nodes makes achieving the majority easier.
 
 
+
+### Database groups follow the same rule when you use cluster-wide transactions
+
+The recommendation above is about the cluster itself - the nodes that vote on
+Raft commands. The same odd-numbered sizing matters for an individual
+**database group** when the database uses
+[cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
+(or the [atomic guards](../../compare-exchange/atomic-guards.mdx) that wrap them).
+
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it. With three members, two must accept; with
+five, three must accept; with seven, four. An odd size keeps that count well-
+defined and keeps a single node failure inside the majority.
+
+If the database does not use cluster-wide transactions, you do not have to
+keep the group size odd. The database is kept in sync by
+[internal replication](../../server/clustering/replication/replication-overview.mdx#internal-replication),
+which keeps writes flowing on any node that is up - so a group of two members
+already lets the database survive losing a node.
 
 
 

--- a/docs/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/docs/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -11,19 +11,26 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Cluster: Best Practices
 <Admonition type="note" title="">
 
 * In this page:
-   * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
-   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
+   * [Recommended cluster and database group size](../../server/clustering/cluster-best-practice-and-configuration.mdx#recommended-cluster-and-database-group-size)
+     * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+     * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
 
 
+<Panel heading="Recommended cluster and database group size">
+
 ### Clusters should have an odd number of at least 3 nodes
+
+<ContentFrame>
 
 We recommend setting up clusters with an odd number of nodes equal to or greater than 3.
 
@@ -41,18 +48,22 @@ command will be created, although any database on the surviving node will still 
 For ACID guarantees, a majority of the nodes must agree on every [cluster-wide transaction](../../server/clustering/cluster-transactions.mdx), 
 so having an odd number of nodes makes achieving the majority easier.
 
+</ContentFrame>
 
+---
 
 ### Database groups follow the same rule when you use cluster-wide transactions
 
-The recommendation above is about the cluster itself - the nodes that vote on
+<ContentFrame>
+
+The recommendation above relates to the cluster itself - the nodes that vote on
 Raft commands. The same odd-numbered sizing matters for an individual
-**database group** when the database uses
+**[database group](../../glossary/database-group.mdx)** when the database uses
 [cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
 (or the [atomic guards](../../compare-exchange/atomic-guards.mdx) that wrap them).
 
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it. With three members, two must accept; with
+group's voting members have accepted it. With three members, two must accept; with
 five, three must accept; with seven, four. An odd size keeps that count well-
 defined and keeps a single node failure inside the majority.
 
@@ -62,13 +73,21 @@ keep the group size odd. The database is kept in sync by
 which keeps writes flowing on any node that is up - so a group of two members
 already lets the database survive losing a node.
 
+</ContentFrame>
 
+</Panel>
 
-### Avoid different cluster configurations among the cluster's nodes
+<Panel heading="Avoid different cluster configurations among the cluster's nodes">
+
+<ContentFrame>
 
 Configuration mismatches tend to cause interaction problems between nodes.
 
 If you must set [cluster configurations](../../server/configuration/cluster-configuration.mdx) differently in separate nodes,  
 **we recommend first testing it** in a development environment to see that each node interacts properly with the others.
+
+</ContentFrame>
+
+</Panel>
 
 

--- a/docs/server/clustering/distribution/distributed-database.mdx
+++ b/docs/server/clustering/distribution/distributed-database.mdx
@@ -68,7 +68,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/docs/server/clustering/distribution/distributed-database.mdx
+++ b/docs/server/clustering/distribution/distributed-database.mdx
@@ -55,7 +55,26 @@ In either case, the number of nodes will represent the `Replication Factor`.
 Once the database is created by getting a [Consensus](../../../server/clustering/rachis/consensus-operations.mdx),  
 the [Cluster Observer](../../../server/clustering/distribution/cluster-observer.mdx) begins monitoring the _Database Group_ in order to maintain this Replication Factor.
 
+<Admonition type="note" title="">
 
+**Sizing the database group**
+
+For high availability, use a database group of at least three nodes so the
+database survives losing a node, and rely on
+[internal replication](../replication/replication-overview.mdx#internal-replication)
+to keep the remaining nodes in sync.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
 
 ## Database Topology
 

--- a/docs/server/clustering/replication/replication-overview.mdx
+++ b/docs/server/clustering/replication/replication-overview.mdx
@@ -63,7 +63,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/docs/server/clustering/replication/replication-overview.mdx
+++ b/docs/server/clustering/replication/replication-overview.mdx
@@ -51,6 +51,26 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * You can _write_ to any node in the database group,  
   that _write_ will be recorded and automatically replicated to all other nodes in the database-group.
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+For high availability through internal replication, use a database group of at
+least three nodes so the database survives losing a node.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 #### External replication
 
 * __Replicate between__: Two databases that are typically set on different clusters.   

--- a/docs/studio/database/create-new-database/general-flow.mdx
+++ b/docs/studio/database/create-new-database/general-flow.mdx
@@ -77,6 +77,27 @@ From the database list view, click the **'New database'** button.
    If no node is checked, then the replication nodes will be selected randomly from the cluster.  
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+When choosing a **Replication Factor**, use at least three nodes for high
+availability - that way the database survives losing a node and stays
+synchronized through
+[internal replication](../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 
 ## 4. Configure Path
 

--- a/docs/studio/database/create-new-database/general-flow.mdx
+++ b/docs/studio/database/create-new-database/general-flow.mdx
@@ -90,7 +90,7 @@ If the database also uses
 [cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -33,7 +33,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -19,6 +19,28 @@ import CodeBlock from '@theme/CodeBlock';
    * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -32,7 +32,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -18,6 +18,28 @@ import CodeBlock from '@theme/CodeBlock';
     * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/versioned_docs/version-6.2/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/versioned_docs/version-6.2/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -10,19 +10,26 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Cluster: Best Practices
 <Admonition type="note" title="">
 
 * In this page:
-   * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
-   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
+   * [Recommended cluster and database group size](../../server/clustering/cluster-best-practice-and-configuration.mdx#recommended-cluster-and-database-group-size)
+     * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+     * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
 
 
+<Panel heading="Recommended cluster and database group size">
+
 ### Clusters should have an odd number of at least 3 nodes
+
+<ContentFrame>
 
 We recommend setting up clusters with an odd number of nodes equal to or greater than 3.
 
@@ -40,18 +47,22 @@ command will be created, although any database on the surviving node will still 
 For ACID guarantees, a majority of the nodes must agree on every [cluster-wide transaction](../../server/clustering/cluster-transactions.mdx), 
 so having an odd number of nodes makes achieving the majority easier.
 
+</ContentFrame>
 
+---
 
 ### Database groups follow the same rule when you use cluster-wide transactions
 
-The recommendation above is about the cluster itself - the nodes that vote on
+<ContentFrame>
+
+The recommendation above relates to the cluster itself - the nodes that vote on
 Raft commands. The same odd-numbered sizing matters for an individual
-**database group** when the database uses
+**[database group](../../glossary/database-group.mdx)** when the database uses
 [cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
 (or the [atomic guards](../../client-api/session/cluster-transaction/atomic-guards.mdx) that wrap them).
 
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it. With three members, two must accept; with
+group's voting members have accepted it. With three members, two must accept; with
 five, three must accept; with seven, four. An odd size keeps that count well-
 defined and keeps a single node failure inside the majority.
 
@@ -61,13 +72,21 @@ keep the group size odd. The database is kept in sync by
 which keeps writes flowing on any node that is up - so a group of two members
 already lets the database survive losing a node.
 
+</ContentFrame>
 
+</Panel>
 
-### Avoid different cluster configurations among the cluster's nodes
+<Panel heading="Avoid different cluster configurations among the cluster's nodes">
+
+<ContentFrame>
 
 Configuration mismatches tend to cause interaction problems between nodes.
 
 If you must set [cluster configurations](../../server/configuration/cluster-configuration.mdx) differently in separate nodes,  
 **we recommend first testing it** in a development environment to see that each node interacts properly with the others.
+
+</ContentFrame>
+
+</Panel>
 
 

--- a/versioned_docs/version-6.2/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/versioned_docs/version-6.2/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -16,6 +16,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
    * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
@@ -40,6 +41,25 @@ For ACID guarantees, a majority of the nodes must agree on every [cluster-wide t
 so having an odd number of nodes makes achieving the majority easier.
 
 
+
+### Database groups follow the same rule when you use cluster-wide transactions
+
+The recommendation above is about the cluster itself - the nodes that vote on
+Raft commands. The same odd-numbered sizing matters for an individual
+**database group** when the database uses
+[cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
+(or the [atomic guards](../../client-api/session/cluster-transaction/atomic-guards.mdx) that wrap them).
+
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it. With three members, two must accept; with
+five, three must accept; with seven, four. An odd size keeps that count well-
+defined and keeps a single node failure inside the majority.
+
+If the database does not use cluster-wide transactions, you do not have to
+keep the group size odd. The database is kept in sync by
+[internal replication](../../server/clustering/replication/replication-overview.mdx#internal-replication),
+which keeps writes flowing on any node that is up - so a group of two members
+already lets the database survive losing a node.
 
 
 

--- a/versioned_docs/version-6.2/server/clustering/distribution/distributed-database.mdx
+++ b/versioned_docs/version-6.2/server/clustering/distribution/distributed-database.mdx
@@ -54,7 +54,26 @@ In either case, the number of nodes will represent the `Replication Factor`.
 Once the database is created by getting a [Consensus](../../../server/clustering/rachis/consensus-operations.mdx),  
 the [Cluster Observer](../../../server/clustering/distribution/cluster-observer.mdx) begins monitoring the _Database Group_ in order to maintain this Replication Factor.
 
+<Admonition type="note" title="">
 
+**Sizing the database group**
+
+For high availability, use a database group of at least three nodes so the
+database survives losing a node, and rely on
+[internal replication](../replication/replication-overview.mdx#internal-replication)
+to keep the remaining nodes in sync.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
 
 ## Database Topology
 

--- a/versioned_docs/version-6.2/server/clustering/distribution/distributed-database.mdx
+++ b/versioned_docs/version-6.2/server/clustering/distribution/distributed-database.mdx
@@ -67,7 +67,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-6.2/server/clustering/replication/replication-overview.mdx
+++ b/versioned_docs/version-6.2/server/clustering/replication/replication-overview.mdx
@@ -50,6 +50,26 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * You can _write_ to any node in the database group,  
   that _write_ will be recorded and automatically replicated to all other nodes in the database-group.
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+For high availability through internal replication, use a database group of at
+least three nodes so the database survives losing a node.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 #### External replication
 
 * __Replicate between__: Two databases that are typically set on different clusters.   

--- a/versioned_docs/version-6.2/server/clustering/replication/replication-overview.mdx
+++ b/versioned_docs/version-6.2/server/clustering/replication/replication-overview.mdx
@@ -62,7 +62,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-6.2/studio/database/create-new-database/general-flow.mdx
+++ b/versioned_docs/version-6.2/studio/database/create-new-database/general-flow.mdx
@@ -76,6 +76,27 @@ From the database list view, click the **'New database'** button.
    If no node is checked, then the replication nodes will be selected randomly from the cluster.  
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+When choosing a **Replication Factor**, use at least three nodes for high
+availability - that way the database survives losing a node and stays
+synchronized through
+[internal replication](../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 
 ## 4. Configure Path
 

--- a/versioned_docs/version-6.2/studio/database/create-new-database/general-flow.mdx
+++ b/versioned_docs/version-6.2/studio/database/create-new-database/general-flow.mdx
@@ -89,7 +89,7 @@ If the database also uses
 [cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -33,7 +33,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -19,6 +19,28 @@ import CodeBlock from '@theme/CodeBlock';
    * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -32,7 +32,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -18,6 +18,28 @@ import CodeBlock from '@theme/CodeBlock';
     * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/versioned_docs/version-7.0/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/versioned_docs/version-7.0/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -10,19 +10,26 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Cluster: Best Practices
 <Admonition type="note" title="">
 
 * In this page:
-   * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
-   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
+   * [Recommended cluster and database group size](../../server/clustering/cluster-best-practice-and-configuration.mdx#recommended-cluster-and-database-group-size)
+     * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+     * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
 
 
+<Panel heading="Recommended cluster and database group size">
+
 ### Clusters should have an odd number of at least 3 nodes
+
+<ContentFrame>
 
 We recommend setting up clusters with an odd number of nodes equal to or greater than 3.
 
@@ -40,18 +47,22 @@ command will be created, although any database on the surviving node will still 
 For ACID guarantees, a majority of the nodes must agree on every [cluster-wide transaction](../../server/clustering/cluster-transactions.mdx), 
 so having an odd number of nodes makes achieving the majority easier.
 
+</ContentFrame>
 
+---
 
 ### Database groups follow the same rule when you use cluster-wide transactions
 
-The recommendation above is about the cluster itself - the nodes that vote on
+<ContentFrame>
+
+The recommendation above relates to the cluster itself - the nodes that vote on
 Raft commands. The same odd-numbered sizing matters for an individual
-**database group** when the database uses
+**[database group](../../glossary/database-group.mdx)** when the database uses
 [cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
 (or the [atomic guards](../../client-api/session/cluster-transaction/atomic-guards.mdx) that wrap them).
 
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it. With three members, two must accept; with
+group's voting members have accepted it. With three members, two must accept; with
 five, three must accept; with seven, four. An odd size keeps that count well-
 defined and keeps a single node failure inside the majority.
 
@@ -61,13 +72,21 @@ keep the group size odd. The database is kept in sync by
 which keeps writes flowing on any node that is up - so a group of two members
 already lets the database survive losing a node.
 
+</ContentFrame>
 
+</Panel>
 
-### Avoid different cluster configurations among the cluster's nodes
+<Panel heading="Avoid different cluster configurations among the cluster's nodes">
+
+<ContentFrame>
 
 Configuration mismatches tend to cause interaction problems between nodes.
 
 If you must set [cluster configurations](../../server/configuration/cluster-configuration.mdx) differently in separate nodes,  
 **we recommend first testing it** in a development environment to see that each node interacts properly with the others.
+
+</ContentFrame>
+
+</Panel>
 
 

--- a/versioned_docs/version-7.0/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/versioned_docs/version-7.0/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -16,6 +16,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
    * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
@@ -40,6 +41,25 @@ For ACID guarantees, a majority of the nodes must agree on every [cluster-wide t
 so having an odd number of nodes makes achieving the majority easier.
 
 
+
+### Database groups follow the same rule when you use cluster-wide transactions
+
+The recommendation above is about the cluster itself - the nodes that vote on
+Raft commands. The same odd-numbered sizing matters for an individual
+**database group** when the database uses
+[cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
+(or the [atomic guards](../../client-api/session/cluster-transaction/atomic-guards.mdx) that wrap them).
+
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it. With three members, two must accept; with
+five, three must accept; with seven, four. An odd size keeps that count well-
+defined and keeps a single node failure inside the majority.
+
+If the database does not use cluster-wide transactions, you do not have to
+keep the group size odd. The database is kept in sync by
+[internal replication](../../server/clustering/replication/replication-overview.mdx#internal-replication),
+which keeps writes flowing on any node that is up - so a group of two members
+already lets the database survive losing a node.
 
 
 

--- a/versioned_docs/version-7.0/server/clustering/distribution/distributed-database.mdx
+++ b/versioned_docs/version-7.0/server/clustering/distribution/distributed-database.mdx
@@ -54,7 +54,26 @@ In either case, the number of nodes will represent the `Replication Factor`.
 Once the database is created by getting a [Consensus](../../../server/clustering/rachis/consensus-operations.mdx),  
 the [Cluster Observer](../../../server/clustering/distribution/cluster-observer.mdx) begins monitoring the _Database Group_ in order to maintain this Replication Factor.
 
+<Admonition type="note" title="">
 
+**Sizing the database group**
+
+For high availability, use a database group of at least three nodes so the
+database survives losing a node, and rely on
+[internal replication](../replication/replication-overview.mdx#internal-replication)
+to keep the remaining nodes in sync.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
 
 ## Database Topology
 

--- a/versioned_docs/version-7.0/server/clustering/distribution/distributed-database.mdx
+++ b/versioned_docs/version-7.0/server/clustering/distribution/distributed-database.mdx
@@ -67,7 +67,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.0/server/clustering/replication/replication-overview.mdx
+++ b/versioned_docs/version-7.0/server/clustering/replication/replication-overview.mdx
@@ -50,6 +50,26 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * You can _write_ to any node in the database group,  
   that _write_ will be recorded and automatically replicated to all other nodes in the database-group.
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+For high availability through internal replication, use a database group of at
+least three nodes so the database survives losing a node.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 #### External replication
 
 * __Replicate between__: Two databases that are typically set on different clusters.   

--- a/versioned_docs/version-7.0/server/clustering/replication/replication-overview.mdx
+++ b/versioned_docs/version-7.0/server/clustering/replication/replication-overview.mdx
@@ -62,7 +62,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.0/studio/database/create-new-database/general-flow.mdx
+++ b/versioned_docs/version-7.0/studio/database/create-new-database/general-flow.mdx
@@ -76,6 +76,27 @@ From the database list view, click the **'New database'** button.
    If no node is checked, then the replication nodes will be selected randomly from the cluster.  
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+When choosing a **Replication Factor**, use at least three nodes for high
+availability - that way the database survives losing a node and stays
+synchronized through
+[internal replication](../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 
 ## 4. Configure Path
 

--- a/versioned_docs/version-7.0/studio/database/create-new-database/general-flow.mdx
+++ b/versioned_docs/version-7.0/studio/database/create-new-database/general-flow.mdx
@@ -89,7 +89,7 @@ If the database also uses
 [cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -33,7 +33,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-csharp.mdx
@@ -19,6 +19,28 @@ import CodeBlock from '@theme/CodeBlock';
    * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -32,7 +32,7 @@ If the database also uses
 [cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
 prefer an odd replication factor (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-java.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/content/_create-database-java.mdx
@@ -18,6 +18,28 @@ import CodeBlock from '@theme/CodeBlock';
     * [Syntax](../../../../client-api/operations/server-wide/create-database.mdx#syntax)
 
 </Admonition>
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+The default replication factor is 1, which puts the database on a single node.
+For high availability, set the replication factor to at least 3 so the database
+survives losing a node and stays synchronized through
+[internal replication](../../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../../server/clustering/cluster-transactions.mdx),
+prefer an odd replication factor (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 ## Create new database
 
 <Admonition type="note" title="">

--- a/versioned_docs/version-7.1/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/versioned_docs/version-7.1/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -16,6 +16,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this page:
    * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
@@ -40,6 +41,25 @@ For ACID guarantees, a majority of the nodes must agree on every [cluster-wide t
 so having an odd number of nodes makes achieving the majority easier.
 
 
+
+### Database groups follow the same rule when you use cluster-wide transactions
+
+The recommendation above is about the cluster itself - the nodes that vote on
+Raft commands. The same odd-numbered sizing matters for an individual
+**database group** when the database uses
+[cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
+(or the [atomic guards](../../compare-exchange/atomic-guards.mdx) that wrap them).
+
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it. With three members, two must accept; with
+five, three must accept; with seven, four. An odd size keeps that count well-
+defined and keeps a single node failure inside the majority.
+
+If the database does not use cluster-wide transactions, you do not have to
+keep the group size odd. The database is kept in sync by
+[internal replication](../../server/clustering/replication/replication-overview.mdx#internal-replication),
+which keeps writes flowing on any node that is up - so a group of two members
+already lets the database survive losing a node.
 
 
 

--- a/versioned_docs/version-7.1/server/clustering/cluster-best-practice-and-configuration.mdx
+++ b/versioned_docs/version-7.1/server/clustering/cluster-best-practice-and-configuration.mdx
@@ -10,19 +10,26 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Cluster: Best Practices
 <Admonition type="note" title="">
 
 * In this page:
-   * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
-   * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
+   * [Recommended cluster and database group size](../../server/clustering/cluster-best-practice-and-configuration.mdx#recommended-cluster-and-database-group-size)
+     * [Clusters should have an odd number of at least 3 nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes)
+     * [Database groups follow the same rule when you use cluster-wide transactions](../../server/clustering/cluster-best-practice-and-configuration.mdx#database-groups-follow-the-same-rule-when-you-use-cluster-wide-transactions)
    * [Avoid different cluster configurations among the cluster's nodes](../../server/clustering/cluster-best-practice-and-configuration.mdx#avoid-different-cluster-configurations-among-the-clusters-nodes)
 
 </Admonition>
 
 
+<Panel heading="Recommended cluster and database group size">
+
 ### Clusters should have an odd number of at least 3 nodes
+
+<ContentFrame>
 
 We recommend setting up clusters with an odd number of nodes equal to or greater than 3.
 
@@ -40,18 +47,22 @@ command will be created, although any database on the surviving node will still 
 For ACID guarantees, a majority of the nodes must agree on every [cluster-wide transaction](../../server/clustering/cluster-transactions.mdx), 
 so having an odd number of nodes makes achieving the majority easier.
 
+</ContentFrame>
 
+---
 
 ### Database groups follow the same rule when you use cluster-wide transactions
 
-The recommendation above is about the cluster itself - the nodes that vote on
+<ContentFrame>
+
+The recommendation above relates to the cluster itself - the nodes that vote on
 Raft commands. The same odd-numbered sizing matters for an individual
-**database group** when the database uses
+**[database group](../../glossary/database-group.mdx)** when the database uses
 [cluster-wide transactions](../../server/clustering/cluster-transactions.mdx)
 (or the [atomic guards](../../compare-exchange/atomic-guards.mdx) that wrap them).
 
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it. With three members, two must accept; with
+group's voting members have accepted it. With three members, two must accept; with
 five, three must accept; with seven, four. An odd size keeps that count well-
 defined and keeps a single node failure inside the majority.
 
@@ -61,13 +72,21 @@ keep the group size odd. The database is kept in sync by
 which keeps writes flowing on any node that is up - so a group of two members
 already lets the database survive losing a node.
 
+</ContentFrame>
 
+</Panel>
 
-### Avoid different cluster configurations among the cluster's nodes
+<Panel heading="Avoid different cluster configurations among the cluster's nodes">
+
+<ContentFrame>
 
 Configuration mismatches tend to cause interaction problems between nodes.
 
 If you must set [cluster configurations](../../server/configuration/cluster-configuration.mdx) differently in separate nodes,  
 **we recommend first testing it** in a development environment to see that each node interacts properly with the others.
+
+</ContentFrame>
+
+</Panel>
 
 

--- a/versioned_docs/version-7.1/server/clustering/distribution/distributed-database.mdx
+++ b/versioned_docs/version-7.1/server/clustering/distribution/distributed-database.mdx
@@ -54,7 +54,26 @@ In either case, the number of nodes will represent the `Replication Factor`.
 Once the database is created by getting a [Consensus](../../../server/clustering/rachis/consensus-operations.mdx),  
 the [Cluster Observer](../../../server/clustering/distribution/cluster-observer.mdx) begins monitoring the _Database Group_ in order to maintain this Replication Factor.
 
+<Admonition type="note" title="">
 
+**Sizing the database group**
+
+For high availability, use a database group of at least three nodes so the
+database survives losing a node, and rely on
+[internal replication](../replication/replication-overview.mdx#internal-replication)
+to keep the remaining nodes in sync.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
 
 ## Database Topology
 

--- a/versioned_docs/version-7.1/server/clustering/distribution/distributed-database.mdx
+++ b/versioned_docs/version-7.1/server/clustering/distribution/distributed-database.mdx
@@ -67,7 +67,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.1/server/clustering/replication/replication-overview.mdx
+++ b/versioned_docs/version-7.1/server/clustering/replication/replication-overview.mdx
@@ -50,6 +50,26 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * You can _write_ to any node in the database group,  
   that _write_ will be recorded and automatically replicated to all other nodes in the database-group.
+
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+For high availability through internal replication, use a database group of at
+least three nodes so the database survives losing a node.
+
+If the database also uses
+[cluster-wide transactions](../cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database
+group's voting members accept it, and an odd group size means that majority
+is always a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 #### External replication
 
 * __Replicate between__: Two databases that are typically set on different clusters.   

--- a/versioned_docs/version-7.1/server/clustering/replication/replication-overview.mdx
+++ b/versioned_docs/version-7.1/server/clustering/replication/replication-overview.mdx
@@ -62,7 +62,7 @@ If the database also uses
 [cluster-wide transactions](../cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database
-group's voting members accept it, and an odd group size means that majority
+group's voting members have accepted it, and an odd group size means that majority
 is always a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see

--- a/versioned_docs/version-7.1/studio/database/create-new-database/general-flow.mdx
+++ b/versioned_docs/version-7.1/studio/database/create-new-database/general-flow.mdx
@@ -76,6 +76,27 @@ From the database list view, click the **'New database'** button.
    If no node is checked, then the replication nodes will be selected randomly from the cluster.  
 </Admonition>
 
+<Admonition type="note" title="">
+
+**Sizing the database group**
+
+When choosing a **Replication Factor**, use at least three nodes for high
+availability - that way the database survives losing a node and stays
+synchronized through
+[internal replication](../../../server/clustering/replication/replication-overview.mdx#internal-replication).
+
+If the database also uses
+[cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
+prefer an odd group size (3, 5, or 7).  
+A cluster-wide transaction commits only after a majority of the database group's
+voting members accept it, and an odd group size means that majority is always
+a clean (n/2 + 1) - never a tie.
+
+For the full reasoning, see
+[Cluster: Best Practices](../../../server/clustering/cluster-best-practice-and-configuration.mdx#clusters-should-have-an-odd-number-of-at-least-3-nodes).
+
+</Admonition>
+
 
 ## 4. Configure Path
 

--- a/versioned_docs/version-7.1/studio/database/create-new-database/general-flow.mdx
+++ b/versioned_docs/version-7.1/studio/database/create-new-database/general-flow.mdx
@@ -89,7 +89,7 @@ If the database also uses
 [cluster-wide transactions](../../../server/clustering/cluster-transactions.mdx),
 prefer an odd group size (3, 5, or 7).  
 A cluster-wide transaction commits only after a majority of the database group's
-voting members accept it, and an odd group size means that majority is always
+voting members have accepted it, and an odd group size means that majority is always
 a clean (n/2 + 1) - never a tie.
 
 For the full reasoning, see


### PR DESCRIPTION
### Issue link
[RDoc-2211](https://issues.hibernatingrhinos.com/issue/RDoc-2211)

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

