### PR TITLE
RDoc-3865 - Explain how to track inserts with OnProgress while using BulkInsert

### DIFF
--- a/docs/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/docs/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -21,7 +21,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
    * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
       * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
       * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Track progress with OnProgress](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#track-progress-with-onprogress)
    * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+      * [Method signatures](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#method-signatures)
+      * [Event signature](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#event-signature)
+      * [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
 
 </Admonition>
 
@@ -210,9 +214,60 @@ using (var bulk = store.BulkInsert(new BulkInsertOptions
 
 </Panel>
 
+<Panel heading="Track progress with OnProgress">
+
+A long-running bulk insert can take some time to complete. To track its progress -
+for example, to show a progress bar or to log how many documents have been inserted
+so far - subscribe to the `OnProgress` event.
+
+The bulk insert delivers a progress snapshot to your handler each time the server
+reports new progress, with counters such as `DocumentsProcessed`, `BatchCount`, and
+the ID of the document processed most recently (`LastProcessedId`).  
+See [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
+for the full property list.
+
+* Updates arrive asynchronously over the
+  [Changes](../../../client-api/changes/what-is-changes-api.mdx)
+  stream that the server opens for the operation.  
+  Your handler is invoked by the server's progress reports, not by your `Store`
+  calls - a single progress event typically covers many `Store` calls at once.
+* The subscription opens after the first `Store` call. Attach the handler before
+  storing anything to avoid missing early updates.
+* Each snapshot is **cumulative** from the start of the bulk insert. `DocumentsProcessed`,
+  `BatchCount`, `Total`, and the other counters grow over time and do not reset between
+  events.  
+  To find the number of documents added between two consecutive events, subtract the
+  older snapshot's `DocumentsProcessed` from the newer one's. For example, if event A
+  reports `DocumentsProcessed = 1000` and event B reports `DocumentsProcessed = 1500`,
+  then 500 documents were added in the interval.
+
+#### Example: Print progress to the console
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    // Attach the handler before the first Store call so early updates are not missed.
+    bulkInsert.OnProgress += (sender, args) =>
+    {
+        // Each event carries a cumulative snapshot since the bulk insert started.
+        Console.WriteLine(
+            $"Processed {args.Progress.DocumentsProcessed} documents " +
+            $"(last: {args.Progress.LastProcessedId})");
+    };
+
+    // Each employee inserted here advances the counters reported to the handler above.
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
+
+</Panel>
+
 <Panel heading="Syntax">
 
-### Methods
+### Method signatures
 
 <Tabs groupId='bulkInsertOverloads'>
 <TabItem value="bulkInsert" label="BulkInsert">
@@ -325,6 +380,90 @@ using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
 | Return value | |
 |-----------|-------------|
 | `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+---
+
+### Event signature
+
+<Tabs groupId='bulkInsertEvents'>
+<TabItem value="onProgress" label="OnProgress">
+
+Raised while a bulk insert is running, each time the server reports new progress.
+Each invocation carries a cumulative progress snapshot since the start of the
+operation.
+
+```csharp
+public event EventHandler<BulkInsertOnProgressEventArgs> OnProgress;
+```
+
+<br />
+
+Usage:
+
+```csharp
+bulkInsert.OnProgress += (sender, args) =>
+{
+    // Read args.Progress for the current snapshot.
+};
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+### Classes
+
+<Tabs groupId='bulkInsertEventClasses'>
+<TabItem value="BulkInsertOnProgressEventArgs" label="BulkInsertOnProgressEventArgs">
+
+The event arguments delivered to an `OnProgress` handler.
+
+```csharp
+public class BulkInsertOnProgressEventArgs : EventArgs
+{
+    public BulkInsertProgress Progress { get; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Progress** | `BulkInsertProgress` | The cumulative progress snapshot for this update. |
+
+</TabItem>
+<TabItem value="BulkInsertProgress" label="BulkInsertProgress">
+
+A cumulative snapshot of the bulk insert's progress, reported by the server.
+
+```csharp
+public class BulkInsertProgress
+{
+    public long Total { get; set; }
+    public long BatchCount { get; set; }
+    public string LastProcessedId { get; set; }
+    public long DocumentsProcessed { get; set; }
+    public long AttachmentsProcessed { get; set; }
+    public long CountersProcessed { get; set; }
+    public long TimeSeriesProcessed { get; set; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Total** | `long` | Total items processed since the bulk insert started, across documents, attachments, counters, and time series. |
+| **BatchCount** | `long` | Number of server-side batches processed so far. |
+| **LastProcessedId** | `string` | The identifier of the document that was processed most recently. |
+| **DocumentsProcessed** | `long` | Number of documents inserted so far. |
+| **AttachmentsProcessed** | `long` | Number of attachments stored so far. |
+| **CountersProcessed** | `long` | Number of counters created or modified so far. |
+| **TimeSeriesProcessed** | `long` | Number of time series entries appended so far. |
 
 </TabItem>
 </Tabs>

--- a/docs/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/docs/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -2,127 +2,120 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 <Admonition type="note" title="">
 
 * `BulkInsert` is useful when inserting a large quantity of data from the client to the server.  
-* It is an optimized time-saving approach with a few 
-  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations) 
+* It is an optimized time-saving approach with a few
+  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
   like the possibility that interruptions will occur during the operation.  
 
-In this page:
-
-* [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
-* [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation) 
-  * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
-  * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
-  * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
-* [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
-  * [`CompressionLevel`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section)
-  * [`SkipOverwriteIfUnchanged`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1)
+* In this page:
+   * [Quick example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#quick-example)
+   * [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation)
+      * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
+      * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
+      * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
+   * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+      * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
+      * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
 
 </Admonition>
 
-## Syntax
+<Panel heading="Quick example">
 
-<TabItem value="bulk_inserts_1" label="bulk_inserts_1">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database = null, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+Open a bulk insert from the document store and store entities through it.  
+Each `Store` call is buffered and streamed to the server in batches; the operation finalizes
+when the bulk insert is disposed.
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_2" label="bulk_inserts_2">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database, BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+<br />
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+For the full set of `BulkInsert` overloads and their parameters, see the
+[Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+section at the end of this page.
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_3" label="bulk_inserts_3">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+</Panel>
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
-
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-
-
-
-## `BulkInsertOperation`
+<Panel heading="BulkInsertOperation">
 
 The following methods can be used when creating a bulk insert.
+
+<ContentFrame>
 
 ### Methods
 
 | Signature | Description |
-| ----------| ----- |
-| **void Abort()** | Abort the operation |
-| **void Store(object entity, IMetadataDictionary metadata = null)** | Store the entity, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
-| **void Store(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
-| **void StoreAsync(object entity, IMetadataDictionary metadata = null)** | Store the entity in an async manner, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
-| **void StoreAsync(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity in an async manner, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
-| **void Dispose()** | Dispose of an object |
-| **void DisposeAsync()** | Dispose of an object in an async manner |
+| --------- | ----------- |
+| `void Abort()` | Abort the operation. |
+| `string Store(object entity, IMetadataDictionary metadata = null)` | Store the entity. The identifier is generated automatically on the client side and returned. Optional metadata can be provided for the stored entity. |
+| `void Store(object entity, string id, IMetadataDictionary metadata = null)` | Store the entity with an explicit `id`. Optional metadata can be provided for the stored entity. |
+| `Task<string> StoreAsync(object entity, IMetadataDictionary metadata = null)` | Store the entity asynchronously. The identifier is generated automatically on the client side and returned. Optional metadata can be provided for the stored entity. |
+| `Task StoreAsync(object entity, string id, IMetadataDictionary metadata = null)` | Store the entity asynchronously, with an explicit `id`. Optional metadata can be provided for the stored entity. |
+| `void Dispose()` | Dispose of the operation. |
+| `ValueTask DisposeAsync()` | Dispose of the operation asynchronously. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Limitations
 
 * BulkInsert is designed to efficiently push large volumes of data.  
   Data is therefore streamed and **processed by the server in batches**.  
-  Each batch is fully transactional, but there are no transaction guarantees between the batches 
-  and the operation as a whole is non-transactional.  
-  If the bulk insert operation is interrupted mid-way, some of your data might be persisted 
+  Each batch is fully transactional, but there are no transaction guarantees between the
+  batches, and the operation as a whole is non-transactional.  
+  If the bulk insert operation is interrupted mid-way, some of your data might be persisted
   on the server while some of it might not.  
-   * Make sure that your logic accounts for the possibility of an interruption that would cause 
-     some of your data not to persist on the server yet.  
-   * If the operation was interrupted and you choose to re-insert the whole dataset in a new 
-     operation, you can set 
-     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1) 
-     as `true` so the operation will overwrite existing documents only if they changed since 
+   * Make sure that your logic accounts for the possibility of an interruption that would
+     cause some of your data not to persist on the server yet.  
+   * If the operation was interrupted and you choose to re-insert the whole dataset in a
+     new operation, you can set
+     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+     to `true` so the operation overwrites existing documents only if they changed since
      the last insertion.  
-   * **If you need full transactionality**, using [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx) 
+   * **If you need full transactionality**, using a
+     [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx)
      may be a better option.  
-     Note that if `session` is used all of the data is processed in a single transaction, so the 
-     server must have sufficient resources to handle the entire data set included in the transaction.  
+     Note that if a session is used, all of the data is processed in a single transaction,
+     so the server must have sufficient resources to handle the entire data set included
+     in the transaction.  
 * Bulk insert is **not thread-safe**.  
   A single bulk insert should not be accessed concurrently.  
    * Using multiple bulk inserts concurrently on the same client is supported.  
-   * Usage in an async context is also supported.
+   * Usage in an async context is also supported.  
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
 #### Create bulk insert
 
 Here we create a bulk insert operation and insert a million documents of type `Employee`:
+
 <Tabs groupId='languageSyntax'>
 <TabItem value="sync" label="sync">
-<CodeBlock language="csharp">
-{`using (BulkInsertOperation bulkInsert = store.BulkInsert())
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
 {
     for (int i = 0; i < 1000 * 1000; i++)
     {
@@ -133,12 +126,13 @@ Here we create a bulk insert operation and insert a million documents of type `E
         });
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="async" label="async">
-<CodeBlock language="csharp">
-{`BulkInsertOperation bulkInsert = null;
+
+```csharp
+BulkInsertOperation bulkInsert = null;
 try
 {
     bulkInsert = store.BulkInsert();
@@ -158,49 +152,181 @@ finally
         await bulkInsert.DisposeAsync().ConfigureAwait(false);
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</ContentFrame>
 
+</Panel>
 
-## `BulkInsertOptions`
+<Panel heading="BulkInsertOptions">
 
 The following options can be configured for BulkInsert.
 
-#### `CompressionLevel`:
+<ContentFrame>
 
-| Parameter | Type | Description |
-| ------------- | ------------- | ----- |
-| **Optimal** | `string` | Compression level to be used when compressing static files. |
-| **Fastest**<br/>(Default)| `string` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
-| **NoCompression** | `string` | Does not compress. |
+### CompressionLevel
+
+| Value | Type | Description |
+| ----- | ---- | ----------- |
+| **Optimal** | `CompressionLevel` | Compression level to be used when compressing static files. |
+| **Fastest**<br/>(Default) | `CompressionLevel` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
+| **NoCompression** | `CompressionLevel` | Does not compress. |
 
 <Admonition type="info" title="Default compression level" id="default-compression-level" href="#default-compression-level">
 For RavenDB versions up to `6.2`, bulk-insert compression is Disabled (`NoCompression`) by default.  
 For RavenDB versions from `7.0` on, bulk-insert compression is Enabled (set to `Fastest`) by default.  
 </Admonition>
 
-#### `SkipOverwriteIfUnchanged`:
+</ContentFrame>
 
-Use this option to avoid overriding documents when the inserted document and the existing one are similar.  
+---
 
-Enabling this flag can exempt the server of many operations triggered by document-change, 
-like re-indexation and subscription or ETL-tasks updates.  
-There is a slight potential cost in the additional comparison that has to be made between 
-the existing documents and the ones that are being inserted. 
+<ContentFrame>
 
-<TabItem value="bulk_insert_option_SkipOverwriteIfUnchanged" label="bulk_insert_option_SkipOverwriteIfUnchanged">
-<CodeBlock language="csharp">
-{`using (var bulk = store.BulkInsert(new BulkInsertOptions
-\{
+### SkipOverwriteIfUnchanged
+
+Use this option to avoid overwriting documents when the inserted document and the existing
+one are similar.  
+
+Enabling this flag can exempt the server from many operations triggered by document-change,
+like re-indexation and subscription or ETL-task updates.  
+There is a slight potential cost in the additional comparison that has to be made between
+the existing documents and the ones that are being inserted.  
+
+```csharp
+using (var bulk = store.BulkInsert(new BulkInsertOptions
+{
     SkipOverwriteIfUnchanged = true
-\}));
-`}
-</CodeBlock>
+}))
+{
+    // ...
+}
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Syntax">
+
+### Methods
+
+<Tabs groupId='bulkInsertOverloads'>
+<TabItem value="bulkInsert" label="BulkInsert">
+
+Opens a bulk insert against the given database, or the document store's default database
+when `database` is `null`.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database = null,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert())
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
 </TabItem>
+<TabItem value="bulkInsert-with-options" label="BulkInsert (with options)">
 
+Opens a bulk insert against the given database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
 
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database,
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
 
+<br />
 
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert("Northwind", new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+<TabItem value="bulkInsert-options-only" label="BulkInsert (options only)">
+
+Opens a bulk insert against the document store's default database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+</Panel>

--- a/docs/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/docs/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -21,6 +21,14 @@ see_also:
        link: "document-extensions/timeseries/client-api/bulk-insert/append-in-bulk"
        source: "docs"
        path: "Document Extensions > Time Series > Client API > Bulk Insert"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
+     - title: "Create or Modify Counters"
+       link: "document-extensions/counters/create-or-modify"
+       source: "docs"
+       path: "Document Extensions > Counters"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/docs/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/docs/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -29,6 +29,10 @@ see_also:
        link: "document-extensions/counters/create-or-modify"
        source: "docs"
        path: "Document Extensions > Counters"
+     - title: "What is the Changes API"
+       link: "client-api/changes/what-is-changes-api"
+       source: "docs"
+       path: "Client API > Changes"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-6.2/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -64,12 +64,12 @@ The following methods can be used when creating a bulk insert.
 | Signature | Description |
 | ----------| ----- |
 | **void Abort()** | Abort the operation |
-| **void Store(object entity, IMetadataDictionary metadata = null)** | Store the entity, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
+| **string Store(object entity, IMetadataDictionary metadata = null)** | Store the entity, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
 | **void Store(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
-| **void StoreAsync(object entity, IMetadataDictionary metadata = null)** | Store the entity in an async manner, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
-| **void StoreAsync(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity in an async manner, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
+| **Task&lt;string&gt; StoreAsync(object entity, IMetadataDictionary metadata = null)** | Store the entity in an async manner, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
+| **Task StoreAsync(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity in an async manner, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
 | **void Dispose()** | Dispose of an object |
-| **void DisposeAsync()** | Dispose of an object in an async manner |
+| **ValueTask DisposeAsync()** | Dispose of an object in an async manner |
 
 </ContentFrame>
 

--- a/versioned_docs/version-6.2/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -21,7 +21,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
    * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
       * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
       * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Track progress with OnProgress](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#track-progress-with-onprogress)
    * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+      * [Method signatures](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#method-signatures)
+      * [Event signature](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#event-signature)
+      * [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
 
 </Admonition>
 
@@ -204,9 +208,60 @@ using (var bulk = store.BulkInsert(new BulkInsertOptions
 
 </Panel>
 
+<Panel heading="Track progress with OnProgress">
+
+A long-running bulk insert can take some time to complete. To track its progress -
+for example, to show a progress bar or to log how many documents have been inserted
+so far - subscribe to the `OnProgress` event.
+
+The bulk insert delivers a progress snapshot to your handler each time the server
+reports new progress, with counters such as `DocumentsProcessed`, `BatchCount`, and
+the ID of the document processed most recently (`LastProcessedId`).  
+See [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
+for the full property list.
+
+* Updates arrive asynchronously over the
+  [Changes](../../../client-api/changes/what-is-changes-api.mdx)
+  stream that the server opens for the operation.  
+  Your handler is invoked by the server's progress reports, not by your `Store`
+  calls - a single progress event typically covers many `Store` calls at once.
+* The subscription opens after the first `Store` call. Attach the handler before
+  storing anything to avoid missing early updates.
+* Each snapshot is **cumulative** from the start of the bulk insert. `DocumentsProcessed`,
+  `BatchCount`, `Total`, and the other counters grow over time and do not reset between
+  events.  
+  To find the number of documents added between two consecutive events, subtract the
+  older snapshot's `DocumentsProcessed` from the newer one's. For example, if event A
+  reports `DocumentsProcessed = 1000` and event B reports `DocumentsProcessed = 1500`,
+  then 500 documents were added in the interval.
+
+#### Example: Print progress to the console
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    // Attach the handler before the first Store call so early updates are not missed.
+    bulkInsert.OnProgress += (sender, args) =>
+    {
+        // Each event carries a cumulative snapshot since the bulk insert started.
+        Console.WriteLine(
+            $"Processed {args.Progress.DocumentsProcessed} documents " +
+            $"(last: {args.Progress.LastProcessedId})");
+    };
+
+    // Each employee inserted here advances the counters reported to the handler above.
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
+
+</Panel>
+
 <Panel heading="Syntax">
 
-### Methods
+### Method signatures
 
 <Tabs groupId='bulkInsertOverloads'>
 <TabItem value="bulkInsert" label="BulkInsert">
@@ -319,6 +374,90 @@ using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
 | Return value | |
 |-----------|-------------|
 | `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+---
+
+### Event signature
+
+<Tabs groupId='bulkInsertEvents'>
+<TabItem value="onProgress" label="OnProgress">
+
+Raised while a bulk insert is running, each time the server reports new progress.
+Each invocation carries a cumulative progress snapshot since the start of the
+operation.
+
+```csharp
+public event EventHandler<BulkInsertOnProgressEventArgs> OnProgress;
+```
+
+<br />
+
+Usage:
+
+```csharp
+bulkInsert.OnProgress += (sender, args) =>
+{
+    // Read args.Progress for the current snapshot.
+};
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+### Classes
+
+<Tabs groupId='bulkInsertEventClasses'>
+<TabItem value="BulkInsertOnProgressEventArgs" label="BulkInsertOnProgressEventArgs">
+
+The event arguments delivered to an `OnProgress` handler.
+
+```csharp
+public class BulkInsertOnProgressEventArgs : EventArgs
+{
+    public BulkInsertProgress Progress { get; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Progress** | `BulkInsertProgress` | The cumulative progress snapshot for this update. |
+
+</TabItem>
+<TabItem value="BulkInsertProgress" label="BulkInsertProgress">
+
+A cumulative snapshot of the bulk insert's progress, reported by the server.
+
+```csharp
+public class BulkInsertProgress
+{
+    public long Total { get; set; }
+    public long BatchCount { get; set; }
+    public string LastProcessedId { get; set; }
+    public long DocumentsProcessed { get; set; }
+    public long AttachmentsProcessed { get; set; }
+    public long CountersProcessed { get; set; }
+    public long TimeSeriesProcessed { get; set; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Total** | `long` | Total items processed since the bulk insert started, across documents, attachments, counters, and time series. |
+| **BatchCount** | `long` | Number of server-side batches processed so far. |
+| **LastProcessedId** | `string` | The identifier of the document that was processed most recently. |
+| **DocumentsProcessed** | `long` | Number of documents inserted so far. |
+| **AttachmentsProcessed** | `long` | Number of attachments stored so far. |
+| **CountersProcessed** | `long` | Number of counters created or modified so far. |
+| **TimeSeriesProcessed** | `long` | Number of time series entries appended so far. |
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-6.2/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -2,81 +2,58 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 <Admonition type="note" title="">
 
 * `BulkInsert` is useful when inserting a large quantity of data from the client to the server.  
-* It is an optimized time-saving approach with a few 
-  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations) 
-  like the possibility that interruptions will occure during the operation.  
+* It is an optimized time-saving approach with a few
+  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
+  like the possibility that interruptions will occur during the operation.  
 
-In this page:
-
-* [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
-* [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation) 
-  * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
-  * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
-  * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
-* [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
-  * [`CompressionLevel`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section)
-  * [`SkipOverwriteIfUnchanged`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1)
+* In this page:
+   * [Quick example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#quick-example)
+   * [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation)
+      * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
+      * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
+      * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
+   * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+      * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
+      * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
 
 </Admonition>
 
-## Syntax
+<Panel heading="Quick example">
 
-<TabItem value="bulk_inserts_1" label="bulk_inserts_1">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database = null, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+Open a bulk insert from the document store and store entities through it.  
+Each `Store` call is buffered and streamed to the server in batches; the operation finalizes
+when the bulk insert is disposed.
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_2" label="bulk_inserts_2">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database, BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+<br />
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+For the full set of `BulkInsert` overloads and their parameters, see the
+[Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+section at the end of this page.
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_3" label="bulk_inserts_3">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+</Panel>
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
-
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-
-
-
-## `BulkInsertOperation`
+<Panel heading="BulkInsertOperation">
 
 The following methods can be used when creating a bulk insert.
+
+<ContentFrame>
 
 ### Methods
 
@@ -90,39 +67,55 @@ The following methods can be used when creating a bulk insert.
 | **void Dispose()** | Dispose of an object |
 | **void DisposeAsync()** | Dispose of an object in an async manner |
 
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
 ### Limitations
 
 * BulkInsert is designed to efficiently push high quantities of data.  
   Data is therefore streamed and **processed by the server in batches**.  
-  Each batch is fully transactional, but there are no transaction guarantees between the batches 
-  and the operation as a whole is non-transactional.  
-  If the bulk insert operation is interrupted mid-way, some of your data might be persisted 
+  Each batch is fully transactional, but there are no transaction guarantees between the
+  batches and the operation as a whole is non-transactional.  
+  If the bulk insert operation is interrupted mid-way, some of your data might be persisted
   on the server while some of it might not.  
-   * Make sure that your logic accounts for the possibility of an interruption that would cause 
-     some of your data not to persist on the server yet.  
-   * If the operation was interrupted and you choose to re-insert the whole dataset in a new 
-     operation, you can set 
-     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1) 
-     as `true` so the operation will overwrite existing documents only if they changed since 
-     the last insertion.  
-   * **If you need full transactionality**, using [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx) 
+   * Make sure that your logic accounts for the possibility of an interruption that would
+     cause some of your data not to persist on the server yet.  
+   * If the operation was interrupted and you choose to re-insert the whole dataset in a
+     new operation, you can set
+     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+     as `true` so the operation will overwrite existing documents only if they changed
+     since the last insertion.  
+   * **If you need full transactionality**, using a
+     [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx)
      may be a better option.  
-     Note that if `session` is used all of the data is processed in a single transaction, so the 
-     server must have sufficient resources to handle the entire data-set included in the transaction.  
+     Note that if `session` is used, all of the data is processed in a single transaction,
+     so the server must have sufficient resources to handle the entire data-set included
+     in the transaction.  
 * Bulk insert is **not thread-safe**.  
   A single bulk insert should not be accessed concurrently.  
    * The use of multiple bulk inserts concurrently on the same client is supported.  
-   * Usage in an async context is also supported.
+   * Usage in an async context is also supported.  
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
 #### Create bulk insert
 
 Here we create a bulk insert operation and insert a million documents of type `Employee`:
+
 <Tabs groupId='languageSyntax'>
 <TabItem value="sync" label="sync">
-<CodeBlock language="csharp">
-{`using (BulkInsertOperation bulkInsert = store.BulkInsert())
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
 {
     for (int i = 0; i < 1000 * 1000; i++)
     {
@@ -133,12 +126,13 @@ Here we create a bulk insert operation and insert a million documents of type `E
         });
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="async" label="async">
-<CodeBlock language="csharp">
-{`BulkInsertOperation bulkInsert = null;
+
+```csharp
+BulkInsertOperation bulkInsert = null;
 try
 {
     bulkInsert = store.BulkInsert();
@@ -158,44 +152,175 @@ finally
         await bulkInsert.DisposeAsync().ConfigureAwait(false);
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</ContentFrame>
 
+</Panel>
 
-## `BulkInsertOptions`
+<Panel heading="BulkInsertOptions">
 
 The following options can be configured for BulkInsert.
 
-### `CompressionLevel`
+<ContentFrame>
 
-| Parameter | Type | Description |
-| ------------- | ------------- | ----- |
-| **Optimal** | `string` | Compression level to be used when compressing static files. |
-| **Fastest** | `string` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
-| **NoCompression**<br/>(Default) | `string` | Does not compress. |
+### CompressionLevel
 
-### `SkipOverwriteIfUnchanged`
+| Value | Type | Description |
+| ----- | ---- | ----------- |
+| **Optimal** | `CompressionLevel` | Compression level to be used when compressing static files. |
+| **Fastest** | `CompressionLevel` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
+| **NoCompression**<br/>(Default) | `CompressionLevel` | Does not compress. |
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
+### SkipOverwriteIfUnchanged
 
 Prevents overriding documents when the inserted document and the existing one are similar.  
 
-Enabling this flag can exempt the server of many operations triggered by document-change, 
-like re-indexation and subscription or ETL-tasks updatess.  
-There is a slight potential cost in the additional comparison that has to be made between 
-the existing documents and the ones that are being inserted. 
+Enabling this flag can exempt the server of many operations triggered by document-change,
+like re-indexation and subscription or ETL-tasks updates.  
+There is a slight potential cost in the additional comparison that has to be made between
+the existing documents and the ones that are being inserted.  
 
-<TabItem value="bulk_insert_option_SkipOverwriteIfUnchanged" label="bulk_insert_option_SkipOverwriteIfUnchanged">
-<CodeBlock language="csharp">
-{`using (var bulk = store.BulkInsert(new BulkInsertOptions
-\{
+```csharp
+using (var bulk = store.BulkInsert(new BulkInsertOptions
+{
     SkipOverwriteIfUnchanged = true
-\}));
-`}
-</CodeBlock>
+}))
+{
+    // ...
+}
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Syntax">
+
+### Methods
+
+<Tabs groupId='bulkInsertOverloads'>
+<TabItem value="bulkInsert" label="BulkInsert">
+
+Opens a bulk insert against the given database, or the document store's default database
+when `database` is `null`.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database = null,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert())
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
 </TabItem>
+<TabItem value="bulkInsert-with-options" label="BulkInsert (with options)">
 
+Opens a bulk insert against the given database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
 
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database,
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
 
+<br />
 
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert("Northwind", new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+<TabItem value="bulkInsert-options-only" label="BulkInsert (options only)">
+
+Opens a bulk insert against the document store's default database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+</Panel>

--- a/versioned_docs/version-6.2/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/versioned_docs/version-6.2/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -28,6 +28,10 @@ see_also:
        link: "document-extensions/counters/create-or-modify"
        source: "docs"
        path: "Document Extensions > Counters"
+     - title: "What is the Changes API"
+       link: "client-api/changes/what-is-changes-api"
+       source: "docs"
+       path: "Client API > Changes"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-6.2/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/versioned_docs/version-6.2/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -20,6 +20,14 @@ see_also:
        link: "document-extensions/timeseries/client-api/bulk-insert/append-in-bulk"
        source: "docs"
        path: "Document Extensions > Time Series > Client API > Bulk Insert"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
+     - title: "Create or Modify Counters"
+       link: "document-extensions/counters/create-or-modify"
+       source: "docs"
+       path: "Document Extensions > Counters"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-7.0/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -2,81 +2,58 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 <Admonition type="note" title="">
 
 * `BulkInsert` is useful when inserting a large quantity of data from the client to the server.  
-* It is an optimized time-saving approach with a few 
-  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations) 
+* It is an optimized time-saving approach with a few
+  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
   like the possibility that interruptions will occur during the operation.  
 
-In this page:
-
-* [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
-* [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation) 
-  * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
-  * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
-  * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
-* [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
-  * [`CompressionLevel`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section)
-  * [`SkipOverwriteIfUnchanged`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1)
+* In this page:
+   * [Quick example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#quick-example)
+   * [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation)
+      * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
+      * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
+      * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
+   * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+      * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
+      * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
 
 </Admonition>
 
-## Syntax
+<Panel heading="Quick example">
 
-<TabItem value="bulk_inserts_1" label="bulk_inserts_1">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database = null, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+Open a bulk insert from the document store and store entities through it.  
+Each `Store` call is buffered and streamed to the server in batches; the operation finalizes
+when the bulk insert is disposed.
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_2" label="bulk_inserts_2">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database, BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+<br />
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+For the full set of `BulkInsert` overloads and their parameters, see the
+[Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+section at the end of this page.
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_3" label="bulk_inserts_3">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+</Panel>
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
-
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-
-
-
-## `BulkInsertOperation`
+<Panel heading="BulkInsertOperation">
 
 The following methods can be used when creating a bulk insert.
+
+<ContentFrame>
 
 ### Methods
 
@@ -90,39 +67,55 @@ The following methods can be used when creating a bulk insert.
 | **void Dispose()** | Dispose of an object |
 | **void DisposeAsync()** | Dispose of an object in an async manner |
 
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
 ### Limitations
 
 * BulkInsert is designed to efficiently push large volumes of data.  
   Data is therefore streamed and **processed by the server in batches**.  
-  Each batch is fully transactional, but there are no transaction guarantees between the batches 
-  and the operation as a whole is non-transactional.  
-  If the bulk insert operation is interrupted mid-way, some of your data might be persisted 
+  Each batch is fully transactional, but there are no transaction guarantees between the
+  batches, and the operation as a whole is non-transactional.  
+  If the bulk insert operation is interrupted mid-way, some of your data might be persisted
   on the server while some of it might not.  
-   * Make sure that your logic accounts for the possibility of an interruption that would cause 
-     some of your data not to persist on the server yet.  
-   * If the operation was interrupted and you choose to re-insert the whole dataset in a new 
-     operation, you can set 
-     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1) 
-     as `true` so the operation will overwrite existing documents only if they changed since 
+   * Make sure that your logic accounts for the possibility of an interruption that would
+     cause some of your data not to persist on the server yet.  
+   * If the operation was interrupted and you choose to re-insert the whole dataset in a
+     new operation, you can set
+     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+     to `true` so the operation overwrites existing documents only if they changed since
      the last insertion.  
-   * **If you need full transactionality**, using [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx) 
+   * **If you need full transactionality**, using a
+     [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx)
      may be a better option.  
-     Note that if `session` is used all of the data is processed in a single transaction, so the 
-     server must have sufficient resources to handle the entire data set included in the transaction.  
+     Note that if a session is used, all of the data is processed in a single transaction,
+     so the server must have sufficient resources to handle the entire data set included
+     in the transaction.  
 * Bulk insert is **not thread-safe**.  
   A single bulk insert should not be accessed concurrently.  
    * Using multiple bulk inserts concurrently on the same client is supported.  
-   * Usage in an async context is also supported.
+   * Usage in an async context is also supported.  
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
 #### Create bulk insert
 
 Here we create a bulk insert operation and insert a million documents of type `Employee`:
+
 <Tabs groupId='languageSyntax'>
 <TabItem value="sync" label="sync">
-<CodeBlock language="csharp">
-{`using (BulkInsertOperation bulkInsert = store.BulkInsert())
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
 {
     for (int i = 0; i < 1000 * 1000; i++)
     {
@@ -133,12 +126,13 @@ Here we create a bulk insert operation and insert a million documents of type `E
         });
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="async" label="async">
-<CodeBlock language="csharp">
-{`BulkInsertOperation bulkInsert = null;
+
+```csharp
+BulkInsertOperation bulkInsert = null;
 try
 {
     bulkInsert = store.BulkInsert();
@@ -158,49 +152,181 @@ finally
         await bulkInsert.DisposeAsync().ConfigureAwait(false);
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</ContentFrame>
 
+</Panel>
 
-## `BulkInsertOptions`
+<Panel heading="BulkInsertOptions">
 
 The following options can be configured for BulkInsert.
 
-#### `CompressionLevel`:
+<ContentFrame>
 
-| Parameter | Type | Description |
-| ------------- | ------------- | ----- |
-| **Optimal** | `string` | Compression level to be used when compressing static files. |
-| **Fastest**<br/>(Default)| `string` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
-| **NoCompression** | `string` | Does not compress. |
+### CompressionLevel
+
+| Value | Type | Description |
+| ----- | ---- | ----------- |
+| **Optimal** | `CompressionLevel` | Compression level to be used when compressing static files. |
+| **Fastest**<br/>(Default) | `CompressionLevel` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
+| **NoCompression** | `CompressionLevel` | Does not compress. |
 
 <Admonition type="info" title="Default compression level" id="default-compression-level" href="#default-compression-level">
 For RavenDB versions up to `6.2`, bulk-insert compression is Disabled (`NoCompression`) by default.  
 For RavenDB versions from `7.0` on, bulk-insert compression is Enabled (set to `Fastest`) by default.  
 </Admonition>
 
-#### `SkipOverwriteIfUnchanged`:
+</ContentFrame>
 
-Use this option to avoid overriding documents when the inserted document and the existing one are similar.  
+---
 
-Enabling this flag can exempt the server of many operations triggered by document-change, 
+<ContentFrame>
+
+### SkipOverwriteIfUnchanged
+
+Use this option to avoid overriding documents when the inserted document and the existing
+one are similar.  
+
+Enabling this flag can exempt the server of many operations triggered by document-change,
 like re-indexation and subscription or ETL-tasks updates.  
-There is a slight potential cost in the additional comparison that has to be made between 
-the existing documents and the ones that are being inserted. 
+There is a slight potential cost in the additional comparison that has to be made between
+the existing documents and the ones that are being inserted.  
 
-<TabItem value="bulk_insert_option_SkipOverwriteIfUnchanged" label="bulk_insert_option_SkipOverwriteIfUnchanged">
-<CodeBlock language="csharp">
-{`using (var bulk = store.BulkInsert(new BulkInsertOptions
-\{
+```csharp
+using (var bulk = store.BulkInsert(new BulkInsertOptions
+{
     SkipOverwriteIfUnchanged = true
-\}));
-`}
-</CodeBlock>
+}))
+{
+    // ...
+}
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Syntax">
+
+### Methods
+
+<Tabs groupId='bulkInsertOverloads'>
+<TabItem value="bulkInsert" label="BulkInsert">
+
+Opens a bulk insert against the given database, or the document store's default database
+when `database` is `null`.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database = null,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert())
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
 </TabItem>
+<TabItem value="bulkInsert-with-options" label="BulkInsert (with options)">
 
+Opens a bulk insert against the given database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
 
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database,
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
 
+<br />
 
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert("Northwind", new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+<TabItem value="bulkInsert-options-only" label="BulkInsert (options only)">
+
+Opens a bulk insert against the document store's default database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+</Panel>

--- a/versioned_docs/version-7.0/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -64,12 +64,12 @@ The following methods can be used when creating a bulk insert.
 | Signature | Description |
 | ----------| ----- |
 | **void Abort()** | Abort the operation |
-| **void Store(object entity, IMetadataDictionary metadata = null)** | Store the entity, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
+| **string Store(object entity, IMetadataDictionary metadata = null)** | Store the entity, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
 | **void Store(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
-| **void StoreAsync(object entity, IMetadataDictionary metadata = null)** | Store the entity in an async manner, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
-| **void StoreAsync(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity in an async manner, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
+| **Task&lt;string&gt; StoreAsync(object entity, IMetadataDictionary metadata = null)** | Store the entity in an async manner, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
+| **Task StoreAsync(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity in an async manner, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
 | **void Dispose()** | Dispose of an object |
-| **void DisposeAsync()** | Dispose of an object in an async manner |
+| **ValueTask DisposeAsync()** | Dispose of an object in an async manner |
 
 </ContentFrame>
 

--- a/versioned_docs/version-7.0/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -21,7 +21,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
    * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
       * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
       * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Track progress with OnProgress](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#track-progress-with-onprogress)
    * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+      * [Method signatures](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#method-signatures)
+      * [Event signature](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#event-signature)
+      * [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
 
 </Admonition>
 
@@ -210,9 +214,60 @@ using (var bulk = store.BulkInsert(new BulkInsertOptions
 
 </Panel>
 
+<Panel heading="Track progress with OnProgress">
+
+A long-running bulk insert can take some time to complete. To track its progress -
+for example, to show a progress bar or to log how many documents have been inserted
+so far - subscribe to the `OnProgress` event.
+
+The bulk insert delivers a progress snapshot to your handler each time the server
+reports new progress, with counters such as `DocumentsProcessed`, `BatchCount`, and
+the ID of the document processed most recently (`LastProcessedId`).  
+See [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
+for the full property list.
+
+* Updates arrive asynchronously over the
+  [Changes](../../../client-api/changes/what-is-changes-api.mdx)
+  stream that the server opens for the operation.  
+  Your handler is invoked by the server's progress reports, not by your `Store`
+  calls - a single progress event typically covers many `Store` calls at once.
+* The subscription opens after the first `Store` call. Attach the handler before
+  storing anything to avoid missing early updates.
+* Each snapshot is **cumulative** from the start of the bulk insert. `DocumentsProcessed`,
+  `BatchCount`, `Total`, and the other counters grow over time and do not reset between
+  events.  
+  To find the number of documents added between two consecutive events, subtract the
+  older snapshot's `DocumentsProcessed` from the newer one's. For example, if event A
+  reports `DocumentsProcessed = 1000` and event B reports `DocumentsProcessed = 1500`,
+  then 500 documents were added in the interval.
+
+#### Example: Print progress to the console
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    // Attach the handler before the first Store call so early updates are not missed.
+    bulkInsert.OnProgress += (sender, args) =>
+    {
+        // Each event carries a cumulative snapshot since the bulk insert started.
+        Console.WriteLine(
+            $"Processed {args.Progress.DocumentsProcessed} documents " +
+            $"(last: {args.Progress.LastProcessedId})");
+    };
+
+    // Each employee inserted here advances the counters reported to the handler above.
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
+
+</Panel>
+
 <Panel heading="Syntax">
 
-### Methods
+### Method signatures
 
 <Tabs groupId='bulkInsertOverloads'>
 <TabItem value="bulkInsert" label="BulkInsert">
@@ -325,6 +380,90 @@ using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
 | Return value | |
 |-----------|-------------|
 | `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+---
+
+### Event signature
+
+<Tabs groupId='bulkInsertEvents'>
+<TabItem value="onProgress" label="OnProgress">
+
+Raised while a bulk insert is running, each time the server reports new progress.
+Each invocation carries a cumulative progress snapshot since the start of the
+operation.
+
+```csharp
+public event EventHandler<BulkInsertOnProgressEventArgs> OnProgress;
+```
+
+<br />
+
+Usage:
+
+```csharp
+bulkInsert.OnProgress += (sender, args) =>
+{
+    // Read args.Progress for the current snapshot.
+};
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+### Classes
+
+<Tabs groupId='bulkInsertEventClasses'>
+<TabItem value="BulkInsertOnProgressEventArgs" label="BulkInsertOnProgressEventArgs">
+
+The event arguments delivered to an `OnProgress` handler.
+
+```csharp
+public class BulkInsertOnProgressEventArgs : EventArgs
+{
+    public BulkInsertProgress Progress { get; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Progress** | `BulkInsertProgress` | The cumulative progress snapshot for this update. |
+
+</TabItem>
+<TabItem value="BulkInsertProgress" label="BulkInsertProgress">
+
+A cumulative snapshot of the bulk insert's progress, reported by the server.
+
+```csharp
+public class BulkInsertProgress
+{
+    public long Total { get; set; }
+    public long BatchCount { get; set; }
+    public string LastProcessedId { get; set; }
+    public long DocumentsProcessed { get; set; }
+    public long AttachmentsProcessed { get; set; }
+    public long CountersProcessed { get; set; }
+    public long TimeSeriesProcessed { get; set; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Total** | `long` | Total items processed since the bulk insert started, across documents, attachments, counters, and time series. |
+| **BatchCount** | `long` | Number of server-side batches processed so far. |
+| **LastProcessedId** | `string` | The identifier of the document that was processed most recently. |
+| **DocumentsProcessed** | `long` | Number of documents inserted so far. |
+| **AttachmentsProcessed** | `long` | Number of attachments stored so far. |
+| **CountersProcessed** | `long` | Number of counters created or modified so far. |
+| **TimeSeriesProcessed** | `long` | Number of time series entries appended so far. |
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-7.0/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/versioned_docs/version-7.0/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -28,6 +28,10 @@ see_also:
        link: "document-extensions/counters/create-or-modify"
        source: "docs"
        path: "Document Extensions > Counters"
+     - title: "What is the Changes API"
+       link: "client-api/changes/what-is-changes-api"
+       source: "docs"
+       path: "Client API > Changes"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-7.0/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/versioned_docs/version-7.0/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -20,6 +20,14 @@ see_also:
        link: "document-extensions/timeseries/client-api/bulk-insert/append-in-bulk"
        source: "docs"
        path: "Document Extensions > Time Series > Client API > Bulk Insert"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
+     - title: "Create or Modify Counters"
+       link: "document-extensions/counters/create-or-modify"
+       source: "docs"
+       path: "Document Extensions > Counters"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-7.1/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -2,81 +2,58 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 <Admonition type="note" title="">
 
 * `BulkInsert` is useful when inserting a large quantity of data from the client to the server.  
-* It is an optimized time-saving approach with a few 
-  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations) 
+* It is an optimized time-saving approach with a few
+  [limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
   like the possibility that interruptions will occur during the operation.  
 
-In this page:
-
-* [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
-* [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation) 
-  * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
-  * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
-  * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
-* [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
-  * [`CompressionLevel`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section)
-  * [`SkipOverwriteIfUnchanged`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1)
+* In this page:
+   * [Quick example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#quick-example)
+   * [`BulkInsertOperation`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoperation)
+      * [Methods](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#methods)
+      * [Limitations](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#limitations)
+      * [Example](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#example)
+   * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+      * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
+      * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
 
 </Admonition>
 
-## Syntax
+<Panel heading="Quick example">
 
-<TabItem value="bulk_inserts_1" label="bulk_inserts_1">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database = null, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+Open a bulk insert from the document store and store entities through it.  
+Each `Store` call is buffered and streamed to the server in batches; the operation finalizes
+when the bulk insert is disposed.
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_2" label="bulk_inserts_2">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(string database, BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+<br />
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the DocumentStore `Database` will be used. |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+For the full set of `BulkInsert` overloads and their parameters, see the
+[Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+section at the end of this page.
 
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-<TabItem value="bulk_inserts_3" label="bulk_inserts_3">
-<CodeBlock language="csharp">
-{`BulkInsertOperation BulkInsert(BulkInsertOptions options, CancellationToken token = default);
-`}
-</CodeBlock>
-</TabItem>
+</Panel>
 
-| Parameters | Type | Description |
-| ------------- | ------------- | ----- |
-| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
-| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
-
-| Return Value | |
-| ------------- | ----- |
-| `BulkInsertOperation`| Instance of `BulkInsertOperation` used for interaction. |
-
-
-
-## `BulkInsertOperation`
+<Panel heading="BulkInsertOperation">
 
 The following methods can be used when creating a bulk insert.
+
+<ContentFrame>
 
 ### Methods
 
@@ -90,39 +67,55 @@ The following methods can be used when creating a bulk insert.
 | **void Dispose()** | Dispose of an object |
 | **void DisposeAsync()** | Dispose of an object in an async manner |
 
+</ContentFrame>
+
+---
+
+<ContentFrame>
+
 ### Limitations
 
 * BulkInsert is designed to efficiently push large volumes of data.  
   Data is therefore streamed and **processed by the server in batches**.  
-  Each batch is fully transactional, but there are no transaction guarantees between the batches 
-  and the operation as a whole is non-transactional.  
-  If the bulk insert operation is interrupted mid-way, some of your data might be persisted 
+  Each batch is fully transactional, but there are no transaction guarantees between the
+  batches, and the operation as a whole is non-transactional.  
+  If the bulk insert operation is interrupted mid-way, some of your data might be persisted
   on the server while some of it might not.  
-   * Make sure that your logic accounts for the possibility of an interruption that would cause 
-     some of your data not to persist on the server yet.  
-   * If the operation was interrupted and you choose to re-insert the whole dataset in a new 
-     operation, you can set 
-     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#section-1) 
-     as `true` so the operation will overwrite existing documents only if they changed since 
+   * Make sure that your logic accounts for the possibility of an interruption that would
+     cause some of your data not to persist on the server yet.  
+   * If the operation was interrupted and you choose to re-insert the whole dataset in a
+     new operation, you can set
+     [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+     to `true` so the operation overwrites existing documents only if they changed since
      the last insertion.  
-   * **If you need full transactionality**, using [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx) 
+   * **If you need full transactionality**, using a
+     [session](../../../client-api/session/what-is-a-session-and-how-does-it-work.mdx)
      may be a better option.  
-     Note that if `session` is used all of the data is processed in a single transaction, so the 
-     server must have sufficient resources to handle the entire data set included in the transaction.  
+     Note that if a session is used, all of the data is processed in a single transaction,
+     so the server must have sufficient resources to handle the entire data set included
+     in the transaction.  
 * Bulk insert is **not thread-safe**.  
   A single bulk insert should not be accessed concurrently.  
    * Using multiple bulk inserts concurrently on the same client is supported.  
-   * Usage in an async context is also supported.
+   * Usage in an async context is also supported.  
+
+</ContentFrame>
+
+---
+
+<ContentFrame>
 
 ### Example
 
 #### Create bulk insert
 
 Here we create a bulk insert operation and insert a million documents of type `Employee`:
+
 <Tabs groupId='languageSyntax'>
 <TabItem value="sync" label="sync">
-<CodeBlock language="csharp">
-{`using (BulkInsertOperation bulkInsert = store.BulkInsert())
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
 {
     for (int i = 0; i < 1000 * 1000; i++)
     {
@@ -133,12 +126,13 @@ Here we create a bulk insert operation and insert a million documents of type `E
         });
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="async" label="async">
-<CodeBlock language="csharp">
-{`BulkInsertOperation bulkInsert = null;
+
+```csharp
+BulkInsertOperation bulkInsert = null;
 try
 {
     bulkInsert = store.BulkInsert();
@@ -158,49 +152,181 @@ finally
         await bulkInsert.DisposeAsync().ConfigureAwait(false);
     }
 }
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</ContentFrame>
 
+</Panel>
 
-## `BulkInsertOptions`
+<Panel heading="BulkInsertOptions">
 
 The following options can be configured for BulkInsert.
 
-#### `CompressionLevel`:
+<ContentFrame>
 
-| Parameter | Type | Description |
-| ------------- | ------------- | ----- |
-| **Optimal** | `string` | Compression level to be used when compressing static files. |
-| **Fastest**<br/>(Default)| `string` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
-| **NoCompression** | `string` | Does not compress. |
+### CompressionLevel
+
+| Value | Type | Description |
+| ----- | ---- | ----------- |
+| **Optimal** | `CompressionLevel` | Compression level to be used when compressing static files. |
+| **Fastest**<br/>(Default) | `CompressionLevel` | Compression level to be used when compressing HTTP responses with `GZip` or `Deflate`. |
+| **NoCompression** | `CompressionLevel` | Does not compress. |
 
 <Admonition type="info" title="Default compression level" id="default-compression-level" href="#default-compression-level">
 For RavenDB versions up to `6.2`, bulk-insert compression is Disabled (`NoCompression`) by default.  
 For RavenDB versions from `7.0` on, bulk-insert compression is Enabled (set to `Fastest`) by default.  
 </Admonition>
 
-#### `SkipOverwriteIfUnchanged`:
+</ContentFrame>
 
-Use this option to avoid overriding documents when the inserted document and the existing one are similar.  
+---
 
-Enabling this flag can exempt the server of many operations triggered by document-change, 
+<ContentFrame>
+
+### SkipOverwriteIfUnchanged
+
+Use this option to avoid overriding documents when the inserted document and the existing
+one are similar.  
+
+Enabling this flag can exempt the server of many operations triggered by document-change,
 like re-indexation and subscription or ETL-tasks updates.  
-There is a slight potential cost in the additional comparison that has to be made between 
-the existing documents and the ones that are being inserted. 
+There is a slight potential cost in the additional comparison that has to be made between
+the existing documents and the ones that are being inserted.  
 
-<TabItem value="bulk_insert_option_SkipOverwriteIfUnchanged" label="bulk_insert_option_SkipOverwriteIfUnchanged">
-<CodeBlock language="csharp">
-{`using (var bulk = store.BulkInsert(new BulkInsertOptions
-\{
+```csharp
+using (var bulk = store.BulkInsert(new BulkInsertOptions
+{
     SkipOverwriteIfUnchanged = true
-\}));
-`}
-</CodeBlock>
+}))
+{
+    // ...
+}
+```
+
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Syntax">
+
+### Methods
+
+<Tabs groupId='bulkInsertOverloads'>
+<TabItem value="bulkInsert" label="BulkInsert">
+
+Opens a bulk insert against the given database, or the document store's default database
+when `database` is `null`.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database = null,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert())
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
 </TabItem>
+<TabItem value="bulkInsert-with-options" label="BulkInsert (with options)">
 
+Opens a bulk insert against the given database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
 
+```csharp
+public BulkInsertOperation BulkInsert(
+    string database,
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
 
+<br />
 
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert("Northwind", new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **database** | `string` | The name of the database to perform the bulk operation on.<br/>If `null`, the `DocumentStore.Database` is used. |
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+<TabItem value="bulkInsert-options-only" label="BulkInsert (options only)">
+
+Opens a bulk insert against the document store's default database with a
+[`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
+instance to configure compression and overwrite behavior.
+
+```csharp
+public BulkInsertOperation BulkInsert(
+    BulkInsertOptions options,
+    CancellationToken token = default);
+```
+
+<br />
+
+Usage:
+
+```csharp
+using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
+{
+    SkipOverwriteIfUnchanged = true
+}))
+{
+    // ...
+}
+```
+
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **options** | `BulkInsertOptions` | [Options](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions) to configure BulkInsert. |
+| **token** | `CancellationToken` | Cancellation token used to halt the worker operation. |
+
+| Return value | |
+|-----------|-------------|
+| `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+</Panel>

--- a/versioned_docs/version-7.1/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -64,12 +64,12 @@ The following methods can be used when creating a bulk insert.
 | Signature | Description |
 | ----------| ----- |
 | **void Abort()** | Abort the operation |
-| **void Store(object entity, IMetadataDictionary metadata = null)** | Store the entity, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
+| **string Store(object entity, IMetadataDictionary metadata = null)** | Store the entity, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
 | **void Store(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
-| **void StoreAsync(object entity, IMetadataDictionary metadata = null)** | Store the entity in an async manner, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
-| **void StoreAsync(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity in an async manner, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
+| **Task&lt;string&gt; StoreAsync(object entity, IMetadataDictionary metadata = null)** | Store the entity in an async manner, identifier will be generated automatically on client-side. Optional, metadata can be provided for the stored entity. |
+| **Task StoreAsync(object entity, string id, IMetadataDictionary metadata = null)** | Store the entity in an async manner, with `id` parameter to explicitly declare the entity identifier. Optional, metadata can be provided for the stored entity.|
 | **void Dispose()** | Dispose of an object |
-| **void DisposeAsync()** | Dispose of an object in an async manner |
+| **ValueTask DisposeAsync()** | Dispose of an object in an async manner |
 
 </ContentFrame>
 

--- a/versioned_docs/version-7.1/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/bulk-insert/content/_how-to-work-with-bulk-insert-operation-csharp.mdx
@@ -21,7 +21,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
    * [`BulkInsertOptions`](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#bulkinsertoptions)
       * [CompressionLevel](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#compressionlevel)
       * [SkipOverwriteIfUnchanged](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#skipoverwriteifunchanged)
+   * [Track progress with OnProgress](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#track-progress-with-onprogress)
    * [Syntax](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#syntax)
+      * [Method signatures](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#method-signatures)
+      * [Event signature](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#event-signature)
+      * [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
 
 </Admonition>
 
@@ -210,9 +214,60 @@ using (var bulk = store.BulkInsert(new BulkInsertOptions
 
 </Panel>
 
+<Panel heading="Track progress with OnProgress">
+
+A long-running bulk insert can take some time to complete. To track its progress -
+for example, to show a progress bar or to log how many documents have been inserted
+so far - subscribe to the `OnProgress` event.
+
+The bulk insert delivers a progress snapshot to your handler each time the server
+reports new progress, with counters such as `DocumentsProcessed`, `BatchCount`, and
+the ID of the document processed most recently (`LastProcessedId`).  
+See [Classes](../../../client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx#classes)
+for the full property list.
+
+* Updates arrive asynchronously over the
+  [Changes](../../../client-api/changes/what-is-changes-api.mdx)
+  stream that the server opens for the operation.  
+  Your handler is invoked by the server's progress reports, not by your `Store`
+  calls - a single progress event typically covers many `Store` calls at once.
+* The subscription opens after the first `Store` call. Attach the handler before
+  storing anything to avoid missing early updates.
+* Each snapshot is **cumulative** from the start of the bulk insert. `DocumentsProcessed`,
+  `BatchCount`, `Total`, and the other counters grow over time and do not reset between
+  events.  
+  To find the number of documents added between two consecutive events, subtract the
+  older snapshot's `DocumentsProcessed` from the newer one's. For example, if event A
+  reports `DocumentsProcessed = 1000` and event B reports `DocumentsProcessed = 1500`,
+  then 500 documents were added in the interval.
+
+#### Example: Print progress to the console
+
+```csharp
+using (BulkInsertOperation bulkInsert = store.BulkInsert())
+{
+    // Attach the handler before the first Store call so early updates are not missed.
+    bulkInsert.OnProgress += (sender, args) =>
+    {
+        // Each event carries a cumulative snapshot since the bulk insert started.
+        Console.WriteLine(
+            $"Processed {args.Progress.DocumentsProcessed} documents " +
+            $"(last: {args.Progress.LastProcessedId})");
+    };
+
+    // Each employee inserted here advances the counters reported to the handler above.
+    foreach (var employee in employees)
+    {
+        bulkInsert.Store(employee);
+    }
+}
+```
+
+</Panel>
+
 <Panel heading="Syntax">
 
-### Methods
+### Method signatures
 
 <Tabs groupId='bulkInsertOverloads'>
 <TabItem value="bulkInsert" label="BulkInsert">
@@ -325,6 +380,90 @@ using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
 | Return value | |
 |-----------|-------------|
 | `BulkInsertOperation` | Instance of `BulkInsertOperation` used for interaction. |
+
+</TabItem>
+</Tabs>
+
+---
+
+### Event signature
+
+<Tabs groupId='bulkInsertEvents'>
+<TabItem value="onProgress" label="OnProgress">
+
+Raised while a bulk insert is running, each time the server reports new progress.
+Each invocation carries a cumulative progress snapshot since the start of the
+operation.
+
+```csharp
+public event EventHandler<BulkInsertOnProgressEventArgs> OnProgress;
+```
+
+<br />
+
+Usage:
+
+```csharp
+bulkInsert.OnProgress += (sender, args) =>
+{
+    // Read args.Progress for the current snapshot.
+};
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+### Classes
+
+<Tabs groupId='bulkInsertEventClasses'>
+<TabItem value="BulkInsertOnProgressEventArgs" label="BulkInsertOnProgressEventArgs">
+
+The event arguments delivered to an `OnProgress` handler.
+
+```csharp
+public class BulkInsertOnProgressEventArgs : EventArgs
+{
+    public BulkInsertProgress Progress { get; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Progress** | `BulkInsertProgress` | The cumulative progress snapshot for this update. |
+
+</TabItem>
+<TabItem value="BulkInsertProgress" label="BulkInsertProgress">
+
+A cumulative snapshot of the bulk insert's progress, reported by the server.
+
+```csharp
+public class BulkInsertProgress
+{
+    public long Total { get; set; }
+    public long BatchCount { get; set; }
+    public string LastProcessedId { get; set; }
+    public long DocumentsProcessed { get; set; }
+    public long AttachmentsProcessed { get; set; }
+    public long CountersProcessed { get; set; }
+    public long TimeSeriesProcessed { get; set; }
+}
+```
+
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Total** | `long` | Total items processed since the bulk insert started, across documents, attachments, counters, and time series. |
+| **BatchCount** | `long` | Number of server-side batches processed so far. |
+| **LastProcessedId** | `string` | The identifier of the document that was processed most recently. |
+| **DocumentsProcessed** | `long` | Number of documents inserted so far. |
+| **AttachmentsProcessed** | `long` | Number of attachments stored so far. |
+| **CountersProcessed** | `long` | Number of counters created or modified so far. |
+| **TimeSeriesProcessed** | `long` | Number of time series entries appended so far. |
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-7.1/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/versioned_docs/version-7.1/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -28,6 +28,10 @@ see_also:
        link: "document-extensions/counters/create-or-modify"
        source: "docs"
        path: "Document Extensions > Counters"
+     - title: "What is the Changes API"
+       link: "client-api/changes/what-is-changes-api"
+       source: "docs"
+       path: "Client API > Changes"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-7.1/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
+++ b/versioned_docs/version-7.1/client-api/bulk-insert/how-to-work-with-bulk-insert-operation.mdx
@@ -20,6 +20,14 @@ see_also:
        link: "document-extensions/timeseries/client-api/bulk-insert/append-in-bulk"
        source: "docs"
        path: "Document Extensions > Time Series > Client API > Bulk Insert"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
+     - title: "Create or Modify Counters"
+       link: "document-extensions/counters/create-or-modify"
+       source: "docs"
+       path: "Document Extensions > Counters"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";


### PR DESCRIPTION
### Issue link
[RDoc-3865](https://issues.hibernatingrhinos.com/issue/RDoc-3865) 

### Additional description
Reformat the `/client-api/bulk-insert/how-to-work-with-bulk-insert-operation` page and add to it a "Track progress with OnProgress" section.

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)