### PR TITLE
RDoc-3941 [Python] Control order of NULLs directly in query

### DIFF
--- a/docs/client-api/session/querying/content/_how-to-make-a-spatial-query-csharp.mdx
+++ b/docs/client-api/session/querying/content/_how-to-make-a-spatial-query-csharp.mdx
@@ -15,7 +15,7 @@ import Panel from '@site/src/components/Panel';
       An auto-index will be created by the server.  
 
     * **Spatial index query**  
-      Index your documents' spatial data in a static-index (see [indexing spatial data](../../../../indexes/indexing-spatial-data.mdx)) 
+      Index your documents' spatial data in a static-index (see [indexing spatial data](../../../../indexes/indexing-spatial-data.mdx))  
       and then make a spatial query on this index (see [query a spatial index](../../../../indexes/querying/spatial.mdx)).  
 
 * To perform a spatial search,  
@@ -579,7 +579,8 @@ order by spatial.distance(
 <TabItem value="Query" label="Query">
 ```csharp
 // Return all employee entities.
-// Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+// Results are sorted by their distance to a specified point
+// rounded to the nearest 100 km interval.
 // A secondary sort can be applied within the 100 km range, e.g. by field LastName.
 
 List<Employee> employeesSortedByRoundedDistance = session
@@ -602,7 +603,8 @@ List<Employee> employeesSortedByRoundedDistance = session
 <TabItem value="Query_async" label="Query_async">
 ```csharp
 // Return all employee entities.
-// Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+// Results are sorted by their distance to a specified point
+// rounded to the nearest 100 km interval.
 // A secondary sort can be applied within the 100 km range, e.g. by field LastName.
 
 List<Employee> employeesSortedByRoundedDistance = await asyncSession
@@ -625,7 +627,8 @@ List<Employee> employeesSortedByRoundedDistance = await asyncSession
 <TabItem value="DocumentQuery" label="DocumentQuery">
 ```csharp
 // Return all employee entities.
-// Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+// Results are sorted by their distance to a specified point
+// rounded to the nearest 100 km interval.
 // A secondary sort can be applied within the 100 km range, e.g. by field LastName.
 
 List<Employee> employeesSortedByRoundedDistance = session.Advanced
@@ -648,7 +651,8 @@ List<Employee> employeesSortedByRoundedDistance = session.Advanced
 <TabItem value="RQL" label="RQL">
 ```sql
 // Return all employee entities.
-// Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+// Results are sorted by their distance to a specified point
+// rounded to the nearest 100 km interval.
 // A secondary sort can be applied within the 100 km range, e.g. by field LastName.
 
 from Employees
@@ -671,9 +675,9 @@ order by spatial.distance(
     
 * Use:
   * `NullsOrdering.First`  
-    to place documents with `null` or missing spatial values **before** documents with spatial values.
+    to place documents with `null` or missing spatial values **before** documents with non-null spatial values.
   * `NullsOrdering.Last`  
-    to place documents with `null` or missing spatial values **after** documents with spatial values.
+    to place documents with `null` or missing spatial values **after** documents with non-null spatial values.
   * `NullsOrdering.Default`  
     to use the default configuration, which is set by the [Indexing.Querying.Corax.NullsSortMode](../../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) configuration key.
 
@@ -771,7 +775,6 @@ order by spatial.distance(
       To get this metadata property you must set the [Indexing.Corax.IncludeSpatialDistance](../../../../server/configuration/indexing-configuration.mdx#indexingcoraxincludespatialdistance) configuration value to _true_.  
       Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../../server/configuration/indexing-configuration.mdx) article.
 
-<TabItem>
 ```csharp
 // Get the distance of the results:
 // ================================
@@ -786,7 +789,6 @@ var distance = spatialResults["Distance"];   // The distance of the entity from 
 var latitude = spatialResults["Latitude"];   // The entity's latitude value
 var longitude = spatialResults["Longitude"]; // The entity's longitude value
 ```
-</TabItem>
 
 </Panel>
 
@@ -794,7 +796,6 @@ var longitude = spatialResults["Longitude"]; // The entity's longitude value
 
 ### `Spatial`
 
-<TabItem>
 ```csharp
 IRavenQueryable<T> Spatial<T>(
     Expression<Func<T, object>> path,
@@ -812,7 +813,7 @@ IRavenQueryable<T> Spatial<T>(
     DynamicSpatialField field,
     Func<SpatialCriteriaFactory, SpatialCriteria> clause);
 ```
-</TabItem>
+<br/>
 
 | Parameters    | Type                                                                                      | Description                                                                                                              |
 |---------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
@@ -823,7 +824,6 @@ IRavenQueryable<T> Spatial<T>(
     
 ### `DynamicSpatialFieldFactory`
 
-<TabItem>
 ```csharp
 PointField Point(
     Expression<Func<T, object>> latitudePath,
@@ -831,7 +831,7 @@ PointField Point(
 
 WktField Wkt(Expression<Func<T, object>> wktPath);
 ```
-</TabItem>
+<br/>
 
 | Parameters                                         | Type                          | Description                                                                  |
 |----------------------------------------------------|-------------------------------|------------------------------------------------------------------------------|
@@ -839,7 +839,6 @@ WktField Wkt(Expression<Func<T, object>> wktPath);
     
 ### `SpatialCriteriaFactory`
 
-<TabItem>
 ```csharp
 SpatialCriteria RelatesToShape(
     string shapeWkt,
@@ -895,7 +894,7 @@ SpatialCriteria WithinRadius(
     SpatialUnits? radiusUnits = null,
     double distErrorPercent = Constants.Documents.Indexing.Spatial.DefaultDistanceErrorPct);
 ```
-</TabItem>
+<br/> 
 
 | Parameter                                 | Type              | Description                                                                                                                         |
 |-------------------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------|
@@ -907,7 +906,6 @@ SpatialCriteria WithinRadius(
     
 ### `OrderByDistance`
 
-<TabItem>
 ```csharp
 // From point
 IOrderedQueryable<T> OrderByDistance<T>(
@@ -970,11 +968,9 @@ IOrderedQueryable<T> OrderByDistance<T>(
     string shapeWkt,
     double roundFactor);
 ```
-</TabItem>
     
 ### `OrderByDistanceDescending`
 
-<TabItem>
 ```csharp
 // From point
 IOrderedQueryable<T> OrderByDistanceDescending<T>(
@@ -1037,7 +1033,7 @@ IOrderedQueryable<T> OrderByDistanceDescending<T>(
     string shapeWkt,
     double roundFactor);
 ```
-</TabItem>
+<br/>
     
 <Admonition type="note" title="">    
 
@@ -1063,7 +1059,7 @@ IOrderedQueryable<T> OrderByDistanceDescending<T>(
         double longitude,
         double roundFactor,
         NullsOrdering nulls);    
-    ```
+    ```   
         
 </Admonition>    
 

--- a/docs/client-api/session/querying/content/_how-to-make-a-spatial-query-python.mdx
+++ b/docs/client-api/session/querying/content/_how-to-make-a-spatial-query-python.mdx
@@ -1,7 +1,8 @@
 import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
 <Admonition type="note" title="">
 
@@ -13,7 +14,7 @@ import CodeBlock from '@theme/CodeBlock';
       An auto-index will be created by the server.  
 
     * **Spatial index query**  
-      Index your documents' spatial data in a static-index (see [indexing spatial data](../../../../indexes/indexing-spatial-data.mdx)) 
+      Index your documents' spatial data in a static-index (see [indexing spatial data](../../../../indexes/indexing-spatial-data.mdx))  
       and then make a spatial query on this index (see [query a spatial index](../../../../indexes/querying/spatial.mdx)).  
 
 * To perform a spatial search,  
@@ -21,6 +22,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 * When making a dynamic spatial query from Studio,  
   results are also displayed on the global map. See [spatial queries map view](../../../../studio/database/queries/spatial-queries-map-view.mdx).
+    
 * In this article:
 
   * [Search by radius](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#search-by-radius)  
@@ -31,6 +33,7 @@ import CodeBlock from '@theme/CodeBlock';
       * [Order by distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#order-by-distance)
       * [Order by distance descending](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#order-by-distance-descending)
       * [Sort results by rounded distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#sort-results-by-rounded-distance)
+      * [Control null placement when sorting by distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#control-null-placement-when-sorting-by-distance)
       * [Get resulting distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#get-resulting-distance)
   * [Spatial API](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#spatial-api)
       * [`spatial`](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#section)
@@ -40,15 +43,16 @@ import CodeBlock from '@theme/CodeBlock';
       * [`order_by_distance_descending`, `order_by_distance_descending_wkt`](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#section-4)
 
 </Admonition>
-## Search by radius
+
+<Panel heading="Search by radius">
 
 Use the `within_radius` method to search for all documents containing spatial data that is located  
 within the specified distance from the given center point.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`# This query will return all matching employee entities
+```python
+# This query will return all matching employee entities
 # that are located within 20 kilometers radius
 # from point (47.623473 latitude, -122.3060097 longitude).
 
@@ -65,12 +69,11 @@ employees_within_radius = list(
         lambda criteria: criteria.within_radius(20, 47.623473, -122.3060097),
     )
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`// This query will return all matching employee entities
+```sql
+// This query will return all matching employee entities
 // that are located within 20 kilometers radius
 // from point (47.623473 latitude, -122.3060097 longitude).
 
@@ -79,14 +82,13 @@ where spatial.within(
     spatial.point(Address.Location.Latitude, Address.Location.Longitude),
     spatial.circle(20, 47.623473, -122.3060097)
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
+</Panel>
 
-
-## Search by shape
+<Panel heading="Search by shape"> 
 
 * Use the `relates_to_shape` method to search for all documents containing spatial data that is located  
   in the specified relation to the given shape.
@@ -94,12 +96,15 @@ where spatial.within(
 * The shape is specified as either a **circle** or a **polygon** in a [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) format.
 
 * The relation to the shape can be one of: `WITHIN`, `CONTAINS`, `DISJOINT`, `INTERSECTS`.
-#### Circle
+
+---    
+    
+### Circle
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`# This query will return all matching employee entities
+```python
+# This query will return all matching employee entities
 # that are located within 20 kilometers radius
 # from point (47.623473 latitude, -122.3060097 longitude).
 
@@ -122,12 +127,11 @@ employees_within_shape = list(
         ),
     )
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`// This query will return all matching employee entities
+```sql
+// This query will return all matching employee entities
 // that are located within 20 kilometers radius
 // from point (47.623473 latitude, -122.3060097 longitude).
 
@@ -136,16 +140,16 @@ where spatial.within(
     spatial.point(Address.Location.Latitude, Address.Location.Longitude),
     spatial.wkt("CIRCLE(-122.3060097 47.623473 d=20)", "miles")
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
-#### Polygon
+
+### Polygon
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`# This query will return all matching company entities
+```python
+# This query will return all matching company entities
 # that are located within the specified polygon.
 
 # Define a query on Companies collection
@@ -173,12 +177,11 @@ companies_within_shape = list(
         ),
     )
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`// This query will return all matching company entities
+```sql
+// This query will return all matching company entities
 // that are located within the specified polygon.
 
 from companies
@@ -193,8 +196,7 @@ where spatial.within(
         -118.7406746 32.7853769,
         -118.6527948 32.7114894))")
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -208,20 +210,23 @@ where spatial.within(
 
 </Admonition>
 
+</Panel>
 
-
-## Spatial sorting
+<Panel heading="Spatial sorting">  
 
 * Use `order_by_distance` or `order_by_distance_descending` to sort the results by distance from a given point.
 
 * By default, distance is measured by RavenDB in **kilometers**.  
   The distance can be rounded to a specific range.  
+
+---
+    
 #### Order by distance
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`# Return all matching employee entities located within 20 kilometers radius
+```python
+# Return all matching employee entities located within 20 kilometers radius
 # from point (47.623473 latitude, -122.3060097 longitude)
 
 # Sort the results by their distance from a specified point,
@@ -239,12 +244,11 @@ employees_sorted_by_distance = list(
         PointField("Address.Location.Latitude", "Address.Location.Longitude"), 47.623473, -122.3060097
     )
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`// Return all matching employee entities located within 20 kilometers radius
+```sql
+// Return all matching employee entities located within 20 kilometers radius
 // from point (47.623473 latitude, -122.3060097 longitude).
 
 // Sort the results by their distance from a specified point,
@@ -259,16 +263,18 @@ order by spatial.distance(
     spatial.point(Address.Location.Latitude, Address.Location.Longitude),
     spatial.point(47.623473, -122.3060097)
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
+    
+---
+    
 #### Order by distance descending
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`# Return all employee entities sorted by their distance from a specified point.
+```python
+# Return all employee entities sorted by their distance from a specified point.
 # The farthest results will be listed first.
 
 employees_sorted_by_distance_desc = list(
@@ -282,12 +288,11 @@ employees_sorted_by_distance_desc = list(
         -122.3060097,
     )
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`// Return all employee entities sorted by their distance from a specified point.
+```sql
+// Return all employee entities sorted by their distance from a specified point.
 // The farthest results will be listed first.
 
 from Employees
@@ -295,17 +300,20 @@ order by spatial.distance(
     spatial.point(Address.Location.Latitude, Address.Location.Longitude),
     spatial.point(47.623473, -122.3060097)
 ) desc
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
+
+---    
+
 #### Sort results by rounded distance
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`# Return all employee entities.
-# Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+```python
+# Return all employee entities.
+# Results are sorted by their distance to a specified point
+# rounded to the nearest 100 km interval.
 # A secondary sort can be applied within the 100 km range, e.g. by field LastName.
 
 employees_sorted_by_rounded_distance = list(
@@ -323,23 +331,13 @@ employees_sorted_by_rounded_distance = list(
         "LastName"
     )
 )
-
-pass
-
-o:
-gion spatial_7
-spatial(
-self,
-field_name_or_field: Union[str, DynamicSpatialField],
-clause: Callable[[SpatialCriteriaFactory], SpatialCriteria],
-..
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`// Return all employee entities.
-// Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+```sql
+// Return all employee entities.
+// Results are sorted by their distance to a specified point
+// rounded to the nearest 100 km interval.
 // A secondary sort can be applied within the 100 km range, e.g. by field LastName.
 
 from Employees
@@ -348,10 +346,66 @@ order by spatial.distance(
     spatial.point(47.623473, -122.3060097),
     100
 ), LastName
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
+
+---
+    
+#### Control null placement when sorting by distance    
+
+* Some documents may have `null` or missing spatial values.  
+  When sorting by distance with the [Corax](../../../../indexes/search-engine/corax.mdx) search engine,  
+  you can control whether these documents appear first or last in the sorted results.
+
+* Use:
+  * `NullsOrdering.FIRST`  
+    to place documents with `null` or missing spatial values **before** documents with non-null spatial values.
+  * `NullsOrdering.LAST`  
+    to place documents with `null` or missing spatial values **after** documents with non-null spatial values.
+  * `NullsOrdering.DEFAULT`  
+    to use the default configuration, which is set by the [Indexing.Querying.Corax.NullsSortMode](../../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) configuration key.
+
+* The requested null placement is independent of the sorting direction.  
+  For example, `NullsOrdering.LAST` will place documents with `null` or missing spatial values last when using either `order_by_distance` or `order_by_distance_descending`.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```python
+# Return all employee entities sorted by their distance from a specified point.
+# Documents with null or missing spatial values will be placed last.
+
+employees_sorted_by_distance = list(
+    session.query(object_type=Employee)
+    # Call 'order_by_distance'
+    .order_by_distance(
+        # Pass the path to the document fields containing the spatial data
+        PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        # Sort the results by their distance from this point
+        47.623473,
+        -122.3060097,
+        # Place documents with null or missing spatial values last
+        nulls=NullsOrdering.LAST,
+    )
+)
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// Return all employee entities sorted by their distance from a specified point.
+// Documents with null or missing spatial values will be placed last.
+
+from Employees
+order by spatial.distance(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.point(47.623473, -122.3060097)
+) nulls last
+```
+</TabItem>
+</Tabs>
+
+---
+    
 #### Get resulting distance
 
 * The distance is available in the `@spatial` metadata property within each result.
@@ -363,9 +417,8 @@ order by spatial.distance(
       To get this metadata property you must set the [Indexing.Corax.IncludeSpatialDistance](../../../../server/configuration/indexing-configuration.mdx#indexingcoraxincludespatialdistance) configuration value to _true_.  
       Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../../server/configuration/indexing-configuration.mdx) article.
 
-<TabItem value="spatial_4_getDistance" label="spatial_4_getDistance">
-<CodeBlock language="python">
-{`# Get the distance of the results:
+```python
+# Get the distance of the results:
 # ================================
 
 # Call 'get_metadata_for', pass an entity from the resulting employees list
@@ -377,54 +430,49 @@ spatial_results = metadata["@spatial"]
 distance = spatial_results["Distance"]  # The distance of the entity from the queried location
 latitude = spatial_results["Latitude"]  # The entity's latitude value
 longitude = spatial_results["Longitude"]  # The entity's longitude value
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Spatial API">
 
-## Spatial API
+### `spatial`
 
-#### `spatial`
-
-<TabItem value="spatial_7" label="spatial_7">
-<CodeBlock language="python">
-{`def spatial(
+```python
+def spatial(
     self,
     field_name_or_field: Union[str, DynamicSpatialField],
     clause: Callable[[SpatialCriteriaFactory], SpatialCriteria],
 ): ...
-`}
-</CodeBlock>
-</TabItem>
+```    
+<br/>
 
-| Parameters    | Type                                                                                       | Description                                                                                                                |
-|---------------|--------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Parameters              | Type | Description |
+|-------------------------|------|-------------|
 | **field_name_or_field** | `Union[str, DynamicSpatialField]` | `Str` - Path to spatial field in an index (when querying an index)<br/><br/>**-or-**<br/><br/>`DynamicSpatialField` - Object that contains the document's spatial fields, either `PointField` or `WktField`(when making a dynamic query). |
-| **clause**    | `Callable[[SpatialCriteriaFactory], SpatialCriteria]` | Callback taking leverage of SpatialCriteriaFactory that comes as an argument, allowing to build SpatialCriteria. |
-#### `DynamicSpatialField`
+| **clause**              | `Callable[[SpatialCriteriaFactory], SpatialCriteria]` | Callback taking leverage of SpatialCriteriaFactory that comes as an argument, allowing to build SpatialCriteria. |
 
-<TabItem value="spatial_8" label="spatial_8">
-<CodeBlock language="python">
-{`class PointField(DynamicSpatialField):
+### `DynamicSpatialField`
+
+```python
+class PointField(DynamicSpatialField):
     def __init__(self, latitude: str, longitude: str): ...
 
 class WktField(DynamicSpatialField):
     def __init__(self, wkt: str): ...
-`}
-</CodeBlock>
-</TabItem>
+```
+<br/>
 
-| Parameters    | Type  | Description                                               |
-|---------------|-------|-----------------------------------------------------------|
-| **latitude**  | `str` | Path to a document point field that contains the latitude |
+| Parameters    | Type  | Description                                                |
+|---------------|-------|------------------------------------------------------------|
+| **latitude**  | `str` | Path to a document point field that contains the latitude  |
 | **longitude** | `str` | Path to a document point field that contains the longitude |
-| **wkt** | `str` | Path to a document wkt field that contains the WKT string |
-#### `SpatialCriteria`
+| **wkt**       | `str` | Path to a document wkt field that contains the WKT string  |
 
-<TabItem value="spatial_9" label="spatial_9">
-<CodeBlock language="python">
-{`def relates_to_shape(
+### `SpatialCriteria`
+
+```python
+def relates_to_shape(
     self,
     shape_wkt: str,
     relation: SpatialRelation,
@@ -468,9 +516,8 @@ def within_radius(
     radius_units: Optional[SpatialUnits] = None,
     dist_error_percent: Optional[float] = constants.Documents.Indexing.Spatial.DEFAULT_DISTANCE_ERROR_PCT,
 ) -> SpatialCriteria: ...
-`}
-</CodeBlock>
-</TabItem>
+```
+<br/>
 
 | Parameter     | Type  | Description        |
 |---------------|-------|--------------------|
@@ -479,11 +526,11 @@ def within_radius(
 | **units** / **radius_units** | `SpatialUnits` | Determines if circle or shape should be calculated in `KILOMETERS` or `MILES`.<br/>By default, distances are measured in kilometers. |
 | **dist_error_percent** (Optional) | `float` | Maximum distance error tolerance in percents.<br/>**Default: 0.025** |
 | **radius** / **latitude** / **longitude** | `float` | Used to define a radius of a circle |
-#### `order_by_distance`, `order_by_distance_wkt`
 
-<TabItem value="spatial_10" label="spatial_10">
-<CodeBlock language="python">
-{`# From point & rounding
+### `order_by_distance`, `order_by_distance_wkt`
+
+```python
+# From point & rounding
 
 def order_by_distance(
     self,
@@ -491,21 +538,23 @@ def order_by_distance(
     latitude: float,
     longitude: float,
     round_factor: Optional[float] = 0.0,
+    nulls: NullsOrdering = NullsOrdering.DEFAULT,
 ) -> DocumentQuery[_T]: ...
 
 # From center of WKT shape
 
 def order_by_distance_wkt(
-    self, field_or_field_name: Union[str, DynamicSpatialField], shape_wkt: str
+    self,
+    field_or_field_name: Union[str, DynamicSpatialField],
+    shape_wkt: str,
+    nulls: NullsOrdering = NullsOrdering.DEFAULT,
 ) -> DocumentQuery[_T]: ...
-`}
-</CodeBlock>
-</TabItem>
-#### `order_by_distance_descending`, `order_by_distance_descending_wkt`
+```
 
-<TabItem value="spatial_11" label="spatial_11">
-<CodeBlock language="python">
-{`# From point & rounding
+### `order_by_distance_descending`, `order_by_distance_descending_wkt`
+
+```python
+# From point & rounding
 
 def order_by_distance_descending(
     self,
@@ -513,25 +562,27 @@ def order_by_distance_descending(
     latitude: float,
     longitude: float,
     round_factor: Optional[float] = 0.0,
+    nulls: NullsOrdering = NullsOrdering.DEFAULT,
 ) -> DocumentQuery[_T]: ...
 
 # From center of WKT shape
 
 def order_by_distance_descending_wkt(
-    self, field_or_field_name: Union[str, DynamicSpatialField], shape_wkt: str
+    self,
+    field_or_field_name: Union[str, DynamicSpatialField],
+    shape_wkt: str,
+    nulls: NullsOrdering = NullsOrdering.DEFAULT,
 ) -> DocumentQuery[_T]: ...
-`}
-</CodeBlock>
-</TabItem>
+```
+<br/>
 
 | Parameter                    | Type                                                                                       | Description                                                                                                                                                                                                                                                      |
 |------------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **field_or_field_name** | `Union[str, DynamicSpatialField]` |  `Str` - Path to spatial field in an index (when querying an index)<br/><br/>**-or-**<br/><br/>`DynamicSpatialField` - Object that contains the document's spatial fields, either `PointField` or `WktField`(when making a dynamic query). |
+| **field_or_field_name** | `Union[str, DynamicSpatialField]` |  `str` - Path to spatial field in an index (when querying an index)<br/><br/>**-or-**<br/><br/>`DynamicSpatialField` - Object that contains the document's spatial fields, either `PointField` or `WktField`(when making a dynamic query). |
 | **latitude** | `float` | The latitude of the point from which the distance is measured |
 | **longitude** | `float` | The longitude of the point from which the distance is measured |
 | **round_factor** (Optional) | `float` | A distance interval in kilometers.<br/>The distance from the point is rounded up to the nearest interval.<br/>Use `order_by` to apply a secondary sort to results within the same distance interval. |
 | **shape_wkt** | `str` | [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)-based shape used in query criteria |
+| **nulls** (Optional) | `NullsOrdering` | Controls whether documents with `null` or missing spatial values appear first or last in the sorted results.<br/>Possible values: `NullsOrdering.DEFAULT`, `NullsOrdering.FIRST`, `NullsOrdering.LAST`.<br/>Supported only when using [Corax](../../../../indexes/search-engine/corax.mdx). |
 
-
-
-
+</Panel>

--- a/docs/querying/sorting-query-results/content/_sort-query-results-csharp.mdx
+++ b/docs/querying/sorting-query-results/content/_sort-query-results-csharp.mdx
@@ -13,7 +13,7 @@ import Panel from '@site/src/components/Panel';
     * Note: An exception to the above rule is when [Boosting](../../../indexes/boosting.mdx) is involved in the query.  
       Learn more in [Automatic score-based ordering](../../../indexes/boosting.mdx#automatic-score-based-ordering).
 
-* Sorting is applied by the server after the query filtering stage.
+* Sorting is applied by the server after the query filtering stage.  
   Filtering is recommended, as it reduces the number of results RavenDB needs to sort when querying a large dataset.
 
 * Multiple sorting operations can be [chained](../../../querying/sorting-query-results/sort-query-results.mdx#chain-ordering).
@@ -216,7 +216,8 @@ order by UnitsInStock as long desc
   Null placement can be requested when ordering by:  
   * a field
   * a field with an explicit ordering type, e.g. `as long`, `as double`, `as string`
-  * method expressions such as `id()` or `OrderByDistance()` (see [Control null placement when sorting by distance](../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#control-null-placement-when-sorting-by-distance))
+  * method expressions such as `id()` or `OrderByDistance()`  
+    (see [Control null placement when sorting by distance](../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#control-null-placement-when-sorting-by-distance))
 
 * The requested null placement is a per-query, per-sort-clause setting.   
   When using multiple `order by` clauses, each clause can define its own null placement.    
@@ -730,27 +731,25 @@ The score details can be retrieved by either:
 
     * The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:  
 
-<TabItem>
-```csharp
-// Make a query:
-// =============
-
-List<Employee> employees = session
-    .Query<Employee>()
-    .Search(x => x.Notes, "English")
-    .Search(x => x.Notes, "Italian", boost: 10)
-    .ToList();
-
-// Get the score:
-// ==============
-
-// Call 'GetMetadataFor', pass an entity from the resulting employees list
-var metadata = session.Advanced.GetMetadataFor(employees[0]);
-
-// Score is available in the '@index-score' metadata property
-var score = metadata[Constants.Documents.Metadata.IndexScore];
-```
-</TabItem>
+        ```csharp
+        // Make a query:
+        // =============
+        
+        List<Employee> employees = session
+            .Query<Employee>()
+            .Search(x => x.Notes, "English")
+            .Search(x => x.Notes, "Italian", boost: 10)
+            .ToList();
+        
+        // Get the score:
+        // ==============
+        
+        // Call 'GetMetadataFor', pass an entity from the resulting employees list
+        var metadata = session.Advanced.GetMetadataFor(employees[0]);
+        
+        // Score is available in the '@index-score' metadata property
+        var score = metadata[Constants.Documents.Metadata.IndexScore];
+        ```
  
 </Admonition>
 
@@ -1316,7 +1315,6 @@ order by custom(UnitsInStock, "MyCustomSorter")
 
 <Panel heading="Syntax">
 
-<TabItem>
 ```csharp
 // OrderBy overloads:
 IOrderedQueryable<T> OrderBy<T>(string path, OrderingType ordering);
@@ -1354,7 +1352,7 @@ public enum NullsOrdering
     Last,      // place null/missing values AFTER non-null values, regardless of ASC/DESC
 }
 ```
-</TabItem>
+<br/>                                                
 
 | Parameter      | Type                          | Description                                                                                                                                                                                                                                              |
 |----------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/querying/sorting-query-results/content/_sort-query-results-python.mdx
+++ b/docs/querying/sorting-query-results/content/_sort-query-results-python.mdx
@@ -1,7 +1,6 @@
 import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 import ContentFrame from '@site/src/components/ContentFrame';
 import Panel from '@site/src/components/Panel';
 
@@ -13,7 +12,7 @@ import Panel from '@site/src/components/Panel';
     * Note: An exception to the above rule is when [Boosting](../../../indexes/boosting.mdx) is involved in the query.  
       Learn more in [Automatic score-based ordering](../../../indexes/boosting.mdx#automatic-score-based-ordering).
 
-* Sorting is applied by the server after the query filtering stage.
+* Sorting is applied by the server after the query filtering stage.  
   Filtering is recommended, as it reduces the number of results RavenDB needs to sort when querying a large dataset.
 
 * Multiple sorting operations can be [chained](../../../querying/sorting-query-results/sort-query-results.mdx#chain-ordering).
@@ -23,7 +22,10 @@ import Panel from '@site/src/components/Panel';
 
 * In this article:
     * [Order by field value](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-field-value) 
+        * [Order by field value - dynamic query](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-field-value---dynamic-query) 
+        * [Order by field value - querying a static-index ](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-field-value---querying-a-static-index) 
         * [Ordering type](../../../querying/sorting-query-results/sort-query-results.mdx#ordering-type) 
+        * [Control position of null values](../../../querying/sorting-query-results/sort-query-results.mdx#control-position-of-null-values) 
     * [Order by searchable fields](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-searchable-fields)
     * [Order by score](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-score)
         * [Get resulting score](../../../querying/sorting-query-results/sort-query-results.mdx#get-resulting-score)  
@@ -46,34 +48,32 @@ import Panel from '@site/src/components/Panel';
     
 ### Order by field value - dynamic query       
 
-Use `OrderBy` or `OrderByDescending` to order the results by the specified document-field.
+Use `order_by` or `order_by_descending` to order the results by the specified document-field.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
+```python
+products = list(
     session
     # Make a dynamic query on the 'Products' collection
     .query_collection("Products")
     # Apply filtering (optional)
-    .where_greater_than("units_in_stock", 10)
+    .where_greater_than("UnitsInStock", 10)
     # Call 'order_by'
     # Pass the document-field by which to order the results and the ordering type
-    .order_by("units_in_stock", OrderingType.LONG)
+    .order_by("UnitsInStock", OrderingType.LONG)
 )
 
-# Results will be sorted by the 'units_in_stock' value in ascending order,
+# Results will be sorted by the 'UnitsInStock' value in ascending order,
 # with smaller values listed first
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 where UnitsInStock > 10
 order by UnitsInStock as long
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -87,8 +87,8 @@ Use `order_by` or `order_by_descending` to order the results by the specified in
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
+```python
+products = list(
     session
     # Query the index
     .query_index_type(Products_ByUnitsInStock, Products_ByUnitsInStock.IndexEntry)
@@ -100,18 +100,18 @@ Use `order_by` or `order_by_descending` to order the results by the specified in
 
 # Results will be sorted by the 'UnitsInStock' value in descending order,
 # with higher values listed first.
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="Index" label="Index">
-<CodeBlock language="python">
-{`class Products_ByUnitsInStock(AbstractIndexCreationTask):
+```python
+class Products_ByUnitsInStock(AbstractIndexCreationTask):
 
     class IndexEntry:
         def __init__(self, units_in_stock: int = None):
             self.units_in_stock = units_in_stock
 
-        # Handle different casing
+        # Map the index-field 'UnitsInStock' 
+        # to the Python attribute 'units_in_stock'
         @classmethod
         def from_json(cls, json_dict: Dict[str, Any]):
             return cls(json_dict["UnitsInStock"])
@@ -119,16 +119,14 @@ Use `order_by` or `order_by_descending` to order the results by the specified in
     def __init__(self):
         super().__init__()
         self.map = "from p in products select new { UnitsInStock = p.UnitsInStock }"
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index "Products/ByUnitsInStock"
+```sql
+from index "Products/ByUnitsInStock"
 where UnitsInStock > 10
 order by UnitsInStock as long desc
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>    
 
@@ -141,12 +139,152 @@ order by UnitsInStock as long desc
 * By default, the `order_by` methods will determine the `OrderingType` from the property path expression  
   and specify that ordering type in the generated RQL that is sent to the server.  
 
-* E.g. in the above example, ordering by `x => x.units_in_stock` will result in `OrderingType.LONG`  
+* E.g. in the above example, ordering by `"UnitsInStock"` will result in `OrderingType.LONG`
   because that property data type is an integer.
 
 * Different ordering can be forced - see [Force ordering type](../../../querying/sorting-query-results/sort-query-results.mdx#force-ordering-type) below.
 
 </Admonition>
+
+<ContentFrame>
+    
+### Control position of null values     
+
+* When ordering query results, you can specify where documents with `null` values should appear in the sorted results.
+  Null placement can be requested when ordering by:  
+  * a field
+  * a field with an explicit ordering type, e.g. `OrderingType.LONG`, `OrderingType.FLOAT`, `OrderingType.STRING`
+  * method expressions such as `id()` or `order_by_distance()`  
+    (see [Control null placement when sorting by distance](../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#control-null-placement-when-sorting-by-distance))
+
+* The requested null placement is a per-query, per-sort-clause setting.   
+  When using multiple `order by` clauses, each clause can define its own null placement.    
+  Learn more in [Chain ordering](../../../querying/sorting-query-results/sort-query-results.mdx#chain-ordering).     
+    
+* Use `NullsOrdering.FIRST` to place documents with `null` values **before** documents with non-null values.  
+  Use `NullsOrdering.LAST` to place documents with `null` values **after** documents with non-null values.    
+  If no null placement is specified, RavenDB uses the configured default behavior,  
+  which is set by the [Indexing.Querying.Corax.NullsSortMode](../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) configuration key.       
+    
+* The requested null placement is independent of the sorting direction.      
+  The following table summarizes how the null placement modifier affects the sorted results:
+    
+    | RQL clause                             | Result |
+    | -------------------------------------- | ------ |
+    | `order by Name asc nulls first`        | `null` values first, then non-null values in ascending order  |
+    | `order by Name desc nulls first`       | `null` values first, then non-null values in descending order |
+    | `order by Name asc nulls last`         | non-null values in ascending order, then `null` values last   |
+    | `order by Name desc nulls last`        | non-null values in descending order, then `null` values last  |
+    | No `NULLS FIRST` / `NULLS LAST` clause | uses the behavior configured by [Indexing.Querying.Corax.NullsSortMode](../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) |
+    
+* <Admonition type="note" title="">    
+  Requested null placement is supported only when using the [Corax](../../../indexes/search-engine/corax.mdx) search engine.  
+  Issuing a query that contains this clause against a Lucene index will return an `InvalidQueryException`.    
+  </Admonition>
+    
+---    
+    
+Examples:
+    
+**Place null values last**:
+
+The following query orders employees by `FirstName` in ascending order.  
+Employee documents whose `FirstName` field is `null` are placed at the end of the results.
+    
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```python
+employees = list(
+    session.query_collection("Employees", Employee)
+    # Order by 'FirstName' in ascending order,
+    # placing employees with a null 'FirstName' at the end of the results
+    .order_by("FirstName", nulls=NullsOrdering.LAST)
+)
+
+# Results will be sorted by the 'FirstName' value in ascending order.
+# Documents with a null FirstName value will be listed last.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Employees"
+order by FirstName nulls last
+
+// Results will be sorted by the 'FirstName' value in ascending order.
+// Documents with a null FirstName value will be listed last.
+```
+</TabItem>
+</Tabs>
+    
+---
+    
+**Place null values first**:      
+
+The following query orders employees by `FirstName` in descending order.  
+Employee documents whose `FirstName` field is `null` are placed at the beginning of the results.  
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```python
+employees = list(
+    session.query_collection("Employees", Employee)
+    # Order by 'FirstName' in descending order,
+    # placing employees with a null 'FirstName' at the beginning of the results
+    .order_by_descending("FirstName", nulls=NullsOrdering.FIRST)
+)
+
+# Results will be sorted by the 'FirstName' value in descending order.
+# Documents with a null FirstName value will be listed first.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Employees"
+order by FirstName desc nulls first
+
+// Results will be sorted by the 'FirstName' value in descending order.
+// Documents with a null FirstName value will be listed first.
+```
+</TabItem>
+</Tabs> 
+    
+---
+    
+**Use null placement with explicit ordering type**:
+
+The following query orders products by `ReorderLevel` using **numeric** ordering (`OrderingType.LONG`),  
+while placing products whose `ReorderLevel` field is `null` at the end of the results.
+
+This combines two settings in the same `order by` clause:  
+  * the ordering type, which determines how non-null values are compared
+  * the null placement, which determines where `null` values appear in the sorted results    
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```python
+products = list(
+    session.query_collection("Products", Product)
+    # Order by 'ReorderLevel' numerically,
+    # placing products with a null 'ReorderLevel' at the end of the results
+    .order_by("ReorderLevel", OrderingType.LONG, NullsOrdering.LAST)
+)
+
+# Results will be sorted by 'ReorderLevel' as a number (ascending).
+# Documents with a null ReorderLevel value will be listed last.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+order by ReorderLevel as long nulls last
+
+// Results will be sorted by 'ReorderLevel' as a number (ascending).
+// Documents with a null ReorderLevel value will be listed last.
+```
+</TabItem>
+</Tabs>
+    
+</ContentFrame>    
 
 </Panel>
 
@@ -165,8 +303,8 @@ For example, consider the following dynamic query:
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
+```python
+products = list(
     session
     # Make a dynamic query on the 'Products' collection
     .query_collection("Products", Product)
@@ -177,8 +315,7 @@ For example, consider the following dynamic query:
     # Order the results by the original value of field 'Name'.
     .order_by("Name")
 )
-`}
-</CodeBlock>
+```
 </TabItem>   
 <TabItem value="RQL" label="RQL">
 ```sql
@@ -224,8 +361,8 @@ See the following static-index example.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Index" label="Index">
-<CodeBlock language="python">
-{`class Products_BySearchName(AbstractIndexCreationTask):
+```python
+class Products_BySearchName(AbstractIndexCreationTask):
     class IndexEntry:
         def __init__(self, name: str = None, name_for_sorting: str = None):
             # Index-field 'Name' will be configured below for full-text search
@@ -245,22 +382,21 @@ See the following static-index example.
 
         # Configure only the 'Name' index-field for FTS
         self._index("Name", FieldIndexing.SEARCH)
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
+```python
+products = list(
     session
     # Query the index
     .query_index_type(Products_BySearchName, Products_BySearchName.IndexEntry)
     # Call 'search':
     # Pass the index-field that was configured for FTS and the term to search for.
     # Here we search for terms that start with "ch" within index-field 'Name'.
-    .search("name", "ch*")
+    .search("Name", "ch*")
     # Call 'order_by':
     # Pass the other index-field by which to order the results.
-    .order_by("name_for_sorting").of_type(Product)
+    .order_by("NameForSorting").of_type(Product)
 )
 # Running the above query on the NorthWind sample data, ordering by 'NameForSorting' field,
 # we get the following order:
@@ -288,14 +424,13 @@ See the following static-index example.
 # "Teatime Chocolate Biscuits"
 # "Chef Anton's Gumbo Mix"
 # "Jack's New England Clam Chowder"
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
 ```sql
 from index "Products/BySearchName" 
-where search(name, "ch*")
-order by name_for_sorting
+where search(Name, "ch*")
+order by NameForSorting
 ```
 </TabItem>
 </Tabs>
@@ -315,29 +450,27 @@ order by name_for_sorting
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
+```python
+products = list(
     session.query_collection("Products")
     # Apply filtering
-    .where_less_than("units_in_stock", 5)
+    .where_less_than("UnitsInStock", 5)
     .or_else()
-    .where_equals("discontinued", True)
+    .where_equals("Discontinued", True)
     # Call 'order_by_score'
     .order_by_score()
 )
 
 # Results will be sorted by the score value
 # with best matching documents (higher score values) listed first.
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 where UnitsInStock < 5 or Discontinued == true
 order by score()
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -363,24 +496,48 @@ The score details can be retrieved by either:
 
       * When using **Corax**:  
           In order to enhance performance, this metadata property is Not included in the results by default.  
-          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration.mdx#indexingcoraxincludedocumentscore) configuration value to `True`  
+          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration.mdx#indexingcoraxincludedocumentscore) configuration value to `True`.  
           Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../server/configuration/indexing-configuration.mdx) article.
 
+    * The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:  
+
+        ```python
+        # Make a query:
+        # =============
+        
+        employees = list(
+            session.query(object_type=Employee)
+            .search("notes", "English")
+            .or_else()
+            .search("notes", "Italian")
+            .boost(10)
+        )
+        
+        # Get the score:
+        # ==============
+        
+        # Call 'get_metadata_for', pass an entity from the resulting employees list
+        metadata = session.advanced.get_metadata_for(employees[0])
+        
+        # Score is available in the '@index-score' metadata property
+        score = metadata["@index-score"]
+        ```
+ 
 </Admonition>
 
 </Panel>
 
 <Panel heading="Order by random">
 
-* Use `RandomOrdering` to randomize the order of the query results.
+* Use `random_ordering` to randomize the order of the query results.
 
 * An optional seed parameter can be passed.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
-    session.query_collection("Products").where_greater_than("units_in_stock", 10)
+```python
+products = list(
+    session.query_collection("Products").where_greater_than("UnitsInStock", 10)
     # Call 'random_ordering'
     .random_ordering()
     # An optional seed can be passed, e.g.:
@@ -388,17 +545,15 @@ The score details can be retrieved by either:
 )
 
 # Results will be randomly ordered
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 where UnitsInStock > 10
 order by random()
 // order by random(someSeed)
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -419,11 +574,11 @@ order by random()
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`number_of_products_per_category = list(
+```python
+number_of_products_per_category = list(
     session.query_collection("Products", Product)
     # Group by category
-    .group_by("category").select_key("category")
+    .group_by("Category").select_key("Category")
     # Count the number of product documents per category
     .select_count()
     # Order by the count value
@@ -432,17 +587,15 @@ order by random()
 
 # Results will contain the number of Product documents per category
 # ordered by that count in ascending order.
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 group by Category
 order by count() as long
 select key() as "Category", count()
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -454,30 +607,28 @@ select key() as "Category", count()
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`number_of_units_in_stock_per_category = list(
+```python
+number_of_units_in_stock_per_category = list(
     session.query_collection("Products", Product)
     # Group by category
-    .group_by("category").select_key("category")
+    .group_by("Category").select_key("Category")
     # Sum the number of units in stock per category
-    .select_sum(GroupByField("units_in_stock", "sum"))
+    .select_sum(GroupByField("UnitsInStock", "Sum"))
     # Order by the sum value
-    .order_by("sum", OrderingType.LONG)
+    .order_by("Sum", OrderingType.LONG)
 )
 
 # Results will contain the total number of units in stock per category
 # ordered by that number in ascending order.
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 group by Category
 order by Sum as long
 select key() as 'Category', sum(UnitsInStock) as Sum
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -493,8 +644,8 @@ select key() as 'Category', sum(UnitsInStock) as Sum
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="DocumentQuery" label="DocumentQuery">
-<CodeBlock language="python">
-{`recent = list(
+```python
+recent = list(
     session.advanced
     .document_query(object_type=Order)
     # Order by the document's last modification time,
@@ -502,16 +653,14 @@ select key() as 'Category', sum(UnitsInStock) as Sum
     .order_by_descending("@metadata.@last-modified")
     .take(20)
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Orders"
+```sql
+from "Orders"
 order by @metadata.@last-modified desc
 limit 20
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -526,7 +675,7 @@ limit 20
   The following ordering types are available:
 
     * `OrderingType.LONG`
-    * `OrderingType.DOUBLE`
+    * `OrderingType.FLOAT`
     * `OrderingType.ALPHA_NUMERIC`
     * `OrderingType.STRING` (lexicographic ordering)
     
@@ -550,22 +699,20 @@ limit 20
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
-    session.query_collection("products")
-    # Call 'order_by', order by field 'quantity_per_unit'
+```python
+products = list(
+    session.query_collection("Products")
+    # Call 'order_by', order by field 'QuantityPerUnit'
     # Pass a second param, requesting to order the text alphanumerically
-    .order_by("quantity_per_unit", OrderingType.ALPHA_NUMERIC)
+    .order_by("QuantityPerUnit", OrderingType.ALPHA_NUMERIC)
 )
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 order by QuantityPerUnit as alphanumeric
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -577,6 +724,9 @@ order by QuantityPerUnit as alphanumeric
 
 * It is possible to chain multiple orderings in the query.  
   Any combination of secondary sorting is possible as the fields are indexed independently of one another.
+
+* When ordering by a field, each ordering clause can also define its own [null placement](../../../querying/sorting-query-results/sort-query-results.mdx#control-position-of-null-values) (Corax only).  
+  If no null placement is specified for an ordering clause, RavenDB uses the behavior configured by [Indexing.Querying.Corax.NullsSortMode](../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) for that clause.
     
 * **When using the Lucene search engine** -  
   there is no limit on the number of sorting actions that can be chained in a query.  
@@ -587,30 +737,32 @@ order by QuantityPerUnit as alphanumeric
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
-    session.query_collection("Products").where_greater_than("units_in_stock", 10)
-    # Apply the primary sort by 'units_in_stock'
-    .order_by_descending("units_in_stock", OrderingType.LONG)
+```python
+products = list(
+    session.query_collection("Products").where_greater_than("UnitsInStock", 10)
+    # Apply the primary sort by 'UnitsInStock' in descending order,
+    # placing products with a null 'UnitsInStock' at the end of the results
+    .order_by_descending("UnitsInStock", OrderingType.LONG, nulls=NullsOrdering.LAST)
     # Apply a secondary sort by the score
     .order_by_score()
-    # Apply another sort by 'Name'
-    .order_by("name")
+    # Apply another sort by 'Name' in ascending order,
+    # placing products with a null 'Name' at the beginning of each group
+    .order_by("Name", nulls=NullsOrdering.FIRST)
 )
 
-#  Results will be sorted by the 'units_in_stock' value (descending),
-#  then by score,
-#  and then by 'name' (ascending).
-`}
-</CodeBlock>
+# Results will be sorted by the 'UnitsInStock' value in descending order,
+# with null UnitsInStock values listed last.
+# Products that have the same UnitsInStock value will then be sorted by score.
+# Products that have the same UnitsInStock value and same score
+# will then be sorted by 'Name', with null Name values listed first.
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 where UnitsInStock > 10
-order by UnitsInStock as long desc, score(), Name
-`}
-</CodeBlock>
+order by UnitsInStock as long desc nulls last, score(), Name nulls first
+```
 </TabItem>
 </Tabs>
 
@@ -635,28 +787,26 @@ order by UnitsInStock as long desc, score(), Name
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="python">
-{`products = list(
-    session.query(object_type=Product).where_greater_than("units_in_stock", 10)
-    # Order by field 'units_in_stock', pass the name of your custom sorter class
-    .order_by("units_in_stock", "MyCustomSorter")
+```python
+products = list(
+    session.query(object_type=Product).where_greater_than("UnitsInStock", 10)
+    # Order by field 'UnitsInStock', pass the name of your custom sorter class
+    .order_by("UnitsInStock", "MyCustomSorter")
 )
 
-# Results will be sorted by the 'units_in_stock' value
+# Results will be sorted by the 'UnitsInStock' value
 # according to the logic from 'MyCustomSorter' class
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from "Products"
+```sql
+from "Products"
 where UnitsInStock > 10
 order by custom(UnitsInStock, "MyCustomSorter")
     
-# Results will be sorted by the 'units_in_stock' value
+# Results will be sorted by the 'UnitsInStock' value
 # according to the logic from 'MyCustomSorter' class    
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
@@ -678,24 +828,35 @@ order by custom(UnitsInStock, "MyCustomSorter")
 
 <Panel heading="Syntax">
 
-<TabItem>
-<CodeBlock language="python">
-{`# order_by:
+```python
+# order_by:
 def order_by(
-    self, field: str, sorter_name_or_ordering_type: Union[str, OrderingType] = OrderingType.STRING
+    self,
+    field: str,
+    sorter_name_or_ordering_type: Union[str, OrderingType] = OrderingType.STRING,
+    nulls: NullsOrdering = NullsOrdering.DEFAULT,
 ) -> DocumentQuery[_T]: ...
 
 # order_by_descending:
 def order_by_descending(
-    self, field: str, sorter_name_or_ordering_type: Union[str, OrderingType] = OrderingType.STRING
+    self,
+    field: str,
+    sorter_name_or_ordering_type: Union[str, OrderingType] = OrderingType.STRING,
+    nulls: NullsOrdering = NullsOrdering.DEFAULT,
 ) -> DocumentQuery[_T]: ...
-`}
-</CodeBlock>
-</TabItem>
 
-| Parameter      | Type            | Description                                                                                                                                                                |
-|----------------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **field**      | `str`           | The name of the field to sort by                                                                                                                                           |
-| **sorter_name_or_ordering_type** | `Union[str, OrderingType]` | The custom sorter class name<br/>**-or-**<br/>The results sorting ordering type<br/>Can be:<br/>`OrderingType.LONG`<br/>`OrderingType.DOUBLE`<br/>`OrderingType.ALPHA_NUMERIC`<br/>`OrderingType.STRING` (default) |
+# NullsOrdering enum:
+class NullsOrdering(Enum):
+    DEFAULT = "Default"
+    FIRST = "First"
+    LAST = "Last"
+```
+<br/>
+
+| Parameter      | Type            | Description |
+|----------------|-----------------|-------------|
+| **field**      | `str`           | The name of the field to sort by |
+| **sorter_name_or_ordering_type** | `Union[str, OrderingType]` | The custom sorter class name<br/>**-or-**<br/>The results sorting ordering type<br/>Can be:<br/>`OrderingType.LONG`<br/>`OrderingType.FLOAT` (renders as `double` in RQL)<br/>`OrderingType.ALPHA_NUMERIC`<br/>`OrderingType.STRING` (default) |
+| **nulls**      | `NullsOrdering` | Per-clause placement of `null` / missing values ([Corax](../../../indexes/search-engine/corax.mdx) only):<br/>`NullsOrdering.DEFAULT` (use configured default)<br/>`NullsOrdering.FIRST` (nulls before non-nulls)<br/>`NullsOrdering.LAST` (nulls after non-nulls)<br/>Direction-independent: behavior is the same under `ASC` and `DESC`. |
 
 </Panel>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3941/Python-Control-order-of-NULLs-directly-in-query

### Additional description
Apply the C# client updates from https://github.com/ravendb/docs/pull/2454 to the **Python** article.

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

