### PR TITLE
RDoc-3947 [Java] Control order of NULLs directly in query + Update file

### DIFF
--- a/docs/client-api/session/querying/content/_how-to-make-a-spatial-query-java.mdx
+++ b/docs/client-api/session/querying/content/_how-to-make-a-spatial-query-java.mdx
@@ -2,271 +2,631 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
-Spatial indexes can be queried using the `spatial` method which contains a full spectrum of spatial methods. The following article will cover these methods:
+<Admonition type="note" title="">
 
-- [Spatial](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#spatial)
-- [OrderByDistance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#orderbydistance)
-- [OrderByDistanceDescending](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#orderbydistancedescending)
+* Documents that contain spatial data can be queried by spatial queries that employ geographical criteria.  
+  You can use either _Dynamic spatial query_ or _Spatial index query_.  
+  
+    * **Dynamic spatial query**  
+      Make a dynamic spatial query on a collection (described below).  
+      An auto-index will be created by the server.  
 
-## Spatial
+    * **Spatial index query**  
+      Index your documents' spatial data in a static-index (see [indexing spatial data](../../../../indexes/indexing-spatial-data.mdx)) 
+      and then make a spatial query on this index (see [query a spatial index](../../../../indexes/querying/spatial.mdx)).  
 
-<TabItem value="spatial_1" label="spatial_1">
-<CodeBlock language="java">
-{`IDocumentQuery<T> spatial(String fieldName, Function<SpatialCriteriaFactory, SpatialCriteria> clause);
+* To perform a spatial search,  
+  use the `spatial` method, which provides a wide range of spatial functionalities.
 
-IDocumentQuery<T> spatial(DynamicSpatialField field, Function<SpatialCriteriaFactory, SpatialCriteria> clause);
-`}
-</CodeBlock>
+* When making a dynamic spatial query from Studio,  
+  results are also displayed on the global map. See [spatial queries map view](../../../../studio/database/queries/spatial-queries-map-view.mdx).
+    
+* In this article:
+  * [Search by radius](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#search-by-radius)  
+  * [Search by shape](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#search-by-shape)
+      * [Circle](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#circle)
+      * [Polygon](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#polygon)    
+  * [Spatial sorting](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#spatial-sorting)
+      * [Order by distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#order-by-distance)
+      * [Order by distance descending](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#order-by-distance-descending)
+      * [Sort results by rounded distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#sort-results-by-rounded-distance)
+      * [Control null placement when sorting by distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#control-null-placement-when-sorting-by-distance)
+      * [Get resulting distance](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#get-resulting-distance)
+  * [Spatial API](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#spatial-api)
+      * [`spatial`](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#section)
+      * [`DynamicSpatialField`](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#section-1)
+      * [`SpatialCriteriaFactory`](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#section-2)
+      * [`orderByDistance`](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#section-3)
+      * [`orderByDistanceDescending`](../../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#section-4)
+
+</Admonition>
+
+<Panel heading="Search by radius">
+
+Use the `withinRadius` method to search for all documents containing spatial data that is located  
+within the specified distance from the given center point.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+// This query will return all matching employee entities
+// that are located within 20 kilometers radius
+// from point (47.623473 latitude, -122.3060097 longitude).
+
+// Define a dynamic query on Employees collection
+List<Employee> employeesWithinRadius = session
+    .query(Employee.class)
+     // Call 'spatial' method
+    .spatial(
+        // Pass the document fields containing the spatial data
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        // Set the geographical area in which to search for matching documents
+        // Call 'withinRadius', pass the radius and the center points coordinates  
+        criteria -> criteria.withinRadius(20, 47.623473, -122.3060097))
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// This query will return all matching employee entities
+// that are located within 20 kilometers radius
+// from point (47.623473 latitude, -122.3060097 longitude).
+
+from Employees
+where spatial.within(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.circle(20, 47.623473, -122.3060097)
+)
+```
+</TabItem>
+</Tabs>
+
+</Panel>
+
+<Panel heading="Search by shape"> 
+
+* Use the `relatesToShape` method to search for all documents containing spatial data that is located  
+  in the specified relation to the given shape.
+
+* The shape is specified as either a **circle** or a **polygon** in a [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) format.
+
+* The relation to the shape can be one of: `WITHIN`, `CONTAINS`, `DISJOINT`, `INTERSECTS`.
+
+---
+    
+### Circle
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+// This query will return all matching employee entities
+// that are located within 20 kilometers radius
+// from point (47.623473 latitude, -122.3060097 longitude).
+
+// Define a dynamic query on Employees collection
+List<Employee> employeesWithinShape = session
+    .query(Employee.class)
+     // Call 'spatial' method
+    .spatial(
+        // Pass the document fields containing the spatial data
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        // Set the geographical search criteria, call 'relatesToShape'
+        criteria -> criteria.relatesToShape(
+            // Specify the WKT string. Note: longitude is written FIRST
+            "CIRCLE(-122.3060097 47.623473 d=20)",
+            // Specify the relation between the WKT shape and the documents spatial data
+            SpatialRelation.WITHIN,
+            // Optional: customize radius units (default is Kilometers)
+            SpatialUnits.MILES,
+            // Distance error percentage (default is 0.025)
+            0.025))
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// This query will return all matching employee entities
+// that are located within 20 kilometers radius
+// from point (47.623473 latitude, -122.3060097 longitude).
+
+from Employees
+where spatial.within(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.wkt("CIRCLE(-122.3060097 47.623473 d=20)", "miles")
+)
+```
+</TabItem>
+</Tabs>
+
+### Polygon
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+// This query will return all matching company entities
+// that are located within the specified polygon.
+
+// Define a dynamic query on Companies collection
+List<Company> companiesWithinShape = session
+    .query(Company.class)
+     // Call 'spatial' method
+    .spatial(
+        // Pass the document fields containing the spatial data
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        // Set the geographical search criteria, call 'relatesToShape'
+        criteria -> criteria.relatesToShape(
+            // Specify the WKT string
+            "POLYGON ((" +
+            "    -118.6527948 32.7114894," +
+            "    -95.8040242 37.5929338," +
+            "    -102.8344151 53.3349629," +
+            "    -127.5286633 48.3485664," +
+            "    -129.4620208 38.0786067," +
+            "    -118.7406746 32.7853769," +
+            "    -118.6527948 32.7114894" +
+            "))",
+            // Specify the relation between the WKT shape and the documents spatial data
+            SpatialRelation.WITHIN))
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// This query will return all matching company entities
+// that are located within the specified polygon.
+
+from companies
+where spatial.within(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.wkt("POLYGON ((
+        -118.6527948 32.7114894,
+        -95.8040242 37.5929338,
+        -102.8344151 53.3349629,
+        -127.5286633 48.3485664,
+        -129.4620208 38.0786067,
+        -118.7406746 32.7853769,
+        -118.6527948 32.7114894))")
+)
+```
+</TabItem>
+</Tabs>
+
+<Admonition type="info" title="Polygon rules" id="polygon-rules" href="#polygon-rules">
+
+* The polygon's coordinates must be provided in counterclockwise order.
+
+* The first and last coordinates must mark the same location to form a closed region.
+
+![WKT polygon](../assets/spatial_1.png)
+
+</Admonition>
+    
+</Panel>
+
+<Panel heading="Spatial sorting">   
+
+* Use `orderByDistance` or `orderByDistanceDescending` to sort the results by distance from a given point.
+
+* By default, distance is measured by RavenDB in **kilometers**.  
+  The distance can be rounded to a specific range.  
+
+---
+    
+#### Order by distance
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+// Return all matching employee entities located within 20 kilometers radius
+// from point (47.623473 latitude, -122.3060097 longitude).
+
+// Sort the results by their distance from a specified point,
+// the closest results will be listed first.
+
+List<Employee> employeesSortedByDistance = session
+    .query(Employee.class)
+     // Provide the query criteria:
+    .spatial(
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        criteria -> criteria.withinRadius(20, 47.623473, -122.3060097))
+     // Call 'orderByDistance'
+    .orderByDistance(
+        // Pass the document fields containing the spatial data
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        // Sort the results by their distance from this point: 
+        47.623473, -122.3060097)
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// Return all matching employee entities located within 20 kilometers radius
+// from point (47.623473 latitude, -122.3060097 longitude).
+
+// Sort the results by their distance from a specified point,
+// the closest results will be listed first.       
+
+from Employees
+where spatial.within(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.circle(20, 47.623473, -122.3060097)
+)
+order by spatial.distance(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.point(47.623473, -122.3060097)
+)
+```
+</TabItem>
+</Tabs>
+
+---
+    
+#### Order by distance descending
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+// Return all employee entities sorted by their distance from a specified point.
+// The farthest results will be listed first.
+
+List<Employee> employeesSortedByDistanceDesc = session
+    .query(Employee.class)
+     // Call 'orderByDistanceDescending'
+    .orderByDistanceDescending(
+        // Pass the document fields containing the spatial data
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        // Sort the results by their distance (descending) from this point: 
+        47.623473, -122.3060097)
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// Return all employee entities sorted by their distance from a specified point.
+// The farthest results will be listed first.
+
+from Employees
+order by spatial.distance(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.point(47.623473, -122.3060097)
+) desc
+```
+</TabItem>
+</Tabs>
+    
+---    
+
+#### Sort results by rounded distance
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+// Return all employee entities.
+// Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+// A secondary sort can be applied within the 100 km range, e.g. by field LastName.
+
+List<Employee> employeesSortedByRoundedDistance = session
+    .query(Employee.class)
+     // Call 'orderByDistance'
+    .orderByDistance(
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude")
+             // Round up distance to 100 km 
+            .roundTo(100),
+        // Sort the results by their distance from this point: 
+        47.623473, -122.3060097)
+     // A secondary sort can be applied
+    .orderBy("LastName")
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// Return all employee entities.
+// Results are sorted by their distance to a specified point rounded to the nearest 100 km interval.
+// A secondary sort can be applied within the 100 km range, e.g. by field LastName.
+
+from Employees
+order by spatial.distance(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.point(47.623473, -122.3060097),
+    100
+), LastName
+```
+</TabItem>
+</Tabs>
+
+---
+    
+#### Control null placement when sorting by distance    
+
+* Some documents may have `null` or missing spatial values.  
+  When sorting by distance with the [Corax](../../../../indexes/search-engine/corax.mdx) search engine,  
+  you can control whether these documents appear first or last in the sorted results.
+    
+* Use:
+  * `NullsOrdering.FIRST`  
+    to place documents with `null` or missing spatial values **before** documents with spatial values.
+  * `NullsOrdering.LAST`  
+    to place documents with `null` or missing spatial values **after** documents with spatial values.
+  * `NullsOrdering.DEFAULT`  
+    to use the default configuration, which is set by the [Indexing.Querying.Corax.NullsSortMode](../../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) configuration key.
+
+* The requested null placement is independent of the sorting direction.  
+  For example, `NullsOrdering.LAST` will place documents with `null` or missing spatial values last when using either `orderByDistance` or `orderByDistanceDescending`.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+// Return all employee entities sorted by their distance from a specified point.
+// Documents with null or missing spatial values will be placed last.
+
+List<Employee> employeesSortedByDistance = session
+    .query(Employee.class)
+     // Call 'orderByDistance'
+    .orderByDistance(
+        // Pass the document fields containing the spatial data
+        new PointField("Address.Location.Latitude", "Address.Location.Longitude"),
+        // Sort the results by their distance from this point
+        47.623473, -122.3060097,
+        // Place documents with null or missing spatial values last
+        NullsOrdering.LAST)
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+// Return all employee entities sorted by their distance from a specified point.
+// Documents with null or missing spatial values will be placed last.
+
+from Employees
+order by spatial.distance(
+    spatial.point(Address.Location.Latitude, Address.Location.Longitude),
+    spatial.point(47.623473, -122.3060097)
+) nulls last
+```
+</TabItem>
+</Tabs>    
+    
+---
+    
+#### Get resulting distance
+
+* The distance is available in the `@spatial` metadata property within each result.
+* Note the following difference between the underlying search engines:
+    * When using **Lucene**:  
+      This metadata property is always available in the results.
+    * When using **Corax**:  
+      In order to enhance performance, this property is not included in the results by default.  
+      To get this metadata property you must set the [Indexing.Corax.IncludeSpatialDistance](../../../../server/configuration/indexing-configuration.mdx#indexingcoraxincludespatialdistance) configuration value to _true_.  
+      Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../../server/configuration/indexing-configuration.mdx) article.
+
+<TabItem>
+```java
+// Get the distance of the results:
+// ================================
+
+// Call 'getMetadataFor', pass an entity from the resulting employees list
+IMetadataDictionary metadata = session.advanced().getMetadataFor(employeesSortedByDistance.get(0));
+
+// The distance is available in the '@spatial' metadata property
+IMetadataDictionary spatialResults = (IMetadataDictionary) metadata.get("@spatial");
+
+Object distance = spatialResults.get("Distance");   // The distance of the entity from the queried location
+Object latitude = spatialResults.get("Latitude");   // The entity's latitude value
+Object longitude = spatialResults.get("Longitude"); // The entity's longitude value
+```
 </TabItem>
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **fieldName** | String | Path to spatial field in an index |
-| **field** | DynamicSpatialField  | Field that points to a dynamic field (used with auto-indexes). Either `PointField` or `WktField` |
-| **clause** | Function&lt;SpatialCriteriaFactory, SpatialCriteria&gt; | Spatial criteria |
+</Panel>
 
-### DynamicSpatialField  
+<Panel heading="Spatial API">
 
-<TabItem value="spatial_2" label="spatial_2">
-<CodeBlock language="java">
-{`public PointField(String latitude, String longitude)
+### `spatial`
 
-public WktField(String wkt)
-`}
-</CodeBlock>
+<TabItem>
+```java
+IDocumentQuery<T> spatial(
+    String fieldName,
+    Function<SpatialCriteriaFactory, SpatialCriteria> clause);
+
+IDocumentQuery<T> spatial(
+    DynamicSpatialField field,
+    Function<SpatialCriteriaFactory, SpatialCriteria> clause);
+```
 </TabItem>
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **latitude** or **longitude** or **wkt** | String | Path to the field in a document containing either longitude, latitude or WKT |
+| Parameters    | Type                                              | Description                                                                                                              |
+|---------------|---------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| **fieldName** | `String`                                          | Path to spatial field in an index<br/>(when querying an index)                                                            |
+| **field**     | `DynamicSpatialField`                             | Field that points to a document field<br/>(when making a dynamic query).<br/>Either `PointField` or `WktField`.            |
+| **clause**    | `Function<SpatialCriteriaFactory, SpatialCriteria>` | Spatial criteria that will be executed on a given spatial field                                                          |
+    
+### `DynamicSpatialField`
 
-### SpatialCriteriaFactory
+<TabItem>
+```java
+public PointField(String latitude, String longitude);
 
-<TabItem value="spatial_3" label="spatial_3">
-<CodeBlock language="java">
-{`SpatialCriteria relatesToShape(String shapeWkt, SpatialRelation relation);
+public WktField(String wkt);
+```
+</TabItem>
+
+| Parameters                                 | Type     | Description                                                                  |
+|--------------------------------------------|----------|------------------------------------------------------------------------------|
+| **latitude** / **longitude** / **wkt**     | `String` | Path to the field in a document containing either longitude, latitude or WKT |
+    
+### `SpatialCriteriaFactory`
+
+<TabItem>
+```java
+SpatialCriteria relatesToShape(String shapeWkt, SpatialRelation relation);
 
 SpatialCriteria relatesToShape(String shapeWkt, SpatialRelation relation, double distErrorPercent);
 
+SpatialCriteria relatesToShape(String shapeWkt, SpatialRelation relation, SpatialUnits units, double distErrorPercent);
+
 SpatialCriteria intersects(String shapeWkt);
 
-SpatialCriteria intersects(String shapeWkt, double distErrorPercent) ;
+SpatialCriteria intersects(String shapeWkt, double distErrorPercent);
+
+SpatialCriteria intersects(String shapeWkt, SpatialUnits units);
+
+SpatialCriteria intersects(String shapeWkt, SpatialUnits units, double distErrorPercent);
 
 SpatialCriteria contains(String shapeWkt);
 
 SpatialCriteria contains(String shapeWkt, double distErrorPercent);
 
+SpatialCriteria contains(String shapeWkt, SpatialUnits units);
+
+SpatialCriteria contains(String shapeWkt, SpatialUnits units, double distErrorPercent);
+
 SpatialCriteria disjoint(String shapeWkt);
 
 SpatialCriteria disjoint(String shapeWkt, double distErrorPercent);
 
+SpatialCriteria disjoint(String shapeWkt, SpatialUnits units);
+
+SpatialCriteria disjoint(String shapeWkt, SpatialUnits units, double distErrorPercent);
+
 SpatialCriteria within(String shapeWkt);
 
 SpatialCriteria within(String shapeWkt, double distErrorPercent);
+
+SpatialCriteria within(String shapeWkt, SpatialUnits units);
+
+SpatialCriteria within(String shapeWkt, SpatialUnits units, double distErrorPercent);
 
 SpatialCriteria withinRadius(double radius, double latitude, double longitude);
 
 SpatialCriteria withinRadius(double radius, double latitude, double longitude, SpatialUnits radiusUnits);
 
 SpatialCriteria withinRadius(double radius, double latitude, double longitude, SpatialUnits radiusUnits, double distErrorPercent);
-`}
-</CodeBlock>
+```
 </TabItem>
 
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **shapeWkt** | String | [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)-based shape to be used in operation |
-| **relation** | SpatialRelation | Shape relation. Can be `WITHIN`, `CONTAINS`, `DISJOINT`, `INTERSECTS` |
-| **distErrorPercent** | double | Maximum distance error tolerance in percents. Default: 0.025 |
-| **radius** or **latitude** or **longitude** | double | Used to define a radius circle |
-| **radiusUnits** | SpatialUnits | Determines if circle should be calculated in `KILOMETERS` or `MILES` units |
+| Parameter                                 | Type              | Description                                                                                                                         |
+|-------------------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| **shapeWkt**                              | `String`          | [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)-based shape used in query criteria                  |
+| **relation**                              | `SpatialRelation` | Relation of the shape to the spatial data in the document/index.<br/>Can be `WITHIN`, `CONTAINS`, `DISJOINT`, `INTERSECTS`.          |
+| **distErrorPercent**                      | `double`          | Maximum distance error tolerance in percents. Default: 0.025                                                                        |
+| **radius** / **latitude** / **longitude** | `double`          | Used to define a radius of a circle                                                                                                 |
+| **radiusUnits** / **units**               | `SpatialUnits`    | Determines if circle or shape should be calculated in `KILOMETERS` or `MILES`.<br/>By default, distances are measured in kilometers. |
+    
+### `orderByDistance`
 
-<Admonition type="info" title="Polygons" id="polygons" href="#polygons">
-When using `spatial.wkt()` to define a **polygon**, the vertices (points that form the corners of the polygon) must be listed 
-in a counter-clockwise order:  
+<TabItem>
+```java
+// From point
+IDocumentQuery<T> orderByDistance(
+    DynamicSpatialField field,
+    double latitude,
+    double longitude);
 
+IDocumentQuery<T> orderByDistance(
+    String fieldName,
+    double latitude,
+    double longitude);
 
+// From center of WKT shape
+IDocumentQuery<T> orderByDistance(
+    DynamicSpatialField field,
+    String shapeWkt);
 
-![NoSQL DB - Query a Spatial Index](../assets/spatial_1.png)
-</Admonition>
+IDocumentQuery<T> orderByDistance(
+    String fieldName,
+    String shapeWkt);
 
-### Example I
+// Rounding
+IDocumentQuery<T> orderByDistance(
+    String fieldName,
+    double latitude,
+    double longitude,
+    double roundFactor);
 
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`// return all matching entities
-// within 10 kilometers radius
-// from 32.1234 latitude and 23.4321 longitude coordinates
-List<House> results = session
-    .query(House.class)
-    .spatial(
-        new PointField("latitude", "longitude"),
-        f -> f.withinRadius(10, 32.1234, 23.4321))
-    .toList();
-`}
-</CodeBlock>
+IDocumentQuery<T> orderByDistance(
+    String fieldName,
+    String shapeWkt,
+    double roundFactor);
+```
 </TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from Houses
-where spatial.within(spatial.point(Latitude, Longitude), spatial.circle(10, 32.1234. 23.4321))
-`}
-</CodeBlock>
+    
+### `orderByDistanceDescending`
+
+<TabItem>
+```java
+// From point
+IDocumentQuery<T> orderByDistanceDescending(
+    DynamicSpatialField field,
+    double latitude,
+    double longitude);
+
+IDocumentQuery<T> orderByDistanceDescending(
+    String fieldName,
+    double latitude,
+    double longitude);
+
+// From center of WKT shape
+IDocumentQuery<T> orderByDistanceDescending(
+    DynamicSpatialField field,
+    String shapeWkt);
+
+IDocumentQuery<T> orderByDistanceDescending(
+    String fieldName,
+    String shapeWkt);
+
+// Rounding
+IDocumentQuery<T> orderByDistanceDescending(
+    String fieldName,
+    double latitude,
+    double longitude,
+    double roundFactor);
+
+IDocumentQuery<T> orderByDistanceDescending(
+    String fieldName,
+    String shapeWkt,
+    double roundFactor);
+```
 </TabItem>
-</Tabs>
+    
+<Admonition type="note" title="">    
 
-### Example II
+* Each `orderByDistance` and `orderByDistanceDescending` overload has a matching overload that accepts a `NullsOrdering nulls` parameter.
+    
+* When using the Corax search engine, use this parameter to control whether documents with `null` or missing spatial values appear first or last in the sorted results.
+  
+* The `nulls` parameter is added as the **last** parameter in the method signature.  
+  For example:
+    
+    ```java
+    // Existing overload:
+    IDocumentQuery<T> orderByDistance(
+        String fieldName,
+        double latitude,
+        double longitude,
+        double roundFactor);
+    
+    // Matching overload with null placement:
+    IDocumentQuery<T> orderByDistance(
+        String fieldName,
+        double latitude,
+        double longitude,
+        double roundFactor,
+        NullsOrdering nulls);    
+    ```
+        
+</Admonition>    
 
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`// return all matching entities
-// within 10 kilometers radius
-// from 32.1234 latitude and 23.4321 longitude coordinates
-// this equals to WithinRadius(10, 32.1234, 23.4321)
-List<House> results = session
-    .query(House.class)
-    .spatial(
-        new PointField("latitude", "longitude"),
-        f -> f.relatesToShape("Circle(32.1234 23.4321 d=10.0000)", SpatialRelation.WITHIN)
-    )
-    .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from Houses
-where spatial.within(spatial.point(Latitude, Longitude), spatial.wkt('Circle(32.1234 23.4321 d=10.0000)'))
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
-
-
-
-## OrderByDistance
-
-To sort by distance from given point use the `orderByDistance` method. The closest results will come first.
-
-<TabItem value="spatial_6" label="spatial_6">
-<CodeBlock language="java">
-{`IDocumentQuery<T> orderByDistance(DynamicSpatialField field, double latitude, double longitude);
-
-IDocumentQuery<T> orderByDistance(DynamicSpatialField field, String shapeWkt);
-
-IDocumentQuery<T> orderByDistance(String fieldName, double latitude, double longitude);
-
-IDocumentQuery<T> orderByDistance(String fieldName, String shapeWkt);
-`}
-</CodeBlock>
-</TabItem>
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **fieldName** | String | Path to spatial field in index |
-| **field** | DynamicSpatialField | Field that points to a dynamic field (used with auto-indexes). Either `PointField` or `WktField` |
-| **shapeWkt** | String | [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)-based shape to be used as a point from which distance will be measured. If the shape is not a single point, then the center of the shape will be used as a reference. |
-| **latitude** or **longitude** | double | Used to define a point from which distance will be measured |
-
-### Example
-
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`// return all matching entities
-// within 10 kilometers radius
-// from 32.1234 latitude and 23.4321 longitude coordinates
-// sort results by distance from 32.1234 latitude and 23.4321 longitude point
-List<House> results = session
-    .query(House.class)
-    .spatial(
-        new PointField("latitude", "longitude"),
-        f -> f.withinRadius(10, 32.1234, 23.4321)
-    )
-    .orderByDistance(
-        new PointField("latitude", "longtude"),
-        32.12324, 23.4321)
-    .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from Houses
-where spatial.within(spatial.point(Latitude, Longitude), spatial.circle(10, 32.1234. 23.4321))
-order by spatial.distance(spatial.point(Latitude, Longitude), spatial.point(32.1234, 23.4321))
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
-
-
-
-## OrderByDistanceDescending
-
-To sort by distance from given point use the `OrderByDistanceDescending` method. The farthest results will come first.
-
-<TabItem value="spatial_8" label="spatial_8">
-<CodeBlock language="java">
-{`IDocumentQuery<T> orderByDistanceDescending(DynamicSpatialField field, double latitude, double longitude);
-
-IDocumentQuery<T> orderByDistanceDescending(DynamicSpatialField field, String shapeWkt);
-
-IDocumentQuery<T> orderByDistanceDescending(String fieldName, double latitude, double longitude);
-
-IDocumentQuery<T> orderByDistanceDescending(String fieldName, String shapeWkt);
-`}
-</CodeBlock>
-</TabItem>
-
-| Parameters | | |
-| ------------- | ------------- | ----- |
-| **fieldName** | String | Path to spatial field in index |
-| **field** | DynamicSpatialField | Field that points to a dynamic field (used with auto-indexes). Either `PointField` or `WktField` |
-| **shapeWkt** | String | WKT-based shape to be used as a point from which distance will be measured. If the shape is not a single point, then the center of the shape will be used as a reference. |
-| **latitude** or **longitude** | double | Used to define a point from which distance will be measured |
-
-### Example
-
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`// return all matching entities
-// within 10 kilometers radius
-// from 32.1234 latitude and 23.4321 longitude coordinates
-// sort results by distance from 32.1234 latitude and 23.4321 longitude point
-List<House> results = session
-    .query(House.class)
-    .spatial(
-        new PointField("latitude", "longitude"),
-        f -> f.withinRadius(10, 32.1234, 23.4321)
-    )
-    .orderByDistanceDescending(
-        new PointField("latitude", "longtude"),
-        32.12324, 23.4321)
-    .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from Houses
-where spatial.within(spatial.point(Latitude, Longitude), spatial.circle(10, 32.1234. 23.4321))
-order by spatial.distance(spatial.point(Latitude, Longitude), spatial.point(32.1234, 23.4321)) desc
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
-
-
-
-## Remarks
-
-<Admonition type="note" title="">
-By default, distances are measured in **kilometers**.
-</Admonition>
-
-
+| Parameter                    | Type                  | Description                                                                                                                                                                                                                                            |
+|------------------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **fieldName**                | `String`              | Path to spatial field in index<br/>(when querying an index)                                                                                                                                                                                            |
+| **field**                    | `DynamicSpatialField` | Field that points to a document field<br/>(when making a dynamic query).<br/>Either `PointField` or `WktField`.                                                                                                                                       |
+| **shapeWkt**                 | `String`              | [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)-based shape to be used as a point from which distance will be measured. If the shape is not a single point, then the center of the shape will be used as a reference.  |
+| **latitude** / **longitude** | `double`              | Used to define a point from which distance will be measured                                                                                                                                                                                            |
+| **roundFactor**              | `double`              | A distance interval in kilometers.<br/>The distance from the point is rounded up to the nearest interval.<br/>Use `orderBy` to apply a secondary sort to results within the same distance interval.                                                    |
+| **nulls**                    | `NullsOrdering`       | Optional. Controls whether documents with `null` or missing spatial values appear first or last in the sorted results.<br/>Possible values: `NullsOrdering.DEFAULT`, `NullsOrdering.FIRST`, `NullsOrdering.LAST`.<br/>Supported only when using Corax. |        
+    
+</Panel>

--- a/docs/querying/sorting-query-results/content/_sort-query-results-java.mdx
+++ b/docs/querying/sorting-query-results/content/_sort-query-results-java.mdx
@@ -2,375 +2,895 @@ import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
-## Basics
+<Admonition type="note" title="">
 
-Starting from RavenDB 4.0, the server will determine possible sorting capabilities automatically from the indexed value,  
-but sorting will **not be applied** until you request it by using the appropriate methods.  
-The following queries will not return ordered results:
+* When making a query, the server will return the results **sorted** only if explicitly requested by the query.  
+  If no sorting method is specified when issuing the query, results will not be sorted.
 
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`List<Product> results = session
-    .query(Product.class, Products_ByUnitsInStock.class)
-    .whereGreaterThan("UnitsInStock", 10)
-    .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
-    public Products_ByUnitsInStock() {
-        map = "docs.Products.Select(product => new {" +
-            "    UnitsInStock = product.UnitsInStock" +
-            "})";
-    }
-}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByUnitsInStock' 
-where UnitsInStock > 10
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
+    * Note: An exception to the above rule is when [Boosting](../../../indexes/boosting.mdx) is involved in the query.  
+      Learn more in [Automatic score-based ordering](../../../indexes/boosting.mdx#automatic-score-based-ordering).
 
-To start sorting, we need to request to order by some specified index field. In our case we will order by `UnitsInStock` in descending order:
+* Sorting is applied by the server after the query filtering stage.
+  Filtering is recommended, as it reduces the number of results RavenDB needs to sort when querying a large dataset.
 
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`List<Product> results = session
-    .query(Product.class, Products_ByUnitsInStock.class)
-    .whereGreaterThan("UnitsInStock", 10)
-    .orderByDescending("UnitsInStock")
-    .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
-    public Products_ByUnitsInStock() {
-        map = "docs.Products.Select(product => new {" +
-            "    UnitsInStock = product.UnitsInStock" +
-            "})";
-    }
-}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByUnitsInStock' 
-where UnitsInStock > 10
-order by UnitsInStock as long desc
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
-
-<Admonition type="info" title="Forcing ordering type" id="forcing-ordering-type" href="#forcing-ordering-type">
-
-By default, `orderBy` methods will determine `orderingType` from the property path expression (e.g. `x => x.unitsInStock` will result in `OrderingType.LONG` because property type is an integer), but a different ordering can be forced by passing `OrderingType` explicitly to one of the `orderBy` methods.
-
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`List<Product> results = session
-    .query(Product.class, Products_ByUnitsInStock.class)
-    .whereGreaterThan("UnitsInStock", 10)
-    .orderByDescending("UnitsInStock", OrderingType.STRING)
-    .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
-    public Products_ByUnitsInStock() {
-        map = "docs.Products.Select(product => new {" +
-            "    UnitsInStock = product.UnitsInStock" +
-            "})";
-    }
-}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByUnitsInStock' 
-where UnitsInStock > 10
-order by UnitsInStock desc
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
+* Multiple sorting operations can be [chained](../../../querying/sorting-query-results/sort-query-results.mdx#chain-ordering).
+    
+* All sorting capabilities available for **dynamic queries** can also be used when querying a **static-index**.  
+  The same syntax used with dynamic queries also applies when querying indexes.
+    
+* In this article:
+    * [Order by field value](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-field-value) 
+        * [Order by field value - dynamic query](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-field-value---dynamic-query) 
+        * [Order by field value - querying a static-index ](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-field-value---querying-a-static-index) 
+        * [Ordering type](../../../querying/sorting-query-results/sort-query-results.mdx#ordering-type) 
+        * [Control position of null values](../../../querying/sorting-query-results/sort-query-results.mdx#control-position-of-null-values) 
+    * [Order by searchable fields](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-searchable-fields)
+    * [Order by score](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-score)
+        * [Get resulting score](../../../querying/sorting-query-results/sort-query-results.mdx#get-resulting-score)  
+    * [Order by random](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-random)   
+    * [Order by spatial](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-spatial)     
+    * [Order by count (aggregation query)](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-count-aggregation-query)  
+    * [Order by sum (aggregation query)](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-sum-aggregation-query)
+    * [Order by metadata](../../../querying/sorting-query-results/sort-query-results.mdx#order-by-metadata)
+    * [Force ordering type](../../../querying/sorting-query-results/sort-query-results.mdx#force-ordering-type)
+    * [Chain ordering](../../../querying/sorting-query-results/sort-query-results.mdx#chain-ordering)
+    * [Custom sorters](../../../querying/sorting-query-results/sort-query-results.mdx#custom-sorters)
+    * [Performance notes](../../../querying/sorting-query-results/sort-query-results.mdx#performance-notes)
+    * [Syntax](../../../querying/sorting-query-results/sort-query-results.mdx#syntax)
 
 </Admonition>
 
-## Ordering by Score
+<Panel heading="Order by field value">
+    
+<ContentFrame>
+    
+### Order by field value - dynamic query    
 
-When a query is issued, each index entry is scored by Lucene (you can read more about Lucene scoring [here](http://lucene.apache.org/core/3_3_0/scoring.html)).  
-This value is available in metadata information of the resulting query documents under `@index-score` (the higher the value, the better the match).  
-To order by this value you can use the `orderByScore` or the `orderByScoreDescending` methods:
-
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`List<Product> results = session
-    .query(Product.class, Products_ByUnitsInStock.class)
-    .whereGreaterThan("UnitsInStock", 10)
-    .orderByScore()
-    .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
-    public Products_ByUnitsInStock() {
-        map = "docs.Products.Select(product => new {" +
-            "    UnitsInStock = product.UnitsInStock" +
-            "})";
-    }
-}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByUnitsInStock' 
-where UnitsInStock > 10
-order by score()
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
-
-## Chaining Orderings
-
-It is also possible to chain multiple orderings of the query results. 
-You can sort the query results first by some specified index field (or by the `@index-score`), then sort all the equal entries by some different index field (or the `@index-score`).  
-This can be achieved by using the `thenBy` (`thenByDescending`) and `thenByScore` (`thenByScoreDescending`) methods.
+Use `orderBy` or `orderByDescending` to order the results by the specified document-field.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="java">
-{`List<Product> results = session
-    .query(Product.class, Products_ByUnitsInStockAndName.class)
+```java
+List<Product> products = session
+     // Make a dynamic query on the 'Products' collection    
+    .query(Product.class)
+     // Apply filtering (optional)
     .whereGreaterThan("UnitsInStock", 10)
-    .orderBy("UnitsInStock")
-    .orderByScore()
-    .orderByDescending("Name")
+     // Call 'orderBy'
+     // Pass the document-field by which to order the results and the ordering type
+    .orderBy("UnitsInStock", OrderingType.LONG)
     .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByUnitsInStockAndName extends AbstractIndexCreationTask {
-    public Products_ByUnitsInStockAndName() {
-        map = "docs.Products.Select(product => new {" +
-            "    UnitsInStock = product.UnitsInStock" +
-            "    Name = product.Name" +
-            "})";
-    }
-}
-`}
-</CodeBlock>
+
+// Results will be sorted by the 'UnitsInStock' value in ascending order,
+// with smaller values listed first.
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByUnitsInStockAndName' 
+```sql
+from "Products"
 where UnitsInStock > 10
-order by UnitsInStock, score(), Name desc
-`}
-</CodeBlock>
+order by UnitsInStock as long
+```
 </TabItem>
 </Tabs>
 
-## Random Ordering
-
-If you want to randomize the order of your results each time the query is executed, use the `randomOrdering` method (API reference [here](../../../querying/customize-query.mdx#randomordering)):
+</ContentFrame>
+    
+<ContentFrame>
+    
+### Order by field value - querying a static-index 
+    
+Use `orderBy` or `orderByDescending` to order the results by the specified index-field.
 
 <Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`List<Product> results = session
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+     // Query the index
     .query(Product.class, Products_ByUnitsInStock.class)
-    .randomOrdering()
+     // Apply filtering (optional)
     .whereGreaterThan("UnitsInStock", 10)
+     // Call 'orderByDescending', pass the index-field by which to order the results
+    .orderByDescending("UnitsInStock", OrderingType.LONG)
     .toList();
-`}
-</CodeBlock>
+
+// Results will be sorted by the 'UnitsInStock' value in descending order,
+// with higher values listed first.
+```
 </TabItem>
 <TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
+```java
+public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
     public Products_ByUnitsInStock() {
         map = "docs.Products.Select(product => new {" +
             "    UnitsInStock = product.UnitsInStock" +
             "})";
     }
 }
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByUnitsInStock' 
+```sql
+from index "Products/ByUnitsInStock"
 where UnitsInStock > 10
-order by random()
-`}
-</CodeBlock>
+order by UnitsInStock as long desc
+```
+</TabItem>
+</Tabs>    
+    
+</ContentFrame>
+    
+<Admonition type="info" title="">
+
+### Ordering Type
+
+* If no ordering type is specified in the query, the field name is sent without a type and the server applies its default (lexicographical) ordering. 
+
+* In the above example, the ordering type was set to `OrderingType.LONG`.
+
+* Different ordering can be forced - see [Force ordering type](../../../querying/sorting-query-results/sort-query-results.mdx#force-ordering-type) below.
+
+</Admonition>
+    
+<ContentFrame>
+    
+### Control position of null values     
+
+* When ordering query results, you can specify where documents with `null` values should appear in the sorted results.
+  Null placement can be requested when ordering by:  
+  * a field
+  * a field with an explicit ordering type, e.g. `as long`, `as double`, `as string`
+  * method expressions such as `id()` or `orderByDistance()`  
+   (see [Control null placement when sorting by distance](../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#control-null-placement-when-sorting-by-distance))
+
+* The requested null placement is a per-query, per-sort-clause setting.   
+  When using multiple `order by` clauses, each clause can define its own null placement.    
+  Learn more in [Chain ordering](../../../querying/sorting-query-results/sort-query-results.mdx#chain-ordering).     
+    
+* Use `NullsOrdering.FIRST` to place documents with `null` values **before** documents with non-null values.  
+  Use `NullsOrdering.LAST` to place documents with `null` values **after** documents with non-null values.    
+  If no null placement is specified, RavenDB uses the configured default behavior,  
+  which is set by the [Indexing.Querying.Corax.NullsSortMode](../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) configuration key.       
+    
+* The requested null placement is independent of the sorting direction.      
+  The following table summarizes how the null placement modifier affects the sorted results:
+    
+    | RQL clause                             | Result |
+    | -------------------------------------- | ------ |
+    | `order by Name asc nulls first`        | `null` values first, then non-null values in ascending order  |
+    | `order by Name desc nulls first`       | `null` values first, then non-null values in descending order |
+    | `order by Name asc nulls last`         | non-null values in ascending order, then `null` values last   |
+    | `order by Name desc nulls last`        | non-null values in descending order, then `null` values last  |
+    | No `NULLS FIRST` / `NULLS LAST` clause | uses the behavior configured by [Indexing.Querying.Corax.NullsSortMode](../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) |
+    
+* <Admonition type="note" title="">    
+  Requested null placement is supported only when using the [Corax](../../../indexes/search-engine/corax.mdx) search engine.  
+  Issuing a query that contains this clause against a Lucene index will return an `InvalidQueryException`.    
+  </Admonition>
+    
+---    
+    
+Examples:
+    
+**Place null values last**:
+
+The following query orders employees by `FirstName` in ascending order.  
+Employee documents whose `FirstName` field is `null` are placed at the end of the results.
+    
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<Employee> employees = session
+    .query(Employee.class)
+     // Order by 'FirstName' as a string in ascending order,
+     // placing employees with a null 'FirstName' at the end of the results
+    .orderBy("FirstName", NullsOrdering.LAST, OrderingType.STRING)
+    .toList();
+
+// Results will be sorted by the 'FirstName' value in ascending order.
+// Documents with a null FirstName value will be listed last.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Employees"
+order by FirstName nulls last
+    
+// Results will be sorted by the 'FirstName' value in ascending order.
+// Documents with a null FirstName value will be listed last.    
+```
 </TabItem>
 </Tabs>
+    
+---
+    
+**Place null values first**:      
 
-## Ordering When a Field is Searchable
-
-When sorting must be done on field that is [Searchable](../../../indexes/using-analyzers.mdx), due to [Lucene](https://lucene.apache.org/) limitations sorting on such a field is not supported. To overcome this, create another field that is not searchable, and sort by it.
+The following query orders employees by `FirstName` in descending order.  
+Employee documents whose `FirstName` field is `null` are placed at the beginning of the results.  
 
 <Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`List<Product> results = session
-    .query(Product.class, Products_ByName_Search.class)
-    .search("Name", "Louisiana")
-    .orderByDescending("NameForSorting")
+<TabItem value="Query" label="Query">
+```java
+List<Employee> employees = session
+    .query(Employee.class)
+     // Order by 'FirstName' as a string in descending order,
+     // placing employees with a null 'FirstName' at the beginning of the results.
+    .orderByDescending("FirstName", NullsOrdering.FIRST, OrderingType.STRING)
     .toList();
-`}
-</CodeBlock>
+
+// Results will be sorted by the 'FirstName' value in descending order.
+// Documents with a null FirstName value will be listed first.
+```
 </TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Employees"
+order by FirstName desc nulls first
+
+// Results will be sorted by the 'FirstName' value in descending order.
+// Documents with a null FirstName value will be listed first.
+```
+</TabItem>
+</Tabs> 
+    
+---
+    
+**Use null placement with explicit ordering type**:
+
+The following query orders products by `ReorderLevel` using **numeric** ordering (`OrderingType.LONG`),  
+while placing products whose `ReorderLevel` field is `null` at the end of the results.
+
+This combines two settings in the same `order by` clause:  
+  * the ordering type, which determines how non-null values are compared
+  * the null placement, which determines where `null` values appear in the sorted results    
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+    .query(Product.class)
+     // Order by 'ReorderLevel' numerically,
+     // placing products with a null 'ReorderLevel' at the end of the results
+    .orderBy("ReorderLevel", NullsOrdering.LAST, OrderingType.LONG)
+    .toList();
+
+// Results will be sorted by 'ReorderLevel' as a number (ascending).
+// Documents with a null ReorderLevel value will be listed last.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+order by ReorderLevel as long nulls last
+
+// Results will be sorted by 'ReorderLevel' as a number (ascending).
+// Documents with a null ReorderLevel value will be listed last.
+```
+</TabItem>
+</Tabs>
+    
+</ContentFrame>    
+
+</Panel>
+
+<Panel heading="Order by searchable fields">
+    
+<ContentFrame>
+    
+### Order by searchable field - dynamic query
+
+When making a [full-text search with a dynamic query](../../../client-api/session/querying/text-search/full-text-search.mdx),  
+RavenDB automatically creates an **auto-index** that contains two index-fields for the queried field:  
+  * one for the tokenized terms (used for searching), 
+  * and one for the original value (used for ordering and other operations).
+
+For example, consider the following dynamic query:
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+    .query(Product.class)
+     // Call 'search':
+     // Search for products with a name that contains 'sauce'.
+    .search("Name", "sauce")
+     // Call 'orderBy':
+     // Order the results by the original value of field 'Name'.
+    .orderBy("Name")
+    .toList();
+```
+</TabItem>     
+<TabItem value="RQL" label="RQL">
+```sql
+from Products
+where search(Name, "sauce")
+order by Name
+```
+</TabItem>
+</Tabs>
+    
+For this query, RavenDB creates the `Auto/Products/BySearch(Name)` auto-index,  
+which contains the following two index-fields:    
+    
+* `search(Name)`  
+  Used for the full-text search.  
+  The field content is tokenized at indexing time according to the analyzer in use,  
+  and the `search()` clause in the query is matched against these tokenized terms.  
+    
+* `Name`  
+  Used for ordering the results.  
+  This field stores the original field value (non-tokenized),  
+  so the `order by` clause sorts results by the original text rather than by individual terms.
+
+**Note**:   
+This behavior is different from querying a static-index, where you must explicitly define an additional non-searchable index-field if you want to sort by the original value.
+See the following static-index example.    
+    
+</ContentFrame>    
+
+<ContentFrame>
+    
+### Order by searchable field - querying a static-index
+    
+* **When configuring an index-field** for [full-text search](../../../indexes/querying/searching.mdx),
+  the content of the index-field is broken down into terms at indexing time. 
+  The specific tokenization depends on the [analyzer](../../../indexes/using-analyzers.mdx) used.
+
+* **When querying such an index**, if you order by that searchable index-field, 
+  results will come back sorted based on the indexed terms, not based on the original text value of the field.
+  
+* To overcome this and order results by the original text value,  
+  you can define another index-field with the same content, leave it non-searchable, and order by that field.       
+
+<Tabs groupId='languageSyntax'>
 <TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByName_Search extends AbstractIndexCreationTask {
-    public static class Result {
-        private String name;
-        private String nameForSorting;
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public String getNameForSorting() {
-            return nameForSorting;
-        }
-
-        public void setNameForSorting(String nameForSorting) {
-            this.nameForSorting = nameForSorting;
-        }
-    }
-
-    public Products_ByName_Search() {
+```java
+public static class Products_BySearchName extends AbstractIndexCreationTask {
+    public Products_BySearchName() {
         map = "docs.Products.Select(product => new {" +
+            // Both index-fields are assigned the same content (the 'Name' from the document)
             "    Name = product.Name," +
             "    NameForSorting = product.Name" +
             "})";
 
+        // Configure only the 'Name' index-field for FTS
         index("Name", FieldIndexing.SEARCH);
     }
 }
-`}
-</CodeBlock>
+```
 </TabItem>
-<TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByName/Search' 
-where search(Name, 'Louisiana')
-order by NameForSorting desc
-`}
-</CodeBlock>
-</TabItem>
-</Tabs>
-
-## AlphaNumeric Ordering
-
-Sometimes when ordering strings, it doesn't make sense to use the default lexicographic ordering.    
-
-For example, "Abc9" will come after "Abc10" because if treated as single characters, 9 is greater than 1.   
-
-If you want digit characters in a string to be treated as numbers and not as text, you should use alphanumeric ordering. In that case, when comparing "Abc10" to "Abc9", the digits 1 and 0 will be treated as the number 10 which will be considered greater than 9.
-
-To order in this mode you can pass the `OrderingType.ALPHA_NUMERIC` type into `orderBy` or `orderByDescending`:   
-
-<Tabs groupId='languageSyntax'>
-<TabItem value="Java" label="Java">
-<CodeBlock language="java">
-{`List<Product> results = session
-    .query(Product.class, Products_ByUnitsInStock.class)
-    .whereGreaterThan("UnitsInStock", 10)
-    .orderBy("Name", OrderingType.ALPHA_NUMERIC)
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+     // Query the index 
+    .query(Product.class, Products_BySearchName.class)
+     // Call 'search':
+     // Pass the index-field that was configured for FTS and the term to search for.
+     // Here we search for terms that start with "ch" within index-field 'Name'.
+    .search("Name", "ch*")
+     // Call 'orderBy':
+     // Pass the other index-field by which to order the results.
+    .orderBy("NameForSorting")
     .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Products_ByUnitsInStock extends AbstractIndexCreationTask {
-    public Products_ByUnitsInStock() {
-        map = "docs.Products.Select(product => new {" +
-            "    UnitsInStock = product.UnitsInStock" +
-            "})";
-    }
-}
-`}
-</CodeBlock>
+
+// Running the above query on the NorthWind sample data, ordering by 'NameForSorting' field,
+// we get the following order:
+// =========================================================================================
+
+// "Chai"
+// "Chang"
+// "Chartreuse verte"
+// "Chef Anton's Cajun Seasoning"
+// "Chef Anton's Gumbo Mix"
+// "Chocolade"
+// "Jack's New England Clam Chowder"
+// "Pâté chinois"
+// "Teatime Chocolate Biscuits"
+
+// While ordering by the searchable 'Name' field would have produced the following order:
+// ======================================================================================
+
+// "Chai"
+// "Chang"
+// "Chartreuse verte"
+// "Chef Anton's Cajun Seasoning"
+// "Pâté chinois"
+// "Chocolade"
+// "Teatime Chocolate Biscuits"
+// "Chef Anton's Gumbo Mix"
+// "Jack's New England Clam Chowder"
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Products/ByUnitsInStock ' 
-where UnitsInStock > 10
-order by Name as alphanumeric
-`}
-</CodeBlock>
+```sql
+from index "Products/BySearchName" 
+where search(Name, "ch*")
+order by NameForSorting
+```
 </TabItem>
 </Tabs>
+    
+</ContentFrame>
+    
+</Panel>
 
-## Spatial Ordering
+<Panel heading="Order by score">
 
-If your data contains geographical locations, you might want to sort the query result by distance from a given point.
+* When querying with some filtering conditions, a basic score is calculated for each item in the results  
+  by the underlying indexing engine.
 
-This can be achieved by using the `orderByDistance` and `orderByDistanceDescending` methods (API reference [here](../../../client-api/session/querying/how-to-make-a-spatial-query.mdx)):
+* The higher the score value the better the match.  
+
+* Use `orderByScore` or `orderByScoreDescending` to order by this score.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="java">
-{`List<Events> results = session
-    .query(Events.class, Events_ByCoordinates.class)
-    .spatial("Coordinates", criteria -> criteria.withinRadius(500, 30, 30))
-    .orderByDistance(new PointField("Latitude", "Longitude"), 32.1234, 23.4321)
+```java
+List<Product> products = session
+    .query(Product.class)
+     // Apply filtering
+    .whereLessThan("UnitsInStock", 5)
+    .orElse()
+    .whereEquals("Discontinued", true)
+     // Call 'orderByScore'
+    .orderByScore()
     .toList();
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="Index" label="Index">
-<CodeBlock language="java">
-{`public static class Events_ByCoordinates extends AbstractIndexCreationTask {
-    public Events_ByCoordinates() {
-        map = "docs.Events.Select(e => new {" +
-            "   Coordinates = this.CreateSpatialField(e.Latitude, e.Longitude)" +
-            "})";
-    }
-}
-`}
-</CodeBlock>
+
+// Results will be sorted by the score value
+// with best matching documents (higher score values) listed first.
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from index 'Events/ByCoordinates'
-where spatial.within(Coordinates, spatial.circle(500, 30, 30))
-order by spatial.distance(spatial.point(Latitude, Longitude), spatial.point(32.1234, 23.4321))
-`}
-</CodeBlock>
+```sql
+from "Products"
+where UnitsInStock < 5 or Discontinued == true
+order by score()
+```
 </TabItem>
 </Tabs>
+
+<Admonition type="info" title="">
+
+#### Get resulting score:
+    
+The score details can be retrieved by either:
+
+* **Request to include explanations**:  
+  You can get the score details and see how it was calculated by requesting to include explanations in the query.
+  Currently, this is only available when using Lucene as the underlying indexing engine.  
+  Learn more in [Include query explanations](../../../client-api/session/querying/debugging/include-explanations.mdx).
+
+* **Get score from metadata**:    
+
+    * The score is available in the `@index-score` metadata property within each result.  
+      Note the following difference between the underlying indexing engines:
+
+      * When using **Lucene**:  
+          This metadata property is always available in the results.  
+          Read more about Lucene scoring [here](https://lucene.apache.org/core/3_3_0/scoring.html).
+
+      * When using **Corax**:  
+          In order to enhance performance, this metadata property is Not included in the results by default.  
+          To get this metadata property you must set the [Indexing.Corax.IncludeDocumentScore](../../../server/configuration/indexing-configuration.mdx#indexingcoraxincludedocumentscore) configuration value to _true_.  
+          Learn about the available methods for setting an indexing configuration key in this [indexing-configuration](../../../server/configuration/indexing-configuration.mdx) article.
+
+    * The following example shows how to get the score from the metadata of the resulting entities that were loaded to the session:  
+
+<TabItem>
+```java
+// Make a query:
+// =============
+
+List<Employee> employees = session
+    .query(Employee.class)
+    .search("Notes", "English")
+    .search("Notes", "Italian")
+    .boost(10)
+    .toList();
+
+// Get the score:
+// ==============
+
+// Call 'getMetadataFor', pass an entity from the resulting employees list
+IMetadataDictionary metadata = session.advanced().getMetadataFor(employees.get(0));
+
+// Score is available in the '@index-score' metadata property
+Object score = metadata.get(Constants.Documents.Metadata.INDEX_SCORE);
+```
+</TabItem>
+ 
+</Admonition>
+
+</Panel>
+
+<Panel heading="Order by random">
+
+* Use `randomOrdering` to randomize the order of the query results.
+
+* An optional seed parameter can be passed.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+    .query(Product.class)
+    .whereGreaterThan("UnitsInStock", 10)
+     // Call 'randomOrdering'
+    .randomOrdering()
+     // An optional seed can be passed, e.g.:
+     // .randomOrdering("someSeed")
+    .toList();
+
+// Results will be randomly ordered.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+where UnitsInStock > 10
+order by random()
+// order by random('someSeed')
+```
+</TabItem>
+</Tabs>
+
+</Panel>
+
+<Panel heading="Order by spatial">
+
+* If your data contains geographical locations,  
+  spatial query results can be sorted based on their distance from a specific point.
+
+* See detailed explanation in [Spatial Sorting](../../../client-api/session/querying/how-to-make-a-spatial-query.mdx#spatial-sorting).
+
+</Panel>
+
+<Panel heading="Order by count (aggregation query)">
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query.mdx) can be sorted by the `count` aggregation operation used in the query.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<ProductsCount> numberOfProductsPerCategory = session
+    .query(Product.class)
+     // Group by Category
+    .groupBy("Category")
+    .selectKey("Category")
+     // Count the number of product documents per category
+    .selectCount()
+     // Order by the count value
+     // Here you need to specify the ordering type explicitly 
+    .orderBy("count", OrderingType.LONG)
+    .ofType(ProductsCount.class)
+    .toList();
+
+// Results will contain the number of Product documents per category
+// ordered by that count in ascending order.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+group by Category
+order by count as long
+select Category, count() as count
+```
+</TabItem>
+</Tabs>
+
+</Panel>
+
+<Panel heading="Order by sum (aggregation query)">
+
+* The results of a [group-by query](../../../client-api/session/querying/how-to-perform-group-by-query.mdx) can be sorted by the `sum` aggregation operation used in the query.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<ProductsSum> numberOfUnitsInStockPerCategory = session
+    .query(Product.class)
+     // Group by Category
+    .groupBy("Category")
+    .selectKey("Category")
+     // Sum the number of units in stock per category
+    .selectSum(new GroupByField("UnitsInStock", "sum"))
+     // Order by the sum value
+     // Here you need to specify the ordering type explicitly 
+    .orderBy("sum", OrderingType.LONG)
+    .ofType(ProductsSum.class)
+    .toList();
+
+// Results will contain the total number of units in stock per category
+// ordered by that number in ascending order.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+group by Category
+order by sum as long
+select Category, sum(UnitsInStock) as sum
+```
+</TabItem>
+</Tabs>
+
+</Panel>
+
+<Panel heading="Order by metadata">
+
+* Documents contain server-maintained metadata fields, such as `@last-modified`.  
+  You can order query results by these fields directly in RQL, or by using `documentQuery`.
+    
+* When no ordering type is specified, metadata fields are ordered lexicographically.  
+  For `@last-modified`, this produces the correct chronological order because the timestamp format is lexically sortable: `yyyy-MM-ddTHH:mm:ss.fffffff`.    
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="DocumentQuery" label="DocumentQuery">
+```java
+List<Order> recent = session.advanced()
+    .documentQuery(Order.class)
+     // Order by the document's last modification time,
+     // with the most recently modified documents listed first
+    .orderByDescending("@metadata.@last-modified")
+    .take(20)
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Orders"
+order by @metadata.@last-modified desc
+limit 20
+```
+</TabItem>
+</Tabs>
+    
+</Panel>    
+
+<Panel heading="Force ordering type">
+
+* If no ordering type is specified in the query then the server will apply the default lexicographical ordering.
+
+* You can force a different ordering type by passing it explicitly to `orderBy` or `orderByDescending`.   
+  The following ordering types are available:
+
+    * `OrderingType.LONG`
+    * `OrderingType.DOUBLE`
+    * `OrderingType.ALPHA_NUMERIC`
+    * `OrderingType.STRING` (lexicographic ordering)
+    
+* Use the appropriate ordering type for the field value.  
+  For example, ordering numeric values as strings can produce lexicographic order, where `"10"` comes before `"9"`.  
+  Use a numeric ordering type when ordering numeric fields explicitly.
+    
+* When using RQL directly, if no ordering type is specified, the server uses the default ordering for the field.  
+  To force a specific ordering type, specify `as long`, `as double`, `as string`, or `as alphanumeric`.
+
+<Admonition type="note" title="">
+
+**Using alphanumeric ordering example**:
+
+* When ordering mixed-character strings by the default lexicographical ordering  
+  then comparison is done character by character based on the Unicode values.  
+  For example, "Abc9" will come after "Abc10" since 9 is greater than 1.
+
+* If you want the digit characters to be ordered as numbers, use alphanumeric ordering.  
+  In that case, `"Abc10"` will come after `"Abc9"`.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+    .query(Product.class)
+     // Call 'orderBy', order by field 'QuantityPerUnit'
+     // Pass a second param, requesting to order the text alphanumerically
+    .orderBy("QuantityPerUnit", OrderingType.ALPHA_NUMERIC)
+    .toList();
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+order by QuantityPerUnit as alphaNumeric
+```
+</TabItem>
+</Tabs>
+
+<TabItem>
+```java
+// Running the above query on the NorthWind sample data,
+// would produce the following order for the QuantityPerUnit field:
+// ================================================================
+
+// "1 kg pkg."
+// "1k pkg."
+// "2 kg box."
+// "4 - 450 g glasses"
+// "5 kg pkg."
+// ...
+
+// While running with the default Lexicographical ordering would have produced:
+// ============================================================================
+
+// "1 kg pkg."
+// "10 - 200 g glasses"
+// "10 - 4 oz boxes"
+// "10 - 500 g pkgs."
+// "10 - 500 g pkgs."
+// ...
+```
+</TabItem>
+
+</Admonition>
+
+</Panel>
+
+<Panel heading="Chain ordering">
+
+* It is possible to chain multiple ordering clauses in a query.  
+  Any combination of secondary sorting is possible, as the fields are indexed independently of one another.
+
+* The first ordering clause defines the primary sort.  
+  Each following clause is used to order documents that have the same value in the previous clause.
+
+* This is achieved by calling the `orderBy` (`orderByDescending`) and `orderByScore` (`orderByScoreDescending`) methods multiple times.
+
+* When ordering by a field, each ordering clause can also define its own [null placement](../../../querying/sorting-query-results/sort-query-results.mdx#control-position-of-null-values) (Corax only).   
+  If no null placement is specified for an ordering clause, RavenDB uses the behavior configured by [Indexing.Querying.Corax.NullsSortMode](../../../server/configuration/indexing-configuration.mdx#indexingqueryingcoraxnullssortmode) for that clause.    
+
+* **When using the Lucene search engine** -  
+  there is no limit on the number of sorting actions that can be chained in a query.  
+  
+  **When using the Corax search engine** -  
+  a maximum of `16` _order by_ clauses is allowed per query. If this limit is exceeded, an exception will be thrown.  
+  To resolve this, simplify your query or switch to the Lucene engine. See [Selecting the search engine](../../../indexes/search-engine/corax.mdx#selecting-the-search-engine).  
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+    .query(Product.class)
+    .whereEquals("Discontinued", false)
+     // Apply the primary sort by 'UnitsInStock' in descending order,
+     // placing products with a null UnitsInStock value at the end of the results
+    .orderByDescending("UnitsInStock", NullsOrdering.LAST, OrderingType.LONG)
+     // Apply a secondary sort by the score
+     // for products with the same UnitsInStock value
+    .orderByScore()
+     // Apply another sort by 'Name' in ascending order,
+     // placing products with a null Name value at the beginning of each group
+    .orderBy("Name", NullsOrdering.FIRST, OrderingType.STRING)
+    .toList();
+
+// Results will be sorted by the 'UnitsInStock' value in descending order,
+// with null UnitsInStock values listed last.
+// Products that have the same UnitsInStock value will then be sorted by score.
+// Products that have the same UnitsInStock value and same score
+// will then be sorted by 'Name', with null Name values listed first.
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+where Discontinued == false
+order by UnitsInStock as long desc nulls last, score(), Name nulls first
+```
+</TabItem>
+</Tabs>
+
+In the query above:
+
+* `UnitsInStock as long desc nulls last` is the primary ordering clause.  
+  Products are first sorted by `UnitsInStock` in descending order.  
+  Products whose `UnitsInStock` field is `null` are placed after products with a non-null `UnitsInStock` value.
+
+* `score()` is the secondary ordering clause.  
+  It applies to products that have the same `UnitsInStock` value.
+
+* `Name nulls first` is the next ordering clause.  
+  It applies to products that have the same `UnitsInStock` value and the same score.  
+  Within that group, products whose `Name` field is `null` are placed before products with a non-null `Name` value.
+
+</Panel>
+
+<Panel heading="Custom sorters">
+
+* The **Lucene** indexing engine allows you to define custom sorters,  
+  so you can apply your own logic when ordering query results.  
+  Custom sorters are not supported by [Corax](../../../indexes/search-engine/corax.mdx).  
+ 
+* Custom sorters can be deployed at either the database level or the server-wide level:  
+  * **Database-level**  
+    Custom sorters can be used only by queries made on that database.  
+    Learn how to deploy a database-level custom sorter in: [Database-level custom sorters](../../../querying/sorting-query-results/custom-sorters/database-level-custom-sorters.mdx).    
+    
+  * **Server-wide**  
+    Custom sorters can be used by queries made on any database in your cluster.  
+    Learn how to deploy a server-wide custom sorter in: [Server-wide custom sorters](../../../querying/sorting-query-results/custom-sorters/server-wide-custom-sorters.mdx).
+    
+* Once deployed, a custom sorter can be specified in a query to sort the results.
+
+<Tabs groupId='languageSyntax'>
+<TabItem value="Query" label="Query">
+```java
+List<Product> products = session
+    .query(Product.class)
+    .whereGreaterThan("UnitsInStock", 10)
+     // Order by field 'UnitsInStock', pass the name of your custom sorter class
+    .orderBy("UnitsInStock", "MyCustomSorter")
+    .toList();
+
+// Results will be sorted by the 'UnitsInStock' value
+// according to the logic from 'MyCustomSorter' class
+```
+</TabItem>
+<TabItem value="RQL" label="RQL">
+```sql
+from "Products"
+where UnitsInStock > 10
+order by custom(UnitsInStock, 'MyCustomSorter')
+    
+// Results will be sorted by the 'UnitsInStock' value
+// according to the logic from 'MyCustomSorter' class    
+```
+</TabItem>
+</Tabs>
+
+</Panel>
+
+<Panel heading="Performance notes">
+
+* **Filter before you sort.**  
+  Sorting cost is proportional to the number of matched documents, not the size of the collection.  
+  A `where` clause that reduces the candidate set materially cheapens the sort.
+    
+* **Sorting requires an indexed field.**  
+  In a dynamic query, if the field you order by is not already available in the auto-index,  
+  RavenDB may create or extend an auto-index to include that field.      
+  This adds indexing work before the sort can be served efficiently.  
+  On hot paths, prefer a static index that already contains the sortable field.    
+
+</Panel>
+
+<Panel heading="Syntax">
+
+<TabItem>
+```java
+// orderBy overloads:
+IDocumentQuery<T> orderBy(String field);
+IDocumentQuery<T> orderBy(String field, OrderingType ordering);
+IDocumentQuery<T> orderBy(String field, String sorterName);
+
+// orderBy overload with null placement (Corax only):
+IDocumentQuery<T> orderBy(String field, NullsOrdering nulls, OrderingType ordering);
+
+// orderByDescending overloads:
+IDocumentQuery<T> orderByDescending(String field);
+IDocumentQuery<T> orderByDescending(String field, OrderingType ordering);
+IDocumentQuery<T> orderByDescending(String field, String sorterName);
+
+// orderByDescending overload with null placement (Corax only):
+IDocumentQuery<T> orderByDescending(String field, NullsOrdering nulls, OrderingType ordering);
+
+// NullsOrdering enum
+public enum NullsOrdering {
+    DEFAULT,   // use the configured default (Indexing.Querying.Corax.NullsSortMode)
+    FIRST,     // place null/missing values BEFORE non-null values, regardless of ASC/DESC
+    LAST       // place null/missing values AFTER non-null values, regardless of ASC/DESC
+}
+```
+</TabItem>
+
+| Parameter      | Type            | Description                                                                                                                                                                                                                                              |
+|----------------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **field**      | `String`        | The name of the field to sort by                                                                                                                                                                                                                         |
+| **ordering**   | `OrderingType`  | The ordering type that will be used to sort the results:<br/>`OrderingType.LONG`<br/>`OrderingType.DOUBLE`<br/>`OrderingType.ALPHA_NUMERIC`<br/>`OrderingType.STRING` (default)                                                                           |
+| **sorterName** | `String`        | The name of your custom sorter class                                                                                                                                                                                                                     |
+| **nulls**      | `NullsOrdering` | Per-clause placement of `null` / missing values ([Corax](../../../indexes/search-engine/corax.mdx) only):<br/>`NullsOrdering.DEFAULT` (use configured default)<br/>`NullsOrdering.FIRST` (nulls before non-nulls)<br/>`NullsOrdering.LAST` (nulls after non-nulls)<br/>Direction-independent: behavior is the same under `ASC` and `DESC`. |
+
+</Panel>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3947/Java-Control-order-of-NULLs-directly-in-query-Update-file

### Additional description
The Java client now supports controlling the order of NULLs.
Applied the same updates that were made in PR: https://github.com/ravendb/docs/pull/2454 to the Java articles.
Updated the 2 Java files that include this feature - they were very outdated:
* `..\querying\sorting-query-results\content\_sort-query-results-java.mdx`
* `..\client-api\session\querying\content\_how-to-make-a-spatial-query-java.mdx`

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

