### PR TITLE
RDoc-3857 Sitemap should contain only canonical URLs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -115,7 +115,7 @@ const config: Config = {
                     lastmod: "date",
                     changefreq: null,
                     priority: null,
-                    ignorePatterns: LEGACY_VERSIONS.map((v) => `/${v}/**`),
+                    ignorePatterns: [...ACTIVE_VERSIONS, ...LEGACY_VERSIONS].map((v) => `/${v}/**`),
                 },
                 googleTagManager: {
                     containerId: "GTM-TDH4JWF2",


### PR DESCRIPTION
Exclude non-current doc versions (7.1, 6.2, legacy) from the sitemap so it lists only the current canonical version's URLs. Stable `sitemap-docs.xml` naming and splitter cleanup are deferred to [RDoc-3955](https://issues.hibernatingrhinos.com/issue/RDoc-3955/Current-only-docs-sub-sitemap-with-stable-name).
