### PR TITLE
RDoc-3918 AI agents "Reading conversation history" page added to document `GetConversationMessages`

### DIFF
--- a/docs/ai-integration/ai-agents/content/_reading-conversation-history-csharp.mdx
+++ b/docs/ai-integration/ai-agents/content/_reading-conversation-history-csharp.mdx
@@ -10,11 +10,11 @@ import ContentFrame from "@site/src/components/ContentFrame";
 * AI agent conversations can be read using the `GetConversationMessages` method.  
 
 * By default, the method returns the whole conversation in one call, oldest first.  
-  A long conversation can be read in fixed-size pages instead, by paging back through earlier 
+  A long conversation can be read in fixed-size pages instead, by paging back through earlier
   history or forward to newer messages.  
 
 * Even a long conversation that has been trimmed over time is returned as a single chronological
-  list of messages, oldest first.  
+  list of messages.  
 
 * This page covers: reading and paging through a conversation's messages, choosing the level of
   detail, and inspecting tool calls and sub-conversations.  
@@ -38,16 +38,16 @@ and pass the conversation document ID.
 
 `GetConversationMessages` returns an [AiConversationMessagesResult](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes) object that includes a `Messages`
 list, holding the conversation's messages in chronological order, oldest first.  
-If no conversation with the given ID exists, the method returns `null`.
+If no conversation with the given ID exists, the method returns `null`.  
 
 Passing only a conversation ID returns the whole conversation in one call: `PageSize`, the maximum
 number of messages in a page, defaults to `int.MaxValue`, so no page limit applies.  
 To read the conversation in fixed-size pages, set `PageSize` and read it a page at a time, as explained in
-[Page through the conversation](../../../ai-integration/ai-agents/reading-conversation-history.mdx#page-through-the-conversation).
+[Page through the conversation](../../../ai-integration/ai-agents/reading-conversation-history.mdx#page-through-the-conversation).  
 
-At the default `Simple` detail level, the result holds the messages between the user and the LLM. 
+At the default `Simple` detail level, the result holds the messages between the user and the LLM.  
 See [Control the level of detail](../../../ai-integration/ai-agents/reading-conversation-history.mdx#control-the-level-of-detail)
-for the other detail levels and the message types each level includes. 
+for the other detail levels and the message types each level includes.
 
 
 #### Example: Read a conversation
@@ -159,7 +159,7 @@ in the [Syntax](../../../ai-integration/ai-agents/reading-conversation-history.m
 Use the `DetailLevel` option to control the level of detail in the result.  
 `Simple`, the default, returns only the messages between the user and the LLM, the visible
 part of the conversation.  
-The higher levels include additional detail: system prompts, tool calls, summaries, 
+The higher levels include additional detail: system prompts, tool calls, summaries,
 and internal messages.  
 Raise the level when debugging an agent or inspecting its steps.
 
@@ -168,8 +168,8 @@ Each level includes a different set of messages:
 | Detail level | Messages returned |
 |--------------|-----------------|
 | `Simple` | User messages (including those that carry only an attachment) and the LLM's messages that have content. System prompts, tool calls, summaries, and internal messages are excluded. |
-| `Detailed` | Everything in `Simple`, plus system prompts, tool calls with their results, and per-message token usage. Summaries and internal messages are excluded. |
-| `Full` | No filtering. Includes every message: system, tool calls, summaries, and internal messages. Intended for debugging. |
+| `Detailed` | Everything in `Simple`, plus system prompts and tool calls with their results. Summaries and internal messages are excluded. |
+| `Full` | Everything in `Detailed`, plus summaries and internal messages. Intended for debugging. |
 
 #### Example: Request the detailed view
 
@@ -235,6 +235,8 @@ foreach (AiConversationMessage message in trace.Messages)
                     ConversationId = toolCall.SubConversationId,
                     DetailLevel = AiConversationDetailLevel.Detailed
                 });
+
+            Console.WriteLine($"  sub-conversation with {subConversation.Messages.Count} messages");
         }
     }
 }
@@ -391,11 +393,11 @@ class AiConversationMessage
 
 | Property | Type | Description |
 |----------|------|-------------|
-| **Role** | `AiMessageRole` | What the message is: a system prompt, a user message, a message from the LLM, a summary, or an internal message.<br />See `AiMessageRole`. |
+| **Role** | `AiMessageRole` | What the message is: a system prompt, a user message, a message from the LLM, a summary, or an internal message.<br />See [AiMessageRole](../../../ai-integration/ai-agents/reading-conversation-history.mdx#enums). |
 | **Content** | `string` | The text content. When the stored message has several text parts, they are joined with line breaks. `null` for a message from the LLM that only initiated tool calls. |
 | **Attachments** | `List<string>` | Names of the attachments associated with this message, if any. |
 | **Timestamp** | `DateTime` | The time the message was recorded (UTC). Unique within the conversation and rising in message order, so a `Timestamp` value can be used to page through the conversation. |
-| **ToolCalls** | `List<AiToolCallResult>` | Tool calls initiated by the LLM in this message, with their results inlined. Empty when the message has no tool calls. |
+| **ToolCalls** | `List<AiToolCallResult>` | Tool calls initiated by the LLM in this message, with their results inlined. `null` when the message has no tool calls. |
 | **Usage** | `AiUsage` | Token usage for this message, or `null` for messages the LLM did not generate (such as user messages and system prompts).<br />See [AiUsage](../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#conversation-and-response-classes). |
 | **SubConversationId** | `string` | For an `Internal` role message, the ID of the sub-conversation the message relates to. |
 
@@ -422,7 +424,7 @@ class AiToolCallResult
 | **Name** | `string` | The tool name. |
 | **Arguments** | `string` | The arguments the LLM passed, as a JSON string. |
 | **Result** | `string` | The tool's response content. `null` if the tool call is still pending. |
-| **SubConversationId** | `string` | If the tool call invoked a sub-agent, the ID of the spawned sub-conversation. Can be read separately using `GetConversationMessages`. |
+| **SubConversationId** | `string` | If the tool call invoked a sub-agent, the ID of the spawned sub-conversation. The sub-conversation can be read separately using `GetConversationMessages`. |
 
 </TabItem>
 </Tabs>
@@ -455,8 +457,8 @@ enum AiConversationDetailLevel
 | Value | Description |
 |-------|-------------|
 | **Simple** | User messages (including those that carry only an attachment) and the LLM's messages that have content. System prompts, tool calls, summaries, and internal messages are excluded. |
-| **Detailed** | Adds system prompts, tool calls with their results, and per-message usage. Summaries and internal messages are excluded. |
-| **Full** | No filtering. Includes all messages: system, tool calls, summaries, and internal. Intended for debugging. |
+| **Detailed** | Adds system prompts and tool calls with their results. Summaries and internal messages are excluded. |
+| **Full** | Everything in `Detailed`, plus summaries and internal messages. Intended for debugging. |
 
 </TabItem>
 <TabItem value="AiMessageRole" label="AiMessageRole">

--- a/docs/ai-integration/ai-agents/content/_reading-conversation-history-csharp.mdx
+++ b/docs/ai-integration/ai-agents/content/_reading-conversation-history-csharp.mdx
@@ -13,7 +13,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
   A long conversation can be read in fixed-size pages instead, by paging back through earlier
   history or forward to newer messages.  
 
-* Even a long conversation that has been trimmed over time is returned as a single chronological
+* Even a long conversation that has been trimmed or summarized over time is returned as a single chronological
   list of messages.  
 
 * This page covers: reading and paging through a conversation's messages, choosing the level of
@@ -92,8 +92,9 @@ conversation ID:
 * Set `Before` to a timestamp to read the page of messages immediately before it.  
 * Set `After` to a timestamp to read the page of messages immediately after it.  
 
-A call sets either `Before` or `After`, never both. The returned page is always ordered oldest to
-newest. `Before`, `After`, and `PageSize` decide only the messages a page covers, not their order.
+`Before` and `After` are mutually exclusive: a call sets one or the other, never both.  
+
+The returned page is always ordered oldest to newest. `Before`, `After`, and `PageSize` decide only the messages a page covers, not their order.
 
 #### Example: Page back through a conversation
 
@@ -185,7 +186,7 @@ var detailed = await store.AI.GetConversationMessagesAsync(
 ```
 <br />
 
-See [AiConversationDetailLevel](../../../ai-integration/ai-agents/reading-conversation-history.mdx#enums)
+See [AiConversationDetailLevel](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-enums)
 in the [Syntax](../../../ai-integration/ai-agents/reading-conversation-history.mdx#syntax) section.
 
 </Panel>
@@ -393,7 +394,7 @@ class AiConversationMessage
 
 | Property | Type | Description |
 |----------|------|-------------|
-| **Role** | `AiMessageRole` | What the message is: a system prompt, a user message, a message from the LLM, a summary, or an internal message.<br />See [AiMessageRole](../../../ai-integration/ai-agents/reading-conversation-history.mdx#enums). |
+| **Role** | `AiMessageRole` | What the message is: a system prompt, a user message, a message from the LLM, a summary, or an internal message.<br />See [AiMessageRole](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-enums). |
 | **Content** | `string` | The text content. When the stored message has several text parts, they are joined with line breaks. `null` for a message from the LLM that only initiated tool calls. |
 | **Attachments** | `List<string>` | Names of the attachments associated with this message, if any. |
 | **Timestamp** | `DateTime` | The time the message was recorded (UTC). Unique within the conversation and rising in message order, so a `Timestamp` value can be used to page through the conversation. |
@@ -437,7 +438,7 @@ class AiToolCallResult
 
 <ContentFrame>
 
-### Enums
+### Conversation history enums
 
 <Tabs groupId='conversation-history-enums'>
 <TabItem value="AiConversationDetailLevel" label="AiConversationDetailLevel">

--- a/docs/ai-integration/ai-agents/content/_reading-conversation-history-csharp.mdx
+++ b/docs/ai-integration/ai-agents/content/_reading-conversation-history-csharp.mdx
@@ -1,0 +1,491 @@
+import Admonition from '@theme/Admonition';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
+
+<Admonition type="note" title="">
+
+* AI agent conversations can be read using the `GetConversationMessages` method.  
+
+* By default, the method returns the whole conversation in one call, oldest first.  
+  A long conversation can be read in fixed-size pages instead, by paging back through earlier 
+  history or forward to newer messages.  
+
+* Even a long conversation that has been trimmed over time is returned as a single chronological
+  list of messages, oldest first.  
+
+* This page covers: reading and paging through a conversation's messages, choosing the level of
+  detail, and inspecting tool calls and sub-conversations.  
+
+* Learn how to create and run a conversation in [Managing conversations](../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#managing-conversations).  
+
+* In this article:
+   * [Get the conversation messages](../../../ai-integration/ai-agents/reading-conversation-history.mdx#get-the-conversation-messages)
+   * [Page through the conversation](../../../ai-integration/ai-agents/reading-conversation-history.mdx#page-through-the-conversation)
+      * [Catch up on new messages](../../../ai-integration/ai-agents/reading-conversation-history.mdx#catch-up-on-new-messages)
+   * [Control the level of detail](../../../ai-integration/ai-agents/reading-conversation-history.mdx#control-the-level-of-detail)
+   * [Inspect tool calls and sub-conversations](../../../ai-integration/ai-agents/reading-conversation-history.mdx#inspect-tool-calls-and-sub-conversations)
+   * [Syntax](../../../ai-integration/ai-agents/reading-conversation-history.mdx#syntax)
+
+</Admonition>
+
+<Panel heading="Get the conversation messages">
+
+To read a conversation's messages, call [GetConversationMessages](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history) (or `GetConversationMessagesAsync`)
+and pass the conversation document ID.  
+
+`GetConversationMessages` returns an [AiConversationMessagesResult](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes) object that includes a `Messages`
+list, holding the conversation's messages in chronological order, oldest first.  
+If no conversation with the given ID exists, the method returns `null`.
+
+Passing only a conversation ID returns the whole conversation in one call: `PageSize`, the maximum
+number of messages in a page, defaults to `int.MaxValue`, so no page limit applies.  
+To read the conversation in fixed-size pages, set `PageSize` and read it a page at a time, as explained in
+[Page through the conversation](../../../ai-integration/ai-agents/reading-conversation-history.mdx#page-through-the-conversation).
+
+At the default `Simple` detail level, the result holds the messages between the user and the LLM. 
+See [Control the level of detail](../../../ai-integration/ai-agents/reading-conversation-history.mdx#control-the-level-of-detail)
+for the other detail levels and the message types each level includes. 
+
+
+#### Example: Read a conversation
+
+```csharp
+// Read the whole conversation (Simple view)
+AiConversationMessagesResult result =
+    await store.AI.GetConversationMessagesAsync("Chats/1-A");
+
+// Messages are returned in chronological order (oldest first)
+foreach (AiConversationMessage message in result.Messages)
+{
+    Console.WriteLine($"[{message.Role}] {message.Content}");
+}
+```
+<br />
+
+Besides the messages, the result includes, among others:
+
+* **`LastMessageAt`**  
+  The time the last message was added to the conversation.  
+* **`TotalUsage`**  
+  The cumulative token usage across the whole conversation.  
+* **`HasMoreMessages`**  
+  `true` when the conversation holds more messages beyond the returned page.  
+
+<br />
+See [GetConversationMessages](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history)
+and [AiConversationMessagesResult](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes)
+in the [Syntax](../../../ai-integration/ai-agents/reading-conversation-history.mdx#syntax) section.
+
+</Panel>
+
+<Panel heading="Page through the conversation">
+
+A single call to `GetConversationMessages` returns one page of messages, up to `PageSize`.  
+By default, the page holds the conversation's most recent messages.
+
+To select another page, pass a [GetConversationMessagesOptions](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes) object instead of a bare
+conversation ID:
+
+* Set `Before` to a timestamp to read the page of messages immediately before it.  
+* Set `After` to a timestamp to read the page of messages immediately after it.  
+
+A call sets either `Before` or `After`, never both. The returned page is always ordered oldest to
+newest. `Before`, `After`, and `PageSize` decide only the messages a page covers, not their order.
+
+#### Example: Page back through a conversation
+
+```csharp
+// Read the most recent page
+var page = await store.AI.GetConversationMessagesAsync(
+    new GetConversationMessagesOptions
+    {
+        ConversationId = "Chats/1-A",
+        PageSize = 20
+    });
+
+// Read the previous page
+var previousPage = await store.AI.GetConversationMessagesAsync(
+    new GetConversationMessagesOptions
+    {
+        ConversationId = "Chats/1-A",
+        // the oldest message's Timestamp
+        Before = page.Messages[0].Timestamp,
+        PageSize = 20
+    });
+```
+<br />
+
+In the example above, `Before` is set to the `Timestamp` of the oldest message on the page just
+read. However, `Before` and `After` accept any `DateTime` value, not only a message's `Timestamp`, so a
+page can start at any point in time, without first reading a page.
+
+Consecutive pages are contiguous, with no gap and no overlap. On the result, `HasMoreMessages` is `true`
+when the conversation holds more messages beyond the page just returned. The further messages are
+**older** when `Before` is set (or when neither `Before` nor `After` is set), and **newer** when
+`After` is set. To read the whole conversation one page at a time, call `GetConversationMessages` again while
+`HasMoreMessages` is `true`.
+
+<ContentFrame>
+
+### Catch up on new messages
+
+To catch up after new messages arrive, pass the `Timestamp` of the newest message already retrieved,
+using `After`. `GetConversationMessages` then returns only the messages added since the last read,
+not the whole conversation.
+
+```csharp
+// Read only the messages added after the newest message already retrieved
+var newMessages = await store.AI.GetConversationMessagesAsync(
+    new GetConversationMessagesOptions
+    {
+        ConversationId = "Chats/1-A",
+        After = lastSeenTimestamp
+    });
+```
+
+</ContentFrame>
+
+<br />
+See [GetConversationMessagesOptions](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes)
+in the [Syntax](../../../ai-integration/ai-agents/reading-conversation-history.mdx#syntax) section.
+
+</Panel>
+
+<Panel heading="Control the level of detail">
+
+Use the `DetailLevel` option to control the level of detail in the result.  
+`Simple`, the default, returns only the messages between the user and the LLM, the visible
+part of the conversation.  
+The higher levels include additional detail: system prompts, tool calls, summaries, 
+and internal messages.  
+Raise the level when debugging an agent or inspecting its steps.
+
+Each level includes a different set of messages:
+
+| Detail level | Messages returned |
+|--------------|-----------------|
+| `Simple` | User messages (including those that carry only an attachment) and the LLM's messages that have content. System prompts, tool calls, summaries, and internal messages are excluded. |
+| `Detailed` | Everything in `Simple`, plus system prompts, tool calls with their results, and per-message token usage. Summaries and internal messages are excluded. |
+| `Full` | No filtering. Includes every message: system, tool calls, summaries, and internal messages. Intended for debugging. |
+
+#### Example: Request the detailed view
+
+```csharp
+// Request the detailed view, e.g. for debugging
+var detailed = await store.AI.GetConversationMessagesAsync(
+    new GetConversationMessagesOptions
+    {
+        ConversationId = "Chats/1-A",
+        DetailLevel = AiConversationDetailLevel.Detailed,
+        PageSize = 50
+    });
+```
+<br />
+
+See [AiConversationDetailLevel](../../../ai-integration/ai-agents/reading-conversation-history.mdx#enums)
+in the [Syntax](../../../ai-integration/ai-agents/reading-conversation-history.mdx#syntax) section.
+
+</Panel>
+
+<Panel heading="Inspect tool calls and sub-conversations">
+
+At the `Detailed` or `Full` detail level, the `ToolCalls` list of a message from the LLM holds
+the tool calls the LLM made. Each entry is an [AiToolCallResult](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes) object, giving the tool's `Name`, the
+`Arguments` the LLM passed, and the `Result` the tool returned.
+
+An agent can hand work to another agent (a [sub-agent](../../../ai-integration/ai-agents/multi-agents.mdx)).  
+The exchange with a sub-agent is held in its own conversation (a **sub-conversation**).
+
+When a tool call invoked a sub-agent, the tool call's `SubConversationId` points to the
+resulting sub-conversation. The result's `SubConversationIds` list gathers every sub-conversation
+started during this conversation. Pass any ID from `SubConversationIds` to `GetConversationMessages` to read the
+matching sub-conversation.
+
+#### Example: Read tool calls and sub-conversations
+
+```csharp
+// Read the conversation with tool calls included
+var trace = await store.AI.GetConversationMessagesAsync(
+    new GetConversationMessagesOptions
+    {
+        ConversationId = "Chats/1-A",
+        DetailLevel = AiConversationDetailLevel.Detailed,
+        PageSize = 50
+    });
+
+foreach (AiConversationMessage message in trace.Messages)
+{
+    if (message.ToolCalls == null)
+        continue;
+
+    foreach (AiToolCallResult toolCall in message.ToolCalls)
+    {
+        // Inspect the tool call and the result returned
+        Console.WriteLine($"{toolCall.Name}({toolCall.Arguments}) -> {toolCall.Result}");
+
+        // If the tool call invoked a sub-agent, read the matching sub-conversation
+        if (toolCall.SubConversationId != null)
+        {
+            var subConversation = await store.AI.GetConversationMessagesAsync(
+                new GetConversationMessagesOptions
+                {
+                    ConversationId = toolCall.SubConversationId,
+                    DetailLevel = AiConversationDetailLevel.Detailed
+                });
+        }
+    }
+}
+```
+<br />
+
+See [AiConversationMessage](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes)
+and [AiToolCallResult](../../../ai-integration/ai-agents/reading-conversation-history.mdx#conversation-history-classes)
+in the [Syntax](../../../ai-integration/ai-agents/reading-conversation-history.mdx#syntax) section.  
+See [Multi-agents](../../../ai-integration/ai-agents/multi-agents.mdx) for the full sub-agent picture.
+
+</Panel>
+
+<Panel heading="Syntax">
+
+## Methods
+
+<ContentFrame>
+
+### Conversation history
+
+<Tabs groupId='conversation-history-methods'>
+<TabItem value="GetConversationMessages" label="GetConversationMessages">
+
+Reads messages from an AI agent conversation.  
+The conversation-ID overload returns the whole conversation at the default `Simple` detail level.  
+The options overload gives full control over paging and the level of detail.
+
+```csharp
+// Async, returns the whole conversation
+public Task<AiConversationMessagesResult> GetConversationMessagesAsync(
+    string conversationId, CancellationToken token = default)
+
+// Async, with paging and detail options
+public Task<AiConversationMessagesResult> GetConversationMessagesAsync(
+    GetConversationMessagesOptions parameters, CancellationToken token = default)
+
+// Sync, returns the whole conversation
+public AiConversationMessagesResult GetConversationMessages(string conversationId)
+
+// Sync, with paging and detail options
+public AiConversationMessagesResult GetConversationMessages(GetConversationMessagesOptions parameters)
+```
+<br />
+Usage:
+
+```csharp
+var result = await store.AI.GetConversationMessagesAsync("Chats/1-A");
+```
+<br />
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **conversationId** | `string` | The conversation document ID. The overload that takes only this ID returns the whole conversation at the default `Simple` detail level. |
+| **parameters** | `GetConversationMessagesOptions` | The `Before` and `After` boundaries, page size, and detail level. |
+| **token** | `CancellationToken` | Optional cancellation token. |
+
+| Return value | |
+|-----------|-------------|
+| `AiConversationMessagesResult` | The conversation's messages, in chronological order, with paging and usage metadata. |
+
+</TabItem>
+</Tabs>
+
+</ContentFrame>
+
+---
+
+## Classes
+
+<ContentFrame>
+
+### Conversation history classes
+
+<Tabs groupId='conversation-history-classes'>
+<TabItem value="GetConversationMessagesOptions" label="GetConversationMessagesOptions">
+
+**Parameters for reading messages from an AI agent conversation.**
+
+```csharp
+class GetConversationMessagesOptions
+{
+    string ConversationId
+    DateTime? Before
+    DateTime? After
+    int PageSize
+    AiConversationDetailLevel DetailLevel
+}
+```
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **ConversationId** | `string` | The conversation document ID. Required. |
+| **Before** | `DateTime?` | Return messages older than this timestamp (exclusive). Interpreted as UTC. Used to page back to earlier messages. Cannot be combined with `After`. |
+| **After** | `DateTime?` | Return messages newer than this timestamp (exclusive). Interpreted as UTC. Used to catch up on new messages. Cannot be combined with `Before`. |
+| **PageSize** | `int` | Maximum number of messages to return. Default: `int.MaxValue`. Must be greater than 0; a value of 0 or less throws an `ArgumentOutOfRangeException`. |
+| **DetailLevel** | `AiConversationDetailLevel` | The level of detail to include in the returned messages. Default: `Simple`. |
+
+</TabItem>
+<TabItem value="AiConversationMessagesResult" label="AiConversationMessagesResult">
+
+**The result of reading conversation messages.**
+
+```csharp
+class AiConversationMessagesResult
+{
+    string ConversationId
+    string Agent
+    Dictionary<string, object> Parameters
+    AiUsage TotalUsage
+    DateTime LastMessageAt
+    List<AiConversationMessage> Messages
+    bool HasMoreMessages
+    List<string> SubConversationIds
+    List<string> Attachments
+}
+```
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **ConversationId** | `string` | The conversation document ID. |
+| **Agent** | `string` | The identifier of the AI agent this conversation belongs to. |
+| **Parameters** | `Dictionary<string, object>` | The conversation parameters as a name-to-value map. |
+| **TotalUsage** | `AiUsage` | Cumulative token usage across all turns of the conversation.<br />See [AiUsage](../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#conversation-and-response-classes). |
+| **LastMessageAt** | `DateTime` | The time the last message was added to the conversation. |
+| **Messages** | `List<AiConversationMessage>` | The returned messages, in chronological order (oldest first). |
+| **HasMoreMessages** | `bool` | `true` when more messages exist beyond the returned page: older messages when `Before` is set (or neither is set), newer messages when `After` is set. |
+| **SubConversationIds** | `List<string>` | IDs of sub-agent conversations spawned during this conversation. Each can be read separately using `GetConversationMessages`. |
+| **Attachments** | `List<string>` | Names of all attachments referenced across the conversation. |
+
+</TabItem>
+</Tabs>
+
+<Tabs groupId='conversation-history-classes-2'>
+<TabItem value="AiConversationMessage" label="AiConversationMessage">
+
+**A single message in a conversation.**
+
+```csharp
+class AiConversationMessage
+{
+    AiMessageRole Role
+    string Content
+    List<string> Attachments
+    DateTime Timestamp
+    List<AiToolCallResult> ToolCalls
+    AiUsage Usage
+    string SubConversationId
+}
+```
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Role** | `AiMessageRole` | What the message is: a system prompt, a user message, a message from the LLM, a summary, or an internal message.<br />See `AiMessageRole`. |
+| **Content** | `string` | The text content. When the stored message has several text parts, they are joined with line breaks. `null` for a message from the LLM that only initiated tool calls. |
+| **Attachments** | `List<string>` | Names of the attachments associated with this message, if any. |
+| **Timestamp** | `DateTime` | The time the message was recorded (UTC). Unique within the conversation and rising in message order, so a `Timestamp` value can be used to page through the conversation. |
+| **ToolCalls** | `List<AiToolCallResult>` | Tool calls initiated by the LLM in this message, with their results inlined. Empty when the message has no tool calls. |
+| **Usage** | `AiUsage` | Token usage for this message, or `null` for messages the LLM did not generate (such as user messages and system prompts).<br />See [AiUsage](../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#conversation-and-response-classes). |
+| **SubConversationId** | `string` | For an `Internal` role message, the ID of the sub-conversation the message relates to. |
+
+</TabItem>
+<TabItem value="AiToolCallResult" label="AiToolCallResult">
+
+**A tool call made during the conversation, and the result returned.**
+
+```csharp
+class AiToolCallResult
+{
+    string Id
+    string Name
+    string Arguments
+    string Result
+    string SubConversationId
+}
+```
+<br />
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **Id** | `string` | The tool call ID from the LLM. |
+| **Name** | `string` | The tool name. |
+| **Arguments** | `string` | The arguments the LLM passed, as a JSON string. |
+| **Result** | `string` | The tool's response content. `null` if the tool call is still pending. |
+| **SubConversationId** | `string` | If the tool call invoked a sub-agent, the ID of the spawned sub-conversation. Can be read separately using `GetConversationMessages`. |
+
+</TabItem>
+</Tabs>
+
+</ContentFrame>
+
+---
+
+## Enums
+
+<ContentFrame>
+
+### Enums
+
+<Tabs groupId='conversation-history-enums'>
+<TabItem value="AiConversationDetailLevel" label="AiConversationDetailLevel">
+
+**Controls the level of detail the returned messages carry.**
+
+```csharp
+enum AiConversationDetailLevel
+{
+    Simple,
+    Detailed,
+    Full
+}
+```
+<br />
+
+| Value | Description |
+|-------|-------------|
+| **Simple** | User messages (including those that carry only an attachment) and the LLM's messages that have content. System prompts, tool calls, summaries, and internal messages are excluded. |
+| **Detailed** | Adds system prompts, tool calls with their results, and per-message usage. Summaries and internal messages are excluded. |
+| **Full** | No filtering. Includes all messages: system, tool calls, summaries, and internal. Intended for debugging. |
+
+</TabItem>
+<TabItem value="AiMessageRole" label="AiMessageRole">
+
+**The kind of message in a conversation.**
+
+```csharp
+enum AiMessageRole
+{
+    System,
+    User,
+    Assistant,
+    Summary,
+    Internal
+}
+```
+<br />
+
+| Value | Description |
+|-------|-------------|
+| **System** | A system prompt message. |
+| **User** | A message from the user. |
+| **Assistant** | A message from the LLM, which may carry content, tool calls, or both. |
+| **Summary** | A summary produced when the conversation was trimmed. |
+| **Internal** | An internal message that relates to a sub-conversation, linked by its `SubConversationId`. |
+
+</TabItem>
+</Tabs>
+
+</ContentFrame>
+
+</Panel>

--- a/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-csharp.mdx
+++ b/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-csharp.mdx
@@ -13,7 +13,7 @@ import ContentFrame from "@site/src/components/ContentFrame";
 
 * Once the agent is created, the client can initiate or resume conversations, get LLM responses, and perform actions based on LLM insights.  
 
-* This page provides a step-by-step guide to creating an AI agent and interacting with it using the Client API.  
+* This page provides a step-by-step guide to creating an AI agent and interacting with it using the client API.  
 
 * In this article:
    * [Creating a connection string](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#creating-a-connection-string)  
@@ -897,6 +897,10 @@ See [DeleteAgent](../../../../ai-integration/ai-agents/creating-ai-agents/creati
 ---
 
 See [Conversation](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#conversation-execution), [SetUserPrompt](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#conversation-execution), and [AiConversationCreationOptions](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#conversation-and-response-classes) in the [Syntax](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#syntax) section.
+
+<br />
+To read the messages of a stored conversation back from the server, see
+[Reading conversation history](../../../../ai-integration/ai-agents/reading-conversation-history.mdx).  
 
 </ContentFrame>
 
@@ -2340,6 +2344,10 @@ class AiConversationParameter
 
 </TabItem>
 
+</Tabs>
+
+<Tabs groupId='conversation-classes-2'>
+
 <TabItem value="AiConversationParameterOptions" label="AiConversationParameterOptions">
 
 **Options for a conversation parameter when using `AddParameter`.**
@@ -2379,6 +2387,11 @@ class AiAgentActionRequest
 | **Arguments** | `string` | The arguments provided by the LLM, as a JSON string. |
 
 </TabItem>
+
+</Tabs>
+
+<Tabs groupId='conversation-classes-3'>
+
 <TabItem value="AiAnswer" label="AiAnswer">
 
 **The typed answer returned from an AI conversation turn.**

--- a/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-nodejs.mdx
+++ b/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-nodejs.mdx
@@ -13,7 +13,7 @@ import Panel from "@site/src/components/Panel";
     
 * Once the agent is created, the client can initiate or resume **conversations**, get LLM responses, and perform actions based on LLM insights.
     
-* This article provides a step-by-step guide to creating an AI agent and interacting with it using the **Client API**.  
+* This article provides a step-by-step guide to creating an AI agent and interacting with it using the **client API**.  
   To create an AI agent from Studio, see [Creating AI agents - Studio](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_studio.mdx).
     
 * In this article:

--- a/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
+++ b/docs/ai-integration/ai-agents/creating-ai-agents/content/_creating-ai-agents_api-python.mdx
@@ -13,7 +13,7 @@ import Panel from "@site/src/components/Panel";
 
 * Once the agent is created, the client can initiate or resume conversations, get LLM responses, and perform actions based on LLM insights.  
 
-* This page provides a step-by-step guide to creating an AI agent and interacting with it using the Client API.  
+* This page provides a step-by-step guide to creating an AI agent and interacting with it using the client API.  
 
 * In this article:
    * [Creating a connection string](../../../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#creating-a-connection-string)  

--- a/docs/ai-integration/ai-agents/overview.mdx
+++ b/docs/ai-integration/ai-agents/overview.mdx
@@ -123,9 +123,11 @@ A conversation is a communication session between the client, the agent, and the
      or be the final LLM response and end the conversation.
 * The agent maintains the continuity of the conversation by [storing all messages](../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#setting-a-conversation) exchanged since the conversation began in a dedicated document in the `@conversation` collection and providing all stored messages to the LLM with each new agent message.  
 * The conversation ends when the LLM provides the agent with its final response.  
+* The stored messages remain available after the conversation ends. You can read them back as a single, time-ordered timeline using the client API, for example to populate a chatbot view or a tracing interface.  
 
 [Initiate a conversation using the API](../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx#managing-conversations)  
 [Initiate a conversation using Studio](../../ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_studio.mdx#start-new-chat)  
+[Read conversation history using the API](../../ai-integration/ai-agents/reading-conversation-history.mdx)  
 
 </ContentFrame>
 

--- a/docs/ai-integration/ai-agents/reading-conversation-history.mdx
+++ b/docs/ai-integration/ai-agents/reading-conversation-history.mdx
@@ -1,0 +1,19 @@
+---
+title: "AI agents: Reading conversation history"
+sidebar_label: "Reading conversation history"
+description: "Read back the messages of a stored AI agent conversation using the Client API, with timestamp-based paging and a selectable level of detail."
+sidebar_position: 3
+---
+
+import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
+import LanguageContent from "@site/src/components/LanguageContent";
+
+import ReadingConversationHistoryCsharp from './content/_reading-conversation-history-csharp.mdx';
+
+export const supportedLanguages = ["csharp"];
+
+<LanguageSwitcher supportedLanguages={supportedLanguages} />
+
+<LanguageContent language="csharp">
+   <ReadingConversationHistoryCsharp />
+</LanguageContent>

--- a/docs/ai-integration/gen-ai-integration/overview.mdx
+++ b/docs/ai-integration/gen-ai-integration/overview.mdx
@@ -183,7 +183,7 @@ These are the elements that need to be defined for a GenAI task.
   to create GenAI tasks. The wizard will guide you through the task creation phases, 
   exemplify where needed, and provide you with convenient, interactive, secluded "playgrounds" 
   for free interactive experimenting.  
-* Or, you can create GenAI tasks using the [Client API](../../ai-integration/gen-ai-integration/create-gen-ai-task/create-gen-ai-task_api.mdx). 
+* Or, you can create GenAI tasks using the [client API](../../ai-integration/gen-ai-integration/create-gen-ai-task/create-gen-ai-task_api.mdx). 
 
 <hr />
 


### PR DESCRIPTION
### Issue link
[RDoc-3918](https://issues.hibernatingrhinos.com/issue/RDoc-3918)

### Type of change

- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

