### PR TITLE
Upgrade Docusaurus to 3.10.1 and fix resulting breakages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # RavenDB Documentation — Claude Context
 
 ## Project Overview
-Official RavenDB documentation site. Built with **Docusaurus 3.9** + React 19 + TypeScript 5.6.
+Official RavenDB documentation site. Built with **Docusaurus 3.10** + React 19 + TypeScript 5.6.
 Serves 18+ product versions simultaneously across four content areas: main docs (current: 7.2), cloud, guides, templates.
 
 ---
@@ -513,7 +513,7 @@ Style guide and live examples for documentation building blocks: ContentFrame/Pa
 ---
 
 ## Tech Stack Summary
-- Docusaurus 3.9.2 · React 19 · TypeScript 5.6
+- Docusaurus 3.10.1 · React 19 · TypeScript 5.6
 - Tailwind CSS 4.1 (via custom PostCSS plugin)
 - Algolia search · Google Tag Manager · Sitemap auto-generation
 - Prism React Renderer for code syntax highlighting

--- a/cloud/cloud-aws-marketplace.mdx
+++ b/cloud/cloud-aws-marketplace.mdx
@@ -35,7 +35,7 @@ If you want to pay for *RavenDB Cloud* services using a credit card associated w
 - Billing and contact information are fully managed by *AWS*. Changing the parameters is not possible via Cloud Portal.
 
 
-## Supported countries {/* #supported-countries */}
+## Supported countries {#supported-countries}
 
 *RavenDB Cloud* is available through the *AWS Marketplace* in countries and regions where AWS provides automated tax collection and remittance services. In these locations, AWS acts as a marketplace facilitator, handling tax calculation, collection, and remittance on behalf of the seller. This ensures a seamless billing experience for both the customer and the provider.
 

--- a/cloud/cloud-aws-marketplace.mdx
+++ b/cloud/cloud-aws-marketplace.mdx
@@ -35,7 +35,7 @@ If you want to pay for *RavenDB Cloud* services using a credit card associated w
 - Billing and contact information are fully managed by *AWS*. Changing the parameters is not possible via Cloud Portal.
 
 
-## Supported countries {#supported-countries}
+## Supported countries {/* #supported-countries */}
 
 *RavenDB Cloud* is available through the *AWS Marketplace* in countries and regions where AWS provides automated tax collection and remittance services. In these locations, AWS acts as a marketplace facilitator, handling tax calculation, collection, and remittance on behalf of the seller. This ensures a seamless billing experience for both the customer and the provider.
 

--- a/cloud/cloud-microsoft-azure-marketplace.mdx
+++ b/cloud/cloud-microsoft-azure-marketplace.mdx
@@ -36,7 +36,7 @@ If you want to pay for *RavenDB Cloud* services using a credit card associated w
 - Billing and contact information are fully managed by *Microsoft Azure*. Changing the parameters is not possible via Cloud Portal.
 
 
-## Supported countries {#supported-countries}
+## Supported countries {/* #supported-countries */}
 
 *RavenDB Cloud* is available through the *Microsoft Azure Marketplace* in countries and regions where Microsoft provides automated tax collection and remittance services. In these locations, Microsoft acts as a tax agent, handling tax calculation, collection, and remittance on behalf of the seller. This ensures a seamless billing experience for both the customer and the provider.
 

--- a/cloud/cloud-microsoft-azure-marketplace.mdx
+++ b/cloud/cloud-microsoft-azure-marketplace.mdx
@@ -36,7 +36,7 @@ If you want to pay for *RavenDB Cloud* services using a credit card associated w
 - Billing and contact information are fully managed by *Microsoft Azure*. Changing the parameters is not possible via Cloud Portal.
 
 
-## Supported countries {/* #supported-countries */}
+## Supported countries {#supported-countries}
 
 *RavenDB Cloud* is available through the *Microsoft Azure Marketplace* in countries and regions where Microsoft provides automated tax collection and remittance services. In these locations, Microsoft acts as a tax agent, handling tax calculation, collection, and remittance on behalf of the seller. This ensures a seamless billing experience for both the customer and the provider.
 

--- a/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
+++ b/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
@@ -1,4 +1,4 @@
-﻿import Admonition from '@theme/Admonition';
+import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
+++ b/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
@@ -1,4 +1,4 @@
-import Admonition from '@theme/Admonition';
+﻿import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
@@ -25,9 +25,7 @@ import Panel from "@site/src/components/Panel";
       * [Set chat trimming configuration](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#set-chat-trimming-configuration)
    * [Adding agent tools](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#adding-agent-tools)
       * [Query tools](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#query-tools)
-<!---
-         * [Initial-context queries](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#initial-context-queries)
--->
+
       * [Action tools](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#action-tools)
    * [Creating the Agent](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#creating-the-agent)
    * [Retrieving existing agent configurations](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#retrieving-existing-agent-configurations)
@@ -535,67 +533,6 @@ A query tool includes a natural-language **description** that explains the LLM w
 
 </ContentFrame>
 
-<!---
-#### <u>Initial-context queries</u>
-
-* You can set a query tool as an [initial-context query](../../../../ai-integration/ai-agents/overview.mdx#initial-context-queries) using its `Options.AddToInitialContext` property, to execute the query and provide the LLM with its results immediately when the agent is started.  
-   * An initial-context query is **not allowed** to use LLM parameters, since the query 
-     runs before the conversation starts, earlier than the first communication with the LLM, and the LLM will have no opportunity to fill the parameters with values.  
-   * An initial-context query **is** allowed to use agent parameters, whose values are provided by the user even before the query is executed.  
-
-*  You can use the `options.allow_model_queries` property to Enable or Disable a query tool .  
-   * When a query tool is enabled, the LLM can freely trigger its execution.  
-   * When a query tool is disabled, the LLM cannot trigger its execution.  
-   * If a query tool is set as an initial-context query, it will be executed when the conversation 
-     starts even if disabled using `options.allow_model_queries`.  
-
-* **Example**  
-  Set a query tool that runs when the agent is started and retrieves all the orders sent everywhere.
-  ```csharp
-  new AiAgentToolQuery
-  {
-     Name = "retrieve-orders-sent-to-all-countries",
-     Description = "a query tool that allows you to retrieve all orders sent to all countries.",
-     Query = "from Orders as O select O.Employee, O.Lines.Quantity",
-     ParametersSampleObject = "{}"
-
-     Options = new AiAgentToolQueryOptions
-     {
-         // The LLM is allowed to trigger the execution of this query during the conversation
-         allow_model_queries = true,
-
-         // The query will be executed when the conversation starts 
-         // and its results will be added to the initial context
-         add_to_initial_context = true
-      }
-  }
-  ```
-
-* **Syntax**  
-  ```csharp
-  public class AiAgentToolQueryOptions : IDynamicJson
-  {
-      public bool? allow_model_queries { get; set; }
-      public bool? add_to_initial_context { get; set; }
-  }
-    ```
-
-      |Property|Type|Description|
-      |--------|----|-----------|
-      |`allow_model_queries`|`bool`| `true`: the LLM can trigger the execution of this query tool.<br />`false`: the LLM cannot trigger the execution of this query tool.<br />`null`: server-side defaults apply.|
-      |`add_to_initial_context`|`bool`| `true`: the query will be executed when the conversation starts and its results added to the initial context.<br />`false`: the query will not be executed when the conversation starts.<br />`null`: server-side defaults apply.|
-
-      <Admonition type="note" title="">
-      Note: the two flags can be set regardless of each other.  
-        * Setting `add_to_initial_context` to `true` and `allow_model_queries` to `false`  
-          will cause the query to be executed when the conversation starts,  
-          but the LLM will not be able to trigger its execution later in the conversation.  
-        * Setting `add_to_initial_context` to `true` and `allow_model_queries` to `true`  
-          will cause the query to be executed when the conversation starts,  
-          and the LLM will also be able to trigger its execution later in the conversation.  
-      </Admonition>
--->
-
 <ContentFrame>
 
 ### Action tools
@@ -707,7 +644,6 @@ You can retrieve the configuration of **existing agents** using `get_agents`.
   | Return value | Description |
   |--------------|-------------|
   | `GetAiAgentsResponse` | A list of agent configurations |
-
 
 * `GetAiAgentsResponse` class  
   ```python
@@ -974,7 +910,6 @@ Receivers are typically used asynchronously for multi-step or delayed operations
   | action_id | `str` | The action request unique ID |
   | action_response | `str` | The response to send back to the LLM through the agent |
 
-
 * `AiAgentActionRequest` class  
   Contains the action request details, sent by the LLM to the agent and passed to the receiver when invoked.  
   ```python
@@ -1010,7 +945,6 @@ The LLM response is returned by the agent to the client in an `AiAnswer` object,
   class AiConversationStatus(enum.Enum):
     DONE = "Done"
     ACTION_REQUIRED = "ActionRequired"
-
 
   class AiAnswer(Generic[TAnswer]):
       def __init__(

--- a/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
+++ b/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
@@ -25,7 +25,9 @@ import Panel from "@site/src/components/Panel";
       * [Set chat trimming configuration](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#set-chat-trimming-configuration)
    * [Adding agent tools](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#adding-agent-tools)
       * [Query tools](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#query-tools)
-
+<!---
+         * [Initial-context queries](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#initial-context-queries)
+-->
       * [Action tools](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#action-tools)
    * [Creating the Agent](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#creating-the-agent)
    * [Retrieving existing agent configurations](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#retrieving-existing-agent-configurations)
@@ -532,6 +534,67 @@ A query tool includes a natural-language **description** that explains the LLM w
   ```
 
 </ContentFrame>
+
+<!---
+#### <u>Initial-context queries</u>
+
+* You can set a query tool as an [initial-context query](../../../../ai-integration/ai-agents/overview.mdx#initial-context-queries) using its `Options.AddToInitialContext` property, to execute the query and provide the LLM with its results immediately when the agent is started.  
+   * An initial-context query is **not allowed** to use LLM parameters, since the query 
+     runs before the conversation starts, earlier than the first communication with the LLM, and the LLM will have no opportunity to fill the parameters with values.  
+   * An initial-context query **is** allowed to use agent parameters, whose values are provided by the user even before the query is executed.  
+
+*  You can use the `options.allow_model_queries` property to Enable or Disable a query tool .  
+   * When a query tool is enabled, the LLM can freely trigger its execution.  
+   * When a query tool is disabled, the LLM cannot trigger its execution.  
+   * If a query tool is set as an initial-context query, it will be executed when the conversation 
+     starts even if disabled using `options.allow_model_queries`.  
+
+* **Example**  
+  Set a query tool that runs when the agent is started and retrieves all the orders sent everywhere.
+  ```csharp
+  new AiAgentToolQuery
+  {
+     Name = "retrieve-orders-sent-to-all-countries",
+     Description = "a query tool that allows you to retrieve all orders sent to all countries.",
+     Query = "from Orders as O select O.Employee, O.Lines.Quantity",
+     ParametersSampleObject = "{}"
+
+     Options = new AiAgentToolQueryOptions
+     {
+         // The LLM is allowed to trigger the execution of this query during the conversation
+         allow_model_queries = true,
+
+         // The query will be executed when the conversation starts 
+         // and its results will be added to the initial context
+         add_to_initial_context = true
+      }
+  }
+  ```
+
+* **Syntax**  
+  ```csharp
+  public class AiAgentToolQueryOptions : IDynamicJson
+  {
+      public bool? allow_model_queries { get; set; }
+      public bool? add_to_initial_context { get; set; }
+  }
+    ```
+
+      |Property|Type|Description|
+      |--------|----|-----------|
+      |`allow_model_queries`|`bool`| `true`: the LLM can trigger the execution of this query tool.<br />`false`: the LLM cannot trigger the execution of this query tool.<br />`null`: server-side defaults apply.|
+      |`add_to_initial_context`|`bool`| `true`: the query will be executed when the conversation starts and its results added to the initial context.<br />`false`: the query will not be executed when the conversation starts.<br />`null`: server-side defaults apply.|
+
+      <Admonition type="note" title="">
+      Note: the two flags can be set regardless of each other.  
+        * Setting `add_to_initial_context` to `true` and `allow_model_queries` to `false`  
+          will cause the query to be executed when the conversation starts,  
+          but the LLM will not be able to trigger its execution later in the conversation.  
+        * Setting `add_to_initial_context` to `true` and `allow_model_queries` to `true`  
+          will cause the query to be executed when the conversation starts,  
+          and the LLM will also be able to trigger its execution later in the conversation.  
+      </Admonition>
+-->
 
 <ContentFrame>
 

--- a/docs/client-api/cluster/document-conflicts-in-client-side.mdx
+++ b/docs/client-api/cluster/document-conflicts-in-client-side.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Cluster: Document Conflicts in Client-side"
 sidebar_label: Document Conflict Exceptions at Client-Side
 description: "Handle document replication conflicts client-side in RavenDB by registering conflict resolution strategies and listening for conflict notifications."

--- a/docs/client-api/cluster/document-conflicts-in-client-side.mdx
+++ b/docs/client-api/cluster/document-conflicts-in-client-side.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Cluster: Document Conflicts in Client-side"
 sidebar_label: Document Conflict Exceptions at Client-Side
 description: "Handle document replication conflicts client-side in RavenDB by registering conflict resolution strategies and listening for conflict notifications."
@@ -12,7 +12,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 import DocumentConflictsInClientSideCsharp from './content/_document-conflicts-in-client-side-csharp.mdx';
 import DocumentConflictsInClientSideJava from './content/_document-conflicts-in-client-side-java.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
@@ -23,7 +22,3 @@ import DocumentConflictsInClientSideJava from './content/_document-conflicts-in-
    <DocumentConflictsInClientSideJava />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/maintenance/ongoing-tasks/ongoing-task-operations.mdx
+++ b/docs/client-api/operations/maintenance/ongoing-tasks/ongoing-task-operations.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Ongoing Task Operations"
 sidebar_label: Ongoing Task Operations
 description: "Manage RavenDB ongoing tasks like ETL, replication, backup, and subscriptions using client API operations to get state or toggle task status."
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import OngoingTaskOperationsCsharp from './content/_ongoing-task-operations-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <OngoingTaskOperationsCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/maintenance/ongoing-tasks/ongoing-task-operations.mdx
+++ b/docs/client-api/operations/maintenance/ongoing-tasks/ongoing-task-operations.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Ongoing Task Operations"
 sidebar_label: Ongoing Task Operations
 description: "Manage RavenDB ongoing tasks like ETL, replication, backup, and subscriptions using client API operations to get state or toggle task status."

--- a/docs/client-api/operations/server-wide/add-database-node.mdx
+++ b/docs/client-api/operations/server-wide/add-database-node.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Adding a Database Node"
 sidebar_label: Add Database Node
 description: "Add a cluster node to a RavenDB database group to increase replication factor and data availability across the cluster."

--- a/docs/client-api/operations/server-wide/add-database-node.mdx
+++ b/docs/client-api/operations/server-wide/add-database-node.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Adding a Database Node"
 sidebar_label: Add Database Node
 description: "Add a cluster node to a RavenDB database group to increase replication factor and data availability across the cluster."
@@ -13,7 +13,6 @@ import AddDatabaseNodeCsharp from './content/_add-database-node-csharp.mdx';
 import AddDatabaseNodePython from './content/_add-database-node-python.mdx';
 import AddDatabaseNodePhp from './content/_add-database-node-php.mdx';
 import AddDatabaseNodeNodejs from './content/_add-database-node-nodejs.mdx';
-
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
@@ -33,7 +32,3 @@ import AddDatabaseNodeNodejs from './content/_add-database-node-nodejs.mdx';
    <AddDatabaseNodeNodejs />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/server-wide/certificates/get-certificate.mdx
+++ b/docs/client-api/operations/server-wide/certificates/get-certificate.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Operations: Server: How to Get a Certificate"
 sidebar_label: Get Certificate
 description: "Retrieve a specific registered client certificate from the RavenDB server by its thumbprint for inspection or management."
@@ -12,7 +12,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 import GetCertificateCsharp from './content/_get-certificate-csharp.mdx';
 import GetCertificateJava from './content/_get-certificate-java.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
@@ -23,7 +22,3 @@ import GetCertificateJava from './content/_get-certificate-java.mdx';
    <GetCertificateJava />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/server-wide/certificates/get-certificate.mdx
+++ b/docs/client-api/operations/server-wide/certificates/get-certificate.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Operations: Server: How to Get a Certificate"
 sidebar_label: Get Certificate
 description: "Retrieve a specific registered client certificate from the RavenDB server by its thumbprint for inspection or management."

--- a/docs/client-api/operations/server-wide/certificates/get-certificates.mdx
+++ b/docs/client-api/operations/server-wide/certificates/get-certificates.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Operations: Server: How to Get Certificates"
 sidebar_label: Get Certificates
 description: "Retrieve all registered client certificates from the RavenDB server with paging support for certificate inventory management."
@@ -12,7 +12,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 import GetCertificatesCsharp from './content/_get-certificates-csharp.mdx';
 import GetCertificatesJava from './content/_get-certificates-java.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
@@ -23,7 +22,3 @@ import GetCertificatesJava from './content/_get-certificates-java.mdx';
    <GetCertificatesJava />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/server-wide/certificates/get-certificates.mdx
+++ b/docs/client-api/operations/server-wide/certificates/get-certificates.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Operations: Server: How to Get Certificates"
 sidebar_label: Get Certificates
 description: "Retrieve all registered client certificates from the RavenDB server with paging support for certificate inventory management."

--- a/docs/client-api/operations/server-wide/delete-database.mdx
+++ b/docs/client-api/operations/server-wide/delete-database.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Operations: Server: How to delete a database?"
 sidebar_label: Delete Databases
 description: "Delete a RavenDB database from one or all cluster nodes using DeleteDatabasesOperation with optional hard-delete to remove data files."
@@ -12,7 +12,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 import DeleteDatabaseCsharp from './content/_delete-database-csharp.mdx';
 import DeleteDatabaseJava from './content/_delete-database-java.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
@@ -23,7 +22,3 @@ import DeleteDatabaseJava from './content/_delete-database-java.mdx';
    <DeleteDatabaseJava />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/server-wide/delete-database.mdx
+++ b/docs/client-api/operations/server-wide/delete-database.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Operations: Server: How to delete a database?"
 sidebar_label: Delete Databases
 description: "Delete a RavenDB database from one or all cluster nodes using DeleteDatabasesOperation with optional hard-delete to remove data files."

--- a/docs/client-api/operations/server-wide/get-build-number.mdx
+++ b/docs/client-api/operations/server-wide/get-build-number.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Operations: Server: How to Get Server Build Number"
 sidebar_label: Get Build Number
 description: "Retrieve the RavenDB server build number, product version, and full version string using the GetBuildNumberOperation."

--- a/docs/client-api/operations/server-wide/get-build-number.mdx
+++ b/docs/client-api/operations/server-wide/get-build-number.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Operations: Server: How to Get Server Build Number"
 sidebar_label: Get Build Number
 description: "Retrieve the RavenDB server build number, product version, and full version string using the GetBuildNumberOperation."
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import GetBuildNumberCsharp from './content/_get-build-number-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <GetBuildNumberCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/server-wide/get-database-names.mdx
+++ b/docs/client-api/operations/server-wide/get-database-names.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Operations: Server: How to Get the Names of Databases on a Server"
 sidebar_label: Get Database Names
 description: "Retrieve a list of all database names from the RavenDB server using GetDatabaseNamesOperation with paging support."

--- a/docs/client-api/operations/server-wide/get-database-names.mdx
+++ b/docs/client-api/operations/server-wide/get-database-names.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Operations: Server: How to Get the Names of Databases on a Server"
 sidebar_label: Get Database Names
 description: "Retrieve a list of all database names from the RavenDB server using GetDatabaseNamesOperation with paging support."
@@ -12,7 +12,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 import GetDatabaseNamesCsharp from './content/_get-database-names-csharp.mdx';
 import GetDatabaseNamesJava from './content/_get-database-names-java.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
@@ -23,7 +22,3 @@ import GetDatabaseNamesJava from './content/_get-database-names-java.mdx';
    <GetDatabaseNamesJava />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/server-wide/modify-conflict-solver.mdx
+++ b/docs/client-api/operations/server-wide/modify-conflict-solver.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Operations: Server: How to Modify a Conflict Solver"
 sidebar_label: Modify Conflict Solver
 description: "Configure the RavenDB automatic conflict resolution strategy to resolve replication conflicts using latest version or custom scripts."

--- a/docs/client-api/operations/server-wide/modify-conflict-solver.mdx
+++ b/docs/client-api/operations/server-wide/modify-conflict-solver.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Operations: Server: How to Modify a Conflict Solver"
 sidebar_label: Modify Conflict Solver
 description: "Configure the RavenDB automatic conflict resolution strategy to resolve replication conflicts using latest version or custom scripts."
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import ModifyConflictSolverCsharp from './content/_modify-conflict-solver-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <ModifyConflictSolverCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/operations/server-wide/reorder-database-members.mdx
+++ b/docs/client-api/operations/server-wide/reorder-database-members.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Operations: Server: How to reoder database members?"
 sidebar_label: Reorder Database Members
 description: "Reorder the RavenDB database group member priority list to control which nodes are preferred for client operations."

--- a/docs/client-api/operations/server-wide/reorder-database-members.mdx
+++ b/docs/client-api/operations/server-wide/reorder-database-members.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Operations: Server: How to reoder database members?"
 sidebar_label: Reorder Database Members
 description: "Reorder the RavenDB database group member priority list to control which nodes are preferred for client operations."
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import ReorderDatabaseMembersCsharp from './content/_reorder-database-members-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <ReorderDatabaseMembersCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/session/querying/debugging/include-explanations.mdx
+++ b/docs/client-api/session/querying/debugging/include-explanations.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Include Query Explanations"
 sidebar_label: Include Query Explanations
 description: "Include score explanations in RavenDB query results to understand why documents matched and how relevance scores were calculated."

--- a/docs/client-api/session/querying/debugging/include-explanations.mdx
+++ b/docs/client-api/session/querying/debugging/include-explanations.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Include Query Explanations"
 sidebar_label: Include Query Explanations
 description: "Include score explanations in RavenDB query results to understand why documents matched and how relevance scores were calculated."
@@ -14,7 +14,6 @@ import IncludeExplanationsCsharp from './content/_include-explanations-csharp.md
 import IncludeExplanationsPython from './content/_include-explanations-python.mdx';
 import IncludeExplanationsPhp from './content/_include-explanations-php.mdx';
 import IncludeExplanationsNodejs from './content/_include-explanations-nodejs.mdx';
-
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
@@ -38,7 +37,3 @@ import IncludeExplanationsNodejs from './content/_include-explanations-nodejs.md
    <IncludeExplanationsNodejs />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/session/querying/debugging/query-timings.mdx
+++ b/docs/client-api/session/querying/debugging/query-timings.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Include Query Timings"
 sidebar_label: Include Query Timings
 description: "Retrieve detailed timing breakdowns for RavenDB queries to identify performance bottlenecks in query parsing, indexing, and execution."
@@ -14,7 +14,6 @@ import QueryTimingsJava from './content/_query-timings-java.mdx';
 import QueryTimingsPython from './content/_query-timings-python.mdx';
 import QueryTimingsPhp from './content/_query-timings-php.mdx';
 import QueryTimingsNodejs from './content/_query-timings-nodejs.mdx';
-
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
@@ -38,7 +37,3 @@ import QueryTimingsNodejs from './content/_query-timings-nodejs.mdx';
    <QueryTimingsNodejs />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/session/querying/debugging/query-timings.mdx
+++ b/docs/client-api/session/querying/debugging/query-timings.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Include Query Timings"
 sidebar_label: Include Query Timings
 description: "Retrieve detailed timing breakdowns for RavenDB queries to identify performance bottlenecks in query parsing, indexing, and execution."

--- a/docs/client-api/session/querying/vector-search.mdx
+++ b/docs/client-api/session/querying/vector-search.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Vector Search"
 sidebar_label: Vector Search Query
 description: "Perform vector similarity search in RavenDB queries using embeddings to find semantically similar documents with configurable distance metrics."
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import VectorSearchCsharp from './content/_vector-search-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <VectorSearchCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/client-api/session/querying/vector-search.mdx
+++ b/docs/client-api/session/querying/vector-search.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Vector Search"
 sidebar_label: Vector Search Query
 description: "Perform vector similarity search in RavenDB queries using embeddings to find semantically similar documents with configurable distance metrics."

--- a/docs/document-extensions/timeseries/indexing.mdx
+++ b/docs/document-extensions/timeseries/indexing.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Indexing Time Series"
 description: "Create RavenDB indexes over time series data using map and map-reduce indexes to enable fast queries on time-stamped measurements."
 sidebar_label: Indexing Time Series
@@ -31,4 +31,18 @@ import IndexingNodejs from './content/_indexing-nodejs.mdx';
 <LanguageContent language="nodejs">
    <IndexingNodejs />
 </LanguageContent>
+
+
+<!--
+### Time Series
+- [Time Series Overview]()
+
+### Indexes
+- [What are Indexes]()
+
+### Client-API
+- [Working with Document IDs]()
+
+
+-->
 

--- a/docs/document-extensions/timeseries/indexing.mdx
+++ b/docs/document-extensions/timeseries/indexing.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Indexing Time Series"
 description: "Create RavenDB indexes over time series data using map and map-reduce indexes to enable fast queries on time-stamped measurements."
 sidebar_label: Indexing Time Series
@@ -13,7 +13,6 @@ import IndexingCsharp from './content/_indexing-csharp.mdx';
 import IndexingPython from './content/_indexing-python.mdx';
 import IndexingPhp from './content/_indexing-php.mdx';
 import IndexingNodejs from './content/_indexing-nodejs.mdx';
-
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
@@ -33,16 +32,3 @@ import IndexingNodejs from './content/_indexing-nodejs.mdx';
    <IndexingNodejs />
 </LanguageContent>
 
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Indexes
-- [What are Indexes]()
-
-### Client-API
-- [Working with Document IDs]()
-
-
--->

--- a/docs/document-extensions/timeseries/time-series-and-other-features.mdx
+++ b/docs/document-extensions/timeseries/time-series-and-other-features.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Time Series and Other Features"
 description: "See how RavenDB time series interact with replication, ETL, data subscriptions, revisions, smuggler import/export, and document changes."
 sidebar_label: Time Series and Other Features
@@ -12,7 +12,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
 import TimeSeriesAndOtherFeaturesCsharp from './content/_time-series-and-other-features-csharp.mdx';
 import TimeSeriesAndOtherFeaturesNodejs from './content/_time-series-and-other-features-nodejs.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
@@ -23,19 +22,3 @@ import TimeSeriesAndOtherFeaturesNodejs from './content/_time-series-and-other-f
    <TimeSeriesAndOtherFeaturesNodejs />
 </LanguageContent>
 
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Client-API
-- [Session Entity Tracking]()
-
-### Server
-- [External replication]()
-
-### Studio
-- [Ongoing tasks]()
-
-
--->

--- a/docs/document-extensions/timeseries/time-series-and-other-features.mdx
+++ b/docs/document-extensions/timeseries/time-series-and-other-features.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Time Series and Other Features"
 description: "See how RavenDB time series interact with replication, ETL, data subscriptions, revisions, smuggler import/export, and document changes."
 sidebar_label: Time Series and Other Features
@@ -21,4 +21,21 @@ import TimeSeriesAndOtherFeaturesNodejs from './content/_time-series-and-other-f
 <LanguageContent language="nodejs">
    <TimeSeriesAndOtherFeaturesNodejs />
 </LanguageContent>
+
+
+<!--
+### Time Series
+- [Time Series Overview]()
+
+### Client-API
+- [Session Entity Tracking]()
+
+### Server
+- [External replication]()
+
+### Studio
+- [Ongoing tasks]()
+
+
+-->
 

--- a/docs/glossary/blittable-json-reader-object.mdx
+++ b/docs/glossary/blittable-json-reader-object.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: BlittableJsonReaderObject"
 description: "Reference for RavenDB BlittableJsonReaderObject — the high-performance, zero-copy JSON reader used internally for document storage and transmission."
 sidebar_label: BlittableJsonReaderObject
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import BlittableJsonReaderObjectCsharp from './content/_blittable-json-reader-object-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <BlittableJsonReaderObjectCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/blittable-json-reader-object.mdx
+++ b/docs/glossary/blittable-json-reader-object.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: BlittableJsonReaderObject"
 description: "Reference for RavenDB BlittableJsonReaderObject — the high-performance, zero-copy JSON reader used internally for document storage and transmission."
 sidebar_label: BlittableJsonReaderObject

--- a/docs/glossary/copy-attachment-command-data.mdx
+++ b/docs/glossary/copy-attachment-command-data.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: CopyAttachmentCommandData"
 description: "API reference for RavenDB CopyAttachmentCommandData class used in batch operations to copy attachments between documents."
 sidebar_label: CopyAttachmentCommandData
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import CopyAttachmentCommandDataCsharp from './content/_copy-attachment-command-data-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <CopyAttachmentCommandDataCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/copy-attachment-command-data.mdx
+++ b/docs/glossary/copy-attachment-command-data.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: CopyAttachmentCommandData"
 description: "API reference for RavenDB CopyAttachmentCommandData class used in batch operations to copy attachments between documents."
 sidebar_label: CopyAttachmentCommandData

--- a/docs/glossary/delete-command-data.mdx
+++ b/docs/glossary/delete-command-data.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: DeleteCommandData"
 description: "API reference for RavenDB DeleteCommandData class used in batch operations to delete documents by ID with optional change vector checks."
 sidebar_label: DeleteCommandData
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import DeleteCommandDataCsharp from './content/_delete-command-data-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <DeleteCommandDataCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/delete-command-data.mdx
+++ b/docs/glossary/delete-command-data.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: DeleteCommandData"
 description: "API reference for RavenDB DeleteCommandData class used in batch operations to delete documents by ID with optional change vector checks."
 sidebar_label: DeleteCommandData

--- a/docs/glossary/index-query.mdx
+++ b/docs/glossary/index-query.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: IndexQuery"
 description: "API reference for the RavenDB IndexQuery class containing the RQL query string, parameters, and pagination settings for index queries."
 sidebar_label: IndexQuery
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import IndexQueryCsharp from './content/_index-query-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <IndexQueryCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/index-query.mdx
+++ b/docs/glossary/index-query.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: IndexQuery"
 description: "API reference for the RavenDB IndexQuery class containing the RQL query string, parameters, and pagination settings for index queries."
 sidebar_label: IndexQuery

--- a/docs/glossary/move-attachment-command-data.mdx
+++ b/docs/glossary/move-attachment-command-data.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: MoveAttachmentCommandData"
 description: "API reference for RavenDB MoveAttachmentCommandData class used in batch operations to move attachments between documents."
 sidebar_label: MoveAttachmentCommandData
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import MoveAttachmentCommandDataCsharp from './content/_move-attachment-command-data-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <MoveAttachmentCommandDataCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/move-attachment-command-data.mdx
+++ b/docs/glossary/move-attachment-command-data.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: MoveAttachmentCommandData"
 description: "API reference for RavenDB MoveAttachmentCommandData class used in batch operations to move attachments between documents."
 sidebar_label: MoveAttachmentCommandData

--- a/docs/glossary/patch-command-data.mdx
+++ b/docs/glossary/patch-command-data.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: PatchCommandData"
 description: "API reference for RavenDB PatchCommandData class used in batch operations to modify documents with JavaScript patch scripts."
 sidebar_label: PatchCommandData

--- a/docs/glossary/patch-command-data.mdx
+++ b/docs/glossary/patch-command-data.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: PatchCommandData"
 description: "API reference for RavenDB PatchCommandData class used in batch operations to modify documents with JavaScript patch scripts."
 sidebar_label: PatchCommandData
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import PatchCommandDataCsharp from './content/_patch-command-data-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <PatchCommandDataCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/put-command-data.mdx
+++ b/docs/glossary/put-command-data.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: PutCommandData"
 description: "API reference for RavenDB PutCommandData class used in batch operations to store or update documents with optional change vector concurrency."
 sidebar_label: PutCommandData
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import PutCommandDataCsharp from './content/_put-command-data-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <PutCommandDataCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/put-command-data.mdx
+++ b/docs/glossary/put-command-data.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: PutCommandData"
 description: "API reference for RavenDB PutCommandData class used in batch operations to store or update documents with optional change vector concurrency."
 sidebar_label: PutCommandData

--- a/docs/glossary/query-result.mdx
+++ b/docs/glossary/query-result.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: QueryResult"
 description: "API reference for the RavenDB QueryResult class containing query results, statistics, included documents, and timing information."
 sidebar_label: QueryResult
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import QueryResultCsharp from './content/_query-result-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <QueryResultCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/query-result.mdx
+++ b/docs/glossary/query-result.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: QueryResult"
 description: "API reference for the RavenDB QueryResult class containing query results, statistics, included documents, and timing information."
 sidebar_label: QueryResult

--- a/docs/glossary/stream-query-statistics.mdx
+++ b/docs/glossary/stream-query-statistics.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: StreamQueryStatistics"
 description: "API reference for the RavenDB StreamQueryStatistics class providing metadata like total results, index name, and staleness for streamed queries."
 sidebar_label: StreamQueryStatistics
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import StreamQueryStatisticsCsharp from './content/_stream-query-statistics-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <StreamQueryStatisticsCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/stream-query-statistics.mdx
+++ b/docs/glossary/stream-query-statistics.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: StreamQueryStatistics"
 description: "API reference for the RavenDB StreamQueryStatistics class providing metadata like total results, index name, and staleness for streamed queries."
 sidebar_label: StreamQueryStatistics

--- a/docs/glossary/stream-result.mdx
+++ b/docs/glossary/stream-result.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Glossary: StreamResult<T>"
 description: "API reference for the RavenDB StreamResult wrapper class containing each streamed document, its ID, change vector, and metadata."
 sidebar_label: StreamResult
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import StreamResultCsharp from './content/_stream-result-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <StreamResultCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/glossary/stream-result.mdx
+++ b/docs/glossary/stream-result.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Glossary: StreamResult<T>"
 description: "API reference for the RavenDB StreamResult wrapper class containing each streamed document, its ID, change vector, and metadata."
 sidebar_label: StreamResult

--- a/docs/indexes/querying/vector-search.mdx
+++ b/docs/indexes/querying/vector-search.mdx
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Vector Search"
 sidebar_label: Vector Search
 description: "Perform vector similarity search against RavenDB static indexes to find semantically related documents using embedding comparisons."
@@ -11,14 +11,9 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import VectorSearchCsharp from './content/_vector-search-csharp.mdx';
 
-
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <VectorSearchCsharp />
 </LanguageContent>
 
-
-<!--
-
--->

--- a/docs/indexes/querying/vector-search.mdx
+++ b/docs/indexes/querying/vector-search.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Vector Search"
 sidebar_label: Vector Search
 description: "Perform vector similarity search against RavenDB static indexes to find semantically related documents using embedding comparisons."

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -6,7 +6,7 @@ pagination_next: null
 pagination_prev: null
 ---
 
-## 7.1.1 (71007) - 2025/07/22 {/* #71007 */}
+## 7.1.1 (71007) - 2025/07/22 {#71007}
 
 ### Server
 
@@ -59,7 +59,7 @@ pagination_prev: null
 * `[Embeddings Generation]` Added info about Quantization + other tooltips
 * `[Indexes]` Improved pause/resume indexing in databases view
 
-## 7.1.0 (71005) - 2025/07/01 {/* #71005 */}
+## 7.1.0 (71005) - 2025/07/01 {#71005}
 
 ### Features
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -6,7 +6,7 @@ pagination_next: null
 pagination_prev: null
 ---
 
-## 7.1.1 (71007) - 2025/07/22 {#71007}
+## 7.1.1 (71007) - 2025/07/22 {/* #71007 */}
 
 ### Server
 
@@ -59,7 +59,7 @@ pagination_prev: null
 * `[Embeddings Generation]` Added info about Quantization + other tooltips
 * `[Indexes]` Improved pause/resume indexing in databases view
 
-## 7.1.0 (71005) - 2025/07/01 {#71005}
+## 7.1.0 (71005) - 2025/07/01 {/* #71005 */}
 
 ### Features
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -34,7 +34,7 @@ const config: Config = {
     // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
     future: {
         v4: true, // Improve compatibility with the upcoming Docusaurus v4
-        experimental_faster: true,
+        faster: true,
     },
 
     customFields: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -37,6 +37,17 @@ const config: Config = {
         faster: true,
     },
 
+    // future.v4 enables mdx1CompatDisabledByDefault in 3.10+, which turns off HTML
+    // comments and {#id} heading anchors. Re-enable them explicitly: read-only
+    // versioned_docs/ snapshots use both and cannot be edited.
+    markdown: {
+        mdx1Compat: {
+            comments: true,
+            headingIds: true,
+            admonitions: true,
+        },
+    },
+
     customFields: {
         latestVersion: CURRENT_VERSION,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19064,15 +19064,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/range-parser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -20178,12 +20169,12 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/serve-handler": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
             "name": "docs-raven-db",
             "version": "0.0.0",
             "dependencies": {
-                "@docusaurus/core": "^3.9.2",
-                "@docusaurus/faster": "^3.9.2",
-                "@docusaurus/plugin-client-redirects": "^3.9.2",
-                "@docusaurus/plugin-ideal-image": "^3.9.2",
-                "@docusaurus/preset-classic": "^3.9.2",
+                "@docusaurus/core": "^3.10.1",
+                "@docusaurus/faster": "^3.10.1",
+                "@docusaurus/plugin-client-redirects": "^3.10.1",
+                "@docusaurus/plugin-ideal-image": "^3.10.1",
+                "@docusaurus/preset-classic": "^3.10.1",
                 "@mdx-js/react": "^3.0.0",
                 "autoprefixer": "^10.4.21",
                 "clsx": "^2.1.1",
@@ -24,9 +24,9 @@
                 "yet-another-react-lightbox": "^3.24.0"
             },
             "devDependencies": {
-                "@docusaurus/module-type-aliases": "^3.9.2",
-                "@docusaurus/tsconfig": "^3.9.2",
-                "@docusaurus/types": "^3.9.2",
+                "@docusaurus/module-type-aliases": "^3.10.1",
+                "@docusaurus/tsconfig": "^3.10.1",
+                "@docusaurus/types": "^3.10.1",
                 "@eslint/js": "^9.32.0",
                 "@tailwindcss/postcss": "^4.1.11",
                 "@typescript-eslint/eslint-plugin": "^8.39.0",
@@ -3511,42 +3511,6 @@
                 }
             }
         },
-        "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/core": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
@@ -3630,17 +3594,18 @@
             }
         },
         "node_modules/@docusaurus/faster": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.9.2.tgz",
-            "integrity": "sha512-DEVIwhbrZZ4ir31X+qQNEQqDWkgCJUV6kiPPAd2MGTY8n5/n0c4B8qA5k1ipF2izwH00JEf0h6Daaut71zzkyw==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.10.1.tgz",
+            "integrity": "sha512-XTZhE5C1gZ/DaYYMlSk02dwP5vhpQON5QHVz1s3892mSESAywgWanURpXEDAvt4GvGuq7s+XP8rTWHZvfaJmdQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.2",
-                "@rspack/core": "^1.5.0",
+                "@docusaurus/types": "3.10.1",
+                "@rspack/core": "^1.7.10",
                 "@swc/core": "^1.7.39",
                 "@swc/html": "^1.13.5",
                 "browserslist": "^4.24.2",
                 "lightningcss": "^1.27.0",
+                "semver": "^7.5.4",
                 "swc-loader": "^0.2.6",
                 "tslib": "^2.6.0",
                 "webpack": "^5.95.0"
@@ -3739,42 +3704,6 @@
                 "react-dom": "*"
             }
         },
-        "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/module-type-aliases/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-client-redirects": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
@@ -3834,42 +3763,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-content-docs": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
@@ -3903,42 +3796,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-content-pages": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
@@ -3962,42 +3819,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-css-cascade-layers": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
@@ -4012,42 +3833,6 @@
             },
             "engines": {
                 "node": ">=20.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-debug": {
@@ -4071,42 +3856,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-google-analytics": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
@@ -4124,42 +3873,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-google-gtag": {
@@ -4182,42 +3895,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-google-tag-manager": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
@@ -4235,42 +3912,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-ideal-image": {
@@ -4303,42 +3944,6 @@
                 }
             }
         },
-        "node_modules/@docusaurus/plugin-ideal-image/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-ideal-image/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-sitemap": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
@@ -4363,42 +3968,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-svgr": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
@@ -4420,42 +3989,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/preset-classic": {
@@ -4486,42 +4019,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/responsive-loader": {
@@ -4587,42 +4084,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/theme-common": {
@@ -4699,16 +4160,16 @@
             }
         },
         "node_modules/@docusaurus/tsconfig": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.2.tgz",
-            "integrity": "sha512-j6/Fp4Rlpxsc632cnRnl5HpOWeb6ZKssDj6/XzzAzVGXXfm9Eptx3rxCC+fDzySn9fHTS+CWJjPineCR1bB5WQ==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.1.tgz",
+            "integrity": "sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@docusaurus/types": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/mdx": "^3.0.0",
@@ -4786,42 +4247,6 @@
                 "node": ">=20.0"
             }
         },
-        "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/utils-validation": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
@@ -4841,57 +4266,21 @@
                 "node": ">=20.0"
             }
         },
-        "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@emnapi/core": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.6.0.tgz",
-            "integrity": "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+            "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.1.0",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
-            "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+            "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -4899,9 +4288,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -5840,56 +5229,56 @@
             }
         },
         "node_modules/@module-federation/error-codes": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.0.tgz",
-            "integrity": "sha512-Woonm8ehyVIUPXChmbu80Zj6uJkC0dD9SJUZ/wOPtO8iiz/m+dkrOugAuKgoiR6qH4F+yorWila954tBz4uKsQ==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+            "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
             "license": "MIT"
         },
         "node_modules/@module-federation/runtime": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.18.0.tgz",
-            "integrity": "sha512-+C4YtoSztM7nHwNyZl6dQKGUVJdsPrUdaf3HIKReg/GQbrt9uvOlUWo2NXMZ8vDAnf/QRrpSYAwXHmWDn9Obaw==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+            "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "0.18.0",
-                "@module-federation/runtime-core": "0.18.0",
-                "@module-federation/sdk": "0.18.0"
+                "@module-federation/error-codes": "0.22.0",
+                "@module-federation/runtime-core": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
             }
         },
         "node_modules/@module-federation/runtime-core": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.18.0.tgz",
-            "integrity": "sha512-ZyYhrDyVAhUzriOsVfgL6vwd+5ebYm595Y13KeMf6TKDRoUHBMTLGQ8WM4TDj8JNsy7LigncK8C03fn97of0QQ==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+            "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "0.18.0",
-                "@module-federation/sdk": "0.18.0"
+                "@module-federation/error-codes": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
             }
         },
         "node_modules/@module-federation/runtime-tools": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.18.0.tgz",
-            "integrity": "sha512-fSga9o4t1UfXNV/Kh6qFvRyZpPp3EHSPRISNeyT8ZoTpzDNiYzhtw0BPUSSD8m6C6XQh2s/11rI4g80UY+d+hA==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+            "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime": "0.18.0",
-                "@module-federation/webpack-bundler-runtime": "0.18.0"
+                "@module-federation/runtime": "0.22.0",
+                "@module-federation/webpack-bundler-runtime": "0.22.0"
             }
         },
         "node_modules/@module-federation/sdk": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.18.0.tgz",
-            "integrity": "sha512-Lo/Feq73tO2unjmpRfyyoUkTVoejhItXOk/h5C+4cistnHbTV8XHrW/13fD5e1Iu60heVdAhhelJd6F898Ve9A==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+            "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
             "license": "MIT"
         },
         "node_modules/@module-federation/webpack-bundler-runtime": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.18.0.tgz",
-            "integrity": "sha512-TEvErbF+YQ+6IFimhUYKK3a5wapD90d90sLsNpcu2kB3QGT7t4nIluE25duXuZDVUKLz86tEPrza/oaaCWTpvQ==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+            "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime": "0.18.0",
-                "@module-federation/sdk": "0.18.0"
+                "@module-federation/runtime": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
@@ -6148,27 +5537,27 @@
             "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="
         },
         "node_modules/@rspack/binding": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.8.tgz",
-            "integrity": "sha512-/91CzhRl9r5BIQCgGsS7jA6MDbw1I2BQpbfcUUdkdKl2P79K3Zo/Mw/TvKzS86catwLaUQEgkGRmYawOfPg7ow==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.11.tgz",
+            "integrity": "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==",
             "license": "MIT",
             "optionalDependencies": {
-                "@rspack/binding-darwin-arm64": "1.5.8",
-                "@rspack/binding-darwin-x64": "1.5.8",
-                "@rspack/binding-linux-arm64-gnu": "1.5.8",
-                "@rspack/binding-linux-arm64-musl": "1.5.8",
-                "@rspack/binding-linux-x64-gnu": "1.5.8",
-                "@rspack/binding-linux-x64-musl": "1.5.8",
-                "@rspack/binding-wasm32-wasi": "1.5.8",
-                "@rspack/binding-win32-arm64-msvc": "1.5.8",
-                "@rspack/binding-win32-ia32-msvc": "1.5.8",
-                "@rspack/binding-win32-x64-msvc": "1.5.8"
+                "@rspack/binding-darwin-arm64": "1.7.11",
+                "@rspack/binding-darwin-x64": "1.7.11",
+                "@rspack/binding-linux-arm64-gnu": "1.7.11",
+                "@rspack/binding-linux-arm64-musl": "1.7.11",
+                "@rspack/binding-linux-x64-gnu": "1.7.11",
+                "@rspack/binding-linux-x64-musl": "1.7.11",
+                "@rspack/binding-wasm32-wasi": "1.7.11",
+                "@rspack/binding-win32-arm64-msvc": "1.7.11",
+                "@rspack/binding-win32-ia32-msvc": "1.7.11",
+                "@rspack/binding-win32-x64-msvc": "1.7.11"
             }
         },
         "node_modules/@rspack/binding-darwin-arm64": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.8.tgz",
-            "integrity": "sha512-spJfpOSN3f7V90ic45/ET2NKB2ujAViCNmqb0iGurMNQtFRq+7Kd+jvVKKGXKBHBbsQrFhidSWbbqy2PBPGK8g==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.11.tgz",
+            "integrity": "sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==",
             "cpu": [
                 "arm64"
             ],
@@ -6179,9 +5568,9 @@
             ]
         },
         "node_modules/@rspack/binding-darwin-x64": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.8.tgz",
-            "integrity": "sha512-YFOzeL1IBknBcri8vjUp43dfUBylCeQnD+9O9p0wZmLAw7DtpN5JEOe2AkGo8kdTqJjYKI+cczJPKIw6lu1LWw==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.11.tgz",
+            "integrity": "sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==",
             "cpu": [
                 "x64"
             ],
@@ -6192,11 +5581,14 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-gnu": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.8.tgz",
-            "integrity": "sha512-UAWCsOnpkvy8eAVRo0uipbHXDhnoDq5zmqWTMhpga0/a3yzCp2e+fnjZb/qnFNYb5MeL0O1mwMOYgn1M3oHILQ==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.11.tgz",
+            "integrity": "sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6205,11 +5597,14 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-musl": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.8.tgz",
-            "integrity": "sha512-GnSvGT4GjokPSD45cTtE+g7LgghuxSP1MRmvd+Vp/I8pnxTVSTsebRod4TAqyiv+l11nuS8yqNveK9qiOkBLWw==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.11.tgz",
+            "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6218,11 +5613,14 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-gnu": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.8.tgz",
-            "integrity": "sha512-XLxh5n/pzUfxsugz/8rVBv+Tx2nqEM+9rharK69kfooDsQNKyz7PANllBQ/v4svJ+W0BRHnDL4qXSGdteZeEjA==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.11.tgz",
+            "integrity": "sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6231,11 +5629,14 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-musl": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.8.tgz",
-            "integrity": "sha512-gE0+MZmwF+01p9/svpEESkzkLpBkVUG2o03YMpwXYC/maeRRhWvF8BJ7R3i/Ls/jFGSE87dKX5NbRLVzqksq/w==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.11.tgz",
+            "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6244,22 +5645,22 @@
             ]
         },
         "node_modules/@rspack/binding-wasm32-wasi": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.8.tgz",
-            "integrity": "sha512-cfg3niNHeJuxuml1Vy9VvaJrI/5TakzoaZvKX2g5S24wfzR50Eyy4JAsZ+L2voWQQp1yMJbmPYPmnTCTxdJQBQ==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.11.tgz",
+            "integrity": "sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^1.0.5"
+                "@napi-rs/wasm-runtime": "1.0.7"
             }
         },
         "node_modules/@rspack/binding-win32-arm64-msvc": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.8.tgz",
-            "integrity": "sha512-7i3ZTHFXKfU/9Jm9XhpMkrdkxO7lfeYMNVEGkuU5dyBfRMQj69dRgPL7zJwc2plXiqu9LUOl+TwDNTjap7Q36g==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.11.tgz",
+            "integrity": "sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==",
             "cpu": [
                 "arm64"
             ],
@@ -6270,9 +5671,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-ia32-msvc": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.8.tgz",
-            "integrity": "sha512-7ZPPWO11J+soea1+mnfaPpQt7GIodBM7A86dx6PbXgVEoZmetcWPrCF2NBfXxQWOKJ9L3RYltC4z+ZyXRgMOrw==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.11.tgz",
+            "integrity": "sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==",
             "cpu": [
                 "ia32"
             ],
@@ -6283,9 +5684,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-x64-msvc": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.8.tgz",
-            "integrity": "sha512-N/zXQgzIxME3YUzXT8qnyzxjqcnXudWOeDh8CAG9zqTCnCiy16SFfQ/cQgEoLlD9geQntV6jx2GbDDI5kpDGMQ==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.11.tgz",
+            "integrity": "sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==",
             "cpu": [
                 "x64"
             ],
@@ -6296,14 +5697,14 @@
             ]
         },
         "node_modules/@rspack/core": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.8.tgz",
-            "integrity": "sha512-sUd2LfiDhqYVfvknuoz0+/c+wSpn693xotnG5g1CSWKZArbtwiYzBIVnNlcHGmuoBRsnj/TkSq8dTQ7gwfBroQ==",
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.11.tgz",
+            "integrity": "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime-tools": "0.18.0",
-                "@rspack/binding": "1.5.8",
-                "@rspack/lite-tapable": "1.0.1"
+                "@module-federation/runtime-tools": "0.22.0",
+                "@rspack/binding": "1.7.11",
+                "@rspack/lite-tapable": "1.1.0"
             },
             "engines": {
                 "node": ">=18.12.0"
@@ -6318,13 +5719,10 @@
             }
         },
         "node_modules/@rspack/lite-tapable": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
-            "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.0.0"
-            }
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+            "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+            "license": "MIT"
         },
         "node_modules/@sideway/address": {
             "version": "4.1.5",
@@ -7372,9 +6770,9 @@
             }
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "prism-react-renderer": "^2.3.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
-                "react-github-btn": "^1.4.0",
                 "yet-another-react-lightbox": "^3.24.0"
             },
             "devDependencies": {
@@ -45,117 +44,47 @@
                 "node": ">=18.0"
             }
         },
-        "node_modules/@ai-sdk/gateway": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.3.tgz",
-            "integrity": "sha512-/vCoMKtod+A74/BbkWsaAflWKz1ovhX5lmJpIaXQXtd6gyexZncjotBTbFM8rVJT9LKJ/Kx7iVVo3vh+KT+IJg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.14",
-                "@vercel/oidc": "3.0.3"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/@ai-sdk/provider": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-            "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "json-schema": "^0.4.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.14",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.14.tgz",
-            "integrity": "sha512-CYRU6L7IlR7KslSBVxvlqlybQvXJln/PI57O8swhOaDIURZbjRP2AY3igKgUsrmWqqnFFUHP+AwTN8xqJAknnA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.5"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/@ai-sdk/react": {
-            "version": "2.0.82",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.82.tgz",
-            "integrity": "sha512-InaGqykKGFq/XA6Vhh2Hyy38nzeMpqp8eWxjTNEQA5Gwcal0BVNuZyTbTIL5t5VNXV+pQPDhe9ak1+mc9qxjog==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider-utils": "3.0.14",
-                "ai": "5.0.82",
-                "swr": "^2.2.5",
-                "throttleit": "2.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "react": "^18 || ^19 || ^19.0.0-rc",
-                "zod": "^3.25.76 || ^4.1.8"
-            },
-            "peerDependenciesMeta": {
-                "zod": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@algolia/abtesting": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.7.0.tgz",
-            "integrity": "sha512-hOEItTFOvNLI6QX6TSGu7VE4XcUcdoKZT8NwDY+5mWwu87rGhkjlY7uesKTInlg6Sh8cyRkDBYRumxbkoBbBhA==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.19.0.tgz",
+            "integrity": "sha512-Lhnez3hhXHk25lfxLAMxvkP4fmN3+1RgADhD2ssMDBYuAsDVReeyP+3SGRx+ntq8ijMrLqUyfvO72TB6jsTteQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-            "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+            "version": "1.19.8",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
+            "integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-                "@algolia/autocomplete-shared": "1.19.2"
+                "@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
+                "@algolia/autocomplete-shared": "1.19.8"
             }
         },
         "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-            "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+            "version": "1.19.8",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
+            "integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.19.2"
+                "@algolia/autocomplete-shared": "1.19.8"
             },
             "peerDependencies": {
                 "search-insights": ">= 1 < 3"
             }
         },
         "node_modules/@algolia/autocomplete-shared": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-            "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+            "version": "1.19.8",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
+            "integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
             "license": "MIT",
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
@@ -163,99 +92,99 @@
             }
         },
         "node_modules/@algolia/client-abtesting": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.41.0.tgz",
-            "integrity": "sha512-iRuvbEyuHCAhIMkyzG3tfINLxTS7mSKo7q8mQF+FbQpWenlAlrXnfZTN19LRwnVjx0UtAdZq96ThMWGS6cQ61A==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.53.0.tgz",
+            "integrity": "sha512-0ZjA5Hcmaoz5Lj6OG0zhfIyeqzJZnLW2CRJA1W17UwMFGRtZAJ9yJKRvPEDA6gkpsIoQxORTSW6sWFiuYncPNQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.41.0.tgz",
-            "integrity": "sha512-OIPVbGfx/AO8l1V70xYTPSeTt/GCXPEl6vQICLAXLCk9WOUbcLGcy6t8qv0rO7Z7/M/h9afY6Af8JcnI+FBFdQ==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.53.0.tgz",
+            "integrity": "sha512-kWNodP75iiEaOtemC9F/hlxNBG5E2QUjN1BusnE6m2b4l7Qh/BUO3fGCVsmKJI65VO4VKGGmT43ICvHtTcJ2JQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.41.0.tgz",
-            "integrity": "sha512-8Mc9niJvfuO8dudWN5vSUlYkz7U3M3X3m1crDLc9N7FZrIVoNGOUETPk3TTHviJIh9y6eKZKbq1hPGoGY9fqPA==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.53.0.tgz",
+            "integrity": "sha512-YPN45TXD9Wrse185t/Ta7nktZsqpv97oOjCzp2sblHnCL6rBc9TDeJAg1IGl2UpdwnSD05Zu/5wLB4watOUMyg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-insights": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.41.0.tgz",
-            "integrity": "sha512-vXzvCGZS6Ixxn+WyzGUVDeR3HO/QO5POeeWy1kjNJbEf6f+tZSI+OiIU9Ha+T3ntV8oXFyBEuweygw4OLmgfiQ==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.53.0.tgz",
+            "integrity": "sha512-qAcYTDJE6m924FDDUQvdD6vh7DYaqOeSpFS74IP37/JRV0v4cGBauyxTF2WzDnokUylQDbqreoFIJZfg0Fitmw==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.41.0.tgz",
-            "integrity": "sha512-tkymXhmlcc7w/HEvLRiHcpHxLFcUB+0PnE9FcG6hfFZ1ZXiWabH+sX+uukCVnluyhfysU9HRU2kUmUWfucx1Dg==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.53.0.tgz",
+            "integrity": "sha512-fQaY+DkSJOpuUVUe8MQTwrdiKAqkJGhpDarB08duBn/sUv7Bkib6MDRQauCcWTWTe4HIW+EbwQP9R4kci1V/Yw==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-query-suggestions": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.41.0.tgz",
-            "integrity": "sha512-vyXDoz3kEZnosNeVQQwf0PbBt5IZJoHkozKRIsYfEVm+ylwSDFCW08qy2YIVSHdKy69/rWN6Ue/6W29GgVlmKQ==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.53.0.tgz",
+            "integrity": "sha512-o72tsiEZGfeS/dxL9IADfzcZWGEwKDEe5CvtrBuT//3JR+SHuTtHRI2ZTf7D7bcKagcbojvO8hnkHdfoakSlYg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.41.0.tgz",
-            "integrity": "sha512-G9I2atg1ShtFp0t7zwleP6aPS4DcZvsV4uoQOripp16aR6VJzbEnKFPLW4OFXzX7avgZSpYeBAS+Zx4FOgmpPw==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.53.0.tgz",
+            "integrity": "sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -268,81 +197,81 @@
             "license": "MIT"
         },
         "node_modules/@algolia/ingestion": {
-            "version": "1.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.41.0.tgz",
-            "integrity": "sha512-sxU/ggHbZtmrYzTkueTXXNyifn+ozsLP+Wi9S2hOBVhNWPZ8uRiDTDcFyL7cpCs1q72HxPuhzTP5vn4sUl74cQ==",
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.53.0.tgz",
+            "integrity": "sha512-oNbT6z4NwD8Pou9VPINGlN/tlG1afESh2EbxqnP6rwl95xKVD/Zlciis1PpNeO/9U/rrajc1+7DcfKi03tX1KQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/monitoring": {
-            "version": "1.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.41.0.tgz",
-            "integrity": "sha512-UQ86R6ixraHUpd0hn4vjgTHbViNO8+wA979gJmSIsRI3yli2v89QSFF/9pPcADR6PbtSio/99PmSNxhZy+CR3Q==",
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.53.0.tgz",
+            "integrity": "sha512-G+KZb/yd+qAOFn/cEvTGeLxQm8aP3a0od50l3z/ylccY+/o4YG3TNcjU1tFQHW4mXC137GPyR7W70R0kRQDLnA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.41.0.tgz",
-            "integrity": "sha512-DxP9P8jJ8whJOnvmyA5mf1wv14jPuI0L25itGfOHSU6d4ZAjduVfPjTS3ROuUN5CJoTdlidYZE+DtfWHxJwyzQ==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.53.0.tgz",
+            "integrity": "sha512-6aVfYd55Un6IUgPLbo84WfgFZlS3L0vA1ttzXL5vahHewUJ8jYgd89TzlWRTeej7w70mb9RWsVlFYGmJ/diQww==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/client-common": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.41.0.tgz",
-            "integrity": "sha512-C21J+LYkE48fDwtLX7YXZd2Fn7Fe0/DOEtvohSfr/ODP8dGDhy9faaYeWB0n1AvmZltugjkjAXT7xk0CYNIXsQ==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.53.0.tgz",
+            "integrity": "sha512-ke27DqgzCOlt+RbeEdCxtXxMQOnAOi8ujr2wid0DmDKzR95Kw/f9sBsuhBxtjevCqJRJszfRTLY0B1pbO6IhkA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0"
+                "@algolia/client-common": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.41.0.tgz",
-            "integrity": "sha512-FhJy/+QJhMx1Hajf2LL8og4J7SqOAHiAuUXq27cct4QnPhSIuIGROzeRpfDNH5BUbq22UlMuGd44SeD4HRAqvA==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.53.0.tgz",
+            "integrity": "sha512-GngiOqt2Gq4oLno6yXQVj9om+qSO9SWAoduoTOEg79dKZ62brB8OOIvSJG/vDNoanYi6a7Al9uDZwXvi+bcVTg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0"
+                "@algolia/client-common": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.41.0.tgz",
-            "integrity": "sha512-tYv3rGbhBS0eZ5D8oCgV88iuWILROiemk+tQ3YsAKZv2J4kKUNvKkrX/If/SreRy4MGP2uJzMlyKcfSfO2mrsQ==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.53.0.tgz",
+            "integrity": "sha512-6mF9LZMUk0QqWvrnxkxBqhswwz6Xfiwy6/gmTzL5HrlhdVG3ITAqGV2k3XmVThP1h0Ulc3VQwiNCD7/Nr4JNlQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.41.0"
+                "@algolia/client-common": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -374,12 +303,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -388,29 +317,29 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-            "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-            "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.4",
-                "@babel/parser": "^7.28.5",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.5",
-                "@babel/types": "^7.28.5",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -436,13 +365,13 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -452,25 +381,25 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+            "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.3"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.27.2",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -489,17 +418,17 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
-            "integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-member-expression-to-functions": "^7.28.5",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.28.5",
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -519,12 +448,12 @@
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
-            "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-annotate-as-pure": "^7.29.7",
                 "regexpu-core": "^6.3.1",
                 "semver": "^6.3.1"
             },
@@ -545,65 +474,65 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
-            "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+            "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "debug": "^4.4.1",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "debug": "^4.4.3",
                 "lodash.debounce": "^4.0.8",
-                "resolve": "^1.22.10"
+                "resolve": "^1.22.11"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+            "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.5",
-                "@babel/types": "^7.28.5"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -613,35 +542,35 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+            "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.1"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
-            "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+            "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-wrap-function": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-wrap-function": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -651,14 +580,14 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-            "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+            "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -668,79 +597,79 @@
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+            "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
-            "integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+            "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.3",
-                "@babel/types": "^7.28.2"
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -750,13 +679,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
-            "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+            "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.28.5"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -766,12 +695,12 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
-            "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+            "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -781,12 +710,28 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
-            "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+            "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
+            "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -796,14 +741,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
-            "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+            "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/plugin-transform-optional-chaining": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-transform-optional-chaining": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -813,13 +758,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
-            "integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+            "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.28.3"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -853,12 +798,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
-            "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+            "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -868,12 +813,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-            "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+            "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -883,12 +828,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+            "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -898,12 +843,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+            "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -929,12 +874,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
-            "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+            "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -944,14 +889,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
-            "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+            "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-remap-async-to-generator": "^7.27.1",
-                "@babel/traverse": "^7.28.0"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-remap-async-to-generator": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -961,14 +906,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-            "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+            "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-remap-async-to-generator": "^7.27.1"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-remap-async-to-generator": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -978,12 +923,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
-            "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+            "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -993,12 +938,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.5.tgz",
-            "integrity": "sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+            "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1008,13 +953,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-            "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+            "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1024,13 +969,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
-            "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+            "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.28.3",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1040,17 +985,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
-            "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+            "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
-                "@babel/traverse": "^7.28.4"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1060,13 +1005,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
-            "integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+            "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/template": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/template": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1076,13 +1021,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
-            "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+            "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.28.5"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1092,13 +1037,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
-            "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+            "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1108,12 +1053,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
-            "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+            "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1123,13 +1068,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
-            "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+            "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1139,12 +1084,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-dynamic-import": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
-            "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+            "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1154,13 +1099,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-explicit-resource-management": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
-            "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+            "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.28.0"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1170,12 +1115,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.5.tgz",
-            "integrity": "sha512-D4WIMaFtwa2NizOp+dnoFjRez/ClKiC2BqqImwKd1X28nqBtZEyCYJ2ozQrrzlxAFrcrjxo39S6khe9RNDlGzw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+            "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1185,12 +1130,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-export-namespace-from": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
-            "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+            "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1200,13 +1145,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
-            "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+            "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1216,14 +1161,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
-            "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+            "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1233,12 +1178,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
-            "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+            "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1248,12 +1193,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
-            "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+            "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1263,12 +1208,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.5.tgz",
-            "integrity": "sha512-axUuqnUTBuXyHGcJEVVh9pORaN6wC5bYfE7FGzPiaWa3syib9m7g+/IT/4VgCOe2Upef43PHzeAvcrVek6QuuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+            "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1278,12 +1223,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
-            "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+            "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1293,13 +1238,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
-            "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+            "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1309,13 +1254,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-            "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+            "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1325,15 +1270,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.29.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
-            "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+            "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.29.0"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1343,13 +1288,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
-            "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+            "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1359,13 +1304,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-            "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+            "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1375,12 +1320,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
-            "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+            "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1390,12 +1335,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-            "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+            "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1405,12 +1350,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
-            "integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+            "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1420,16 +1365,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
-            "integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+            "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.28.0",
-                "@babel/plugin-transform-parameters": "^7.27.7",
-                "@babel/traverse": "^7.28.4"
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7",
+                "@babel/plugin-transform-parameters": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1439,13 +1384,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
-            "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+            "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1455,12 +1400,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
-            "integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+            "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1470,13 +1415,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.5.tgz",
-            "integrity": "sha512-N6fut9IZlPnjPwgiQkXNhb+cT8wQKFlJNqcZkWlcTqkcqx6/kU4ynGmLFoa4LViBSirn05YAwk+sQBbPfxtYzQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+            "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1486,12 +1431,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
-            "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+            "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1501,13 +1446,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
-            "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+            "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1517,14 +1462,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
-            "integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+            "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1534,12 +1479,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
-            "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+            "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1549,12 +1494,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-constant-elements": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.27.1.tgz",
-            "integrity": "sha512-edoidOjl/ZxvYo4lSBOQGDSyToYVkTAwyVoa2tkuYTSmjrB1+uAedoL5iROVLXkxH+vRgA7uP4tMg2pUJpZ3Ug==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.29.7.tgz",
+            "integrity": "sha512-J0wGhKan+rIiE2OhfhRptySLrJ6SjQYM6b6N1FMlhyhCcw1Mig8vQjWchyB+bgHGDvaWo6Diu6CLRMra2uMtmg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1564,12 +1509,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
-            "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+            "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1579,16 +1524,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
-            "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+            "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/plugin-syntax-jsx": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-syntax-jsx": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1598,12 +1543,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
-            "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+            "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/plugin-transform-react-jsx": "^7.27.1"
+                "@babel/plugin-transform-react-jsx": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1613,13 +1558,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
-            "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+            "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1629,12 +1574,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
-            "integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+            "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1644,13 +1589,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-regexp-modifiers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
-            "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+            "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1660,12 +1605,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
-            "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+            "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1675,13 +1620,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
-            "integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.7.tgz",
+            "integrity": "sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
                 "babel-plugin-polyfill-corejs2": "^0.4.14",
                 "babel-plugin-polyfill-corejs3": "^0.13.0",
                 "babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -1704,12 +1649,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
-            "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+            "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1719,13 +1664,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
-            "integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+            "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1735,12 +1680,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
-            "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+            "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1750,12 +1695,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-            "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+            "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1765,12 +1710,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
-            "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+            "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1780,16 +1725,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
-            "integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+            "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-create-class-features-plugin": "^7.28.5",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/plugin-syntax-typescript": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-syntax-typescript": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1799,12 +1744,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
-            "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+            "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1814,13 +1759,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
-            "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+            "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1830,13 +1775,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
-            "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+            "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1846,13 +1791,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
-            "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+            "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1862,80 +1807,81 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.5.tgz",
-            "integrity": "sha512-S36mOoi1Sb6Fz98fBfE+UZSpYw5mJm0NUHtIKrOuNcqeFauy1J6dIvXm2KRVKobOSaGq4t/hBXdN4HGU3wL9Wg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
+            "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
-                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
+                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
+                "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-                "@babel/plugin-syntax-import-assertions": "^7.27.1",
-                "@babel/plugin-syntax-import-attributes": "^7.27.1",
+                "@babel/plugin-syntax-import-assertions": "^7.29.7",
+                "@babel/plugin-syntax-import-attributes": "^7.29.7",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-                "@babel/plugin-transform-arrow-functions": "^7.27.1",
-                "@babel/plugin-transform-async-generator-functions": "^7.28.0",
-                "@babel/plugin-transform-async-to-generator": "^7.27.1",
-                "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-                "@babel/plugin-transform-block-scoping": "^7.28.5",
-                "@babel/plugin-transform-class-properties": "^7.27.1",
-                "@babel/plugin-transform-class-static-block": "^7.28.3",
-                "@babel/plugin-transform-classes": "^7.28.4",
-                "@babel/plugin-transform-computed-properties": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.28.5",
-                "@babel/plugin-transform-dotall-regex": "^7.27.1",
-                "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
-                "@babel/plugin-transform-dynamic-import": "^7.27.1",
-                "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
-                "@babel/plugin-transform-exponentiation-operator": "^7.28.5",
-                "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-                "@babel/plugin-transform-for-of": "^7.27.1",
-                "@babel/plugin-transform-function-name": "^7.27.1",
-                "@babel/plugin-transform-json-strings": "^7.27.1",
-                "@babel/plugin-transform-literals": "^7.27.1",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.28.5",
-                "@babel/plugin-transform-member-expression-literals": "^7.27.1",
-                "@babel/plugin-transform-modules-amd": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-modules-systemjs": "^7.28.5",
-                "@babel/plugin-transform-modules-umd": "^7.27.1",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
-                "@babel/plugin-transform-new-target": "^7.27.1",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-                "@babel/plugin-transform-numeric-separator": "^7.27.1",
-                "@babel/plugin-transform-object-rest-spread": "^7.28.4",
-                "@babel/plugin-transform-object-super": "^7.27.1",
-                "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-                "@babel/plugin-transform-optional-chaining": "^7.28.5",
-                "@babel/plugin-transform-parameters": "^7.27.7",
-                "@babel/plugin-transform-private-methods": "^7.27.1",
-                "@babel/plugin-transform-private-property-in-object": "^7.27.1",
-                "@babel/plugin-transform-property-literals": "^7.27.1",
-                "@babel/plugin-transform-regenerator": "^7.28.4",
-                "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
-                "@babel/plugin-transform-reserved-words": "^7.27.1",
-                "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-                "@babel/plugin-transform-spread": "^7.27.1",
-                "@babel/plugin-transform-sticky-regex": "^7.27.1",
-                "@babel/plugin-transform-template-literals": "^7.27.1",
-                "@babel/plugin-transform-typeof-symbol": "^7.27.1",
-                "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-                "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
-                "@babel/plugin-transform-unicode-regex": "^7.27.1",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+                "@babel/plugin-transform-arrow-functions": "^7.29.7",
+                "@babel/plugin-transform-async-generator-functions": "^7.29.7",
+                "@babel/plugin-transform-async-to-generator": "^7.29.7",
+                "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
+                "@babel/plugin-transform-block-scoping": "^7.29.7",
+                "@babel/plugin-transform-class-properties": "^7.29.7",
+                "@babel/plugin-transform-class-static-block": "^7.29.7",
+                "@babel/plugin-transform-classes": "^7.29.7",
+                "@babel/plugin-transform-computed-properties": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7",
+                "@babel/plugin-transform-dotall-regex": "^7.29.7",
+                "@babel/plugin-transform-duplicate-keys": "^7.29.7",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
+                "@babel/plugin-transform-dynamic-import": "^7.29.7",
+                "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
+                "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
+                "@babel/plugin-transform-export-namespace-from": "^7.29.7",
+                "@babel/plugin-transform-for-of": "^7.29.7",
+                "@babel/plugin-transform-function-name": "^7.29.7",
+                "@babel/plugin-transform-json-strings": "^7.29.7",
+                "@babel/plugin-transform-literals": "^7.29.7",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
+                "@babel/plugin-transform-member-expression-literals": "^7.29.7",
+                "@babel/plugin-transform-modules-amd": "^7.29.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+                "@babel/plugin-transform-modules-systemjs": "^7.29.7",
+                "@babel/plugin-transform-modules-umd": "^7.29.7",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
+                "@babel/plugin-transform-new-target": "^7.29.7",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
+                "@babel/plugin-transform-numeric-separator": "^7.29.7",
+                "@babel/plugin-transform-object-rest-spread": "^7.29.7",
+                "@babel/plugin-transform-object-super": "^7.29.7",
+                "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
+                "@babel/plugin-transform-optional-chaining": "^7.29.7",
+                "@babel/plugin-transform-parameters": "^7.29.7",
+                "@babel/plugin-transform-private-methods": "^7.29.7",
+                "@babel/plugin-transform-private-property-in-object": "^7.29.7",
+                "@babel/plugin-transform-property-literals": "^7.29.7",
+                "@babel/plugin-transform-regenerator": "^7.29.7",
+                "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
+                "@babel/plugin-transform-reserved-words": "^7.29.7",
+                "@babel/plugin-transform-shorthand-properties": "^7.29.7",
+                "@babel/plugin-transform-spread": "^7.29.7",
+                "@babel/plugin-transform-sticky-regex": "^7.29.7",
+                "@babel/plugin-transform-template-literals": "^7.29.7",
+                "@babel/plugin-transform-typeof-symbol": "^7.29.7",
+                "@babel/plugin-transform-unicode-escapes": "^7.29.7",
+                "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
+                "@babel/plugin-transform-unicode-regex": "^7.29.7",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "babel-plugin-polyfill-corejs2": "^0.4.14",
-                "babel-plugin-polyfill-corejs3": "^0.13.0",
-                "babel-plugin-polyfill-regenerator": "^0.6.5",
-                "core-js-compat": "^3.43.0",
+                "babel-plugin-polyfill-corejs2": "^0.4.15",
+                "babel-plugin-polyfill-corejs3": "^0.14.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.6",
+                "core-js-compat": "^3.48.0",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1943,6 +1889,19 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+            "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
+                "core-js-compat": "^3.48.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@babel/preset-env/node_modules/semver": {
@@ -1969,17 +1928,17 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.28.5.tgz",
-            "integrity": "sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
+            "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-transform-react-display-name": "^7.28.0",
-                "@babel/plugin-transform-react-jsx": "^7.27.1",
-                "@babel/plugin-transform-react-jsx-development": "^7.27.1",
-                "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-transform-react-display-name": "^7.29.7",
+                "@babel/plugin-transform-react-jsx": "^7.29.7",
+                "@babel/plugin-transform-react-jsx-development": "^7.29.7",
+                "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1989,16 +1948,16 @@
             }
         },
         "node_modules/@babel/preset-typescript": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
-            "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+            "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-syntax-jsx": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-typescript": "^7.28.5"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-syntax-jsx": "^7.29.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+                "@babel/plugin-transform-typescript": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2015,44 +1974,32 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/runtime-corejs3": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
-            "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
-            "license": "MIT",
-            "dependencies": {
-                "core-js-pure": "^3.43.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -2060,13 +2007,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2315,9 +2262,9 @@
             }
         },
         "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -2736,9 +2683,9 @@
             }
         },
         "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -2975,9 +2922,9 @@
             }
         },
         "node_modules/@csstools/postcss-normalize-display-values": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.0.tgz",
-            "integrity": "sha512-HlEoG0IDRoHXzXnkV4in47dzsxdsjdz6+j7MLjaACABX2NfvjFS6XVAnpaDyGesz9gK2SC7MbNwdCHusObKJ9Q==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+            "integrity": "sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==",
             "funding": [
                 {
                     "type": "github",
@@ -3028,6 +2975,28 @@
                 "postcss": "^8.4"
             }
         },
+        "node_modules/@csstools/postcss-position-area-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-position-area-property/-/postcss-position-area-property-1.0.0.tgz",
+            "integrity": "sha512-fUP6KR8qV2NuUZV3Cw8itx0Ep90aRjAZxAEzC3vrl6yjFv+pFsQbR18UuQctEKmA72K9O27CoYiKEgXxkqjg8Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
+            }
+        },
         "node_modules/@csstools/postcss-progressive-custom-properties": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.2.1.tgz",
@@ -3045,6 +3014,32 @@
             "license": "MIT-0",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
+            }
+        },
+        "node_modules/@csstools/postcss-property-rule-prelude-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-property-rule-prelude-list/-/postcss-property-rule-prelude-list-1.0.0.tgz",
+            "integrity": "sha512-IxuQjUXq19fobgmSSvUDO7fVwijDJaZMvWQugxfEUxmjBeDCVaDuMpsZ31MsTm5xbnhA+ElDi0+rQ7sQQGisFA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "dependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             },
             "engines": {
                 "node": ">=18"
@@ -3135,9 +3130,9 @@
             }
         },
         "node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -3191,6 +3186,57 @@
             "license": "MIT-0",
             "dependencies": {
                 "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
+            }
+        },
+        "node_modules/@csstools/postcss-syntax-descriptor-syntax-production": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-syntax-descriptor-syntax-production/-/postcss-syntax-descriptor-syntax-production-1.0.1.tgz",
+            "integrity": "sha512-GneqQWefjM//f4hJ/Kbox0C6f2T7+pi4/fqTqOFGTL3EjnvOReTqO1qUQ30CaUjkwjYq9qZ41hzarrAxCc4gow==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "dependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
+            }
+        },
+        "node_modules/@csstools/postcss-system-ui-font-family": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-system-ui-font-family/-/postcss-system-ui-font-family-1.0.0.tgz",
+            "integrity": "sha512-s3xdBvfWYfoPSBsikDXbuorcMG1nN1M6GdU0qBsGfcmNR0A/qhloQZpTxjA3Xsyrk1VJvwb2pOfiOT3at/DuIQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "dependencies": {
                 "@csstools/css-parser-algorithms": "^3.0.5",
                 "@csstools/css-tokenizer": "^3.0.4"
             },
@@ -3306,25 +3352,43 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@docsearch/core": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
+            "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": ">= 16.8.0 < 20.0.0",
+                "react": ">= 16.8.0 < 20.0.0",
+                "react-dom": ">= 16.8.0 < 20.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@docsearch/css": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.2.0.tgz",
-            "integrity": "sha512-65KU9Fw5fGsPPPlgIghonMcndyx1bszzrDQYLfierN+Ha29yotMHzVS94bPkZS6On9LS8dE4qmW4P/fGjtCf/g==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
+            "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
             "license": "MIT"
         },
         "node_modules/@docsearch/react": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.2.0.tgz",
-            "integrity": "sha512-zSN/KblmtBcerf7Z87yuKIHZQmxuXvYc6/m0+qnjyNu+Ir67AVOagTa1zBqcxkVUVkmBqUExdcyrdo9hbGbqTw==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
+            "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
             "license": "MIT",
             "dependencies": {
-                "@ai-sdk/react": "^2.0.30",
                 "@algolia/autocomplete-core": "1.19.2",
-                "@docsearch/css": "4.2.0",
-                "ai": "^5.0.30",
-                "algoliasearch": "^5.28.0",
-                "marked": "^16.3.0",
-                "zod": "^4.1.8"
+                "@docsearch/core": "4.6.3",
+                "@docsearch/css": "4.6.3"
             },
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3347,10 +3411,42 @@
                 }
             }
         },
+        "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+            "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+                "@algolia/autocomplete-shared": "1.19.2"
+            }
+        },
+        "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+            "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/autocomplete-shared": "1.19.2"
+            },
+            "peerDependencies": {
+                "search-insights": ">= 1 < 3"
+            }
+        },
+        "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+            "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@algolia/client-search": ">= 4.9.1 < 6",
+                "algoliasearch": ">= 4.9.1 < 6"
+            }
+        },
         "node_modules/@docusaurus/babel": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
-            "integrity": "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
+            "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
@@ -3361,10 +3457,9 @@
                 "@babel/preset-react": "^7.25.9",
                 "@babel/preset-typescript": "^7.25.9",
                 "@babel/runtime": "^7.25.9",
-                "@babel/runtime-corejs3": "^7.25.9",
                 "@babel/traverse": "^7.25.9",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
                 "babel-plugin-dynamic-import-node": "^2.3.3",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0"
@@ -3374,17 +3469,17 @@
             }
         },
         "node_modules/@docusaurus/bundler": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
-            "integrity": "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
+            "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
-                "@docusaurus/babel": "3.9.2",
-                "@docusaurus/cssnano-preset": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/babel": "3.10.1",
+                "@docusaurus/cssnano-preset": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
                 "babel-loader": "^9.2.1",
                 "clean-css": "^5.3.3",
                 "copy-webpack-plugin": "^11.0.0",
@@ -3402,7 +3497,7 @@
                 "tslib": "^2.6.0",
                 "url-loader": "^4.1.1",
                 "webpack": "^5.95.0",
-                "webpackbar": "^6.0.1"
+                "webpackbar": "^7.0.0"
             },
             "engines": {
                 "node": ">=20.0"
@@ -3416,19 +3511,55 @@
                 }
             }
         },
-        "node_modules/@docusaurus/core": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
-            "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
+        "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/babel": "3.9.2",
-                "@docusaurus/bundler": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/mdx-loader": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/core": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
+            "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/babel": "3.10.1",
+                "@docusaurus/bundler": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/mdx-loader": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "boxen": "^6.2.1",
                 "chalk": "^4.1.2",
                 "chokidar": "^3.5.3",
@@ -3440,7 +3571,7 @@
                 "escape-html": "^1.0.3",
                 "eta": "^2.2.0",
                 "eval": "^0.1.8",
-                "execa": "5.1.1",
+                "execa": "^5.1.1",
                 "fs-extra": "^11.1.1",
                 "html-tags": "^3.3.1",
                 "html-webpack-plugin": "^5.6.0",
@@ -3451,12 +3582,12 @@
                 "prompts": "^2.4.2",
                 "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
                 "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-                "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+                "react-loadable-ssr-addon-v5-slorber": "^1.0.3",
                 "react-router": "^5.3.4",
                 "react-router-config": "^5.1.1",
                 "react-router-dom": "^5.3.4",
                 "semver": "^7.5.4",
-                "serve-handler": "^6.1.6",
+                "serve-handler": "^6.1.7",
                 "tinypool": "^1.0.2",
                 "tslib": "^2.6.0",
                 "update-notifier": "^6.0.2",
@@ -3472,15 +3603,21 @@
                 "node": ">=20.0"
             },
             "peerDependencies": {
+                "@docusaurus/faster": "*",
                 "@mdx-js/react": "^3.0.0",
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@docusaurus/faster": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@docusaurus/cssnano-preset": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
-            "integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
+            "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
             "license": "MIT",
             "dependencies": {
                 "cssnano-preset-advanced": "^6.1.2",
@@ -3516,9 +3653,9 @@
             }
         },
         "node_modules/@docusaurus/logger": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
-            "integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
+            "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
@@ -3529,12 +3666,12 @@
             }
         },
         "node_modules/@docusaurus/lqip-loader": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/lqip-loader/-/lqip-loader-3.9.2.tgz",
-            "integrity": "sha512-Q9QO0E+HLKhcpKVOIXRVBdJ1bbxxpfSwBll5NsmGxcx1fArH0fFi68cpEztqBg7WwbFRb976MTlqlBuGrMLpuw==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/lqip-loader/-/lqip-loader-3.10.1.tgz",
+            "integrity": "sha512-ushByv88FWxsh3BS9QccWcEbKsW0QnNvWnl0+NCLe7weL5AkHS4HnSDszGMSzn2v5jidT4QjOVHacNVsU5I9Lw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/logger": "3.10.1",
                 "file-loader": "^6.2.0",
                 "lodash": "^4.17.21",
                 "sharp": "^0.32.3",
@@ -3545,14 +3682,14 @@
             }
         },
         "node_modules/@docusaurus/mdx-loader": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
-            "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
+            "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "@mdx-js/mdx": "^3.0.0",
                 "@slorber/remark-comment": "^1.0.0",
                 "escape-html": "^1.0.3",
@@ -3584,12 +3721,12 @@
             }
         },
         "node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-            "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
+            "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.2",
+                "@docusaurus/types": "3.10.1",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -3602,17 +3739,53 @@
                 "react-dom": "*"
             }
         },
-        "node_modules/@docusaurus/plugin-client-redirects": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
-            "integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
+        "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/module-type-aliases/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-client-redirects": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
+            "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "eta": "^2.2.0",
                 "fs-extra": "^11.1.1",
                 "lodash": "^4.17.21",
@@ -3627,20 +3800,21 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-blog": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
-            "integrity": "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
+            "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/mdx-loader": "3.9.2",
-                "@docusaurus/theme-common": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/mdx-loader": "3.10.1",
+                "@docusaurus/theme-common": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "cheerio": "1.0.0-rc.12",
+                "combine-promises": "^1.1.0",
                 "feed": "^4.2.2",
                 "fs-extra": "^11.1.1",
                 "lodash": "^4.17.21",
@@ -3660,21 +3834,57 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-docs": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
-            "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
+        "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/mdx-loader": "3.9.2",
-                "@docusaurus/module-type-aliases": "3.9.2",
-                "@docusaurus/theme-common": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-docs": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
+            "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/mdx-loader": "3.10.1",
+                "@docusaurus/module-type-aliases": "3.10.1",
+                "@docusaurus/theme-common": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "@types/react-router-config": "^5.0.7",
                 "combine-promises": "^1.1.0",
                 "fs-extra": "^11.1.1",
@@ -3693,17 +3903,53 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-pages": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
-            "integrity": "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA==",
+        "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/mdx-loader": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-pages": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
+            "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/mdx-loader": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0",
                 "webpack": "^5.88.1"
@@ -3716,31 +3962,103 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-css-cascade-layers": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
-            "integrity": "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ==",
+        "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-css-cascade-layers": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
+            "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
                 "node": ">=20.0"
             }
         },
-        "node_modules/@docusaurus/plugin-debug": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
-            "integrity": "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA==",
+        "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-debug": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
+            "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
                 "fs-extra": "^11.1.1",
                 "react-json-view-lite": "^2.3.0",
                 "tslib": "^2.6.0"
@@ -3753,15 +4071,51 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-google-analytics": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
-            "integrity": "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw==",
+        "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-google-analytics": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
+            "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3770,18 +4124,54 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-google-gtag": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.2.tgz",
-            "integrity": "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
+            "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
-                "@types/gtag.js": "^0.0.12",
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
+                "@types/gtag.js": "^0.0.20",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3790,17 +4180,53 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-google-tag-manager": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
-            "integrity": "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
+            "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3811,18 +4237,54 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-ideal-image": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-3.9.2.tgz",
-            "integrity": "sha512-YYYbmC2wSYFd7o4//5rPXt9+DkZwfwjCUmyGi5OIVqEbwELK80o3COXs2Xd0BtVIpuRvG7pKCYrMQwVo32Y9qw==",
+        "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/lqip-loader": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-ideal-image": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-3.10.1.tgz",
+            "integrity": "sha512-zIjQ/BtFS6YwEgnk9ypZxuSnA/Z011Z9cuaawKVfgyT7T+vuGx6T6ZgKur0IFnOkpI7EfI1DhbfdABCtfEzWFA==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/lqip-loader": "3.10.1",
                 "@docusaurus/responsive-loader": "^1.7.0",
-                "@docusaurus/theme-translations": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@docusaurus/theme-translations": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "sharp": "^0.32.3",
                 "tslib": "^2.6.0",
                 "webpack": "^5.88.1"
@@ -3841,18 +4303,54 @@
                 }
             }
         },
-        "node_modules/@docusaurus/plugin-sitemap": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
-            "integrity": "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw==",
+        "node_modules/@docusaurus/plugin-ideal-image/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-ideal-image/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-sitemap": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
+            "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "fs-extra": "^11.1.1",
                 "sitemap": "^7.1.1",
                 "tslib": "^2.6.0"
@@ -3865,16 +4363,52 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-svgr": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
-            "integrity": "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==",
+        "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-svgr": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
+            "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "@svgr/core": "8.1.0",
                 "@svgr/webpack": "^8.1.0",
                 "tslib": "^2.6.0",
@@ -3888,27 +4422,63 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/preset-classic": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
-            "integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
+        "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/plugin-content-blog": "3.9.2",
-                "@docusaurus/plugin-content-docs": "3.9.2",
-                "@docusaurus/plugin-content-pages": "3.9.2",
-                "@docusaurus/plugin-css-cascade-layers": "3.9.2",
-                "@docusaurus/plugin-debug": "3.9.2",
-                "@docusaurus/plugin-google-analytics": "3.9.2",
-                "@docusaurus/plugin-google-gtag": "3.9.2",
-                "@docusaurus/plugin-google-tag-manager": "3.9.2",
-                "@docusaurus/plugin-sitemap": "3.9.2",
-                "@docusaurus/plugin-svgr": "3.9.2",
-                "@docusaurus/theme-classic": "3.9.2",
-                "@docusaurus/theme-common": "3.9.2",
-                "@docusaurus/theme-search-algolia": "3.9.2",
-                "@docusaurus/types": "3.9.2"
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/preset-classic": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
+            "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/plugin-content-blog": "3.10.1",
+                "@docusaurus/plugin-content-docs": "3.10.1",
+                "@docusaurus/plugin-content-pages": "3.10.1",
+                "@docusaurus/plugin-css-cascade-layers": "3.10.1",
+                "@docusaurus/plugin-debug": "3.10.1",
+                "@docusaurus/plugin-google-analytics": "3.10.1",
+                "@docusaurus/plugin-google-gtag": "3.10.1",
+                "@docusaurus/plugin-google-tag-manager": "3.10.1",
+                "@docusaurus/plugin-sitemap": "3.10.1",
+                "@docusaurus/plugin-svgr": "3.10.1",
+                "@docusaurus/theme-classic": "3.10.1",
+                "@docusaurus/theme-common": "3.10.1",
+                "@docusaurus/theme-search-algolia": "3.10.1",
+                "@docusaurus/types": "3.10.1"
             },
             "engines": {
                 "node": ">=20.0"
@@ -3916,6 +4486,42 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/responsive-loader": {
@@ -3943,26 +4549,27 @@
             }
         },
         "node_modules/@docusaurus/theme-classic": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
-            "integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
+            "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/mdx-loader": "3.9.2",
-                "@docusaurus/module-type-aliases": "3.9.2",
-                "@docusaurus/plugin-content-blog": "3.9.2",
-                "@docusaurus/plugin-content-docs": "3.9.2",
-                "@docusaurus/plugin-content-pages": "3.9.2",
-                "@docusaurus/theme-common": "3.9.2",
-                "@docusaurus/theme-translations": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/mdx-loader": "3.10.1",
+                "@docusaurus/module-type-aliases": "3.10.1",
+                "@docusaurus/plugin-content-blog": "3.10.1",
+                "@docusaurus/plugin-content-docs": "3.10.1",
+                "@docusaurus/plugin-content-pages": "3.10.1",
+                "@docusaurus/theme-common": "3.10.1",
+                "@docusaurus/theme-translations": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "@mdx-js/react": "^3.0.0",
                 "clsx": "^2.0.0",
+                "copy-text-to-clipboard": "^3.2.0",
                 "infima": "0.2.0-alpha.45",
                 "lodash": "^4.17.21",
                 "nprogress": "^0.2.0",
@@ -3982,16 +4589,52 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-common": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
-            "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
+        "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/mdx-loader": "3.9.2",
-                "@docusaurus/module-type-aliases": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/theme-common": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
+            "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/mdx-loader": "3.10.1",
+                "@docusaurus/module-type-aliases": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -4011,19 +4654,20 @@
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.2.tgz",
-            "integrity": "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
+            "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
             "license": "MIT",
             "dependencies": {
-                "@docsearch/react": "^3.9.0 || ^4.1.0",
-                "@docusaurus/core": "3.9.2",
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/plugin-content-docs": "3.9.2",
-                "@docusaurus/theme-common": "3.9.2",
-                "@docusaurus/theme-translations": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-validation": "3.9.2",
+                "@algolia/autocomplete-core": "^1.19.2",
+                "@docsearch/react": "^3.9.0 || ^4.3.2",
+                "@docusaurus/core": "3.10.1",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/plugin-content-docs": "3.10.1",
+                "@docusaurus/theme-common": "3.10.1",
+                "@docusaurus/theme-translations": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-validation": "3.10.1",
                 "algoliasearch": "^5.37.0",
                 "algoliasearch-helper": "^3.26.0",
                 "clsx": "^2.0.0",
@@ -4042,9 +4686,9 @@
             }
         },
         "node_modules/@docusaurus/theme-translations": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
-            "integrity": "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
+            "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
             "license": "MIT",
             "dependencies": {
                 "fs-extra": "^11.1.1",
@@ -4098,16 +4742,16 @@
             }
         },
         "node_modules/@docusaurus/utils": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
-            "integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
+            "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/types": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/types": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
                 "escape-string-regexp": "^4.0.0",
-                "execa": "5.1.1",
+                "execa": "^5.1.1",
                 "file-loader": "^6.2.0",
                 "fs-extra": "^11.1.1",
                 "github-slugger": "^1.5.0",
@@ -4130,27 +4774,63 @@
             }
         },
         "node_modules/@docusaurus/utils-common": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
-            "integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
+            "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.2",
+                "@docusaurus/types": "3.10.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
                 "node": ">=20.0"
             }
         },
-        "node_modules/@docusaurus/utils-validation": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
-            "integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
+        "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.9.2",
-                "@docusaurus/utils": "3.9.2",
-                "@docusaurus/utils-common": "3.9.2",
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@docusaurus/utils-validation": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
+            "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/logger": "3.10.1",
+                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/utils-common": "3.10.1",
                 "fs-extra": "^11.2.0",
                 "joi": "^17.9.2",
                 "js-yaml": "^4.1.0",
@@ -4159,6 +4839,42 @@
             },
             "engines": {
                 "node": ">=20.0"
+            }
+        },
+        "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -5232,15 +5948,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@opentelemetry/api": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/@peculiar/asn1-cms": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
@@ -5641,9 +6348,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "version": "0.27.10",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "license": "MIT"
         },
         "node_modules/@sindresorhus/is": {
@@ -5668,12 +6375,6 @@
                 "micromark-util-character": "^1.1.0",
                 "micromark-util-symbol": "^1.0.1"
             }
-        },
-        "node_modules/@standard-schema/spec": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-            "license": "MIT"
         },
         "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
             "version": "8.0.0",
@@ -6784,9 +7485,9 @@
             }
         },
         "node_modules/@types/gtag.js": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-            "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+            "version": "0.0.20",
+            "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
+            "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
             "license": "MIT"
         },
         "node_modules/@types/hast": {
@@ -7024,9 +7725,9 @@
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.34",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.34.tgz",
-            "integrity": "sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A==",
+            "version": "17.0.35",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
             "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -7303,15 +8004,6 @@
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "license": "ISC"
         },
-        "node_modules/@vercel/oidc": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.3.tgz",
-            "integrity": "sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">= 20"
-            }
-        },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -7557,24 +8249,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ai": {
-            "version": "5.0.82",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.82.tgz",
-            "integrity": "sha512-wmZZfsU40qB77umrcj3YzMSk6cUP5gxLXZDPfiSQLBLegTVXPUdSJC603tR7JB5JkhBDzN5VLaliuRKQGKpUXg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/gateway": "2.0.3",
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.14",
-                "@opentelemetry/api": "1.9.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
         "node_modules/ajv": {
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -7619,34 +8293,34 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "5.41.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.41.0.tgz",
-            "integrity": "sha512-9E4b3rJmYbBkn7e3aAPt1as+VVnRhsR4qwRRgOzpeyz4PAOuwKh0HI4AN6mTrqK0S0M9fCCSTOUnuJ8gPY/tvA==",
+            "version": "5.53.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.53.0.tgz",
+            "integrity": "sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/abtesting": "1.7.0",
-                "@algolia/client-abtesting": "5.41.0",
-                "@algolia/client-analytics": "5.41.0",
-                "@algolia/client-common": "5.41.0",
-                "@algolia/client-insights": "5.41.0",
-                "@algolia/client-personalization": "5.41.0",
-                "@algolia/client-query-suggestions": "5.41.0",
-                "@algolia/client-search": "5.41.0",
-                "@algolia/ingestion": "1.41.0",
-                "@algolia/monitoring": "1.41.0",
-                "@algolia/recommend": "5.41.0",
-                "@algolia/requester-browser-xhr": "5.41.0",
-                "@algolia/requester-fetch": "5.41.0",
-                "@algolia/requester-node-http": "5.41.0"
+                "@algolia/abtesting": "1.19.0",
+                "@algolia/client-abtesting": "5.53.0",
+                "@algolia/client-analytics": "5.53.0",
+                "@algolia/client-common": "5.53.0",
+                "@algolia/client-insights": "5.53.0",
+                "@algolia/client-personalization": "5.53.0",
+                "@algolia/client-query-suggestions": "5.53.0",
+                "@algolia/client-search": "5.53.0",
+                "@algolia/ingestion": "1.53.0",
+                "@algolia/monitoring": "1.53.0",
+                "@algolia/recommend": "5.53.0",
+                "@algolia/requester-browser-xhr": "5.53.0",
+                "@algolia/requester-fetch": "5.53.0",
+                "@algolia/requester-node-http": "5.53.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/algoliasearch-helper": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.26.0.tgz",
-            "integrity": "sha512-Rv2x3GXleQ3ygwhkhJubhhYGsICmShLAiqtUuJTUkr9uOCOXyF2E71LVT4XDnVffbknv8XgScP4U0Oxtgm+hIw==",
+            "version": "3.29.1",
+            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.1.tgz",
+            "integrity": "sha512-6ck2YFudF2Pje7szQoPBiRFTGfd+1I+0I/WfLPGn0bj1kvrFoOQmNyedNiDxTk3/r4IfSLDYk+RA4G7u8H6+yA==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/events": "^4.0.1"
@@ -7681,33 +8355,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/ansi-html-community": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -7740,6 +8387,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ansis": {
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+            "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/anymatch": {
@@ -7945,9 +8601,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.21",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-            "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+            "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7962,11 +8618,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.4",
-                "caniuse-lite": "^1.0.30001702",
-                "fraction.js": "^4.3.7",
-                "normalize-range": "^0.1.2",
+                "browserslist": "^4.28.2",
+                "caniuse-lite": "^1.0.30001787",
+                "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8036,13 +8692,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
-            "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+            "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.27.7",
-                "@babel/helper-define-polyfill-provider": "^0.6.5",
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -8072,12 +8728,12 @@
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
-            "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+            "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.5"
+                "@babel/helper-define-polyfill-provider": "^0.6.8"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -8206,12 +8862,15 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.9.19",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-            "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+            "version": "2.10.35",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+            "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
             "license": "Apache-2.0",
             "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/batch": {
@@ -8387,9 +9046,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "version": "4.28.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8406,11 +9065,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -8590,9 +9249,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001770",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-            "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+            "version": "1.0.30001797",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+            "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9116,6 +9775,18 @@
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "license": "MIT"
         },
+        "node_modules/copy-text-to-clipboard": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
+            "integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/copy-webpack-plugin": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
@@ -9194,24 +9865,13 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.46.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.46.0.tgz",
-            "integrity": "sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+            "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.26.3"
+                "browserslist": "^4.28.1"
             },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/core-js-pure": {
-            "version": "3.46.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.46.0.tgz",
-            "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
-            "hasInstallScript": true,
-            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -9331,9 +9991,9 @@
             }
         },
         "node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -9344,9 +10004,9 @@
             }
         },
         "node_modules/css-declaration-sorter": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.0.tgz",
-            "integrity": "sha512-LQF6N/3vkAMYF4xoHLJfG718HRJh34Z8BnNhd6bosOMIVjMlhuZK5++oZa3uYAgrI5+7x2o27gUqTR2U/KjUOQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+            "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
             "license": "ISC",
             "engines": {
                 "node": "^14 || ^16 || >=18"
@@ -9405,9 +10065,9 @@
             }
         },
         "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -9559,9 +10219,9 @@
             }
         },
         "node_modules/cssdb": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.4.2.tgz",
-            "integrity": "sha512-PzjkRkRUS+IHDJohtxkIczlxPPZqRo0nXplsYXOMBRPjcVRjj1W4DfvRgshUYTVuUigU7ptVYkFJQ7abUB0nyg==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.9.0.tgz",
+            "integrity": "sha512-J8jOU/hLjaXcO1LldOLraJSQpfLXRKof0I7mtbRyOy2AAXgqst0x9rlgi2qXeD6d0ou3ZLqcPAMqYVbpCbrxEw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9778,9 +10438,10 @@
             "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
         },
         "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -10161,9 +10822,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.286",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-            "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+            "version": "1.5.371",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+            "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -11102,19 +11763,11 @@
                 "bare-events": "^2.7.0"
             }
         },
-        "node_modules/eventsource-parser": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/execa": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -11346,30 +11999,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/figures": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^1.0.5"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/figures/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -11403,9 +12032,9 @@
             }
         },
         "node_modules/file-loader/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -11616,14 +12245,15 @@
             }
         },
         "node_modules/fraction.js": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+            "license": "MIT",
             "engines": {
                 "node": "*"
             },
             "funding": {
-                "type": "patreon",
+                "type": "github",
                 "url": "https://github.com/sponsors/rawify"
             }
         },
@@ -12253,15 +12883,15 @@
             }
         },
         "node_modules/hast-util-to-parse5": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
-            "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
                 "devlop": "^1.0.0",
-                "property-information": "^6.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0",
                 "web-namespaces": "^2.0.0",
                 "zwitch": "^2.0.0"
@@ -12269,16 +12899,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-to-parse5/node_modules/property-information": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
-            "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/hast-util-whitespace": {
@@ -12621,6 +13241,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
@@ -13297,6 +13918,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -13562,12 +14184,6 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-            "license": "(AFL-2.1 OR BSD-3-Clause)"
-        },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -13637,6 +14253,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
             "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -14071,18 +14688,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/marked": {
-            "version": "16.4.1",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.1.tgz",
-            "integrity": "sha512-ntROs7RaN3EvWfy3EZi14H4YxmT6A5YvywfhO+0pm+cH/dnSQRmdAmoFIc3B9aiwTehyk7pESH4ofyBY+V5hZg==",
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 20"
             }
         },
         "node_modules/math-intrinsics": {
@@ -16390,6 +16995,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -16406,9 +17012,9 @@
             }
         },
         "node_modules/mini-css-extract-plugin": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-            "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+            "integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
             "license": "MIT",
             "dependencies": {
                 "schema-utils": "^4.0.0",
@@ -16632,24 +17238,19 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-            "license": "MIT"
+            "version": "2.0.47",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/normalize-range": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-            "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16669,6 +17270,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -16714,9 +17316,9 @@
             }
         },
         "node_modules/null-loader/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -16899,6 +17501,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -17371,9 +17974,9 @@
             }
         },
         "node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -17615,9 +18218,9 @@
             }
         },
         "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -17653,9 +18256,9 @@
             }
         },
         "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -17781,9 +18384,9 @@
             }
         },
         "node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -17819,9 +18422,9 @@
             }
         },
         "node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18108,9 +18711,9 @@
             }
         },
         "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18136,9 +18739,9 @@
             }
         },
         "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18235,9 +18838,9 @@
             }
         },
         "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18478,9 +19081,9 @@
             }
         },
         "node_modules/postcss-preset-env": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.4.0.tgz",
-            "integrity": "sha512-2kqpOthQ6JhxqQq1FSAAZGe9COQv75Aw8WbsOvQVNJ2nSevc9Yx/IKZGuZ7XJ+iOTtVon7LfO7ELRzg8AZ+sdw==",
+            "version": "10.6.1",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.6.1.tgz",
+            "integrity": "sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==",
             "funding": [
                 {
                     "type": "github",
@@ -18518,23 +19121,27 @@
                 "@csstools/postcss-media-minmax": "^2.0.9",
                 "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
                 "@csstools/postcss-nested-calc": "^4.0.0",
-                "@csstools/postcss-normalize-display-values": "^4.0.0",
+                "@csstools/postcss-normalize-display-values": "^4.0.1",
                 "@csstools/postcss-oklab-function": "^4.0.12",
+                "@csstools/postcss-position-area-property": "^1.0.0",
                 "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+                "@csstools/postcss-property-rule-prelude-list": "^1.0.0",
                 "@csstools/postcss-random-function": "^2.0.1",
                 "@csstools/postcss-relative-color-syntax": "^3.0.12",
                 "@csstools/postcss-scope-pseudo-class": "^4.0.1",
                 "@csstools/postcss-sign-functions": "^1.1.4",
                 "@csstools/postcss-stepped-value-functions": "^4.0.9",
+                "@csstools/postcss-syntax-descriptor-syntax-production": "^1.0.1",
+                "@csstools/postcss-system-ui-font-family": "^1.0.0",
                 "@csstools/postcss-text-decoration-shorthand": "^4.0.3",
                 "@csstools/postcss-trigonometric-functions": "^4.0.9",
                 "@csstools/postcss-unset-value": "^4.0.0",
-                "autoprefixer": "^10.4.21",
-                "browserslist": "^4.26.0",
+                "autoprefixer": "^10.4.23",
+                "browserslist": "^4.28.1",
                 "css-blank-pseudo": "^7.0.1",
                 "css-has-pseudo": "^7.0.3",
                 "css-prefers-color-scheme": "^10.0.0",
-                "cssdb": "^8.4.2",
+                "cssdb": "^8.6.0",
                 "postcss-attribute-case-insensitive": "^7.0.1",
                 "postcss-clamp": "^4.1.0",
                 "postcss-color-functional-notation": "^7.0.12",
@@ -18594,9 +19201,9 @@
             }
         },
         "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18687,9 +19294,9 @@
             }
         },
         "node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+            "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18908,6 +19515,7 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
             "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+            "license": "MIT",
             "dependencies": {
                 "kleur": "^3.0.3",
                 "sisteransi": "^1.0.5"
@@ -19062,6 +19670,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -19225,9 +19834,10 @@
             }
         },
         "node_modules/react-loadable-ssr-addon-v5-slorber": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-            "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+            "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.10.3"
             },
@@ -19495,9 +20105,9 @@
             "license": "MIT"
         },
         "node_modules/regjsparser": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-            "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+            "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "jsesc": "~3.1.0"
@@ -19765,15 +20375,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "node_modules/repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -19797,11 +20398,12 @@
             "license": "MIT"
         },
         "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "license": "MIT",
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
@@ -20018,9 +20620,9 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-            "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
@@ -20181,6 +20783,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -20408,9 +21011,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -20568,12 +21171,13 @@
         "node_modules/sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "license": "MIT"
         },
         "node_modules/sitemap": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
-            "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.3.tgz",
+            "integrity": "sha512-tAjEd+wt/YwnEbfNB2ht51ybBJxbEWwe5ki/Z//Wh0rpBFTCUSj46GnxUKEWzhfuJTsee8x3lybHxFgUMig2hw==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^17.0.5",
@@ -20972,6 +21576,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -21096,19 +21701,6 @@
                 "webpack": ">=2"
             }
         },
-        "node_modules/swr": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
-            "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
-            "license": "MIT",
-            "dependencies": {
-                "dequal": "^2.0.3",
-                "use-sync-external-store": "^1.4.0"
-            },
-            "peerDependencies": {
-                "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
         "node_modules/tailwindcss": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
@@ -21207,15 +21799,14 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.16",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-            "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^4.3.0",
-                "serialize-javascript": "^6.0.2",
                 "terser": "^5.31.1"
             },
             "engines": {
@@ -21229,10 +21820,37 @@
                 "webpack": "^5.1.0"
             },
             "peerDependenciesMeta": {
+                "@minify-html/node": {
+                    "optional": true
+                },
                 "@swc/core": {
                     "optional": true
                 },
+                "@swc/css": {
+                    "optional": true
+                },
+                "@swc/html": {
+                    "optional": true
+                },
+                "clean-css": {
+                    "optional": true
+                },
+                "cssnano": {
+                    "optional": true
+                },
+                "csso": {
+                    "optional": true
+                },
                 "esbuild": {
+                    "optional": true
+                },
+                "html-minifier-terser": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "postcss": {
                     "optional": true
                 },
                 "uglify-js": {
@@ -21295,18 +21913,6 @@
             },
             "peerDependencies": {
                 "tslib": "^2"
-            }
-        },
-        "node_modules/throttleit": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-            "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/thunky": {
@@ -21955,9 +22561,9 @@
             }
         },
         "node_modules/url-loader/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -22022,15 +22628,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/use-sync-external-store": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/util-deprecate": {
@@ -22387,9 +22984,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -22448,75 +23045,30 @@
             }
         },
         "node_modules/webpackbar": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-6.0.1.tgz",
-            "integrity": "sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+            "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
             "license": "MIT",
             "dependencies": {
-                "ansi-escapes": "^4.3.2",
-                "chalk": "^4.1.2",
+                "ansis": "^3.2.0",
                 "consola": "^3.2.3",
-                "figures": "^3.2.0",
-                "markdown-table": "^2.0.0",
                 "pretty-time": "^1.1.0",
-                "std-env": "^3.7.0",
-                "wrap-ansi": "^7.0.0"
+                "std-env": "^3.7.0"
             },
             "engines": {
                 "node": ">=14.21.3"
             },
             "peerDependencies": {
+                "@rspack/core": "*",
                 "webpack": "3 || 4 || 5"
-            }
-        },
-        "node_modules/webpackbar/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
-        },
-        "node_modules/webpackbar/node_modules/markdown-table": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-            "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-            "license": "MIT",
-            "dependencies": {
-                "repeat-string": "^1.0.0"
             },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/webpackbar/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/webpackbar/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            "peerDependenciesMeta": {
+                "@rspack/core": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/websocket-driver": {
@@ -22846,24 +23398,15 @@
             }
         },
         "node_modules/yocto-queue": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-            "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/zod": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-            "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
         "prettier-fix": "prettier --write ."
     },
     "dependencies": {
-        "@docusaurus/core": "^3.9.2",
-        "@docusaurus/faster": "^3.9.2",
-        "@docusaurus/plugin-client-redirects": "^3.9.2",
-        "@docusaurus/plugin-ideal-image": "^3.9.2",
-        "@docusaurus/preset-classic": "^3.9.2",
+        "@docusaurus/core": "^3.10.1",
+        "@docusaurus/faster": "^3.10.1",
+        "@docusaurus/plugin-client-redirects": "^3.10.1",
+        "@docusaurus/plugin-ideal-image": "^3.10.1",
+        "@docusaurus/preset-classic": "^3.10.1",
         "@mdx-js/react": "^3.0.0",
         "autoprefixer": "^10.4.21",
         "clsx": "^2.1.1",
@@ -40,9 +40,9 @@
         "yet-another-react-lightbox": "^3.24.0"
     },
     "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.9.2",
-        "@docusaurus/tsconfig": "^3.9.2",
-        "@docusaurus/types": "^3.9.2",
+        "@docusaurus/module-type-aliases": "^3.10.1",
+        "@docusaurus/tsconfig": "^3.10.1",
+        "@docusaurus/types": "^3.10.1",
         "@eslint/js": "^9.32.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@typescript-eslint/eslint-plugin": "^8.39.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
             "last 5 safari version"
         ]
     },
+    "overrides": {
+        "serialize-javascript": ">=7.0.3"
+    },
     "engines": {
         "node": ">=18.0"
     }

--- a/scripts/split-sitemap.ts
+++ b/scripts/split-sitemap.ts
@@ -15,7 +15,7 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { splitSitemap } from "../src/lib/split-sitemap/lib/split.js";
+import { splitSitemap, type SplitSucceeded } from "../src/lib/split-sitemap/lib/split.js";
 import { LEGACY_VERSIONS } from "./lib/version-policy.js";
 
 const BASE_URL = "https://docs.ravendb.net";
@@ -32,10 +32,12 @@ if (result.skipped) {
     process.exit(0);
 }
 
-for (const { name, urls } of result.files) {
+// process.exit above prevents reaching here when skipped; cast to the success type
+const { files, includedUrls, skippedLegacyUrls } = result as SplitSucceeded;
+for (const { name, urls } of files) {
     console.log(`[split-sitemap]   ${name}: ${urls} URLs`);
 }
 console.log(
-    `[split-sitemap] split into ${result.files.length} sub-sitemaps ` +
-        `(${result.includedUrls} URLs included, ${result.skippedLegacyUrls} legacy URLs excluded)`
+    `[split-sitemap] split into ${files.length} sub-sitemaps ` +
+        `(${includedUrls} URLs included, ${skippedLegacyUrls} legacy URLs excluded)`
 );

--- a/scripts/split-sitemap.ts
+++ b/scripts/split-sitemap.ts
@@ -30,14 +30,15 @@ const result = splitSitemap({ buildDir, legacyVersions: LEGACY_VERSIONS, baseUrl
 if (result.skipped) {
     console.log(`[split-sitemap] skipped: ${result.reason}`);
     process.exit(0);
+} else {
+    // Discriminated-union narrowing on boolean literals requires strictNullChecks, which
+    // this project's tsconfig does not enable. process.exit() above makes the cast safe.
+    const { files, includedUrls, skippedLegacyUrls } = result as SplitSucceeded;
+    for (const { name, urls } of files) {
+        console.log(`[split-sitemap]   ${name}: ${urls} URLs`);
+    }
+    console.log(
+        `[split-sitemap] split into ${files.length} sub-sitemaps ` +
+            `(${includedUrls} URLs included, ${skippedLegacyUrls} legacy URLs excluded)`
+    );
 }
-
-// process.exit above prevents reaching here when skipped; cast to the success type
-const { files, includedUrls, skippedLegacyUrls } = result as SplitSucceeded;
-for (const { name, urls } of files) {
-    console.log(`[split-sitemap]   ${name}: ${urls} URLs`);
-}
-console.log(
-    `[split-sitemap] split into ${files.length} sub-sitemaps ` +
-        `(${includedUrls} URLs included, ${skippedLegacyUrls} legacy URLs excluded)`
-);

--- a/src/components/Common/CustomSearchButton.tsx
+++ b/src/components/Common/CustomSearchButton.tsx
@@ -41,6 +41,8 @@ export default function CustomSearchButton({
         onOpen: onClick,
         onClose: () => {},
         searchButtonRef: buttonRef,
+        isAskAiActive: false,
+        onAskAiToggle: () => {},
     });
 
     return (

--- a/src/components/Common/CustomSearchButton.tsx
+++ b/src/components/Common/CustomSearchButton.tsx
@@ -42,7 +42,7 @@ export default function CustomSearchButton({
         onClose: () => {},
         searchButtonRef: buttonRef,
         isAskAiActive: false,
-        onAskAiToggle: () => {},
+        onAskAiToggle: (_toggle: boolean) => {},
     });
 
     return (

--- a/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -1,17 +1,10 @@
-import React, { version, type ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import clsx from "clsx";
 import { useNavbarSecondaryMenu } from "@docusaurus/theme-common/internal";
 import { ThemeClassNames } from "@docusaurus/theme-common";
 import type { Props } from "@theme/Navbar/MobileSidebar/Layout";
 
-// TODO Docusaurus v4: remove temporary inert workaround
-//  See https://github.com/facebook/react/issues/17157
-//  See https://github.com/radix-ui/themes/pull/509
 function inertProps(inert: boolean) {
-    const isBeforeReact19 = parseInt(version!.split(".")[0]!, 10) < 19;
-    if (isBeforeReact19) {
-        return { inert: inert ? "" : undefined };
-    }
     return { inert };
 }
 

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -35,7 +35,7 @@ function importDocSearchModalIfNeeded() {
         return Promise.resolve();
     }
     return Promise.all([
-        import("@docsearch/react/modal") as Promise<typeof import("@docsearch/react")>,
+        import("@docsearch/react/modal"),
         import("@docsearch/react/style"),
         import("./styles.css"),
     ]).then(([{ DocSearchModal: Modal }]) => {
@@ -199,6 +199,8 @@ function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
         onClose: closeModal,
         onInput: handleInput,
         searchButtonRef,
+        isAskAiActive: false,
+        onAskAiToggle: () => {},
     });
 
     return (

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -200,7 +200,7 @@ function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
         onInput: handleInput,
         searchButtonRef,
         isAskAiActive: false,
-        onAskAiToggle: () => {},
+        onAskAiToggle: (_toggle: boolean) => {},
     });
 
     return (

--- a/src/theme/TabItem/index.tsx
+++ b/src/theme/TabItem/index.tsx
@@ -7,11 +7,7 @@ import type { Props } from "@theme/TabItem";
  * <Tabs> ancestor.  Visibility is driven by the `hidden` prop that the parent
  * <Tabs> component injects via cloneElement.
  */
-export default function TabItem({
-    children,
-    className,
-    hidden,
-}: Props & { hidden?: boolean }): ReactNode {
+export default function TabItem({ children, className, hidden }: Props & { hidden?: boolean }): ReactNode {
     return (
         <div role="tabpanel" hidden={hidden} className={className}>
             {children}

--- a/src/theme/TabItem/index.tsx
+++ b/src/theme/TabItem/index.tsx
@@ -1,0 +1,20 @@
+import React, { type ReactNode } from "react";
+import type { Props } from "@theme/TabItem";
+
+/**
+ * Swizzled to be context-free: no useTabs() call, so bare <TabItem> (used as
+ * a "code-panel" idiom throughout this docs site) renders without needing a
+ * <Tabs> ancestor.  Visibility is driven by the `hidden` prop that the parent
+ * <Tabs> component injects via cloneElement.
+ */
+export default function TabItem({
+    children,
+    className,
+    hidden,
+}: Props & { hidden?: boolean }): ReactNode {
+    return (
+        <div role="tabpanel" hidden={hidden} className={className}>
+            {children}
+        </div>
+    );
+}

--- a/src/theme/Tabs/index.tsx
+++ b/src/theme/Tabs/index.tsx
@@ -129,9 +129,9 @@ function TabContent({ lazy, children, selectedValue }: TabContentProps) {
     }
     return (
         <div className="p-4 bg-pre-background">
-            {childTabs.map((tabItem, i) =>
+            {childTabs.map((tabItem) =>
                 cloneElement(tabItem, {
-                    key: i,
+                    key: tabItem.props.value,
                     hidden: tabItem.props.value !== selectedValue,
                 })
             )}

--- a/src/theme/Tabs/index.tsx
+++ b/src/theme/Tabs/index.tsx
@@ -2,15 +2,33 @@ import React, { cloneElement, type ReactElement, type ReactNode } from "react";
 import clsx from "clsx";
 import {
     useScrollPositionBlocker,
-    useTabs,
+    useTabsContextValue,
     sanitizeTabsChildren,
+    type TabValue,
     type TabItemProps,
 } from "@docusaurus/theme-common/internal";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import type { Props } from "@theme/Tabs";
 import styles from "./styles.module.css";
 
-function TabList({ className, block, selectedValue, selectValue, tabValues }: Props & ReturnType<typeof useTabs>) {
+// TabItem elements enhanced with the `hidden` prop that Tabs injects
+type TabItemElement = ReactElement<TabItemProps & { hidden?: boolean }>;
+
+interface TabListProps {
+    className?: string;
+    block: boolean;
+    selectedValue: string;
+    selectValue: (value: string) => void;
+    tabValues: readonly TabValue[];
+}
+
+interface TabContentProps {
+    lazy: boolean;
+    selectedValue: string;
+    children: ReactNode;
+}
+
+function TabList({ className, block, selectedValue, selectValue, tabValues }: TabListProps) {
     const tabRefs: (HTMLLIElement | null)[] = [];
     const { blockElementScrollPositionUntilNextRender } = useScrollPositionBlocker();
 
@@ -97,8 +115,8 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }: Pr
     );
 }
 
-function TabContent({ lazy, children, selectedValue }: Props & ReturnType<typeof useTabs>) {
-    const childTabs = (Array.isArray(children) ? children : [children]).filter(Boolean) as ReactElement<TabItemProps>[];
+function TabContent({ lazy, children, selectedValue }: TabContentProps) {
+    const childTabs = (Array.isArray(children) ? children : [children]).filter(Boolean) as TabItemElement[];
     if (lazy) {
         const selectedTabItem = childTabs.find((tabItem) => tabItem.props.value === selectedValue);
         if (!selectedTabItem) {
@@ -122,7 +140,7 @@ function TabContent({ lazy, children, selectedValue }: Props & ReturnType<typeof
 }
 
 function TabsComponent(props: Props): ReactNode {
-    const tabs = useTabs(props);
+    const tabs = useTabsContextValue(props);
     return (
         <div
             className={clsx(
@@ -130,8 +148,16 @@ function TabsComponent(props: Props): ReactNode {
                 styles.tabList
             )}
         >
-            <TabList {...tabs} {...props} />
-            <TabContent {...tabs} {...props} />
+            <TabList
+                className={props.className}
+                block={tabs.block}
+                selectedValue={tabs.selectedValue}
+                selectValue={tabs.selectValue}
+                tabValues={tabs.tabValues}
+            />
+            <TabContent lazy={tabs.lazy} selectedValue={tabs.selectedValue}>
+                {props.children}
+            </TabContent>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

- **Docusaurus 3.9.2 → 3.10.1** across all `@docusaurus/*` packages (aligns `package.json` ranges and lock file; three packages that lagged at 3.9.2 — core, tsconfig, types — now consistent)
- **SSG regression fixed:** 3.10.1's upstream `TabItem` calls `useTabs()` context and throws on the ~266 pages that use the bare-`<TabItem>` code-panel idiom (no enclosing `<Tabs>`). Fixed by swizzling `TabItem` as a context-free panel; swizzled `Tabs` updated to use the renamed `useTabsContextValue()` hook with the original `cloneElement`/`hidden` approach — no provider needed
- **DocSearch v4 / `@docsearch/react` v4.6.3:** added `isAskAiActive`/`onAskAiToggle` to both `useDocSearchKeyboardEvents` call sites; dropped an invalid type cast on the modal dynamic import
- **MDX1 compat restored** (`future.v4: true` + new `mdx1CompatDisabledByDefault` flag in 3.10.1): re-enabled `markdown.mdx1Compat` (`comments`, `headingIds`, `admonitions`) so read-only `versioned_docs/` snapshots and existing `.mdx` files compile without changes. Also removed empty `<!-- -->` placeholder comments from 27 `.mdx` files; restored two accidentally removed timeseries placeholder stubs
- **`future.experimental_faster` → `future.faster`** (config key renamed in 3.10)
- **Pre-existing TS bugs** surfaced by typecheck run: refactored `split-sitemap.ts` to use if/else for discriminated-union access (cast remains — boolean-literal narrowing requires `strictNullChecks` which this tsconfig does not enable); simplified `MobileSidebar/Layout` `inertProps` for React 19
- **Security:** added `serialize-javascript >= 7.0.3` override in `package.json` to clear GHSA-5c6j-r48x-rmvq (high severity)
- **Code quality:** keyed Tabs content panels by `tabItem.props.value` instead of array index; fixed `onAskAiToggle` no-op signatures to match DocSearch v4's `(toggle: boolean) => void` type

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `npm test` — 88/88 pass
- [x] `npm run prettier` — clean
- [x] `npm run build` (3-version: 6.2 + 7.1 + current, `DOCUSAURUS_STRICT=true DOCUSAURUS_STRICT_SEO=true`) — clean build, 0 MDX errors, SEO assertions pass, sitemap split and robots.txt generated correctly
- [x] `npm audit --audit-level=high` — 0 high/critical findings; GHSA-5c6j-r48x-rmvq cleared; 20 remaining moderate are dev-only (uuid via webpack-dev-server, no fix available)