### PR TITLE
RDoc-3930 Allow to override `serviceName` in OpenTelemetry configuration

### DIFF
--- a/docs/server/administration/monitoring/open-telemetry.mdx
+++ b/docs/server/administration/monitoring/open-telemetry.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenTelemetry Support"
-sidebar_label: OpenTelemetry
+sidebar_label: "OpenTelemetry"
 description: "Export RavenDB server metrics and traces using OpenTelemetry for integration with observability platforms like Jaeger and Prometheus."
 sidebar_position: 2
 ---
@@ -12,7 +12,6 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# OpenTelemetry Support
 <Admonition type="note" title="">
 
 * [OpenTelemetry](https://opentelemetry.io) is an open-source observability framework that provides a set of APIs, SDKs, and tools 
@@ -27,10 +26,12 @@ import LanguageContent from "@site/src/components/LanguageContent";
   Learn more [below](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus).
 
 * OpenTelemetry support is provided for RavenDB instances both on-premises and in the cloud.
-* In this page:
+    
+* In this article:
   * [Enabling OpenTelemetry in RavenDB](../../../server/administration/monitoring/open-telemetry.mdx#enabling-opentelemetry-in-ravendb)
   * [RavenDB OpenTelemetry meters](../../../server/administration/monitoring/open-telemetry.mdx#ravendb-opentelemetry-meters)
   * [Server identification in metrics](../../../server/administration/monitoring/open-telemetry.mdx#server-identification-in-metrics)
+  * [Service name and namespace](../../../server/administration/monitoring/open-telemetry.mdx#service-name-and-namespace)
   * [The metric instruments](../../../server/administration/monitoring/open-telemetry.mdx#the-metric-instruments)
   * [Metrics export options](../../../server/administration/monitoring/open-telemetry.mdx#metrics-export-options)
       * [Console](../../../server/administration/monitoring/open-telemetry.mdx#console)
@@ -40,6 +41,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       * [Retrieve data from Prometheus](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus)
 
 </Admonition>
+
 ## Enabling OpenTelemetry in RavenDB
 
 * To enable the OpenTelemetry metrics in RavenDB,  
@@ -49,8 +51,6 @@ import LanguageContent from "@site/src/components/LanguageContent";
   which outlines all available options.
 
 * Please remember that it is necessary to restart the RavenDB process for changes to take effect.
-
-
 
 ## RavenDB OpenTelemetry meters
 
@@ -89,7 +89,8 @@ RavenDB exposes the following meters:
 * **ravendb.server.totaldatabases**  
   Description: Exposes aggregated information about databases on the server   
   Enabled by default: _true_   
-  Configuration key: [Monitoring.OpenTelemetry.Meters.Server.TotalDatabases.Enabled](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetrymetersservertotaldatabasesenabled)  
+  Configuration key: [Monitoring.OpenTelemetry.Meters.Server.TotalDatabases.Enabled](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetrymetersservertotaldatabasesenabled)
+
 RavenDB also supports exposing meters developed by Microsoft for AspNetCore and .NET Runtime:  
 
 * **Official AspNetCore instrumentation**  
@@ -100,8 +101,6 @@ RavenDB also supports exposing meters developed by Microsoft for AspNetCore and 
   Description: See the official MS documentation [.NET Runtime documentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Runtime#metrics)  
   Enabled by default: _false_   
   Configuration key: [Monitoring.OpenTelemetry.Meters.Runtime.Enabled](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetrymetersruntimeenabled)  
-
-
 
 ## Server identification in metrics
 
@@ -120,7 +119,26 @@ RavenDB also supports exposing meters developed by Microsoft for AspNetCore and 
     4. **Initialization Failure**  
        If none of the above options are available, OpenTelemetry will Not be initialized.
 
+## Service name and namespace
 
+* RavenDB's OpenTelemetry metrics are emitted with an OpenTelemetry resource that includes the `service.name` and `service.namespace` attributes.
+  Observability tools, such as the .NET Aspire dashboard, can use these values to identify and group RavenDB metrics.
+
+* By default, RavenDB uses `server` as the service name and `ravendb` as the service namespace.
+
+* These values are configured through RavenDB configuration, not through OpenTelemetry environment variables.  
+  To override these values, use the following configuration keys:  
+    * [Monitoring.OpenTelemetry.ServiceName](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)
+    * [Monitoring.OpenTelemetry.ServiceNamespace](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)
+
+<Admonition type="note" title="">
+
+When RavenDB OpenTelemetry monitoring is enabled by setting
+[Monitoring.OpenTelemetry.Enabled](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) to `true`,  
+the effective service name and service namespace values must not be `null`, empty, or whitespace.  
+Otherwise, the server will fail to start.
+
+</Admonition>
 
 ## The metric instruments
 
@@ -238,8 +256,6 @@ RavenDB also supports exposing meters developed by Microsoft for AspNetCore and 
 | ravendb.server.totaldatabases.number.faulty_indexes               | Number of faulty indexes in all loaded databases                                                   | UpDownCounter     |
 | ravendb.server.totaldatabases.writes_per_second                   | Number of writes \(documents, attachments, counters, timeseries\) in all loaded databases          | Gauge             |
 
-
-
 ## Metrics export options
 
 RavenDB offers two options for exporting metrics:  
@@ -320,8 +336,6 @@ The endpoint format should match the transport protocol you are using:
 
 </Admonition>
 
-
-
 ## Configuring the OpenTelemetry Collector
 
 * The OpenTelemetry Collector is a vendor-agnostic proxy that can receive, process, and export telemetry data (traces, metrics, logs)
@@ -394,5 +408,3 @@ The endpoint format should match the transport protocol you are using:
   The collector will access `http://localhost:8080/admin/monitoring/v1/prometheus` to retrieve the metrics.
  
 </Admonition>
-
-

--- a/docs/server/configuration/monitoring-configuration.mdx
+++ b/docs/server/configuration/monitoring-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration: Monitoring Options"
-sidebar_label: Monitoring Configuration
+sidebar_label: "Monitoring Configuration"
 description: "Configure RavenDB monitoring endpoints for SNMP and OpenTelemetry, including ports, community strings, and metric export settings."
 sidebar_position: 14
 ---
@@ -12,10 +12,9 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# Configuration: Monitoring Options
 <Admonition type="note" title="">
 
-* In this page:
+* In this article:
     * OpenTelemetry monitoring:  
       [Monitoring.OpenTelemetry.ConsoleExporter](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryconsoleexporter)  
       [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled)  
@@ -36,6 +35,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Protocol](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocolprotocol)  
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Timeout](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocoltimeout)    
       [Monitoring.OpenTelemetry.ServiceInstanceId](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryserviceinstanceid)    
+      [Monitoring.OpenTelemetry.ServiceName](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)    
+      [Monitoring.OpenTelemetry.ServiceNamespace](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)    
     * SNMP monitoring  
       [Monitoring.Snmp.AuthenticationPassword](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpassword)  
       [Monitoring.Snmp.AuthenticationPassword.Secondary](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpasswordsecondary)  
@@ -58,6 +59,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.Disk.ReadStatsDebounceTimeInMs](../../server/configuration/monitoring-configuration.mdx#monitoringdiskreadstatsdebouncetimeinms)  
 
 </Admonition>
+
 ## Monitoring.OpenTelemetry.ConsoleExporter
 
 Indicates if metrics should be exported to the console output.
@@ -247,6 +249,40 @@ OpenTelemetryProtocol timeout value.
   If the public hostname is unavailable, RavenDB will use the node tag as the identifier.
 - **Type**: `string`
 - **Default**: `null`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceName
+
+* Sets the OpenTelemetry **service name**.
+  This value is reported as the `service.name` resource attribute and is used to identify the RavenDB service in observability tools, such as the .NET Aspire dashboard.
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `server`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceNamespace
+
+* Sets the OpenTelemetry **service namespace**.
+  This value is reported as the `service.namespace` resource attribute and is used to group related services together in observability tools.  
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `ravendb`
 - **Scope**: Server-wide only
 
 

--- a/versioned_docs/version-6.2/server/administration/monitoring/open-telemetry.mdx
+++ b/versioned_docs/version-6.2/server/administration/monitoring/open-telemetry.mdx
@@ -11,7 +11,6 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# OpenTelemetry Support
 <Admonition type="note" title="">
 
 * [OpenTelemetry](https://opentelemetry.io) is an open-source observability framework that provides a set of APIs, SDKs, and tools 
@@ -26,10 +25,12 @@ import LanguageContent from "@site/src/components/LanguageContent";
   Learn more [below](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus).
 
 * OpenTelemetry support is provided for RavenDB instances both on-premises and in the cloud.
-* In this page:
+    
+* In this article:
   * [Enabling OpenTelemetry in RavenDB](../../../server/administration/monitoring/open-telemetry.mdx#enabling-opentelemetry-in-ravendb)
   * [RavenDB OpenTelemetry meters](../../../server/administration/monitoring/open-telemetry.mdx#ravendb-opentelemetry-meters)
   * [Server identification in metrics](../../../server/administration/monitoring/open-telemetry.mdx#server-identification-in-metrics)
+  * [Service name and namespace](../../../server/administration/monitoring/open-telemetry.mdx#service-name-and-namespace)
   * [The metric instruments](../../../server/administration/monitoring/open-telemetry.mdx#the-metric-instruments)
   * [Metrics export options](../../../server/administration/monitoring/open-telemetry.mdx#metrics-export-options)
       * [Console](../../../server/administration/monitoring/open-telemetry.mdx#console)
@@ -39,6 +40,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       * [Retrieve data from Prometheus](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus)
 
 </Admonition>
+
 ## Enabling OpenTelemetry in RavenDB
 
 * To enable the OpenTelemetry metrics in RavenDB,  
@@ -119,7 +121,26 @@ RavenDB also supports exposing meters developed by Microsoft for AspNetCore and 
     4. **Initialization Failure**  
        If none of the above options are available, OpenTelemetry will Not be initialized.
 
+## Service name and namespace
 
+* RavenDB's OpenTelemetry metrics are emitted with an OpenTelemetry resource that includes the `service.name` and `service.namespace` attributes.
+  Observability tools, such as the .NET Aspire dashboard, can use these values to identify and group RavenDB metrics.
+
+* By default, RavenDB uses `server` as the service name and `ravendb` as the service namespace.
+
+* These values are configured through RavenDB configuration, not through OpenTelemetry environment variables.  
+  To override these values, use the following configuration keys:  
+    * [Monitoring.OpenTelemetry.ServiceName](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)
+    * [Monitoring.OpenTelemetry.ServiceNamespace](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)
+
+<Admonition type="note" title="">
+
+When RavenDB OpenTelemetry monitoring is enabled by setting
+[Monitoring.OpenTelemetry.Enabled](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) to `true`,  
+the effective service name and service namespace values must not be `null`, empty, or whitespace.  
+Otherwise, the server will fail to start.
+
+</Admonition>
 
 ## The metric instruments
 

--- a/versioned_docs/version-6.2/server/configuration/monitoring-configuration.mdx
+++ b/versioned_docs/version-6.2/server/configuration/monitoring-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration: Monitoring Options"
-sidebar_label: Monitoring Configuration
+sidebar_label: "Monitoring Configuration"
 sidebar_position: 14
 ---
 
@@ -11,10 +11,9 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# Configuration: Monitoring Options
 <Admonition type="note" title="">
 
-* In this page:
+* In this article:
     * OpenTelemetry monitoring:  
       [Monitoring.OpenTelemetry.ConsoleExporter](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryconsoleexporter)  
       [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled)  
@@ -35,6 +34,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Protocol](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocolprotocol)  
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Timeout](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocoltimeout)    
       [Monitoring.OpenTelemetry.ServiceInstanceId](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryserviceinstanceid)    
+      [Monitoring.OpenTelemetry.ServiceName](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)    
+      [Monitoring.OpenTelemetry.ServiceNamespace](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)   
     * SNMP monitoring  
       [Monitoring.Snmp.AuthenticationPassword](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpassword)  
       [Monitoring.Snmp.AuthenticationPassword.Secondary](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpasswordsecondary)  
@@ -57,6 +58,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.Disk.ReadStatsDebounceTimeInMs](../../server/configuration/monitoring-configuration.mdx#monitoringdiskreadstatsdebouncetimeinms)  
 
 </Admonition>
+
 ## Monitoring.OpenTelemetry.ConsoleExporter
 
 Indicates if metrics should be exported to the console output.
@@ -246,6 +248,40 @@ OpenTelemetryProtocol timeout value.
   If the public hostname is unavailable, RavenDB will use the node tag as the identifier.
 - **Type**: `string`
 - **Default**: `null`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceName
+
+* Sets the OpenTelemetry **service name**.
+  This value is reported as the `service.name` resource attribute and is used to identify the RavenDB service in observability tools, such as the .NET Aspire dashboard.
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `server`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceNamespace
+
+* Sets the OpenTelemetry **service namespace**.
+  This value is reported as the `service.namespace` resource attribute and is used to group related services together in observability tools.  
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `ravendb`
 - **Scope**: Server-wide only
 
 

--- a/versioned_docs/version-7.0/server/administration/monitoring/open-telemetry.mdx
+++ b/versioned_docs/version-7.0/server/administration/monitoring/open-telemetry.mdx
@@ -11,7 +11,6 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# OpenTelemetry Support
 <Admonition type="note" title="">
 
 * [OpenTelemetry](https://opentelemetry.io) is an open-source observability framework that provides a set of APIs, SDKs, and tools 
@@ -26,10 +25,12 @@ import LanguageContent from "@site/src/components/LanguageContent";
   Learn more [below](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus).
 
 * OpenTelemetry support is provided for RavenDB instances both on-premises and in the cloud.
-* In this page:
+    
+* In this article:
   * [Enabling OpenTelemetry in RavenDB](../../../server/administration/monitoring/open-telemetry.mdx#enabling-opentelemetry-in-ravendb)
   * [RavenDB OpenTelemetry meters](../../../server/administration/monitoring/open-telemetry.mdx#ravendb-opentelemetry-meters)
   * [Server identification in metrics](../../../server/administration/monitoring/open-telemetry.mdx#server-identification-in-metrics)
+  * [Service name and namespace](../../../server/administration/monitoring/open-telemetry.mdx#service-name-and-namespace)
   * [The metric instruments](../../../server/administration/monitoring/open-telemetry.mdx#the-metric-instruments)
   * [Metrics export options](../../../server/administration/monitoring/open-telemetry.mdx#metrics-export-options)
       * [Console](../../../server/administration/monitoring/open-telemetry.mdx#console)
@@ -39,6 +40,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       * [Retrieve data from Prometheus](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus)
 
 </Admonition>
+
 ## Enabling OpenTelemetry in RavenDB
 
 * To enable the OpenTelemetry metrics in RavenDB,  
@@ -119,7 +121,26 @@ RavenDB also supports exposing meters developed by Microsoft for AspNetCore and 
     4. **Initialization Failure**  
        If none of the above options are available, OpenTelemetry will Not be initialized.
 
+## Service name and namespace
 
+* RavenDB's OpenTelemetry metrics are emitted with an OpenTelemetry resource that includes the `service.name` and `service.namespace` attributes.
+  Observability tools, such as the .NET Aspire dashboard, can use these values to identify and group RavenDB metrics.
+
+* By default, RavenDB uses `server` as the service name and `ravendb` as the service namespace.
+
+* These values are configured through RavenDB configuration, not through OpenTelemetry environment variables.  
+  To override these values, use the following configuration keys:  
+    * [Monitoring.OpenTelemetry.ServiceName](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)
+    * [Monitoring.OpenTelemetry.ServiceNamespace](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)
+
+<Admonition type="note" title="">
+
+When RavenDB OpenTelemetry monitoring is enabled by setting
+[Monitoring.OpenTelemetry.Enabled](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) to `true`,  
+the effective service name and service namespace values must not be `null`, empty, or whitespace.  
+Otherwise, the server will fail to start.
+
+</Admonition>
 
 ## The metric instruments
 

--- a/versioned_docs/version-7.0/server/configuration/monitoring-configuration.mdx
+++ b/versioned_docs/version-7.0/server/configuration/monitoring-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration: Monitoring Options"
-sidebar_label: Monitoring Configuration
+sidebar_label: "Monitoring Configuration"
 sidebar_position: 14
 ---
 
@@ -11,10 +11,9 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# Configuration: Monitoring Options
 <Admonition type="note" title="">
 
-* In this page:
+* In this article:
     * OpenTelemetry monitoring:  
       [Monitoring.OpenTelemetry.ConsoleExporter](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryconsoleexporter)  
       [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled)  
@@ -35,6 +34,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Protocol](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocolprotocol)  
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Timeout](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocoltimeout)    
       [Monitoring.OpenTelemetry.ServiceInstanceId](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryserviceinstanceid)    
+      [Monitoring.OpenTelemetry.ServiceName](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)    
+      [Monitoring.OpenTelemetry.ServiceNamespace](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)   
     * SNMP monitoring  
       [Monitoring.Snmp.AuthenticationPassword](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpassword)  
       [Monitoring.Snmp.AuthenticationPassword.Secondary](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpasswordsecondary)  
@@ -57,6 +58,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.Disk.ReadStatsDebounceTimeInMs](../../server/configuration/monitoring-configuration.mdx#monitoringdiskreadstatsdebouncetimeinms)  
 
 </Admonition>
+
 ## Monitoring.OpenTelemetry.ConsoleExporter
 
 Indicates if metrics should be exported to the console output.
@@ -246,6 +248,40 @@ OpenTelemetryProtocol timeout value.
   If the public hostname is unavailable, RavenDB will use the node tag as the identifier.
 - **Type**: `string`
 - **Default**: `null`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceName
+
+* Sets the OpenTelemetry **service name**.
+  This value is reported as the `service.name` resource attribute and is used to identify the RavenDB service in observability tools, such as the .NET Aspire dashboard.
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `server`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceNamespace
+
+* Sets the OpenTelemetry **service namespace**.
+  This value is reported as the `service.namespace` resource attribute and is used to group related services together in observability tools.  
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `ravendb`
 - **Scope**: Server-wide only
 
 

--- a/versioned_docs/version-7.1/server/administration/monitoring/open-telemetry.mdx
+++ b/versioned_docs/version-7.1/server/administration/monitoring/open-telemetry.mdx
@@ -11,7 +11,6 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# OpenTelemetry Support
 <Admonition type="note" title="">
 
 * [OpenTelemetry](https://opentelemetry.io) is an open-source observability framework that provides a set of APIs, SDKs, and tools 
@@ -26,10 +25,12 @@ import LanguageContent from "@site/src/components/LanguageContent";
   Learn more [below](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus).
 
 * OpenTelemetry support is provided for RavenDB instances both on-premises and in the cloud.
-* In this page:
+    
+* In this article:
   * [Enabling OpenTelemetry in RavenDB](../../../server/administration/monitoring/open-telemetry.mdx#enabling-opentelemetry-in-ravendb)
   * [RavenDB OpenTelemetry meters](../../../server/administration/monitoring/open-telemetry.mdx#ravendb-opentelemetry-meters)
   * [Server identification in metrics](../../../server/administration/monitoring/open-telemetry.mdx#server-identification-in-metrics)
+  * [Service name and namespace](../../../server/administration/monitoring/open-telemetry.mdx#service-name-and-namespace)
   * [The metric instruments](../../../server/administration/monitoring/open-telemetry.mdx#the-metric-instruments)
   * [Metrics export options](../../../server/administration/monitoring/open-telemetry.mdx#metrics-export-options)
       * [Console](../../../server/administration/monitoring/open-telemetry.mdx#console)
@@ -39,6 +40,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       * [Retrieve data from Prometheus](../../../server/administration/monitoring/open-telemetry.mdx#retrieve-data-from-prometheus)
 
 </Admonition>
+
 ## Enabling OpenTelemetry in RavenDB
 
 * To enable the OpenTelemetry metrics in RavenDB,  
@@ -119,7 +121,26 @@ RavenDB also supports exposing meters developed by Microsoft for AspNetCore and 
     4. **Initialization Failure**  
        If none of the above options are available, OpenTelemetry will Not be initialized.
 
+## Service name and namespace
 
+* RavenDB's OpenTelemetry metrics are emitted with an OpenTelemetry resource that includes the `service.name` and `service.namespace` attributes.
+  Observability tools, such as the .NET Aspire dashboard, can use these values to identify and group RavenDB metrics.
+
+* By default, RavenDB uses `server` as the service name and `ravendb` as the service namespace.
+
+* These values are configured through RavenDB configuration, not through OpenTelemetry environment variables.  
+  To override these values, use the following configuration keys:  
+    * [Monitoring.OpenTelemetry.ServiceName](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)
+    * [Monitoring.OpenTelemetry.ServiceNamespace](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)
+
+<Admonition type="note" title="">
+
+When RavenDB OpenTelemetry monitoring is enabled by setting
+[Monitoring.OpenTelemetry.Enabled](../../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) to `true`,  
+the effective service name and service namespace values must not be `null`, empty, or whitespace.  
+Otherwise, the server will fail to start.
+
+</Admonition>
 
 ## The metric instruments
 

--- a/versioned_docs/version-7.1/server/configuration/monitoring-configuration.mdx
+++ b/versioned_docs/version-7.1/server/configuration/monitoring-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration: Monitoring Options"
-sidebar_label: Monitoring Configuration
+sidebar_label: "Monitoring Configuration"
 sidebar_position: 14
 ---
 
@@ -11,10 +11,9 @@ import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
-# Configuration: Monitoring Options
 <Admonition type="note" title="">
 
-* In this page:
+* In this article:
     * OpenTelemetry monitoring:  
       [Monitoring.OpenTelemetry.ConsoleExporter](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryconsoleexporter)  
       [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled)  
@@ -35,6 +34,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Protocol](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocolprotocol)  
       [Monitoring.OpenTelemetry.OpenTelemetryProtocol.Timeout](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryopentelemetryprotocoltimeout)    
       [Monitoring.OpenTelemetry.ServiceInstanceId](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryserviceinstanceid)    
+      [Monitoring.OpenTelemetry.ServiceName](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicename)    
+      [Monitoring.OpenTelemetry.ServiceNamespace](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryservicenamespace)   
     * SNMP monitoring  
       [Monitoring.Snmp.AuthenticationPassword](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpassword)  
       [Monitoring.Snmp.AuthenticationPassword.Secondary](../../server/configuration/monitoring-configuration.mdx#monitoringsnmpauthenticationpasswordsecondary)  
@@ -57,6 +58,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
       [Monitoring.Disk.ReadStatsDebounceTimeInMs](../../server/configuration/monitoring-configuration.mdx#monitoringdiskreadstatsdebouncetimeinms)  
 
 </Admonition>
+
 ## Monitoring.OpenTelemetry.ConsoleExporter
 
 Indicates if metrics should be exported to the console output.
@@ -246,6 +248,40 @@ OpenTelemetryProtocol timeout value.
   If the public hostname is unavailable, RavenDB will use the node tag as the identifier.
 - **Type**: `string`
 - **Default**: `null`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceName
+
+* Sets the OpenTelemetry **service name**.
+  This value is reported as the `service.name` resource attribute and is used to identify the RavenDB service in observability tools, such as the .NET Aspire dashboard.
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `server`
+- **Scope**: Server-wide only
+
+
+
+## Monitoring.OpenTelemetry.ServiceNamespace
+
+* Sets the OpenTelemetry **service namespace**.
+  This value is reported as the `service.namespace` resource attribute and is used to group related services together in observability tools.  
+
+* If [Monitoring.OpenTelemetry.Enabled](../../server/configuration/monitoring-configuration.mdx#monitoringopentelemetryenabled) is set to `true`,
+  the effective value must not be `null`, empty, or whitespace.  
+  Otherwise, the server will fail to start.
+
+---
+
+- **Type**: `string`
+- **Default**: `ravendb`
 - **Scope**: Server-wide only
 
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3930/Allow-to-override-serviceName-in-OpenTelemetry-configuration

### Additional description

* Added the two new configuration keys in `../server/configuration/monitoring-configuration`
* Added a note in `../server/administration/monitoring/open-telemetry`, 
   explaining that the service name and namespace are now configurable. 

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

