### PR TITLE
RDoc-3315 + RDoc-3929 server-wide snapshot backups + update unsupported features

### DIFF
--- a/docs/sharding/backup-and-restore/backup.mdx
+++ b/docs/sharding/backup-and-restore/backup.mdx
@@ -21,17 +21,17 @@ import ContentFrame from "@site/src/components/ContentFrame";
 * Shards can store backup files **locally** (each shard using its own node machine storage)  
   and/or **remotely** (all shards sending backup files to a common remote destination like an AWS S3 bucket).  
 
-* Both [Full](../../backup/overview#full-backup) and [Incremental](../../backup/overview#incremental-backup) 
+* Both [Full](../../backup/overview.mdx#full-backup) and [Incremental](../../backup/overview#incremental-backup) 
   backups can be created for a sharded database.  
 
-* A [logical](../../backup/overview#logical-backup) backup **can** be:  
+* A [logical](../../backup/overview.mdx#logical-backup) backup **can** be:  
    - Created for a sharded database.  
    - Restored into either a sharded or a non-sharded database.  
 
-* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
+* A [snapshot](../../backup/overview.mdx#snapshot-image) **cannot** be created for a sharded database  
   (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
 
-* A [one-time](../../backup/create/one-time-backup) backup **can** be created for a sharded database.  
+* A [one-time](../../backup/create/one-time-backup.mdx) backup **can** be created for a sharded database.  
 
 * In this article:  
    * [Sharded and non-sharded backup tasks](../../sharding/backup-and-restore/backup.mdx#sharded-and-non-sharded-backup-tasks)  

--- a/docs/sharding/backup-and-restore/backup.mdx
+++ b/docs/sharding/backup-and-restore/backup.mdx
@@ -121,7 +121,7 @@ Backed-up data includes both [database-level and cluster-level content](../../ba
 
 <Panel heading="Backup type">
 
-A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
+A backup task for a sharded database can create a [logical backup](../../backup/overview.mdx#logical-backup) only.
 
 A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
 
@@ -131,7 +131,7 @@ A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created 
 
 <Panel heading="Backup scope">
 
-A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
+A backup task for a sharded database can create a [full backup](../../backup/overview.mdx#full-backup) with the entire content of each shard,  
 or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 </Panel>

--- a/docs/sharding/backup-and-restore/backup.mdx
+++ b/docs/sharding/backup-and-restore/backup.mdx
@@ -121,7 +121,7 @@ Backed-up data includes both [database-level and cluster-level content](../../ba
 
 <Panel heading="Backup type">
 
-A shard backup task can create a [Logical backup](../../backup/overview#logical-backup) only.  
+A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
 
 A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
 
@@ -131,8 +131,8 @@ A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created 
 
 <Panel heading="Backup scope">
 
-A shard backup task can create a [Full backup](../../backup/overview#full-backup) with the entire content of the shard,  
-or an [Incremental Backup](../../backup/overview#incremental-backup) with just the difference between the current database data and the last backed-up data.  
+A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
+or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 </Panel>
 

--- a/docs/sharding/backup-and-restore/backup.mdx
+++ b/docs/sharding/backup-and-restore/backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sharding: Backup"
 description: "Back up RavenDB sharded databases with shard-aware backup tasks that capture data from all shards into coordinated backup sets."
-sidebar_label: Backup
+sidebar_label: "Backup"
 sidebar_position: 0
 ---
 
@@ -14,31 +14,26 @@ import LanguageContent from "@site/src/components/LanguageContent";
 import Panel from "@site/src/components/Panel";
 import ContentFrame from "@site/src/components/ContentFrame";
 
-# Sharding: Backup
-
 <Admonition type="note" title="">
 
-* Sharded databases are backed up using user-defined periodic 
-  [backup tasks](../../backup/overview).  
+* Sharded databases are backed up using user-defined periodic [backup tasks](../../backup/overview).  
 
-* Shards can store backup files **locally** (each shard using its 
-  own node machine storage) and/or **remotely** (all shards sending 
-  backup files to a common remote destination like an AWS S3 bucket).  
+* Shards can store backup files **locally** (each shard using its own node machine storage)  
+  and/or **remotely** (all shards sending backup files to a common remote destination like an AWS S3 bucket).  
 
-* Both [Full](../../backup/overview#full-backup) 
-  and [Incremental](../../backup/overview#incremental-backup) 
+* Both [Full](../../backup/overview#full-backup) and [Incremental](../../backup/overview#incremental-backup) 
   backups can be created for a sharded database.  
 
 * A [logical](../../backup/overview#logical-backup) backup **can** be:  
    - Created for a sharded database.  
    - Restored into either a sharded or a non-sharded database.  
 
-* A [snapshot](../../backup/overview#snapshot-image) 
-  **cannot** be created for a sharded database.  
+* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
+  (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
 
 * A [one-time](../../backup/create/one-time-backup) backup **can** be created for a sharded database.  
 
-* In this page:  
+* In this article:  
    * [Sharded and non-sharded backup tasks](../../sharding/backup-and-restore/backup.mdx#sharded-and-non-sharded-backup-tasks)  
    * [Backup storage: local and remote](../../sharding/backup-and-restore/backup.mdx#backup-storage-local-and-remote)  
    * [Backup files extension and structure](../../sharding/backup-and-restore/backup.mdx#backup-files-extension-and-structure)  
@@ -53,48 +48,33 @@ import ContentFrame from "@site/src/components/ContentFrame";
 
 <Panel heading="Sharded and non-sharded backup tasks">
 
-From a user's perspective, backing up a sharded database is done by 
-defining and running **a single backup task**, just like it is done 
-with a non-sharded database.  
+From a user's perspective, backing up a sharded database is done by defining and running **a single backup task**,  
+just like it is done with a non-sharded database.  
 
-Behind the scenes, though, each shard backs up its own slice of the 
-database independently from other shards.  
+Behind the scenes, though, each shard backs up its own slice of the database independently of other shards.  
 
-Distributing the backup responsibility between the shards allows 
-RavenDB to speed up the backup process and keep backup files in 
-manageable proportions no matter what the overall database size is.  
+Distributing the backup responsibility between the shards allows RavenDB to speed up the backup process  
+and keep backup files in manageable proportions no matter what the overall database size is.  
 
 ### Non-sharded DB backup tasks
 
 * A complete replica of the database is kept by each cluster node.  
-* Any node can therefore be made 
-  [responsible](../../server/clustering/distribution/highly-available-tasks.mdx#responsible-node) 
-  for backups by the cluster.  
-* The responsible node runs the backup task periodically to create 
-  a backup of the entire database.  
+* Any node can therefore be made [responsible](../../server/clustering/distribution/highly-available-tasks.mdx#responsible-node) for backups by the cluster.  
+* The responsible node runs the backup task periodically to create a backup of the entire database.  
   
 ### Sharded DB backup tasks
 
-* Each shard hosts a unique part of the database, so no single node 
-  can create a backup of the entire database.  
-* After a user defines a backup task, RavenDB automatically creates 
-  one backup task per shard, based on the user-defined task.  
-  This operation is automatic and requires no additional actions 
-  from the user.  
-* Each shard appoints [one of its nodes](../../sharding/overview.mdx#shard-replication) 
-  responsible for the execution of the shard's backup task.  
-* Each shard backup task can keep the shard's database 
-  locally (on the shard machine), and/or remotely (on one 
-  or more cloud destinations).  
-* A backup task can store backups on multiple destinations, 
-  e.g., locally, on an S3 bucket, and on an Azure blob.  
-* To [restore](../../sharding/backup-and-restore/restore.mdx) 
-  the entire database, the restore operation is provided with 
-  the locations of the backup folders used by all shards.  
-* When restoring the database, the user doesn't have to restore 
-  all shard backups. It is possible, for example, to restore only 
-  one of the shards. Using this flexibility, a sharded database 
-  can easily be split into several databases.  
+* Each shard hosts a unique part of the database, so no single node can create a backup of the entire database.  
+* After a user defines a backup task, RavenDB automatically creates one backup task per shard, based on the user-defined task.
+  This operation is automatic and requires no additional actions from the user.  
+* Each shard appoints [one of its nodes](../../sharding/overview.mdx#shard-replication) responsible for the execution of the shard's backup task.  
+* Each shard backup task can keep the shard's database locally (on the shard machine),  
+  and/or remotely (on one or more cloud destinations).  
+* A backup task can store backups on multiple destinations, e.g., locally, on an S3 bucket, and on an Azure blob.  
+* To [restore](../../sharding/backup-and-restore/restore.mdx) the entire database, 
+  the restore operation is provided with the locations of the backup folders used by all shards.  
+* When restoring the database, the user doesn't have to restore all shard backups. 
+  It is possible, for example, to restore only one of the shards. Using this flexibility, a sharded database can easily be split into several databases.  
 
 </Panel>
 
@@ -104,79 +84,61 @@ Backup files can be stored locally and remotely.
 Find a code example [here](../../sharding/backup-and-restore/backup.mdx#example).  
 
 * **Local backup**  
-  A shard's backup task may keep backup data locally, 
-  using the node's local storage.  
+  A shard's backup task may keep backup data locally, using the node's local storage.  
 
-    [Restoring](../../sharding/backup-and-restore/restore.mdx#section-2) 
-    backup files that were stored locally requires the user to provide 
-    the restore operation with the location of the backup folder on each 
-    shard's node.  
+    [Restoring](../../sharding/backup-and-restore/restore.mdx#section-2) backup files that were stored locally
+    requires the user to provide the restore operation with the location of the backup folder on each shard's node.  
 
 * **Remote location**  
-  Backups can also be kept remotely. All shards will transfer 
-  the backup files to a common location, using one of the currently 
-  supported platforms:  
+  Backups can also be kept remotely.  
+  All shards will transfer the backup files to a common location, using one of the currently supported platforms:  
    * An FTP/SFTP target  
    * Azure Storage  
    * Amazon S3  
    * Amazon Glacier  
    * Google Cloud  
 
-    [Restoring](../../sharding/backup-and-restore/restore.mdx#section-2) 
-    backup files that were stored remotely requires the user to provide 
-    the restore operation with each shard's backup folder location.  
+    [Restoring](../../sharding/backup-and-restore/restore.mdx#section-2) backup files that were stored remotely
+    requires the user to provide the restore operation with each shard's backup folder location.  
 
 </Panel>
 
 <Panel heading="Backup files extension and structure">
 
-Backup files use the same internal structure as the `.ravendbdump` 
-files that [Studio](../../studio/database/tasks/export-database.mdx) 
-and [Smuggler](../../client-api/smuggler/what-is-smuggler.mdx) 
-create when **exporting** data.  
+Backup files use the same internal structure as the `.ravendbdump` files that [Studio](../../studio/database/tasks/export-database.mdx) 
+and [Smuggler](../../client-api/smuggler/what-is-smuggler.mdx) create when **exporting** data.
 It is therefore possible to not only [restore](../../sharding/backup-and-restore/restore.mdx) 
-but also **import** backup files using [studio](../../studio/database/tasks/import-data/import-data-file.mdx) 
-and [smuggler](../../client-api/smuggler/what-is-smuggler.mdx#import).  
+but also **import** backup files using [studio](../../studio/database/tasks/import-data/import-data-file.mdx) and [smuggler](../../client-api/smuggler/what-is-smuggler.mdx#import).  
 Read more about this feature [here](../../sharding/import-and-export.mdx#import).  
-
 
 <Admonition type="note" title="">
 
-Backed-up data includes both 
-[database-level and cluster-level content](../../backup/overview#backup-content).  
+Backed-up data includes both [database-level and cluster-level content](../../backup/overview#backup-content).
+    
 </Admonition>
 
 </Panel>
 
 <Panel heading="Backup type">
 
-A shard backup task can create a 
-[Logical backup](../../backup/overview#logical-backup) 
-only.  
+A shard backup task can create a [Logical backup](../../backup/overview#logical-backup) only.  
 
-A [Snapshot](../../backup/overview#snapshot-image) 
-backup **cannot** be created for a sharded database.  
+A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
 
-`Logical` backups created for a sharded database can be restored into 
-both sharded and non-sharded databases.  
+`Logical` backups created for a sharded database can be restored into both sharded and non-sharded databases.  
 
 </Panel>
 
 <Panel heading="Backup scope">
 
-A shard backup task can create 
-a [Full backup](../../backup/overview#full-backup) 
-with the entire content of the shard, or an 
-[Incremental Backup](../../backup/overview#incremental-backup) 
-with just the difference between the current database data and the last backed-up data.  
+A shard backup task can create a [Full backup](../../backup/overview#full-backup) with the entire content of the shard,  
+or an [Incremental Backup](../../backup/overview#incremental-backup) with just the difference between the current database data and the last backed-up data.  
 
 </Panel>
 
 <Panel heading="Naming convention">
 
-* Backup files created for a sharded database generally follow the same [naming 
-  convention](../../backup/overview#naming-and-folder-structure) 
-  as non-sharded database backups.  
+* Backup files created for a sharded database generally follow the same [naming convention](../../backup/overview#naming-and-folder-structure) as non-sharded database backups.  
 
 * Each shard keeps its backup files in a folder whose name consists of:  
    * **Date and Time** (when the folder was created)  
@@ -184,8 +146,7 @@ with just the difference between the current database data and the last backed-u
    * `$` symbol  
    * **Shard Number**  
 
-      The backup folders for a 3-shard database named "Books", 
-      for example, can be named:  
+      The backup folders for a 3-shard database named "Books", for example, can be named:  
       `2023-02-05-16-17.Books$0` for shard 0  
       `2023-02-05-16-17.Books$1` for shard 1  
       `2023-02-05-16-17.Books$2` for shard 2  
@@ -193,25 +154,24 @@ with just the difference between the current database data and the last backed-u
 </Panel>
 
 <Panel heading="Server-wide backup">
+   
+[Server-wide backup](../../backup/overview#server-wide-backup) creates and runs the required backup tasks
+for the databases hosted by the cluster at the scheduled time.
+    
+* A server-wide **logical** backup creates backups for both non-sharded and sharded databases.  
+  For a sharded database, RavenDB defines and executes a backup task for each shard,  
+  as if the task was defined manually.  
 
-[Server-wide backup](../../backup/overview#server-wide-backup) 
-backs up all the databases hosted by the cluster, by creating a backup 
-task for each database and executing all tasks at a scheduled time.  
-
-* A server-wide backup will create backups for both non-sharded **and** 
-  sharded databases.  
-* To create a backup for an entire sharded database, the operation will 
-  define and execute a backup task for each shard, behaving as if it was 
-  defined manually.  
+* A server-wide **snapshot** backup excludes sharded databases, since snapshots cannot be created for sharded databases.
+  RavenDB automatically adds sharded database names to the server-wide snapshot task's `ExcludedDatabases` list,
+  including sharded databases created after the task already exists.  
 
 </Panel>
 
 <Panel heading="Example">
 
-The backup task that we define here is similar to the task we 
-would define for a non-sharded database. As part of a sharded 
-database, however, this task will be re-defined automatically 
-by the orchestrator for each shard.  
+The backup task that we define here is similar to the task we would define for a non-sharded database.  
+As part of a sharded database, however, this task will be re-defined automatically by the orchestrator for each shard.  
 
 ```csharp
 var config = new PeriodicBackupConfiguration
@@ -251,11 +211,15 @@ var config = new PeriodicBackupConfiguration
 var operation = new UpdatePeriodicBackupOperation(config);
 var result = await store.Maintenance.SendAsync(operation);
 ```
+<br/>    
 
-<Admonition type="warning" title="Casting Backup Results" id="casting-backup-results" href="#casting-backup-results">
+<Admonition type="warning" title="">
+    
+#### Casting Backup Results  
+    
 In a sharded database, results are returned by Backup in a `ShardedBackupResult` type.  
-This type is specific to a sharded database, and casting it using a non-sharded type 
-[will fail](../../migration/client-api/previous-versions-client-breaking-changes#casting-smuggler-results).  
+This type is specific to a sharded database, and casting it using a non-sharded type [will fail](../../migration/client-api/previous-versions-client-breaking-changes#casting-smuggler-results).
+    
 </Admonition>
 
 </Panel>
@@ -263,16 +227,16 @@ This type is specific to a sharded database, and casting it using a non-sharded 
 <Panel heading="Backup Options Summary">
 
 | Option | Available on a Sharded Database | Comment |
-| -------------------- | --------------- | --------------------- |
-| Store backup files created by shards in **local shard machine storage** | **Yes** | Shards can store the backups they create locally. |
+| ------ | ------------------------------- | ------- |
+| Store backup files created by shards in **local shard machine storage**                                                          | **Yes** | Shards can store the backups they create locally. |
 | Store backup files of sharded databases [remotely](../../sharding/backup-and-restore/backup.mdx#backup-storage-local-and-remote) | **Yes** | Shards can store the backups they create on remote S3, Azure, or Google Cloud destinations. |
-| Create [Full](../../backup/overview#full-backup) backups for sharded databases | **Yes** |  |
-| Create [Incremental](../../backup/overview#incremental-backup) backups for sharded databases | **Yes** |  |
-| Create [Logical](../../backup/overview#logical-backup) backups for sharded databases | **Yes** |  |
-| Create [Snapshot](../../backup/overview#snapshot-image) backups for sharded databases | **No** | Snapshot backups CANNOT be created for (nor restored to) sharded databases. |
-| Create **periodic backup tasks** for sharded databases | **Yes** |  |
-| Run a manual [one-time](../../backup/create/one-time-backup) backup operation on a sharded database | **Yes** |  |
-| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup) | **Yes** | A server-wide backup operation will create backups for all databases, including the sharded ones. |
+| Create [Full](../../backup/overview#full-backup) backups for sharded databases                                                   | **Yes** | |
+| Create [Incremental](../../backup/overview#incremental-backup) backups for sharded databases                                     | **Yes** | |
+| Create [Logical](../../backup/overview#logical-backup) backups for sharded databases                                             | **Yes** | |
+| Create [Snapshot](../../backup/overview#snapshot-image) backups for sharded databases                                            | **No**  | Snapshot backups CANNOT be created for (nor restored to) sharded databases. |
+| Create **periodic backup tasks** for sharded databases                                                                           | **Yes** | |
+| Run a manual [one-time](../../backup/create/one-time-backup) backup operation on a sharded database                              | **Yes** | |
+| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup)   | **Yes (logical only)** | A server-wide **logical** backup includes all databases, including sharded ones. Sharded databases are automatically **excluded** from server-wide **snapshot** backups. |
 
 </Panel>
 

--- a/docs/sharding/unsupported.mdx
+++ b/docs/sharding/unsupported.mdx
@@ -31,6 +31,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
   * [Unsupported Integrations Features](../sharding/unsupported.mdx#unsupported-integrations-features)  
   * [Unsupported Patching Features](../sharding/unsupported.mdx#unsupported-patching-features)  
   * [Unsupported Replication Features](../sharding/unsupported.mdx#unsupported-replication-features)  
+  * [Unsupported AI Features](../sharding/unsupported.mdx#unsupported-ai-features)  
   
 </Admonition>
 
@@ -111,8 +112,8 @@ Reference: [Unsupported querying features](../sharding/indexing.mdx#unsupported-
 | Unsupported Feature | Comment |
 | ------------- | ------------- |
 | [PostgreSQL](../integrations/postgresql-protocol/overview.mdx) |  |
-| [Queue ETL](../server/ongoing-tasks/etl/queue-etl/overview.mdx) | [Kafka ETL](../server/ongoing-tasks/etl/queue-etl/kafka.mdx), [RabbitMQ ETL](../server/ongoing-tasks/etl/queue-etl/rabbit-mq.mdx) |
-| [Queue Sink](../server/ongoing-tasks/queue-sink/overview.mdx) | [Kafka Queue Sink](../server/ongoing-tasks/queue-sink/kafka-queue-sink.mdx), [RabbitMQ Queue Sink](../server/ongoing-tasks/queue-sink/rabbit-mq-queue-sink.mdx) |
+| [Queue ETL](../server/ongoing-tasks/etl/queue-etl/overview.mdx) | [Kafka ETL](../server/ongoing-tasks/etl/queue-etl/kafka.mdx), [RabbitMQ ETL](../server/ongoing-tasks/etl/queue-etl/rabbit-mq.mdx), [Azure Queue Storage ETL](../server/ongoing-tasks/etl/queue-etl/azure-queue.mdx), [Amazon SQS ETL](../server/ongoing-tasks/etl/queue-etl/amazon-sqs.mdx) |
+| [Queue Sink](../server/ongoing-tasks/queue-sink/overview.mdx) | [Kafka Queue Sink](../server/ongoing-tasks/queue-sink/kafka-queue-sink.mdx), [RabbitMQ Queue Sink](../server/ongoing-tasks/queue-sink/rabbit-mq-queue-sink.mdx), Azure Service Bus Queue Sink |
 
 ## Unsupported Patching Features
 
@@ -127,3 +128,10 @@ Reference: [Unsupported querying features](../sharding/indexing.mdx#unsupported-
 | [Filtered Replication](../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview.mdx#filtered-replication) |  |
 | [Hub/Sink Replication](../studio/database/tasks/ongoing-tasks/hub-sink-replication/overview.mdx) |  |
 | **Legacy replication** | From RavenDB 3.x instances |
+
+## Unsupported AI Features
+
+| Unsupported Feature | Comment |
+| ------------- | ------------- |
+| [GenAI](../ai-integration/gen-ai-integration/overview.mdx) |  |
+| [AI Agents](../ai-integration/ai-agents/overview.mdx) |  |

--- a/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
@@ -140,23 +140,16 @@ Backed-up data includes both
 
 ## Backup Type
 
-A shard backup task can create a 
-[Logical backup](../../server/ongoing-tasks/backup-overview.mdx#logical-backup) 
-only.  
+A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
 
-A [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) 
-backup **cannot** be created for a sharded database.  
+A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
 
-`Logical` backups created for a sharded database can be restored into 
-both sharded and non-sharded databases.  
+`Logical` backups created for a sharded database can be restored into both sharded and non-sharded databases.  
 
 ## Backup Scope
 
-A shard backup task can create 
-a [Full backup](../../server/ongoing-tasks/backup-overview.mdx#full-backup) 
-with the entire content of the shard, or an 
-[Incremental Backup](../../server/ongoing-tasks/backup-overview.mdx#incremental-backup) 
-with just the difference between the current database data and the last backed-up data.  
+A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
+or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 ## Naming Convention
 

--- a/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
@@ -29,7 +29,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
   backup **can** be created for a sharded database and restored into either 
   a sharded or a non-sharded database.  
 
-* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
+* A [snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) **cannot** be created for a sharded database  
   (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
 
 * A manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) 
@@ -178,7 +178,7 @@ with just the difference between the current database data and the last backed-u
 
 ## Server-Wide Backup
 
-[Server-wide backup](../../backup/overview#server-wide-backup) creates and runs the required backup tasks
+[Server-wide backup](../../studio/server/server-wide-backup.mdx) creates and runs the required backup tasks
 for the databases hosted by the cluster at the scheduled time.
     
 * A server-wide **logical** backup creates backups for both non-sharded and sharded databases.  

--- a/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
@@ -140,16 +140,16 @@ Backed-up data includes both
 
 ## Backup Type
 
-A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
+A backup task for a sharded database can create a [logical backup](../../server/ongoing-tasks/backup-overview.mdx#logical-backup) only.
 
-A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
+A [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) backup **cannot** be created for a sharded database.  
 
 `Logical` backups created for a sharded database can be restored into both sharded and non-sharded databases.  
 
 ## Backup Scope
 
-A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
-or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
+A backup task for a sharded database can create a [full backup](../../server/ongoing-tasks/backup-overview.mdx#full-backup) with the entire content of each shard,  
+or an [incremental backup](../../server/ongoing-tasks/backup-overview.mdx#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 ## Naming Convention
 

--- a/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-6.2/sharding/backup-and-restore/backup.mdx
@@ -29,8 +29,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
   backup **can** be created for a sharded database and restored into either 
   a sharded or a non-sharded database.  
 
-* A [snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) 
-  backup **cannot** be created for a sharded database.  
+* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
+  (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
 
 * A manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) 
   backup **can** be created for a sharded database.  
@@ -178,15 +178,16 @@ with just the difference between the current database data and the last backed-u
 
 ## Server-Wide Backup
 
-[Server-wide backup](../../client-api/operations/maintenance/backup/backup-overview.mdx#server-wide-backup) 
-backs up all the databases hosted by the cluster, by creating a backup 
-task for each database and executing all tasks at a scheduled time.  
+[Server-wide backup](../../backup/overview#server-wide-backup) creates and runs the required backup tasks
+for the databases hosted by the cluster at the scheduled time.
+    
+* A server-wide **logical** backup creates backups for both non-sharded and sharded databases.  
+  For a sharded database, RavenDB defines and executes a backup task for each shard,  
+  as if the task was defined manually.  
 
-* A server-wide backup will create backups for both non-sharded **and** 
-  sharded databases.  
-* To create a backup for an entire sharded database, the operation will 
-  define and execute a backup task for each shard, behaving as if it was 
-  defined manually.  
+* A server-wide **snapshot** backup excludes sharded databases, since snapshots cannot be created for sharded databases.
+  RavenDB automatically adds sharded database names to the server-wide snapshot task's `ExcludedDatabases` list,
+  including sharded databases created after the task already exists.  
 
 ## Example
 
@@ -256,7 +257,7 @@ This type is specific to a sharded database, and casting it using a non-sharded 
 | Create [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) backups for sharded databases | **No** | Snapshot backups CANNOT be created for (nor restored to) sharded databases. |
 | Create **periodic backup tasks** for sharded databases | **Yes** |  |
 | Run a manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) backup operation on a sharded database | **Yes** |  |
-| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup) | **Yes** | A server-wide backup operation will create backups for all databases, including the sharded ones. |
+| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup)   | **Yes (logical only)** | A server-wide **logical** backup includes all databases, including sharded ones. Sharded databases are automatically **excluded** from server-wide **snapshot** backups. |
 
 
 

--- a/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
@@ -140,23 +140,16 @@ Backed-up data includes both
 
 ## Backup Type
 
-A shard backup task can create a 
-[Logical backup](../../server/ongoing-tasks/backup-overview.mdx#logical-backup) 
-only.  
+A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
 
-A [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) 
-backup **cannot** be created for a sharded database.  
+A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
 
-`Logical` backups created for a sharded database can be restored into 
-both sharded and non-sharded databases.  
+`Logical` backups created for a sharded database can be restored into both sharded and non-sharded databases.  
 
 ## Backup Scope
 
-A shard backup task can create 
-a [Full backup](../../server/ongoing-tasks/backup-overview.mdx#full-backup) 
-with the entire content of the shard, or an 
-[Incremental Backup](../../server/ongoing-tasks/backup-overview.mdx#incremental-backup) 
-with just the difference between the current database data and the last backed-up data.  
+A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
+or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 ## Naming Convention
 

--- a/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
@@ -140,16 +140,16 @@ Backed-up data includes both
 
 ## Backup Type
 
-A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
+A backup task for a sharded database can create a [logical backup](../../server/ongoing-tasks/backup-overview.mdx#logical-backup) only.
 
-A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
+A [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) backup **cannot** be created for a sharded database.  
 
 `Logical` backups created for a sharded database can be restored into both sharded and non-sharded databases.  
 
 ## Backup Scope
 
-A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
-or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
+A backup task for a sharded database can create a [full backup](../../server/ongoing-tasks/backup-overview.mdx#full-backup) with the entire content of each shard,  
+or an [incremental backup](../../server/ongoing-tasks/backup-overview.mdx#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 ## Naming Convention
 

--- a/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
@@ -29,8 +29,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
   backup **can** be created for a sharded database and restored into either 
   a sharded or a non-sharded database.  
 
-* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
-  (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
+* A [snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) **cannot** be created for a sharded database  
+  (and sharded databases are automatically excluded from server-wide **snapshot** backups).     
 
 * A manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) 
   backup **can** be created for a sharded database.  
@@ -178,7 +178,7 @@ with just the difference between the current database data and the last backed-u
 
 ## Server-Wide Backup
 
-[Server-wide backup](../../backup/overview#server-wide-backup) creates and runs the required backup tasks
+[Server-wide backup](../../studio/server/server-wide-backup.mdx) creates and runs the required backup tasks
 for the databases hosted by the cluster at the scheduled time.
     
 * A server-wide **logical** backup creates backups for both non-sharded and sharded databases.  

--- a/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.0/sharding/backup-and-restore/backup.mdx
@@ -29,8 +29,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
   backup **can** be created for a sharded database and restored into either 
   a sharded or a non-sharded database.  
 
-* A [snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) 
-  backup **cannot** be created for a sharded database.  
+* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
+  (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
 
 * A manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) 
   backup **can** be created for a sharded database.  
@@ -178,15 +178,16 @@ with just the difference between the current database data and the last backed-u
 
 ## Server-Wide Backup
 
-[Server-wide backup](../../client-api/operations/maintenance/backup/backup-overview.mdx#server-wide-backup) 
-backs up all the databases hosted by the cluster, by creating a backup 
-task for each database and executing all tasks at a scheduled time.  
+[Server-wide backup](../../backup/overview#server-wide-backup) creates and runs the required backup tasks
+for the databases hosted by the cluster at the scheduled time.
+    
+* A server-wide **logical** backup creates backups for both non-sharded and sharded databases.  
+  For a sharded database, RavenDB defines and executes a backup task for each shard,  
+  as if the task was defined manually.  
 
-* A server-wide backup will create backups for both non-sharded **and** 
-  sharded databases.  
-* To create a backup for an entire sharded database, the operation will 
-  define and execute a backup task for each shard, behaving as if it was 
-  defined manually.  
+* A server-wide **snapshot** backup excludes sharded databases, since snapshots cannot be created for sharded databases.
+  RavenDB automatically adds sharded database names to the server-wide snapshot task's `ExcludedDatabases` list,
+  including sharded databases created after the task already exists.  
 
 ## Example
 
@@ -256,7 +257,7 @@ This type is specific to a sharded database, and casting it using a non-sharded 
 | Create [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) backups for sharded databases | **No** | Snapshot backups CANNOT be created for (nor restored to) sharded databases. |
 | Create **periodic backup tasks** for sharded databases | **Yes** |  |
 | Run a manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) backup operation on a sharded database | **Yes** |  |
-| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup) | **Yes** | A server-wide backup operation will create backups for all databases, including the sharded ones. |
+| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup)   | **Yes (logical only)** | A server-wide **logical** backup includes all databases, including sharded ones. Sharded databases are automatically **excluded** from server-wide **snapshot** backups. |
 
 
 

--- a/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
@@ -140,23 +140,16 @@ Backed-up data includes both
 
 ## Backup Type
 
-A shard backup task can create a 
-[Logical backup](../../server/ongoing-tasks/backup-overview.mdx#logical-backup) 
-only.  
+A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
 
-A [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) 
-backup **cannot** be created for a sharded database.  
+A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
 
-`Logical` backups created for a sharded database can be restored into 
-both sharded and non-sharded databases.  
+`Logical` backups created for a sharded database can be restored into both sharded and non-sharded databases.  
 
 ## Backup Scope
 
-A shard backup task can create 
-a [Full backup](../../server/ongoing-tasks/backup-overview.mdx#full-backup) 
-with the entire content of the shard, or an 
-[Incremental Backup](../../server/ongoing-tasks/backup-overview.mdx#incremental-backup) 
-with just the difference between the current database data and the last backed-up data.  
+A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
+or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 ## Naming Convention
 

--- a/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
@@ -29,7 +29,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
   backup **can** be created for a sharded database and restored into either 
   a sharded or a non-sharded database.  
 
-* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
+* A [snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) **cannot** be created for a sharded database  
   (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
 
 * A manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) 
@@ -178,7 +178,7 @@ with just the difference between the current database data and the last backed-u
 
 ## Server-Wide Backup
 
-[Server-wide backup](../../backup/overview#server-wide-backup) creates and runs the required backup tasks
+[Server-wide backup](../../studio/server/server-wide-backup.mdx) creates and runs the required backup tasks
 for the databases hosted by the cluster at the scheduled time.
     
 * A server-wide **logical** backup creates backups for both non-sharded and sharded databases.  

--- a/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
@@ -140,16 +140,16 @@ Backed-up data includes both
 
 ## Backup Type
 
-A backup task for a sharded database can create a [logical backup](../../backup/overview#logical-backup) only.
+A backup task for a sharded database can create a [logical backup](../../server/ongoing-tasks/backup-overview.mdx#logical-backup) only.
 
-A [Snapshot](../../backup/overview#snapshot-image) backup **cannot** be created for a sharded database.  
+A [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) backup **cannot** be created for a sharded database.  
 
 `Logical` backups created for a sharded database can be restored into both sharded and non-sharded databases.  
 
 ## Backup Scope
 
-A backup task for a sharded database can create a [full backup](../../backup/overview#full-backup) with the entire content of each shard,  
-or an [incremental backup](../../backup/overview#incremental-backup) with just the difference between the current data and the last backed-up data.  
+A backup task for a sharded database can create a [full backup](../../server/ongoing-tasks/backup-overview.mdx#full-backup) with the entire content of each shard,  
+or an [incremental backup](../../server/ongoing-tasks/backup-overview.mdx#incremental-backup) with just the difference between the current data and the last backed-up data.  
 
 ## Naming Convention
 

--- a/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
+++ b/versioned_docs/version-7.1/sharding/backup-and-restore/backup.mdx
@@ -29,8 +29,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
   backup **can** be created for a sharded database and restored into either 
   a sharded or a non-sharded database.  
 
-* A [snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) 
-  backup **cannot** be created for a sharded database.  
+* A [snapshot](../../backup/overview#snapshot-image) **cannot** be created for a sharded database  
+  (and sharded databases are automatically excluded from server-wide **snapshot** backups).    
 
 * A manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) 
   backup **can** be created for a sharded database.  
@@ -178,15 +178,16 @@ with just the difference between the current database data and the last backed-u
 
 ## Server-Wide Backup
 
-[Server-wide backup](../../client-api/operations/maintenance/backup/backup-overview.mdx#server-wide-backup) 
-backs up all the databases hosted by the cluster, by creating a backup 
-task for each database and executing all tasks at a scheduled time.  
+[Server-wide backup](../../backup/overview#server-wide-backup) creates and runs the required backup tasks
+for the databases hosted by the cluster at the scheduled time.
+    
+* A server-wide **logical** backup creates backups for both non-sharded and sharded databases.  
+  For a sharded database, RavenDB defines and executes a backup task for each shard,  
+  as if the task was defined manually.  
 
-* A server-wide backup will create backups for both non-sharded **and** 
-  sharded databases.  
-* To create a backup for an entire sharded database, the operation will 
-  define and execute a backup task for each shard, behaving as if it was 
-  defined manually.  
+* A server-wide **snapshot** backup excludes sharded databases, since snapshots cannot be created for sharded databases.
+  RavenDB automatically adds sharded database names to the server-wide snapshot task's `ExcludedDatabases` list,
+  including sharded databases created after the task already exists.  
 
 ## Example
 
@@ -256,7 +257,7 @@ This type is specific to a sharded database, and casting it using a non-sharded 
 | Create [Snapshot](../../server/ongoing-tasks/backup-overview.mdx#snapshot) backups for sharded databases | **No** | Snapshot backups CANNOT be created for (nor restored to) sharded databases. |
 | Create **periodic backup tasks** for sharded databases | **Yes** |  |
 | Run a manual [one-time](../../studio/database/tasks/backup-task.mdx#manually-creating-one-time-backups) backup operation on a sharded database | **Yes** |  |
-| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup) | **Yes** | A server-wide backup operation will create backups for all databases, including the sharded ones. |
+| Include sharded databases in a [server-wide backup operation](../../sharding/backup-and-restore/backup.mdx#server-wide-backup)   | **Yes (logical only)** | A server-wide **logical** backup includes all databases, including sharded ones. Sharded databases are automatically **excluded** from server-wide **snapshot** backups. |
 
 
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3315/Block-server-wide-snapshot-backups-for-sharded-databases
https://issues.hibernatingrhinos.com/issue/RDoc-3929/Sharding-update-unsupported-features

### Additional description
* Updated the **server-wide backup panel** (A server-wide **snapshot** backup excludes sharded databases)
* Updated the **unsupported features page**
* Also, some layout fixes (only in v7.2)

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

