### PR TITLE
HRINT-4883 disable rspackPersistentCache; guard deploy against 0-byte assets

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -34,7 +34,19 @@ const config: Config = {
     // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
     future: {
         v4: true, // Improve compatibility with the upcoming Docusaurus v4
-        faster: true,
+        // All faster flags except rspackPersistentCache, which intermittently emits
+        // 0-byte assets while the build still succeeds, breaking the deployed site.
+        faster: {
+            swcJsLoader: true,
+            swcJsMinimizer: true,
+            swcHtmlMinimizer: true,
+            lightningCssMinimizer: true,
+            mdxCrossCompilerCache: true,
+            rspackBundler: true,
+            ssgWorkerThreads: true,
+            gitEagerVcs: true,
+            rspackPersistentCache: false,
+        },
     },
 
     // future.v4 enables mdx1CompatDisabledByDefault in 3.10+, which turns off HTML

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -185,6 +185,10 @@ if ($LASTEXITCODE) { throw 'Docusaurus build failed' }
 $BuildDir = [IO.Path]::Combine($PSScriptRoot, '..', 'build')
 if (-not (Test-Path $BuildDir)) { throw "Build folder not produced ($BuildDir)" }
 
+# Rspack's persistent cache can emit 0-byte assets while the build still succeeds; abort before sync
+$Empty = Get-ChildItem $BuildDir -Recurse -File | Where-Object { $_.Length -eq 0 -and $_.Name -ne '.nojekyll' }
+if ($Empty) { throw "Empty build artifact(s): $($Empty.Name -join ', '). Re-run a clean build." }
+
 if ($DryRun) {
     Write-Host "Dry run mode enabled. Skipping sync to s3://$S3BucketName/, CloudFront KeyValueStore update and CloudFront invalidation." -ForegroundColor Yellow
 } else {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/HRINT-4887

### Additional description
Disabled buggy rspackPersistentCache which we didn't benefit from anyway and added 0-byte-asset guard for any other rspack bugs. 

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

