### PR TITLE
RDoc-3922 - Remove commented-out old links, add see_also sections

### DIFF
--- a/docs/document-extensions/timeseries/indexing.mdx
+++ b/docs/document-extensions/timeseries/indexing.mdx
@@ -4,6 +4,19 @@ description: "Create RavenDB indexes over time series data using map and map-red
 sidebar_label: Indexing Time Series
 sidebar_position: 3
 supported_languages: ["csharp", "python", "php", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What are Indexes"
+       link: "indexes/what-are-indexes"
+       source: "docs"
+       path: "Indexes"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -31,18 +44,4 @@ import IndexingNodejs from './content/_indexing-nodejs.mdx';
 <LanguageContent language="nodejs">
    <IndexingNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Indexes
-- [What are Indexes]()
-
-### Client-API
-- [Working with Document IDs]()
-
-
--->
 

--- a/docs/document-extensions/timeseries/time-series-and-other-features.mdx
+++ b/docs/document-extensions/timeseries/time-series-and-other-features.mdx
@@ -4,6 +4,23 @@ description: "See how RavenDB time series interact with replication, ETL, data s
 sidebar_label: Time Series and Other Features
 sidebar_position: 5
 supported_languages: ["csharp", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What is a Session and How Does it Work"
+       link: "client-api/session/what-is-a-session-and-how-does-it-work"
+       source: "docs"
+       path: "Client API > Session"
+     - title: "External Replication"
+       link: "server/ongoing-tasks/external-replication"
+       source: "docs"
+       path: "Server > Ongoing Tasks"
+     - title: "Ongoing Tasks"
+       link: "studio/database/tasks/ongoing-tasks/general-info"
+       source: "docs"
+       path: "Studio > Database > Tasks > Ongoing Tasks"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -21,21 +38,4 @@ import TimeSeriesAndOtherFeaturesNodejs from './content/_time-series-and-other-f
 <LanguageContent language="nodejs">
    <TimeSeriesAndOtherFeaturesNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Client-API
-- [Session Entity Tracking]()
-
-### Server
-- [External replication]()
-
-### Studio
-- [Ongoing tasks]()
-
-
--->
 

--- a/versioned_docs/version-6.2/document-extensions/timeseries/indexing.mdx
+++ b/versioned_docs/version-6.2/document-extensions/timeseries/indexing.mdx
@@ -3,6 +3,19 @@ title: "Indexing Time Series"
 sidebar_label: Indexing Time Series
 sidebar_position: 3
 supported_languages: ["csharp", "python", "php", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What are Indexes"
+       link: "indexes/what-are-indexes"
+       source: "docs"
+       path: "Indexes"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -31,17 +44,3 @@ import IndexingNodejs from './content/_indexing-nodejs.mdx';
 <LanguageContent language="nodejs">
    <IndexingNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Indexes
-- [What are Indexes]()
-
-### Client-API
-- [Working with Document IDs]()
-
-
--->

--- a/versioned_docs/version-6.2/document-extensions/timeseries/time-series-and-other-features.mdx
+++ b/versioned_docs/version-6.2/document-extensions/timeseries/time-series-and-other-features.mdx
@@ -3,6 +3,23 @@ title: "Time Series and Other Features"
 sidebar_label: Time Series and Other Features
 sidebar_position: 5
 supported_languages: ["csharp", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What is a Session and How Does it Work"
+       link: "client-api/session/what-is-a-session-and-how-does-it-work"
+       source: "docs"
+       path: "Client API > Session"
+     - title: "External Replication"
+       link: "server/ongoing-tasks/external-replication"
+       source: "docs"
+       path: "Server > Ongoing Tasks"
+     - title: "Ongoing Tasks"
+       link: "studio/database/tasks/ongoing-tasks/general-info"
+       source: "docs"
+       path: "Studio > Database > Tasks > Ongoing Tasks"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -21,20 +38,3 @@ import TimeSeriesAndOtherFeaturesNodejs from './content/_time-series-and-other-f
 <LanguageContent language="nodejs">
    <TimeSeriesAndOtherFeaturesNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Client-API
-- [Session Entity Tracking]()
-
-### Server
-- [External replication]()
-
-### Studio
-- [Ongoing tasks]()
-
-
--->

--- a/versioned_docs/version-7.0/document-extensions/timeseries/indexing.mdx
+++ b/versioned_docs/version-7.0/document-extensions/timeseries/indexing.mdx
@@ -3,6 +3,19 @@ title: "Indexing Time Series"
 sidebar_label: Indexing Time Series
 sidebar_position: 3
 supported_languages: ["csharp", "python", "php", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What are Indexes"
+       link: "indexes/what-are-indexes"
+       source: "docs"
+       path: "Indexes"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -31,17 +44,3 @@ import IndexingNodejs from './content/_indexing-nodejs.mdx';
 <LanguageContent language="nodejs">
    <IndexingNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Indexes
-- [What are Indexes]()
-
-### Client-API
-- [Working with Document IDs]()
-
-
--->

--- a/versioned_docs/version-7.0/document-extensions/timeseries/time-series-and-other-features.mdx
+++ b/versioned_docs/version-7.0/document-extensions/timeseries/time-series-and-other-features.mdx
@@ -3,6 +3,23 @@ title: "Time Series and Other Features"
 sidebar_label: Time Series and Other Features
 sidebar_position: 5
 supported_languages: ["csharp", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What is a Session and How Does it Work"
+       link: "client-api/session/what-is-a-session-and-how-does-it-work"
+       source: "docs"
+       path: "Client API > Session"
+     - title: "External Replication"
+       link: "server/ongoing-tasks/external-replication"
+       source: "docs"
+       path: "Server > Ongoing Tasks"
+     - title: "Ongoing Tasks"
+       link: "studio/database/tasks/ongoing-tasks/general-info"
+       source: "docs"
+       path: "Studio > Database > Tasks > Ongoing Tasks"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -21,20 +38,3 @@ import TimeSeriesAndOtherFeaturesNodejs from './content/_time-series-and-other-f
 <LanguageContent language="nodejs">
    <TimeSeriesAndOtherFeaturesNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Client-API
-- [Session Entity Tracking]()
-
-### Server
-- [External replication]()
-
-### Studio
-- [Ongoing tasks]()
-
-
--->

--- a/versioned_docs/version-7.1/document-extensions/timeseries/indexing.mdx
+++ b/versioned_docs/version-7.1/document-extensions/timeseries/indexing.mdx
@@ -3,6 +3,19 @@ title: "Indexing Time Series"
 sidebar_label: Indexing Time Series
 sidebar_position: 3
 supported_languages: ["csharp", "python", "php", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What are Indexes"
+       link: "indexes/what-are-indexes"
+       source: "docs"
+       path: "Indexes"
+     - title: "Working with Document Identifiers"
+       link: "client-api/document-identifiers/working-with-document-identifiers"
+       source: "docs"
+       path: "Client API > Document Identifiers"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -31,17 +44,3 @@ import IndexingNodejs from './content/_indexing-nodejs.mdx';
 <LanguageContent language="nodejs">
    <IndexingNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Indexes
-- [What are Indexes]()
-
-### Client-API
-- [Working with Document IDs]()
-
-
--->

--- a/versioned_docs/version-7.1/document-extensions/timeseries/time-series-and-other-features.mdx
+++ b/versioned_docs/version-7.1/document-extensions/timeseries/time-series-and-other-features.mdx
@@ -3,6 +3,23 @@ title: "Time Series and Other Features"
 sidebar_label: Time Series and Other Features
 sidebar_position: 5
 supported_languages: ["csharp", "nodejs"]
+see_also:
+     - title: "Time Series Overview"
+       link: "document-extensions/timeseries/overview"
+       source: "docs"
+       path: "Document Extensions > Time Series"
+     - title: "What is a Session and How Does it Work"
+       link: "client-api/session/what-is-a-session-and-how-does-it-work"
+       source: "docs"
+       path: "Client API > Session"
+     - title: "External Replication"
+       link: "server/ongoing-tasks/external-replication"
+       source: "docs"
+       path: "Server > Ongoing Tasks"
+     - title: "Ongoing Tasks"
+       link: "studio/database/tasks/ongoing-tasks/general-info"
+       source: "docs"
+       path: "Studio > Database > Tasks > Ongoing Tasks"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -21,20 +38,3 @@ import TimeSeriesAndOtherFeaturesNodejs from './content/_time-series-and-other-f
 <LanguageContent language="nodejs">
    <TimeSeriesAndOtherFeaturesNodejs />
 </LanguageContent>
-
-
-<!--
-### Time Series
-- [Time Series Overview]()
-
-### Client-API
-- [Session Entity Tracking]()
-
-### Server
-- [External replication]()
-
-### Studio
-- [Ongoing tasks]()
-
-
--->


### PR DESCRIPTION
### Issue link
[RDoc-3922](https://issues.hibernatingrhinos.com/issue/RDoc-3922) Remove commented-out legacy links and add see_also sections

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

