### PR TITLE
HRINT-4887 Relax TC empty file guards to prevent race condition, reduce logs volume 

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -34,8 +34,8 @@ const config: Config = {
     // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
     future: {
         v4: true, // Improve compatibility with the upcoming Docusaurus v4
-        // All faster flags except rspackPersistentCache, which intermittently emits
-        // 0-byte assets while the build still succeeds, breaking the deployed site.
+        // All faster flags except rspackPersistentCache, which only speeds up repeat builds — CI
+        // wipes the workspace between builds, so it provides no benefit here.
         faster: {
             swcJsLoader: true,
             swcJsMinimizer: true,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,8 +2,9 @@ import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { CURRENT_VERSION, LEGACY_VERSIONS } = require("./scripts/lib/version-policy.js") as {
+const { CURRENT_VERSION, ACTIVE_VERSIONS, LEGACY_VERSIONS } = require("./scripts/lib/version-policy.js") as {
     CURRENT_VERSION: string;
+    ACTIVE_VERSIONS: string[];
     LEGACY_VERSIONS: string[];
 };
 
@@ -58,6 +59,21 @@ const config: Config = {
             headingIds: true,
             admonitions: true,
         },
+        hooks: {
+            onBrokenMarkdownLinks: ({ sourceFilePath, url }: { sourceFilePath: string; url: string }) => {
+                const maintained =
+                    !sourceFilePath.includes("versioned_docs") ||
+                    ACTIVE_VERSIONS.some((v) => sourceFilePath.includes(`version-${v}`));
+                if (!maintained) {
+                    return;
+                }
+                const message = `Broken Markdown link in ${sourceFilePath}: "${url}"`;
+                if (isStrict) {
+                    throw new Error(message);
+                }
+                console.warn(`[docusaurus] ${message}`);
+            },
+        },
     },
 
     customFields: {
@@ -68,7 +84,6 @@ const config: Config = {
     baseUrl: "/",
 
     onBrokenLinks: isStrict ? "throw" : "warn",
-    onBrokenMarkdownLinks: isStrict ? "throw" : "warn",
     onBrokenAnchors: "ignore",
 
     i18n: {

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -185,9 +185,11 @@ if ($LASTEXITCODE) { throw 'Docusaurus build failed' }
 $BuildDir = [IO.Path]::Combine($PSScriptRoot, '..', 'build')
 if (-not (Test-Path $BuildDir)) { throw "Build folder not produced ($BuildDir)" }
 
-# Rspack's persistent cache can emit 0-byte assets while the build still succeeds; abort before sync
-$Empty = Get-ChildItem $BuildDir -Recurse -File | Where-Object { $_.Length -eq 0 -and $_.Name -ne '.nojekyll' }
-if ($Empty) { throw "Empty build artifact(s): $($Empty.Name -join ', '). Re-run a clean build." }
+# Warn (don't block) if the build emitted any empty (0-byte) asset.
+$empty = Get-ChildItem $BuildDir -Recurse -File | Where-Object { $_.Length -eq 0 -and $_.Name -ne '.nojekyll' }
+if ($empty) {
+    Write-Warning "Build produced $($empty.Count) empty file(s): $(($empty | Select-Object -First 20 -ExpandProperty Name) -join ', ')"
+}
 
 if ($DryRun) {
     Write-Host "Dry run mode enabled. Skipping sync to s3://$S3BucketName/, CloudFront KeyValueStore update and CloudFront invalidation." -ForegroundColor Yellow

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -201,7 +201,7 @@ if ($DryRun) {
     # on S3 while CloudFront still serves the old index.html from edge cache
     # cached aggresively 
     Write-Host "  [1/4] Upload: hashed assets (assets/*)" -ForegroundColor Gray
-    aws s3 sync $BuildDir "s3://$S3BucketName/" `
+    aws s3 sync $BuildDir "s3://$S3BucketName/" --only-show-errors `
         --exclude "*" `
         --include "assets/*" `
         --cache-control "public, max-age=31536000, immutable"
@@ -211,7 +211,7 @@ if ($DryRun) {
     # these files share the same URLs across deploys (no hashing), so the only
     # deletions are pages intentionally removed from the docs
     Write-Host "  [2/4] Sync: static files with --delete (HTML, images, icons, sitemap, robots.txt, etc.)" -ForegroundColor Gray
-    aws s3 sync $BuildDir "s3://$S3BucketName/" `
+    aws s3 sync $BuildDir "s3://$S3BucketName/" --only-show-errors `
         --exclude "assets/*" `
         --cache-control "public, max-age=3600, must-revalidate" `
         --delete
@@ -231,7 +231,7 @@ if ($DryRun) {
     # Phase 4 — CloudFront now serves only the new index.html, so old hashed
     # bundles are no longer referenced and can be safely removed
     Write-Host "  [4/4] Cleanup: removing stale hashed assets from S3" -ForegroundColor Gray
-    aws s3 sync $BuildDir "s3://$S3BucketName/" `
+    aws s3 sync $BuildDir "s3://$S3BucketName/" --only-show-errors `
         --exclude "*" `
         --include "assets/*" `
         --cache-control "public, max-age=31536000, immutable" `


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/HRINT-4887
https://issues.hibernatingrhinos.com/issue/RDoc-3924/Make-TeamCity-documentation-build-less-verbose

### Additional description
...Include details of the change made, paste screenshots if necessary. Anything that may be useful for the reviewers...

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [x] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

