### PR TITLE
RDoc-2455 Document Microsoft logs and the `Logs.Microsoft.Enabled` key

### DIFF
--- a/docs/server/configuration/logs-configuration.mdx
+++ b/docs/server/configuration/logs-configuration.mdx
@@ -25,6 +25,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Logs.EnableArchiveFileCompression](../../server/configuration/logs-configuration.mdx#logsenablearchivefilecompression)  
       [Logs.MaxArchiveDays](../../server/configuration/logs-configuration.mdx#logsmaxarchivedays)  
       [Logs.MaxArchiveFiles](../../server/configuration/logs-configuration.mdx#logsmaxarchivefiles)  
+      [Logs.Microsoft.Enabled](../../server/configuration/logs-configuration.mdx#logsmicrosoftenabled)  
       [Logs.Microsoft.MinLevel](../../server/configuration/logs-configuration.mdx#logsmicrosoftminlevel)  
       [Logs.MinLevel](../../server/configuration/logs-configuration.mdx#logsminlevel)  
       [Logs.NuGet.AdditionalPackages](../../server/configuration/logs-configuration.mdx#logsnugetadditionalpackages)  
@@ -99,9 +100,22 @@ Set to `null` to keep log files indefinitely.
 
 
 
+## Logs.Microsoft.Enabled
+
+Determines whether [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs) are enabled.  
+When enabled, RavenDB captures the diagnostic logs that .NET and Kestrel (RavenDB's web server)
+emit internally, and writes them to RavenDB's log output.  
+Note that enabling this setting can affect request latency under certain conditions.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+
+
+
 ## Logs.Microsoft.MinLevel
 
-The minimum logging level for Microsoft logs.
+The minimum logging level for [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs).
 
 - **Type**: `enum LogLevel` (`Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`, `Off`)
 - **Default**: `LogLevel.Error`

--- a/docs/server/troubleshooting/logging.mdx
+++ b/docs/server/troubleshooting/logging.mdx
@@ -36,6 +36,7 @@ import Panel from '@site/src/components/Panel';
   * [Available logging levels](../../server/troubleshooting/logging.mdx#available-logging-levels)  
       * [Customizing logging level after Migration](../../server/troubleshooting/logging.mdx#customizing-logging-level-after-migration)  
   * [Default values](../../server/troubleshooting/logging.mdx#default-values)  
+  * [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs)  
   * [CLI customization: immediate temporary changes](../../server/troubleshooting/logging.mdx#cli-customization-immediate-temporary-changes)  
   * [Configuring and using NLog](../../server/troubleshooting/logging.mdx#configuring-and-using-nlog)  
      * [Configure RavenDB to use an external NLog configuration file](../../server/troubleshooting/logging.mdx#1-configure-ravendb-to-use-an-external-nlog-configuration-file)  
@@ -196,6 +197,32 @@ You **will** need to update the logging settings if you want to take advantage o
   The default values provided for settings in the [NLog configuration file template](../../server/troubleshooting/logging.mdx#an-available-template) 
   are **identical** to those used by RavenDB's internal configuration keys.
   See the full list in: [Logging configuration keys and their default values](../../server/configuration/logs-configuration.mdx).  
+
+## Microsoft logs
+
+Beyond its own log entries, RavenDB can capture the diagnostic logs that .NET and Kestrel
+(RavenDB's web server) emit internally.  
+These entries come from the `Microsoft.Extensions.Logging` infrastructure and cover events such as
+ASP.NET Core hosting, Kestrel connections, and the start and finish of each request.  
+They can help you investigate connection-level or HTTP-level behavior that RavenDB's own logs do not describe.
+
+These entries are collectively called **Microsoft logs**, and they are disabled by default.  
+Capturing them can affect request latency under certain conditions, so enable them only when you need them,
+typically while diagnosing a specific problem.
+
+To enable Microsoft logs, set the following configuration keys and restart the server:
+
+* [Logs.Microsoft.Enabled](../../server/configuration/logs-configuration.mdx#logsmicrosoftenabled)  
+  Set to `true` to capture Microsoft logs.
+* [Logs.Microsoft.MinLevel](../../server/configuration/logs-configuration.mdx#logsmicrosoftminlevel)  
+  Set the minimum level of the Microsoft entries that are logged. The default is `Error`.
+
+<Admonition type="note" title="">
+
+Once Microsoft logs are enabled, you can adjust their minimum level at runtime, without restarting the server,
+using the [SetLogsConfigurationOperation](../../client-api/operations/server-wide/logs/set-logs-configuration.mdx) in the Client API.
+
+</Admonition>
 
 ## CLI customization: immediate temporary changes
 

--- a/versioned_docs/version-7.0/server/configuration/logs-configuration.mdx
+++ b/versioned_docs/version-7.0/server/configuration/logs-configuration.mdx
@@ -24,6 +24,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Logs.EnableArchiveFileCompression](../../server/configuration/logs-configuration.mdx#logsenablearchivefilecompression)  
       [Logs.MaxArchiveDays](../../server/configuration/logs-configuration.mdx#logsmaxarchivedays)  
       [Logs.MaxArchiveFiles](../../server/configuration/logs-configuration.mdx#logsmaxarchivefiles)  
+      [Logs.Microsoft.Enabled](../../server/configuration/logs-configuration.mdx#logsmicrosoftenabled)  
       [Logs.Microsoft.MinLevel](../../server/configuration/logs-configuration.mdx#logsmicrosoftminlevel)  
       [Logs.MinLevel](../../server/configuration/logs-configuration.mdx#logsminlevel)  
       [Logs.NuGet.AdditionalPackages](../../server/configuration/logs-configuration.mdx#logsnugetadditionalpackages)  
@@ -98,9 +99,22 @@ Set to `null` to keep log files indefinitely.
 
 
 
+## Logs.Microsoft.Enabled
+
+Determines whether [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs) are enabled.  
+When enabled, RavenDB captures the diagnostic logs that .NET and Kestrel (RavenDB's web server)
+emit internally, and writes them to RavenDB's log output.  
+Note that enabling this setting can affect request latency under certain conditions.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+
+
+
 ## Logs.Microsoft.MinLevel
 
-The minimum logging level for Microsoft logs.
+The minimum logging level for [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs).
 
 - **Type**: `enum LogLevel` (`Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`, `Off`)
 - **Default**: `LogLevel.Error`

--- a/versioned_docs/version-7.0/server/troubleshooting/logging.mdx
+++ b/versioned_docs/version-7.0/server/troubleshooting/logging.mdx
@@ -35,6 +35,7 @@ import Panel from '@site/src/components/Panel';
   * [Available logging levels](../../server/troubleshooting/logging.mdx#available-logging-levels)  
       * [Customizing logging level after Migration](../../server/troubleshooting/logging.mdx#customizing-logging-level-after-migration)  
   * [Default values](../../server/troubleshooting/logging.mdx#default-values)  
+  * [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs)  
   * [CLI customization: immediate temporary changes](../../server/troubleshooting/logging.mdx#cli-customization-immediate-temporary-changes)  
   * [Configuring and using NLog](../../server/troubleshooting/logging.mdx#configuring-and-using-nlog)  
      * [Configure RavenDB to use an external NLog configuration file](../../server/troubleshooting/logging.mdx#1-configure-ravendb-to-use-an-external-nlog-configuration-file)  
@@ -195,6 +196,32 @@ You **will** need to update the logging settings if you want to take advantage o
   The default values provided for settings in the [NLog configuration file template](../../server/troubleshooting/logging.mdx#an-available-template) 
   are **identical** to those used by RavenDB's internal configuration keys.
   See the full list in: [Logging configuration keys and their default values](../../server/configuration/logs-configuration.mdx).  
+
+## Microsoft logs
+
+Beyond its own log entries, RavenDB can capture the diagnostic logs that .NET and Kestrel
+(RavenDB's web server) emit internally.  
+These entries come from the `Microsoft.Extensions.Logging` infrastructure and cover events such as
+ASP.NET Core hosting, Kestrel connections, and the start and finish of each request.  
+They can help you investigate connection-level or HTTP-level behavior that RavenDB's own logs do not describe.
+
+These entries are collectively called **Microsoft logs**, and they are disabled by default.  
+Capturing them can affect request latency under certain conditions, so enable them only when you need them,
+typically while diagnosing a specific problem.
+
+To enable Microsoft logs, set the following configuration keys and restart the server:
+
+* [Logs.Microsoft.Enabled](../../server/configuration/logs-configuration.mdx#logsmicrosoftenabled)  
+  Set to `true` to capture Microsoft logs.
+* [Logs.Microsoft.MinLevel](../../server/configuration/logs-configuration.mdx#logsmicrosoftminlevel)  
+  Set the minimum level of the Microsoft entries that are logged. The default is `Error`.
+
+<Admonition type="note" title="">
+
+Once Microsoft logs are enabled, you can adjust their minimum level at runtime, without restarting the server,
+using the [SetLogsConfigurationOperation](../../client-api/operations/server-wide/logs/set-logs-configuration.mdx) in the Client API.
+
+</Admonition>
 
 ## CLI customization: immediate temporary changes
 

--- a/versioned_docs/version-7.1/server/configuration/logs-configuration.mdx
+++ b/versioned_docs/version-7.1/server/configuration/logs-configuration.mdx
@@ -24,6 +24,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Logs.EnableArchiveFileCompression](../../server/configuration/logs-configuration.mdx#logsenablearchivefilecompression)  
       [Logs.MaxArchiveDays](../../server/configuration/logs-configuration.mdx#logsmaxarchivedays)  
       [Logs.MaxArchiveFiles](../../server/configuration/logs-configuration.mdx#logsmaxarchivefiles)  
+      [Logs.Microsoft.Enabled](../../server/configuration/logs-configuration.mdx#logsmicrosoftenabled)  
       [Logs.Microsoft.MinLevel](../../server/configuration/logs-configuration.mdx#logsmicrosoftminlevel)  
       [Logs.MinLevel](../../server/configuration/logs-configuration.mdx#logsminlevel)  
       [Logs.NuGet.AdditionalPackages](../../server/configuration/logs-configuration.mdx#logsnugetadditionalpackages)  
@@ -98,9 +99,22 @@ Set to `null` to keep log files indefinitely.
 
 
 
+## Logs.Microsoft.Enabled
+
+Determines whether [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs) are enabled.  
+When enabled, RavenDB captures the diagnostic logs that .NET and Kestrel (RavenDB's web server)
+emit internally, and writes them to RavenDB's log output.  
+Note that enabling this setting can affect request latency under certain conditions.
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Scope**: Server-wide only
+
+
+
 ## Logs.Microsoft.MinLevel
 
-The minimum logging level for Microsoft logs.
+The minimum logging level for [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs).
 
 - **Type**: `enum LogLevel` (`Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`, `Off`)
 - **Default**: `LogLevel.Error`

--- a/versioned_docs/version-7.1/server/troubleshooting/logging.mdx
+++ b/versioned_docs/version-7.1/server/troubleshooting/logging.mdx
@@ -35,6 +35,7 @@ import Panel from '@site/src/components/Panel';
   * [Available logging levels](../../server/troubleshooting/logging.mdx#available-logging-levels)  
       * [Customizing logging level after Migration](../../server/troubleshooting/logging.mdx#customizing-logging-level-after-migration)  
   * [Default values](../../server/troubleshooting/logging.mdx#default-values)  
+  * [Microsoft logs](../../server/troubleshooting/logging.mdx#microsoft-logs)  
   * [CLI customization: immediate temporary changes](../../server/troubleshooting/logging.mdx#cli-customization-immediate-temporary-changes)  
   * [Configuring and using NLog](../../server/troubleshooting/logging.mdx#configuring-and-using-nlog)  
      * [Configure RavenDB to use an external NLog configuration file](../../server/troubleshooting/logging.mdx#1-configure-ravendb-to-use-an-external-nlog-configuration-file)  
@@ -195,6 +196,32 @@ You **will** need to update the logging settings if you want to take advantage o
   The default values provided for settings in the [NLog configuration file template](../../server/troubleshooting/logging.mdx#an-available-template) 
   are **identical** to those used by RavenDB's internal configuration keys.
   See the full list in: [Logging configuration keys and their default values](../../server/configuration/logs-configuration.mdx).  
+
+## Microsoft logs
+
+Beyond its own log entries, RavenDB can capture the diagnostic logs that .NET and Kestrel
+(RavenDB's web server) emit internally.  
+These entries come from the `Microsoft.Extensions.Logging` infrastructure and cover events such as
+ASP.NET Core hosting, Kestrel connections, and the start and finish of each request.  
+They can help you investigate connection-level or HTTP-level behavior that RavenDB's own logs do not describe.
+
+These entries are collectively called **Microsoft logs**, and they are disabled by default.  
+Capturing them can affect request latency under certain conditions, so enable them only when you need them,
+typically while diagnosing a specific problem.
+
+To enable Microsoft logs, set the following configuration keys and restart the server:
+
+* [Logs.Microsoft.Enabled](../../server/configuration/logs-configuration.mdx#logsmicrosoftenabled)  
+  Set to `true` to capture Microsoft logs.
+* [Logs.Microsoft.MinLevel](../../server/configuration/logs-configuration.mdx#logsmicrosoftminlevel)  
+  Set the minimum level of the Microsoft entries that are logged. The default is `Error`.
+
+<Admonition type="note" title="">
+
+Once Microsoft logs are enabled, you can adjust their minimum level at runtime, without restarting the server,
+using the [SetLogsConfigurationOperation](../../client-api/operations/server-wide/logs/set-logs-configuration.mdx) in the Client API.
+
+</Admonition>
 
 ## CLI customization: immediate temporary changes
 


### PR DESCRIPTION
### Issue link
[RDoc-2455](https://issues.hibernatingrhinos.com/issue/RDoc-2455)

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

