### PR TITLE
RDoc-3439 New documentation search results improvements

### DIFF
--- a/src/components/Common/CustomSearchButton.tsx
+++ b/src/components/Common/CustomSearchButton.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { forwardRef, useEffect, useState } from "react";
 import clsx from "clsx";
-import { useDocSearchKeyboardEvents } from "@docsearch/react";
 import { Icon } from "./Icon";
 
 interface CustomSearchButtonProps {
@@ -22,51 +21,43 @@ function getShortcutKey(): string {
     return isMac ? "⌘K" : "Ctrl+K";
 }
 
-export default function CustomSearchButton({
-    onClick,
-    onTouchStart,
-    onFocus,
-    onMouseOver,
-    translations = {},
-}: CustomSearchButtonProps) {
-    const buttonRef = React.useRef<HTMLButtonElement>(null);
-    const [shortcutKey, setShortcutKey] = useState("Ctrl+K");
+// Keyboard handling (open shortcut, type-to-open) is owned by the parent SearchBar,
+// which forwards its ref here so the shortcut targets this button.
+const CustomSearchButton = forwardRef<HTMLButtonElement, CustomSearchButtonProps>(
+    ({ onClick, onTouchStart, onFocus, onMouseOver, translations = {} }, ref) => {
+        const [shortcutKey, setShortcutKey] = useState("Ctrl+K");
 
-    useEffect(() => {
-        setShortcutKey(getShortcutKey());
-    }, []);
+        useEffect(() => {
+            setShortcutKey(getShortcutKey());
+        }, []);
 
-    useDocSearchKeyboardEvents({
-        isOpen: false,
-        onOpen: onClick,
-        onClose: () => {},
-        searchButtonRef: buttonRef,
-        isAskAiActive: false,
-        onAskAiToggle: (_toggle: boolean) => {},
-    });
+        return (
+            <button
+                type="button"
+                ref={ref}
+                className={clsx(
+                    "flex items-center gap-2 text-sm cursor-pointer",
+                    "bg-ifm-background border border-black/10 p-2.5 md:py-1.5 md:pr-1.5 md:pl-3",
+                    "dark:border-white/10 text-ifm-menu justify-between rounded-[32px] hover:bg-black/5 dark:hover:bg-white/5"
+                )}
+                aria-label={translations.buttonAriaLabel || "Search"}
+                onClick={onClick}
+                onTouchStart={onTouchStart}
+                onFocus={onFocus}
+                onMouseOver={onMouseOver}
+            >
+                <Icon icon="search" size="xs" />
+                <span className="hidden md:inline-flex text-ifm-menu md:text-sm/3.5 text-left w-auto">
+                    {translations.buttonText || "Search"}
+                </span>
+                <div className="hidden md:inline-flex bg-black/10 dark:bg-white/10 border border-black/10 dark:border-white/10 text-ifm-menu px-1.5 rounded-2xl text-xs font-mono">
+                    {shortcutKey}
+                </div>
+            </button>
+        );
+    }
+);
 
-    return (
-        <button
-            type="button"
-            ref={buttonRef}
-            className={clsx(
-                "flex items-center gap-2 text-sm cursor-pointer",
-                "bg-ifm-background border border-black/10 p-2.5 md:py-1.5 md:pr-1.5 md:pl-3",
-                "dark:border-white/10 text-ifm-menu justify-between rounded-[32px] hover:bg-black/5 dark:hover:bg-white/5"
-            )}
-            aria-label={translations.buttonAriaLabel || "Search"}
-            onClick={onClick}
-            onTouchStart={onTouchStart}
-            onFocus={onFocus}
-            onMouseOver={onMouseOver}
-        >
-            <Icon icon="search" size="xs" />
-            <span className="hidden md:inline-flex text-ifm-menu md:text-sm/3.5 text-left w-auto">
-                {translations.buttonText || "Search"}
-            </span>
-            <div className="hidden md:inline-flex bg-black/10 dark:bg-white/10 border border-black/10 dark:border-white/10 text-ifm-menu px-1.5 rounded-2xl text-xs font-mono">
-                {shortcutKey}
-            </div>
-        </button>
-    );
-}
+CustomSearchButton.displayName = "CustomSearchButton";
+
+export default CustomSearchButton;

--- a/src/components/Common/CustomSearchButton.tsx
+++ b/src/components/Common/CustomSearchButton.tsx
@@ -1,8 +1,10 @@
-import React, { forwardRef, useEffect, useState } from "react";
+import React from "react";
 import clsx from "clsx";
+import useIsBrowser from "@docusaurus/useIsBrowser";
 import { Icon } from "./Icon";
 
 interface CustomSearchButtonProps {
+    ref?: React.Ref<HTMLButtonElement>;
     onClick: () => void;
     onTouchStart?: () => void;
     onFocus?: () => void;
@@ -14,50 +16,43 @@ interface CustomSearchButtonProps {
 }
 
 function getShortcutKey(): string {
-    if (typeof navigator === "undefined") {
-        return "Ctrl+K";
-    }
-    const isMac = /Mac|iPhone|iPod|iPad/.test(navigator.platform);
-    return isMac ? "⌘K" : "Ctrl+K";
+    return /Mac|iPhone|iPod|iPad/.test(navigator.platform) ? "⌘K" : "Ctrl+K";
 }
 
-// Keyboard handling (open shortcut, type-to-open) is owned by the parent SearchBar,
-// which forwards its ref here so the shortcut targets this button.
-const CustomSearchButton = forwardRef<HTMLButtonElement, CustomSearchButtonProps>(
-    ({ onClick, onTouchStart, onFocus, onMouseOver, translations = {} }, ref) => {
-        const [shortcutKey, setShortcutKey] = useState("Ctrl+K");
+// Keyboard handling (open shortcut, type-to-search) is owned by the parent SearchBar,
+// which passes its ref here so the shortcut targets this button.
+export default function CustomSearchButton({
+    ref,
+    onClick,
+    onTouchStart,
+    onFocus,
+    onMouseOver,
+    translations = {},
+}: CustomSearchButtonProps) {
+    const shortcutKey = useIsBrowser() ? getShortcutKey() : "Ctrl+K";
 
-        useEffect(() => {
-            setShortcutKey(getShortcutKey());
-        }, []);
-
-        return (
-            <button
-                type="button"
-                ref={ref}
-                className={clsx(
-                    "flex items-center gap-2 text-sm cursor-pointer",
-                    "bg-ifm-background border border-black/10 p-2.5 md:py-1.5 md:pr-1.5 md:pl-3",
-                    "dark:border-white/10 text-ifm-menu justify-between rounded-[32px] hover:bg-black/5 dark:hover:bg-white/5"
-                )}
-                aria-label={translations.buttonAriaLabel || "Search"}
-                onClick={onClick}
-                onTouchStart={onTouchStart}
-                onFocus={onFocus}
-                onMouseOver={onMouseOver}
-            >
-                <Icon icon="search" size="xs" />
-                <span className="hidden md:inline-flex text-ifm-menu md:text-sm/3.5 text-left w-auto">
-                    {translations.buttonText || "Search"}
-                </span>
-                <div className="hidden md:inline-flex bg-black/10 dark:bg-white/10 border border-black/10 dark:border-white/10 text-ifm-menu px-1.5 rounded-2xl text-xs font-mono">
-                    {shortcutKey}
-                </div>
-            </button>
-        );
-    }
-);
-
-CustomSearchButton.displayName = "CustomSearchButton";
-
-export default CustomSearchButton;
+    return (
+        <button
+            type="button"
+            ref={ref}
+            className={clsx(
+                "flex items-center gap-2 text-sm cursor-pointer",
+                "bg-ifm-background border border-black/10 p-2.5 md:py-1.5 md:pr-1.5 md:pl-3",
+                "dark:border-white/10 text-ifm-menu justify-between rounded-[32px] hover:bg-black/5 dark:hover:bg-white/5"
+            )}
+            aria-label={translations.buttonAriaLabel || "Search"}
+            onClick={onClick}
+            onTouchStart={onTouchStart}
+            onFocus={onFocus}
+            onMouseOver={onMouseOver}
+        >
+            <Icon icon="search" size="xs" />
+            <span className="hidden md:inline-flex text-ifm-menu md:text-sm/3.5 text-left w-auto">
+                {translations.buttonText || "Search"}
+            </span>
+            <div className="hidden md:inline-flex bg-black/10 dark:bg-white/10 border border-black/10 dark:border-white/10 text-ifm-menu px-1.5 rounded-2xl text-xs font-mono">
+                {shortcutKey}
+            </div>
+        </button>
+    );
+}

--- a/src/components/Common/contentSource.ts
+++ b/src/components/Common/contentSource.ts
@@ -1,0 +1,16 @@
+import { IconName } from "@site/src/typescript/iconName";
+
+// Shared by See Also, sample related-resources, and search results.
+export type ContentSource = "docs" | "cloud" | "guides" | "samples" | "external";
+
+export const CONTENT_SOURCES: Record<ContentSource, { label: string; icon: IconName }> = {
+    docs: { label: "Docs", icon: "document2" },
+    cloud: { label: "Cloud", icon: "cloud" },
+    guides: { label: "Guide", icon: "guides" },
+    samples: { label: "Sample", icon: "code" },
+    external: { label: "External", icon: "newtab" },
+};
+
+export const getContentSourceIcon = (source: ContentSource): IconName => CONTENT_SOURCES[source].icon;
+
+export const getContentSourceLabel = (source: ContentSource): string => CONTENT_SOURCES[source].label;

--- a/src/components/Search/SearchFilterPills.tsx
+++ b/src/components/Search/SearchFilterPills.tsx
@@ -1,0 +1,47 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import { SEARCH_FILTERS } from "./searchSource";
+import type { ContentSource } from "@site/src/components/Common/contentSource";
+
+interface SearchFilterPillsProps {
+    active: ContentSource | null;
+    onChange: (kind: ContentSource | null) => void;
+    className?: string;
+}
+
+export default function SearchFilterPills({ active, onChange, className }: SearchFilterPillsProps): ReactNode {
+    return (
+        <div
+            role="group"
+            aria-label="Filter results by source"
+            className={clsx("flex flex-wrap items-center gap-2", className)}
+        >
+            {SEARCH_FILTERS.map((filter) => {
+                const isActive = active === filter.kind;
+                return (
+                    <React.Fragment key={filter.label}>
+                        {filter.separated && (
+                            <span
+                                aria-hidden="true"
+                                className="mx-1 h-4 w-px self-center bg-black/15 dark:bg-white/15"
+                            />
+                        )}
+                        <button
+                            type="button"
+                            aria-pressed={isActive}
+                            onClick={() => onChange(filter.kind)}
+                            className={clsx(
+                                "cursor-pointer select-none rounded-full border px-3 py-1 text-xs font-semibold transition-colors",
+                                isActive
+                                    ? "border-transparent bg-primary text-white"
+                                    : "border-black/10 bg-black/5 text-ifm-menu hover:bg-black/10 dark:border-white/15 dark:bg-white/5 dark:hover:bg-white/10"
+                            )}
+                        >
+                            {filter.label}
+                        </button>
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/components/Search/SearchFilterPills.tsx
+++ b/src/components/Search/SearchFilterPills.tsx
@@ -23,7 +23,7 @@ export default function SearchFilterPills({ active, onChange, className }: Searc
                         {filter.separated && (
                             <span
                                 aria-hidden="true"
-                                className="mx-1 h-4 w-px self-center bg-black/15 dark:bg-white/15"
+                                className="mx-1 h-4 w-px self-center bg-black/10 dark:bg-white/10"
                             />
                         )}
                         <button
@@ -33,8 +33,8 @@ export default function SearchFilterPills({ active, onChange, className }: Searc
                             className={clsx(
                                 "cursor-pointer select-none rounded-full border px-3 py-1 text-xs font-semibold transition-colors",
                                 isActive
-                                    ? "border-transparent bg-primary text-white"
-                                    : "border-black/10 bg-black/5 text-ifm-menu hover:bg-black/10 dark:border-white/15 dark:bg-white/5 dark:hover:bg-white/10"
+                                    ? "border-transparent bg-primary text-white dark:text-black"
+                                    : "border-black/10 bg-black/5 text-ifm-menu hover:bg-black/10 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
                             )}
                         >
                             {filter.label}

--- a/src/components/Search/SearchFilterPills.tsx
+++ b/src/components/Search/SearchFilterPills.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from "react";
 import clsx from "clsx";
-import { SEARCH_FILTERS } from "./searchSource";
+import { SEARCH_FILTER_GROUPS } from "./searchSource";
 import type { ContentSource } from "@site/src/components/Common/contentSource";
 
 interface SearchFilterPillsProps {
@@ -16,32 +16,29 @@ export default function SearchFilterPills({ active, onChange, className }: Searc
             aria-label="Filter results by source"
             className={clsx("flex flex-wrap items-center gap-2", className)}
         >
-            {SEARCH_FILTERS.map((filter) => {
-                const isActive = active === filter.kind;
-                return (
-                    <React.Fragment key={filter.label}>
-                        {filter.separated && (
-                            <span
-                                aria-hidden="true"
-                                className="mx-1 h-4 w-px self-center bg-black/10 dark:bg-white/10"
-                            />
-                        )}
+            {SEARCH_FILTER_GROUPS.map((group, groupIndex) => (
+                <React.Fragment key={groupIndex}>
+                    {groupIndex > 0 && (
+                        <span aria-hidden="true" className="mx-1 h-4 w-px self-center bg-black/10 dark:bg-white/10" />
+                    )}
+                    {group.map((filter) => (
                         <button
+                            key={filter.label}
                             type="button"
-                            aria-pressed={isActive}
+                            aria-pressed={active === filter.kind}
                             onClick={() => onChange(filter.kind)}
                             className={clsx(
                                 "cursor-pointer select-none rounded-full border px-3 py-1 text-xs font-semibold transition-colors",
-                                isActive
+                                active === filter.kind
                                     ? "border-transparent bg-primary text-white dark:text-black"
                                     : "border-black/10 bg-black/5 text-ifm-menu hover:bg-black/10 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
                             )}
                         >
                             {filter.label}
                         </button>
-                    </React.Fragment>
-                );
-            })}
+                    ))}
+                </React.Fragment>
+            ))}
         </div>
     );
 }

--- a/src/components/Search/SearchResultBadge.tsx
+++ b/src/components/Search/SearchResultBadge.tsx
@@ -1,0 +1,40 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import { Icon } from "@site/src/components/Common/Icon";
+import { ContentSource, getContentSourceIcon, getContentSourceLabel } from "@site/src/components/Common/contentSource";
+
+// Color per source.
+const BADGE_CLASSES: Record<ContentSource, string> = {
+    docs: "bg-slate-500/15 text-slate-700 dark:text-slate-300 ring-slate-500/25",
+    guides: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 ring-emerald-600/25 dark:ring-emerald-400/25",
+    cloud: "bg-sky-500/15 text-sky-700 dark:text-sky-300 ring-sky-600/25 dark:ring-sky-400/25",
+    samples: "bg-violet-500/15 text-violet-700 dark:text-violet-300 ring-violet-600/25 dark:ring-violet-400/25",
+    external: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-300 ring-zinc-500/25",
+};
+
+interface SearchResultBadgeProps {
+    source: ContentSource | null;
+    className?: string;
+}
+
+export default function SearchResultBadge({ source, className }: SearchResultBadgeProps): ReactNode {
+    if (!source) {
+        return null;
+    }
+
+    return (
+        <span
+            className={clsx(
+                "search-source-badge inline-flex shrink-0 items-center gap-1 select-none",
+                "rounded-full py-0.5 pl-1.5 pr-2 text-[11px] font-semibold leading-4 ring-1 ring-inset",
+                BADGE_CLASSES[source],
+                className
+            )}
+        >
+            <span aria-hidden="true" className="inline-flex">
+                <Icon icon={getContentSourceIcon(source)} size="2xs" />
+            </span>
+            {getContentSourceLabel(source)}
+        </span>
+    );
+}

--- a/src/components/Search/SearchResultBadge.tsx
+++ b/src/components/Search/SearchResultBadge.tsx
@@ -3,13 +3,13 @@ import clsx from "clsx";
 import { Icon } from "@site/src/components/Common/Icon";
 import { ContentSource, getContentSourceIcon, getContentSourceLabel } from "@site/src/components/Common/contentSource";
 
-// Color per source.
+// Color per source. Neutral docs/external reuse the repo's chip tokens; the rest tint that chip.
 const BADGE_CLASSES: Record<ContentSource, string> = {
-    docs: "bg-slate-500/15 text-slate-700 dark:text-slate-300 ring-slate-500/25",
-    guides: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 ring-emerald-600/25 dark:ring-emerald-400/25",
-    cloud: "bg-sky-500/15 text-sky-700 dark:text-sky-300 ring-sky-600/25 dark:ring-sky-400/25",
-    samples: "bg-violet-500/15 text-violet-700 dark:text-violet-300 ring-violet-600/25 dark:ring-violet-400/25",
-    external: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-300 ring-zinc-500/25",
+    docs: "bg-black/5 dark:bg-white/5 text-ifm-menu border-black/10 dark:border-white/10",
+    guides: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-600/25 dark:border-emerald-400/25",
+    cloud: "bg-sky-500/15 text-sky-700 dark:text-sky-300 border-sky-600/25 dark:border-sky-400/25",
+    samples: "bg-violet-500/15 text-violet-700 dark:text-violet-300 border-violet-600/25 dark:border-violet-400/25",
+    external: "bg-black/5 dark:bg-white/5 text-ifm-menu border-black/10 dark:border-white/10",
 };
 
 interface SearchResultBadgeProps {
@@ -25,8 +25,8 @@ export default function SearchResultBadge({ source, className }: SearchResultBad
     return (
         <span
             className={clsx(
-                "search-source-badge inline-flex shrink-0 items-center gap-1 select-none",
-                "rounded-full py-0.5 pl-1.5 pr-2 text-[11px] font-semibold leading-4 ring-1 ring-inset",
+                "inline-flex h-5 shrink-0 items-center gap-1 select-none border",
+                "rounded-full pl-1.5 pr-2 text-[11px] font-medium leading-4",
                 BADGE_CLASSES[source],
                 className
             )}

--- a/src/components/Search/searchSource.ts
+++ b/src/components/Search/searchSource.ts
@@ -1,0 +1,119 @@
+import { ContentSource } from "@site/src/components/Common/contentSource";
+
+// docusaurus_tag is `docs-<pluginId>-<version>`; main docs has the implicit id "default".
+const SOURCE_BY_PLUGIN_ID: Record<string, ContentSource> = {
+    default: "docs",
+    cloud: "cloud",
+    guides: "guides",
+    samples: "samples",
+};
+
+export function getSearchResultSource(docusaurusTag: string | string[] | undefined | null): ContentSource | null {
+    const tags = Array.isArray(docusaurusTag) ? docusaurusTag : docusaurusTag ? [docusaurusTag] : [];
+
+    for (const tag of tags) {
+        const parts = tag.split("-");
+        if (parts[0] === "docs" && parts.length >= 3) {
+            const source = SOURCE_BY_PLUGIN_ID[parts[1]];
+            if (source) {
+                return source;
+            }
+        }
+    }
+
+    return null;
+}
+
+// docusaurus_tag is faceted but not returned unless explicitly requested.
+export const SEARCH_ATTRIBUTES_TO_RETRIEVE = [
+    "hierarchy.lvl0",
+    "hierarchy.lvl1",
+    "hierarchy.lvl2",
+    "hierarchy.lvl3",
+    "hierarchy.lvl4",
+    "hierarchy.lvl5",
+    "hierarchy.lvl6",
+    "content",
+    "type",
+    "url",
+    "docusaurus_tag",
+];
+
+const BREADCRUMB_ACRONYMS = new Set([
+    "ai",
+    "api",
+    "rest",
+    "sql",
+    "rql",
+    "etl",
+    "olap",
+    "snmp",
+    "kb",
+    "faq",
+    "url",
+    "cli",
+    "ui",
+    "aws",
+    "gcp",
+    "sdk",
+    "http",
+    "json",
+    "csv",
+    "dns",
+    "ssl",
+    "tls",
+    "jwt",
+    "s3",
+    "sqs",
+    "eks",
+    "aks",
+    "gke",
+]);
+
+const BREADCRUMB_SKIP_ROOTS = new Set(["guides", "cloud", "samples", "templates"]);
+
+function humanizeSegment(segment: string): string {
+    return segment
+        .split("-")
+        .map((word) =>
+            BREADCRUMB_ACRONYMS.has(word) ? word.toUpperCase() : word.charAt(0).toUpperCase() + word.slice(1)
+        )
+        .join(" ");
+}
+
+// Category chain from the URL (the crawler's hierarchy is too shallow), e.g.
+// /7.2/ai-integration/vector-search/overview -> ["AI Integration", "Vector Search"].
+export function getResultBreadcrumb(url: string | undefined | null): string[] {
+    if (!url) {
+        return [];
+    }
+    let segments = url.split(/[?#]/)[0].split("/").filter(Boolean);
+    if (segments.length && /^\d+\.\d+$/.test(segments[0])) {
+        segments = segments.slice(1);
+    }
+    if (segments.length && BREADCRUMB_SKIP_ROOTS.has(segments[0])) {
+        segments = segments.slice(1);
+    }
+    return segments.slice(0, -1).map(humanizeSegment);
+}
+
+export interface SearchFilter {
+    label: string;
+    kind: ContentSource | null;
+    pluginId: string | null;
+    tag: string | null;
+    // Render a divider before this pill: a separate scope, excluded from "All".
+    separated?: boolean;
+}
+
+export const SEARCH_FILTERS: SearchFilter[] = [
+    { label: "All", kind: null, pluginId: null, tag: null },
+    { label: "Docs", kind: "docs", pluginId: "default", tag: "docs-default-current" },
+    { label: "Guides", kind: "guides", pluginId: "guides", tag: "docs-guides-current" },
+    { label: "Cloud", kind: "cloud", pluginId: "cloud", tag: "docs-cloud-current" },
+    { label: "Samples", kind: "samples", pluginId: "samples", tag: "docs-samples-current", separated: true },
+];
+
+// Tags kept out of the default "All" scope, derived from the separated pills so the
+// divider, the pill, and the exclusion never drift.
+export const ALL_SCOPE_EXCLUDED_TAGS = SEARCH_FILTERS.filter((f) => f.separated && f.tag).map((f) => f.tag as string);

--- a/src/components/Search/searchSource.ts
+++ b/src/components/Search/searchSource.ts
@@ -24,7 +24,7 @@ export function getSearchResultSource(docusaurusTag: string | string[] | undefin
     return null;
 }
 
-// docusaurus_tag is faceted but not returned unless explicitly requested.
+// docusaurus_tag and breadcrumb are indexed but not returned unless explicitly requested.
 export const SEARCH_ATTRIBUTES_TO_RETRIEVE = [
     "hierarchy.lvl0",
     "hierarchy.lvl1",
@@ -37,83 +37,26 @@ export const SEARCH_ATTRIBUTES_TO_RETRIEVE = [
     "type",
     "url",
     "docusaurus_tag",
+    "breadcrumb",
 ];
-
-const BREADCRUMB_ACRONYMS = new Set([
-    "ai",
-    "api",
-    "rest",
-    "sql",
-    "rql",
-    "etl",
-    "olap",
-    "snmp",
-    "kb",
-    "faq",
-    "url",
-    "cli",
-    "ui",
-    "aws",
-    "gcp",
-    "sdk",
-    "http",
-    "json",
-    "csv",
-    "dns",
-    "ssl",
-    "tls",
-    "jwt",
-    "s3",
-    "sqs",
-    "eks",
-    "aks",
-    "gke",
-]);
-
-const BREADCRUMB_SKIP_ROOTS = new Set(["guides", "cloud", "samples", "templates"]);
-
-function humanizeSegment(segment: string): string {
-    return segment
-        .split("-")
-        .map((word) =>
-            BREADCRUMB_ACRONYMS.has(word) ? word.toUpperCase() : word.charAt(0).toUpperCase() + word.slice(1)
-        )
-        .join(" ");
-}
-
-// Category chain from the URL (the crawler's hierarchy is too shallow), e.g.
-// /7.2/ai-integration/vector-search/overview -> ["AI Integration", "Vector Search"].
-export function getResultBreadcrumb(url: string | undefined | null): string[] {
-    if (!url) {
-        return [];
-    }
-    let segments = url.split(/[?#]/)[0].split("/").filter(Boolean);
-    if (segments.length && /^\d+\.\d+$/.test(segments[0])) {
-        segments = segments.slice(1);
-    }
-    if (segments.length && BREADCRUMB_SKIP_ROOTS.has(segments[0])) {
-        segments = segments.slice(1);
-    }
-    return segments.slice(0, -1).map(humanizeSegment);
-}
 
 export interface SearchFilter {
     label: string;
     kind: ContentSource | null;
     pluginId: string | null;
-    tag: string | null;
     // Render a divider before this pill: a separate scope, excluded from "All".
     separated?: boolean;
 }
 
 export const SEARCH_FILTERS: SearchFilter[] = [
-    { label: "All", kind: null, pluginId: null, tag: null },
-    { label: "Docs", kind: "docs", pluginId: "default", tag: "docs-default-current" },
-    { label: "Guides", kind: "guides", pluginId: "guides", tag: "docs-guides-current" },
-    { label: "Cloud", kind: "cloud", pluginId: "cloud", tag: "docs-cloud-current" },
-    { label: "Samples", kind: "samples", pluginId: "samples", tag: "docs-samples-current", separated: true },
+    { label: "All", kind: null, pluginId: null },
+    { label: "Docs", kind: "docs", pluginId: "default" },
+    { label: "Guides", kind: "guides", pluginId: "guides" },
+    { label: "Cloud", kind: "cloud", pluginId: "cloud" },
+    { label: "Samples", kind: "samples", pluginId: "samples", separated: true },
 ];
 
-// Tags kept out of the default "All" scope, derived from the separated pills so the
-// divider, the pill, and the exclusion never drift.
-export const ALL_SCOPE_EXCLUDED_TAGS = SEARCH_FILTERS.filter((f) => f.separated && f.tag).map((f) => f.tag as string);
+// Plugin instances kept out of the default "All" scope; each is reachable via its own separated pill.
+export const ALL_SCOPE_EXCLUDED_PLUGIN_IDS = SEARCH_FILTERS.filter((f) => f.separated && f.pluginId).map(
+    (f) => f.pluginId as string
+);

--- a/src/components/Search/searchSource.ts
+++ b/src/components/Search/searchSource.ts
@@ -44,19 +44,24 @@ export interface SearchFilter {
     label: string;
     kind: ContentSource | null;
     pluginId: string | null;
-    // Render a divider before this pill: a separate scope, excluded from "All".
-    separated?: boolean;
 }
 
-export const SEARCH_FILTERS: SearchFilter[] = [
-    { label: "All", kind: null, pluginId: null },
-    { label: "Docs", kind: "docs", pluginId: "default" },
-    { label: "Guides", kind: "guides", pluginId: "guides" },
-    { label: "Cloud", kind: "cloud", pluginId: "cloud" },
-    { label: "Samples", kind: "samples", pluginId: "samples", separated: true },
+// Filter pills, grouped. The UI draws a divider between groups, and every group after the
+// first is a separate scope excluded from the default "All".
+export const SEARCH_FILTER_GROUPS: SearchFilter[][] = [
+    [
+        { label: "All", kind: null, pluginId: null },
+        { label: "Docs", kind: "docs", pluginId: "default" },
+        { label: "Guides", kind: "guides", pluginId: "guides" },
+        { label: "Cloud", kind: "cloud", pluginId: "cloud" },
+    ],
+    [{ label: "Samples", kind: "samples", pluginId: "samples" }],
 ];
 
-// Plugin instances kept out of the default "All" scope; each is reachable via its own separated pill.
-export const ALL_SCOPE_EXCLUDED_PLUGIN_IDS = SEARCH_FILTERS.filter((f) => f.separated && f.pluginId).map(
-    (f) => f.pluginId as string
-);
+export const SEARCH_FILTERS: SearchFilter[] = SEARCH_FILTER_GROUPS.flat();
+
+// Plugin instances kept out of the default "All" scope (every group after the first).
+export const ALL_SCOPE_EXCLUDED_PLUGIN_IDS = SEARCH_FILTER_GROUPS.slice(1)
+    .flat()
+    .map((f) => f.pluginId)
+    .filter((id): id is string => id !== null);

--- a/src/components/Search/useExternalGuides.ts
+++ b/src/components/Search/useExternalGuides.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import { usePluginData } from "@docusaurus/useGlobalData";
+
+type GuidesData = { guides?: Array<{ permalink?: string; external_url?: string }> };
+
+function normalizePath(url: string): string {
+    const path = url.replace(/^https?:\/\/[^/]+/, "").split(/[?#]/)[0];
+    return path.replace(/\/+$/, "") || "/";
+}
+
+// External guides render a shim page (reachable by direct link or search); map each one's
+// permalink to its external_url so search results can redirect straight to the article.
+export function useExternalGuideUrls(): Map<string, string> {
+    const data = usePluginData("recent-guides-plugin") as GuidesData | undefined;
+    return useMemo(() => {
+        const map = new Map<string, string>();
+        for (const guide of data?.guides ?? []) {
+            if (guide.permalink && guide.external_url) {
+                map.set(normalizePath(guide.permalink), guide.external_url);
+            }
+        }
+        return map;
+    }, [data]);
+}
+
+export function resolveExternalGuideUrl(map: Map<string, string>, url: string | undefined | null): string | null {
+    return url ? (map.get(normalizePath(url)) ?? null) : null;
+}

--- a/src/components/SeeAlso/SeeAlsoItem.tsx
+++ b/src/components/SeeAlso/SeeAlsoItem.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import Link from "@docusaurus/Link";
 import { Icon } from "@site/src/components/Common/Icon";
-import { getIconName, parsePath } from "./utils";
+import { getContentSourceIcon } from "@site/src/components/Common/contentSource";
+import { parsePath } from "./utils";
 import clsx from "clsx";
 import { SeeAlsoItemType } from "./types";
 import { useVersionedLink } from "./useVersionedLink";
@@ -11,7 +12,7 @@ interface SeeAlsoItemProps {
 }
 
 export function SeeAlsoItem({ item }: SeeAlsoItemProps) {
-    const iconName = getIconName(item.source);
+    const iconName = getContentSourceIcon(item.source);
     const { mainCategory, restOfPath, fullPath } = parsePath(item.path);
     const { getVersionedLink } = useVersionedLink();
 

--- a/src/components/SeeAlso/types.ts
+++ b/src/components/SeeAlso/types.ts
@@ -1,6 +1,8 @@
+import { ContentSource } from "@site/src/components/Common/contentSource";
+
 export interface SeeAlsoItemType {
     title: string;
     link: string;
-    source: "docs" | "cloud" | "guides" | "samples" | "external";
+    source: ContentSource;
     path: string;
 }

--- a/src/components/SeeAlso/utils.ts
+++ b/src/components/SeeAlso/utils.ts
@@ -1,23 +1,3 @@
-import { IconName } from "@site/src/typescript/iconName";
-import { SeeAlsoItemType } from "./types";
-
-export const getIconName = (source: SeeAlsoItemType["source"]): IconName => {
-    switch (source) {
-        case "docs":
-            return "document2";
-        case "cloud":
-            return "cloud";
-        case "guides":
-            return "guides";
-        case "samples":
-            return "code";
-        case "external":
-            return "newtab";
-        default:
-            return "document";
-    }
-};
-
 export const parsePath = (path: string) => {
     const parts = path ? path.split(">") : [];
     const mainCategory = parts[0]?.trim() || path;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -330,8 +330,7 @@ a.breadcrumbs__link:hover {
 }
 
 /* Custom styling for search */
-.DocSearch-Logo,
-.searchLogoColumn_rJIA {
+.DocSearch-Logo {
     display: none;
 }
 

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -38,6 +38,12 @@ type DocSearchProps = Omit<DocSearchModalProps, "onClose" | "initialScrollY"> & 
     searchPagePath: boolean | string;
 };
 
+// A DocSearch hit augmented with the custom fields our Algolia crawler emits.
+type SearchHit = (InternalDocSearchHit | StoredDocSearchHit) & {
+    docusaurus_tag?: string | string[];
+    breadcrumb?: string;
+};
+
 let DocSearchModal: typeof DocSearchModalType | null = null;
 
 function importDocSearchModalIfNeeded() {
@@ -136,31 +142,17 @@ function useResultsFooterComponent({
     );
 }
 
-function Hit({ hit, children }: { hit: InternalDocSearchHit | StoredDocSearchHit; children: React.ReactNode }) {
-    const source = getSearchResultSource((hit as { docusaurus_tag?: string | string[] }).docusaurus_tag);
+function Hit({ hit, children }: { hit: SearchHit; children: React.ReactNode }) {
+    const source = getSearchResultSource(hit.docusaurus_tag);
     const externalUrl = resolveExternalGuideUrl(useExternalGuideUrls(), hit.url);
-    // Crawler-provided section trail; drop the leading source root ("Docs ›" / "Guides") — the
-    // source is already shown by the badge and section header.
-    const breadcrumb = ((hit as { breadcrumb?: string }).breadcrumb ?? "").split(" › ").slice(1).join(" › ");
-
-    // DocSearch renders no path for page-level (lvl1) hits; inject the section trail into that slot.
-    const injectBreadcrumb = (node: HTMLAnchorElement | null) => {
-        if (!node || !breadcrumb) {
-            return;
-        }
-        const wrapper = node.querySelector(".DocSearch-Hit-content-wrapper");
-        if (!wrapper || wrapper.querySelector(".DocSearch-Hit-path")) {
-            return;
-        }
-        const pathEl = document.createElement("div");
-        pathEl.className = "DocSearch-Hit-path";
-        pathEl.textContent = breadcrumb;
-        wrapper.appendChild(pathEl);
-    };
+    // Crawler section trail, minus the leading source root ("Docs ›" / "Guides") — the source is
+    // already shown by the badge.
+    const breadcrumb = (hit.breadcrumb ?? "").split(" › ").slice(1).join(" › ");
 
     return (
-        <Link to={externalUrl ?? hit.url} ref={injectBreadcrumb}>
+        <Link to={externalUrl ?? hit.url}>
             {children}
+            {breadcrumb && <span className="DocSearch-Hit-breadcrumb">{breadcrumb}</span>}
             {(source || externalUrl) && (
                 <span className="DocSearch-Hit-sourceBadge">
                     <SearchResultBadge source={source} />

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
@@ -21,6 +21,17 @@ import {
 import type { AutocompleteState } from "@algolia/autocomplete-core";
 import type { FacetFilters } from "algoliasearch/lite";
 import CustomSearchButton from "@site/src/components/Common/CustomSearchButton";
+import SearchResultBadge from "@site/src/components/Search/SearchResultBadge";
+import SearchFilterPills from "@site/src/components/Search/SearchFilterPills";
+import {
+    ALL_SCOPE_EXCLUDED_TAGS,
+    getResultBreadcrumb,
+    getSearchResultSource,
+    SEARCH_ATTRIBUTES_TO_RETRIEVE,
+    SEARCH_FILTERS,
+} from "@site/src/components/Search/searchSource";
+import type { ContentSource } from "@site/src/components/Common/contentSource";
+import { resolveExternalGuideUrl, useExternalGuideUrls } from "@site/src/components/Search/useExternalGuides";
 
 type DocSearchProps = Omit<DocSearchModalProps, "onClose" | "initialScrollY"> & {
     contextualSearch?: string;
@@ -43,34 +54,49 @@ function importDocSearchModalIfNeeded() {
     });
 }
 
-function useNavigator({ externalUrlRegex }: Pick<DocSearchProps, "externalUrlRegex">) {
+function useNavigator(
+    { externalUrlRegex }: Pick<DocSearchProps, "externalUrlRegex">,
+    externalGuideUrls: Map<string, string>
+): DocSearchModalProps["navigator"] {
     const history = useHistory();
-    const [navigator] = useState<DocSearchModalProps["navigator"]>(() => {
-        return {
+    return useMemo(
+        () => ({
             navigate(params) {
-                // Algolia results could contain URL's from other domains which cannot
-                // be served through history and should navigate with window.location
-                if (isRegexpStringMatch(externalUrlRegex, params.itemUrl)) {
-                    window.location.href = params.itemUrl;
+                const url = resolveExternalGuideUrl(externalGuideUrls, params.itemUrl) ?? params.itemUrl;
+                if (/^https?:\/\//.test(url) || isRegexpStringMatch(externalUrlRegex, url)) {
+                    // Open external destinations (incl. external guides) in a new tab, matching the Link.
+                    if (!window.open(url, "_blank", "noopener,noreferrer")) {
+                        window.location.href = url;
+                    }
                 } else {
-                    history.push(params.itemUrl);
+                    history.push(url);
                 }
             },
-        };
-    });
-    return navigator;
+        }),
+        [externalUrlRegex, externalGuideUrls, history]
+    );
 }
 
-function useTransformSearchClient(): DocSearchModalProps["transformSearchClient"] {
+function useTransformSearchClient(realNbHits: { current: number }): DocSearchModalProps["transformSearchClient"] {
     const {
         siteMetadata: { docusaurusVersion },
     } = useDocusaurusContext();
     return useCallback(
         (searchClient: DocSearchTransformClient) => {
             searchClient.addAlgoliaAgent("docusaurus", docusaurusVersion);
+            // DocSearch accumulates nbHits across keystrokes; capture the real per-query count instead.
+            const originalSearch = searchClient.search.bind(searchClient);
+            searchClient.search = ((...args: Parameters<typeof originalSearch>) =>
+                originalSearch(...args).then((response) => {
+                    const firstResult = (response as { results?: Array<{ nbHits?: number }> })?.results?.[0];
+                    if (firstResult && typeof firstResult.nbHits === "number") {
+                        realNbHits.current = firstResult.nbHits;
+                    }
+                    return response;
+                })) as typeof searchClient.search;
             return searchClient;
         },
-        [docusaurusVersion]
+        [docusaurusVersion, realNbHits]
     );
 }
 
@@ -79,10 +105,8 @@ function useTransformItems(props: Pick<DocSearchProps, "transformItems">) {
     const [transformItems] = useState<DocSearchModalProps["transformItems"]>(() => {
         return (items: DocSearchHit[]) =>
             props.transformItems
-                ? // Custom transformItems
-                  props.transformItems(items)
-                : // Default transformItems
-                  items.map((item) => ({
+                ? props.transformItems(items)
+                : items.map((item) => ({
                       ...item,
                       url: processSearchResultUrl(item.url),
                   }));
@@ -92,71 +116,148 @@ function useTransformItems(props: Pick<DocSearchProps, "transformItems">) {
 
 function useResultsFooterComponent({
     closeModal,
+    realNbHits,
+    activeFilter,
 }: {
     closeModal: () => void;
+    realNbHits: { current: number };
+    activeFilter: ContentSource | null;
 }): DocSearchProps["resultsFooterComponent"] {
     return useMemo(
         () =>
-            ({ state }) => <ResultsFooter state={state} onClose={closeModal} />,
-        [closeModal]
+            ({ state }) => (
+                <ResultsFooter
+                    state={state}
+                    onClose={closeModal}
+                    nbHits={realNbHits.current}
+                    activeFilter={activeFilter}
+                />
+            ),
+        [closeModal, realNbHits, activeFilter]
     );
 }
 
 function Hit({ hit, children }: { hit: InternalDocSearchHit | StoredDocSearchHit; children: React.ReactNode }) {
-    return <Link to={hit.url}>{children}</Link>;
+    const source = getSearchResultSource((hit as { docusaurus_tag?: string | string[] }).docusaurus_tag);
+    const externalUrl = resolveExternalGuideUrl(useExternalGuideUrls(), hit.url);
+    const breadcrumb = getResultBreadcrumb(hit.url);
+
+    // DocSearch renders no path for page-level (lvl1) hits; inject the URL chain into that empty slot.
+    const injectBreadcrumb = (node: HTMLAnchorElement | null) => {
+        if (!node || breadcrumb.length === 0) {
+            return;
+        }
+        const wrapper = node.querySelector(".DocSearch-Hit-content-wrapper");
+        if (!wrapper || wrapper.querySelector(".DocSearch-Hit-path")) {
+            return;
+        }
+        const pathEl = document.createElement("div");
+        pathEl.className = "DocSearch-Hit-path";
+        pathEl.textContent = breadcrumb.join(" › ");
+        wrapper.appendChild(pathEl);
+    };
+
+    return (
+        <Link to={externalUrl ?? hit.url} ref={injectBreadcrumb}>
+            {children}
+            {(source || externalUrl) && (
+                <span className="DocSearch-Hit-sourceBadge">
+                    <SearchResultBadge source={source} />
+                    {externalUrl && <SearchResultBadge source="external" />}
+                </span>
+            )}
+        </Link>
+    );
 }
 
 type ResultsFooterProps = {
     state: AutocompleteState<InternalDocSearchHit>;
     onClose: () => void;
+    nbHits: number;
+    activeFilter: ContentSource | null;
 };
 
-function ResultsFooter({ state, onClose }: ResultsFooterProps) {
+function ResultsFooter({ state, onClose, nbHits, activeFilter }: ResultsFooterProps) {
     const createSearchLink = useSearchLinkCreator();
+    let to = createSearchLink(state.query);
+    if (activeFilter) {
+        // Carry the active source filter through to the full search page.
+        to += `${to.includes("?") ? "&" : "?"}source=${activeFilter}`;
+    }
 
     return (
-        <Link to={createSearchLink(state.query)} onClick={onClose}>
-            <Translate id="theme.SearchBar.seeAll" values={{ count: state.context.nbHits }}>
+        <Link to={to} onClick={onClose}>
+            <Translate id="theme.SearchBar.seeAll" values={{ count: nbHits }}>
                 {"See all {count} results"}
             </Translate>
         </Link>
     );
 }
 
-function useSearchParameters({ contextualSearch, ...props }: DocSearchProps): DocSearchProps["searchParameters"] {
-    function mergeFacetFilters(f1: FacetFilters, f2: FacetFilters): FacetFilters {
-        const normalize = (f: FacetFilters): FacetFilters => (typeof f === "string" ? [f] : f);
-        return [...normalize(f1), ...normalize(f2)];
+function useSearchParameters(
+    { contextualSearch, ...props }: DocSearchProps,
+    activePluginId: string | null
+): DocSearchProps["searchParameters"] {
+    const contextual = useAlgoliaContextualFacetFilters() as (string | string[])[];
+    const configFilters = (props.searchParameters?.facetFilters ?? []) as (string | string[])[];
+
+    // Contextual filters look like ["language:en", ["docusaurus_tag:..", ...]]. Narrow the tag
+    // group: one pill -> just that instance's tag, keeping the version already in the contextual
+    // group (so the Docs pill stays on the page's version); "All" -> drop separated scopes (samples).
+    const excluded = ALL_SCOPE_EXCLUDED_TAGS.map((tag) => `docusaurus_tag:${tag}`);
+    const narrowed = contextual.map((entry) => {
+        if (!Array.isArray(entry)) {
+            return entry;
+        }
+        return activePluginId
+            ? entry.filter((tag) => tag.startsWith(`docusaurus_tag:docs-${activePluginId}-`))
+            : entry.filter((tag) => !excluded.includes(tag));
+    });
+
+    let facetFilters: (string | string[])[];
+    if (contextualSearch) {
+        facetFilters = [...narrowed, ...configFilters];
+    } else if (activePluginId) {
+        facetFilters = [[`docusaurus_tag:docs-${activePluginId}-current`], ...configFilters];
+    } else {
+        facetFilters = configFilters;
     }
 
-    const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters() as FacetFilters;
-
-    const configFacetFilters: FacetFilters = props.searchParameters?.facetFilters ?? [];
-
-    const facetFilters: FacetFilters = contextualSearch
-        ? // Merge contextual search filters with config filters
-          mergeFacetFilters(contextualSearchFacetFilters, configFacetFilters)
-        : // ... or use config facetFilters
-          configFacetFilters;
-
-    // We let users override default searchParameters if they want to
     return {
         ...props.searchParameters,
-        facetFilters,
+        attributesToRetrieve: props.searchParameters?.attributesToRetrieve ?? SEARCH_ATTRIBUTES_TO_RETRIEVE,
+        facetFilters: facetFilters as FacetFilters,
     };
 }
 
+// Text fields where typing must not hijack the type-to-search shortcut.
+function isEditableElement(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+    return (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable
+    );
+}
+
 function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
-    const navigator = useNavigator({ externalUrlRegex });
-    const searchParameters = useSearchParameters({ ...props });
+    const externalGuideUrls = useExternalGuideUrls();
+    const navigator = useNavigator({ externalUrlRegex }, externalGuideUrls);
+    const [activeFilter, setActiveFilter] = useState<ContentSource | null>(null);
+    const activePluginId = SEARCH_FILTERS.find((f) => f.kind === activeFilter)?.pluginId ?? null;
+    const searchParameters = useSearchParameters({ ...props }, activePluginId);
     const transformItems = useTransformItems(props);
-    const transformSearchClient = useTransformSearchClient();
+    const realNbHits = useRef(0);
+    const transformSearchClient = useTransformSearchClient(realNbHits);
 
     const searchContainer = useRef<HTMLDivElement | null>(null);
-    // TODO remove "as any" after React 19 upgrade
-    const searchButtonRef = useRef<HTMLButtonElement>(null as any);
+    const searchButtonRef = useRef<HTMLButtonElement>(null);
     const [isOpen, setIsOpen] = useState(false);
     const [initialQuery, setInitialQuery] = useState<string | undefined>(undefined);
+    const [pillHost, setPillHost] = useState<HTMLElement | null>(null);
 
     const prepareSearchContainer = useCallback(() => {
         if (!searchContainer.current) {
@@ -175,30 +276,71 @@ function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
         setIsOpen(false);
         searchButtonRef.current?.focus();
         setInitialQuery(undefined);
+        setActiveFilter(null);
     }, []);
 
-    const handleInput = useCallback(
-        (event: KeyboardEvent) => {
-            if (event.key === "f" && (event.metaKey || event.ctrlKey)) {
-                // ignore browser's ctrl+f
+    // The DocSearch modal has no slot for custom controls, so insert a host node after its search bar
+    // and portal the pills into it. Visibility (hidden until the user types) is pure CSS, so typing
+    // never touches React state and the first character is never dropped.
+    useEffect(() => {
+        if (!isOpen) {
+            setPillHost(null);
+            return undefined;
+        }
+        const searchBar = document.querySelector(".DocSearch-Modal .DocSearch-SearchBar");
+        if (!searchBar) {
+            return undefined;
+        }
+        const host = document.createElement("div");
+        host.className = "DocSearch-SourceFilters";
+        searchBar.insertAdjacentElement("afterend", host);
+        setPillHost(host);
+        return () => host.remove();
+    }, [isOpen, activeFilter]);
+
+    // DocSearch reads searchParameters only at mount, so a filter change remounts the modal
+    // (keyed on the filter); the typed query is fed back as the next initial query.
+    const handleFilterChange = useCallback((kind: ContentSource | null) => {
+        const input = document.querySelector<HTMLInputElement>(".DocSearch-Input");
+        setInitialQuery(input?.value || undefined);
+        setPillHost(null);
+        setActiveFilter(kind);
+    }, []);
+
+    // Type-to-search: a printable key pressed anywhere outside a text field opens the modal
+    // seeded with that character (Space and "/" keep their usual behavior). Seeding the query
+    // is also what guarantees the first keystroke survives the modal's lazy mount.
+    useEffect(() => {
+        if (isOpen) {
+            return undefined;
+        }
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (
+                event.key.length !== 1 ||
+                event.key === " " ||
+                event.key === "/" ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.altKey ||
+                event.isComposing ||
+                isEditableElement(event.composedPath()[0] ?? event.target)
+            ) {
                 return;
             }
-            // prevents duplicate key insertion in the modal input
             event.preventDefault();
-            setInitialQuery(event.key);
+            setInitialQuery((prev) => (prev ?? "") + event.key);
             openModal();
-        },
-        [openModal]
-    );
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, [isOpen, openModal]);
 
-    const resultsFooterComponent = useResultsFooterComponent({ closeModal });
+    const resultsFooterComponent = useResultsFooterComponent({ closeModal, realNbHits, activeFilter });
 
     useDocSearchKeyboardEvents({
         isOpen,
         onOpen: openModal,
         onClose: closeModal,
-        onInput: handleInput,
-        searchButtonRef,
         isAskAiActive: false,
         onAskAiToggle: (_toggle: boolean) => {},
     });
@@ -206,13 +348,12 @@ function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
     return (
         <>
             <Head>
-                {/* This hints the browser that the website will load data from Algolia,
-        and allows it to preconnect to the DocSearch cluster. It makes the first
-        query faster, especially on mobile. */}
+                {/* Preconnect to the Algolia cluster to speed up the first query. */}
                 <link rel="preconnect" href={`https://${props.appId}-dsn.algolia.net`} crossOrigin="anonymous" />
             </Head>
 
             <CustomSearchButton
+                ref={searchButtonRef}
                 onTouchStart={importDocSearchModalIfNeeded}
                 onFocus={importDocSearchModalIfNeeded}
                 onMouseOver={importDocSearchModalIfNeeded}
@@ -225,6 +366,7 @@ function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
                 searchContainer.current &&
                 createPortal(
                     <DocSearchModal
+                        key={activeFilter ?? "all"}
                         onClose={closeModal}
                         initialScrollY={window.scrollY}
                         initialQuery={initialQuery}
@@ -242,6 +384,10 @@ function DocSearch({ externalUrlRegex, ...props }: DocSearchProps) {
                     />,
                     searchContainer.current
                 )}
+
+            {isOpen &&
+                pillHost &&
+                createPortal(<SearchFilterPills active={activeFilter} onChange={handleFilterChange} />, pillHost)}
         </>
     );
 }

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -24,8 +24,7 @@ import CustomSearchButton from "@site/src/components/Common/CustomSearchButton";
 import SearchResultBadge from "@site/src/components/Search/SearchResultBadge";
 import SearchFilterPills from "@site/src/components/Search/SearchFilterPills";
 import {
-    ALL_SCOPE_EXCLUDED_TAGS,
-    getResultBreadcrumb,
+    ALL_SCOPE_EXCLUDED_PLUGIN_IDS,
     getSearchResultSource,
     SEARCH_ATTRIBUTES_TO_RETRIEVE,
     SEARCH_FILTERS,
@@ -140,11 +139,13 @@ function useResultsFooterComponent({
 function Hit({ hit, children }: { hit: InternalDocSearchHit | StoredDocSearchHit; children: React.ReactNode }) {
     const source = getSearchResultSource((hit as { docusaurus_tag?: string | string[] }).docusaurus_tag);
     const externalUrl = resolveExternalGuideUrl(useExternalGuideUrls(), hit.url);
-    const breadcrumb = getResultBreadcrumb(hit.url);
+    // Crawler-provided section trail; drop the leading source root ("Docs ›" / "Guides") — the
+    // source is already shown by the badge and section header.
+    const breadcrumb = ((hit as { breadcrumb?: string }).breadcrumb ?? "").split(" › ").slice(1).join(" › ");
 
-    // DocSearch renders no path for page-level (lvl1) hits; inject the URL chain into that empty slot.
+    // DocSearch renders no path for page-level (lvl1) hits; inject the section trail into that slot.
     const injectBreadcrumb = (node: HTMLAnchorElement | null) => {
-        if (!node || breadcrumb.length === 0) {
+        if (!node || !breadcrumb) {
             return;
         }
         const wrapper = node.querySelector(".DocSearch-Hit-content-wrapper");
@@ -153,7 +154,7 @@ function Hit({ hit, children }: { hit: InternalDocSearchHit | StoredDocSearchHit
         }
         const pathEl = document.createElement("div");
         pathEl.className = "DocSearch-Hit-path";
-        pathEl.textContent = breadcrumb.join(" › ");
+        pathEl.textContent = breadcrumb;
         wrapper.appendChild(pathEl);
     };
 
@@ -204,14 +205,15 @@ function useSearchParameters(
     // Contextual filters look like ["language:en", ["docusaurus_tag:..", ...]]. Narrow the tag
     // group: one pill -> just that instance's tag, keeping the version already in the contextual
     // group (so the Docs pill stays on the page's version); "All" -> drop separated scopes (samples).
-    const excluded = ALL_SCOPE_EXCLUDED_TAGS.map((tag) => `docusaurus_tag:${tag}`);
+    const isExcludedFromAll = (tag: string) =>
+        ALL_SCOPE_EXCLUDED_PLUGIN_IDS.some((pluginId) => tag.startsWith(`docusaurus_tag:docs-${pluginId}-`));
     const narrowed = contextual.map((entry) => {
         if (!Array.isArray(entry)) {
             return entry;
         }
         return activePluginId
             ? entry.filter((tag) => tag.startsWith(`docusaurus_tag:docs-${activePluginId}-`))
-            : entry.filter((tag) => !excluded.includes(tag));
+            : entry.filter((tag) => !isExcludedFromAll(tag));
     });
 
     let facetFilters: (string | string[])[];

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -11,3 +11,32 @@
 .DocSearch-Container {
     z-index: calc(var(--ifm-z-index-fixed) + 1);
 }
+
+/* Source badge appended to each result row (Docs / Guide / Cloud / Sample / External). */
+.DocSearch-Hit a {
+    display: flex;
+    align-items: center;
+}
+
+.DocSearch-Hit a > .DocSearch-Hit-Container {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.DocSearch-Hit-sourceBadge {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0 12px 0 8px;
+}
+
+/* Source filter pills injected after the modal search bar. */
+.DocSearch-SourceFilters {
+    padding: 10px var(--docsearch-spacing) 2px;
+}
+
+/* Hidden until the user types (while the input still shows its placeholder). */
+.DocSearch-Modal:has(.DocSearch-Input:placeholder-shown) .DocSearch-SourceFilters {
+    display: none;
+}

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -23,6 +23,18 @@
     min-width: 0;
 }
 
+/* Crawler section trail, shown muted to the right of the title (truncates if tight). */
+.DocSearch-Hit-breadcrumb {
+    flex: 0 1 auto;
+    min-width: 0;
+    margin-left: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--docsearch-muted-color);
+    font-size: 0.85em;
+}
+
 /* Wrapper for the source badge(s); a flex row with a gap so dual badges (e.g. Guide + External) don't touch. */
 .DocSearch-Hit-sourceBadge {
     flex: 0 0 auto;

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -12,7 +12,7 @@
     z-index: calc(var(--ifm-z-index-fixed) + 1);
 }
 
-/* Source badge appended to each result row (Docs / Guide / Cloud / Sample / External). */
+/* Lay out each result row as a flex row so the source badge sits beside the content. */
 .DocSearch-Hit a {
     display: flex;
     align-items: center;
@@ -23,6 +23,7 @@
     min-width: 0;
 }
 
+/* Wrapper for the source badge(s); a flex row with a gap so dual badges (e.g. Guide + External) don't touch. */
 .DocSearch-Hit-sourceBadge {
     flex: 0 0 auto;
     display: inline-flex;

--- a/src/theme/SearchPage/index.tsx
+++ b/src/theme/SearchPage/index.tsx
@@ -1,0 +1,479 @@
+/**
+ * Swizzled from @docusaurus/theme-search-algolia, kept close to upstream for diffing.
+ * Adds per-hit source badges and source filter pills (see SEARCH_FILTERS).
+ */
+import React, { useEffect, useReducer, useRef, useState, type ReactNode } from "react";
+import { useHistory, useLocation } from "@docusaurus/router";
+import clsx from "clsx";
+import algoliaSearchHelper from "algoliasearch-helper";
+import { liteClient } from "algoliasearch/lite";
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import Head from "@docusaurus/Head";
+import Link from "@docusaurus/Link";
+import { useAllDocsData } from "@docusaurus/plugin-content-docs/client";
+import {
+    HtmlClassNameProvider,
+    PageMetadata,
+    useEvent,
+    usePluralForm,
+    useSearchQueryString,
+} from "@docusaurus/theme-common";
+import Translate, { translate } from "@docusaurus/Translate";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { useAlgoliaThemeConfig, useSearchResultUrlProcessor } from "@docusaurus/theme-search-algolia/client";
+import Layout from "@theme/Layout";
+import Heading from "@theme/Heading";
+import SearchResultBadge from "@site/src/components/Search/SearchResultBadge";
+import SearchFilterPills from "@site/src/components/Search/SearchFilterPills";
+import {
+    ALL_SCOPE_EXCLUDED_TAGS,
+    getSearchResultSource,
+    SEARCH_ATTRIBUTES_TO_RETRIEVE,
+    SEARCH_FILTERS,
+} from "@site/src/components/Search/searchSource";
+import type { ContentSource } from "@site/src/components/Common/contentSource";
+import { resolveExternalGuideUrl, useExternalGuideUrls } from "@site/src/components/Search/useExternalGuides";
+import styles from "./styles.module.css";
+
+interface ResultItem {
+    title: string;
+    url: string;
+    summary: string;
+    breadcrumbs: string[];
+    source: ContentSource | null;
+    external: boolean;
+}
+
+interface SearchResultState {
+    items: ResultItem[];
+    query: string | null;
+    totalResults: number | null;
+    totalPages: number | null;
+    lastPage: number | null;
+    hasMore: boolean | null;
+    loading: boolean | null;
+}
+
+type SearchResultAction =
+    | { type: "reset" }
+    | { type: "loading" }
+    | { type: "update"; value: SearchResultState }
+    | { type: "advance" };
+
+// Very simple pluralization: probably good enough for now
+function useDocumentsFoundPlural() {
+    const { selectMessage } = usePluralForm();
+    return (count: number) =>
+        selectMessage(
+            count,
+            translate(
+                {
+                    id: "theme.SearchPage.documentsFound.plurals",
+                    description:
+                        'Pluralized label for "{count} documents found". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+                    message: "One document found|{count} documents found",
+                },
+                { count }
+            )
+        );
+}
+
+function useDocsSearchVersionsHelpers() {
+    const allDocsData = useAllDocsData();
+    // State of the version select menus / algolia facet filters
+    // docsPluginId -> versionName map
+    const [searchVersions, setSearchVersions] = useState<Record<string, string>>(() =>
+        Object.entries(allDocsData).reduce(
+            (acc, [pluginId, pluginData]) => ({ ...acc, [pluginId]: pluginData.versions[0].name }),
+            {}
+        )
+    );
+    // Set the value of a single select menu
+    const setSearchVersion = (pluginId: string, searchVersion: string) =>
+        setSearchVersions((s) => ({ ...s, [pluginId]: searchVersion }));
+    const versioningEnabled = Object.values(allDocsData).some((docsData) => docsData.versions.length > 1);
+    return { allDocsData, versioningEnabled, searchVersions, setSearchVersion };
+}
+
+type DocsSearchVersionsHelpers = ReturnType<typeof useDocsSearchVersionsHelpers>;
+
+// We want to display one select per versioned docs plugin instance
+function SearchVersionSelectList({
+    docsSearchVersionsHelpers,
+}: {
+    docsSearchVersionsHelpers: DocsSearchVersionsHelpers;
+}) {
+    const versionedPluginEntries = Object.entries(docsSearchVersionsHelpers.allDocsData)
+        // Do not show a version select for unversioned docs plugin instances
+        .filter(([, docsData]) => docsData.versions.length > 1);
+    return (
+        <div className={clsx("col", "col--3", "padding-left--none", styles.searchVersionColumn)}>
+            {versionedPluginEntries.map(([pluginId, docsData]) => {
+                const labelPrefix = versionedPluginEntries.length > 1 ? `${pluginId}: ` : "";
+                return (
+                    <select
+                        key={pluginId}
+                        onChange={(e) => docsSearchVersionsHelpers.setSearchVersion(pluginId, e.target.value)}
+                        defaultValue={docsSearchVersionsHelpers.searchVersions[pluginId]}
+                        className={styles.searchVersionInput}
+                    >
+                        {docsData.versions.map((version, i) => (
+                            <option key={i} label={`${labelPrefix}${version.label}`} value={version.name} />
+                        ))}
+                    </select>
+                );
+            })}
+        </div>
+    );
+}
+
+function getSearchPageTitle(searchQuery: string): string {
+    return searchQuery
+        ? translate(
+              {
+                  id: "theme.SearchPage.existingResultsTitle",
+                  message: 'Search results for "{query}"',
+                  description: "The search page title for non-empty query",
+              },
+              { query: searchQuery }
+          )
+        : translate({
+              id: "theme.SearchPage.emptyResultsTitle",
+              message: "Search the documentation",
+              description: "The search page title for empty query",
+          });
+}
+
+function SearchPageContent(): ReactNode {
+    const {
+        i18n: { currentLocale },
+    } = useDocusaurusContext();
+    const {
+        algolia: { appId, apiKey, indexName, contextualSearch },
+    } = useAlgoliaThemeConfig();
+    const processSearchResultUrl = useSearchResultUrlProcessor();
+    const documentsFoundPlural = useDocumentsFoundPlural();
+    const docsSearchVersionsHelpers = useDocsSearchVersionsHelpers();
+    const [searchQuery, setSearchQuery] = useSearchQueryString();
+    const history = useHistory();
+    const location = useLocation();
+    const [activeFilter, setActiveFilter] = useState<ContentSource | null>(null);
+    // The URL's ?source= is the source of truth for the active pill. Synced after mount (so the
+    // first client render matches the query-less prerendered HTML) and on every URL change (so the
+    // modal's "See all results" link and back/forward stay in sync).
+    useEffect(() => {
+        const source = new URLSearchParams(location.search).get("source");
+        setActiveFilter(SEARCH_FILTERS.find((f) => f.kind === source)?.kind ?? null);
+    }, [location.search]);
+    const handleFilterChange = (kind: ContentSource | null) => {
+        const params = new URLSearchParams(location.search);
+        if (kind) {
+            params.set("source", kind);
+        } else {
+            params.delete("source");
+        }
+        history.replace({ search: params.toString() });
+    };
+    const pageTitle = getSearchPageTitle(searchQuery);
+    const initialSearchResultState: SearchResultState = {
+        items: [],
+        query: null,
+        totalResults: null,
+        totalPages: null,
+        lastPage: null,
+        hasMore: null,
+        loading: null,
+    };
+    const [searchResultState, searchResultStateDispatcher] = useReducer(
+        (prevState: SearchResultState, data: SearchResultAction): SearchResultState => {
+            switch (data.type) {
+                case "reset": {
+                    return initialSearchResultState;
+                }
+                case "loading": {
+                    return { ...prevState, loading: true };
+                }
+                case "update": {
+                    if (searchQuery !== data.value.query) {
+                        return prevState;
+                    }
+                    return {
+                        ...data.value,
+                        items: data.value.lastPage === 0 ? data.value.items : prevState.items.concat(data.value.items),
+                    };
+                }
+                case "advance": {
+                    const hasMore = (prevState.totalPages ?? 0) > (prevState.lastPage ?? 0) + 1;
+                    return {
+                        ...prevState,
+                        lastPage: hasMore ? (prevState.lastPage ?? 0) + 1 : prevState.lastPage,
+                        hasMore,
+                    };
+                }
+                default:
+                    return prevState;
+            }
+        },
+        initialSearchResultState
+    );
+
+    const externalGuideUrls = useExternalGuideUrls();
+
+    // respect settings from the theme config for facets
+    const disjunctiveFacets = contextualSearch ? ["language", "docusaurus_tag"] : [];
+    const algoliaClient = liteClient(appId, apiKey);
+    const algoliaHelper = algoliaSearchHelper(algoliaClient as any, indexName, {
+        hitsPerPage: 15,
+        advancedSyntax: true,
+        disjunctiveFacets,
+        attributesToRetrieve: SEARCH_ATTRIBUTES_TO_RETRIEVE,
+    } as any);
+
+    algoliaHelper.on("result", ({ results }: any) => {
+        const { query, hits, page, nbHits, nbPages } = results;
+        if (query === "" || !Array.isArray(hits)) {
+            searchResultStateDispatcher({ type: "reset" });
+            return;
+        }
+        const sanitizeValue = (value: string) =>
+            value.replace(/algolia-docsearch-suggestion--highlight/g, "search-result-match");
+        const items: ResultItem[] = hits.map((hit: any) => {
+            const {
+                url,
+                _highlightResult: { hierarchy },
+                _snippetResult: snippet = {},
+            } = hit;
+            const source = getSearchResultSource(hit.docusaurus_tag);
+            const externalUrl = resolveExternalGuideUrl(externalGuideUrls, url);
+            const titles = Object.keys(hierarchy).map((key) => sanitizeValue(hierarchy[key].value));
+            return {
+                title: titles.pop() ?? "",
+                url: externalUrl ?? processSearchResultUrl(url),
+                summary: snippet.content ? `${sanitizeValue(snippet.content.value)}...` : "",
+                breadcrumbs: titles,
+                source,
+                external: !!externalUrl,
+            };
+        });
+        searchResultStateDispatcher({
+            type: "update",
+            value: {
+                items,
+                query,
+                totalResults: nbHits,
+                totalPages: nbPages,
+                lastPage: page,
+                hasMore: nbPages > page + 1,
+                loading: false,
+            },
+        });
+    });
+
+    const [loaderRef, setLoaderRef] = useState<HTMLDivElement | null>(null);
+    const prevY = useRef(0);
+    const observer = useRef(
+        ExecutionEnvironment.canUseIntersectionObserver &&
+            new IntersectionObserver(
+                (entries) => {
+                    const {
+                        isIntersecting,
+                        boundingClientRect: { y: currentY },
+                    } = entries[0];
+                    if (isIntersecting && prevY.current > currentY) {
+                        searchResultStateDispatcher({ type: "advance" });
+                    }
+                    prevY.current = currentY;
+                },
+                { threshold: 1 }
+            )
+    );
+
+    const makeSearch = useEvent((page = 0) => {
+        if (contextualSearch) {
+            algoliaHelper.addDisjunctiveFacetRefinement("language", currentLocale);
+            const activeFilterDef = SEARCH_FILTERS.find((f) => f.kind === activeFilter);
+            if (activeFilterDef?.pluginId) {
+                // One source selected: restrict to that instance's tag at its selected version.
+                const version = docsSearchVersionsHelpers.searchVersions[activeFilterDef.pluginId] ?? "current";
+                algoliaHelper.addDisjunctiveFacetRefinement(
+                    "docusaurus_tag",
+                    `docs-${activeFilterDef.pluginId}-${version}`
+                );
+            } else {
+                // "All": every instance except separated scopes (samples).
+                algoliaHelper.addDisjunctiveFacetRefinement("docusaurus_tag", "default");
+                Object.entries(docsSearchVersionsHelpers.searchVersions).forEach(([pluginId, searchVersion]) => {
+                    const tag = `docs-${pluginId}-${searchVersion}`;
+                    if (!ALL_SCOPE_EXCLUDED_TAGS.includes(tag)) {
+                        algoliaHelper.addDisjunctiveFacetRefinement("docusaurus_tag", tag);
+                    }
+                });
+            }
+        }
+        algoliaHelper.setQuery(searchQuery).setPage(page).search();
+    });
+
+    useEffect(() => {
+        if (!loaderRef) {
+            return undefined;
+        }
+        const currentObserver = observer.current;
+        if (currentObserver) {
+            currentObserver.observe(loaderRef);
+            return () => currentObserver.unobserve(loaderRef);
+        }
+        return () => true;
+    }, [loaderRef]);
+
+    useEffect(() => {
+        searchResultStateDispatcher({ type: "reset" });
+        if (searchQuery) {
+            searchResultStateDispatcher({ type: "loading" });
+            setTimeout(() => {
+                makeSearch();
+            }, 300);
+        }
+    }, [searchQuery, activeFilter, docsSearchVersionsHelpers.searchVersions, makeSearch]);
+
+    useEffect(() => {
+        if (!searchResultState.lastPage || searchResultState.lastPage === 0) {
+            return;
+        }
+        makeSearch(searchResultState.lastPage);
+    }, [makeSearch, searchResultState.lastPage]);
+
+    return (
+        <Layout>
+            <PageMetadata title={pageTitle} />
+
+            <Head>
+                {/*
+                 We should not index search pages
+                  See https://github.com/facebook/docusaurus/pull/3233
+                */}
+                <meta property="robots" content="noindex, follow" />
+            </Head>
+
+            <div className="container margin-vert--lg">
+                <Heading as="h1">{pageTitle}</Heading>
+
+                <form className="row" onSubmit={(e) => e.preventDefault()}>
+                    <div
+                        className={clsx("col", styles.searchQueryColumn, {
+                            "col--9": docsSearchVersionsHelpers.versioningEnabled,
+                            "col--12": !docsSearchVersionsHelpers.versioningEnabled,
+                        })}
+                    >
+                        <input
+                            type="search"
+                            name="q"
+                            className={styles.searchQueryInput}
+                            placeholder={translate({
+                                id: "theme.SearchPage.inputPlaceholder",
+                                message: "Type your search here",
+                                description: "The placeholder for search page input",
+                            })}
+                            aria-label={translate({
+                                id: "theme.SearchPage.inputLabel",
+                                message: "Search",
+                                description: "The ARIA label for search page input",
+                            })}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            value={searchQuery}
+                            autoComplete="off"
+                            autoFocus
+                        />
+                    </div>
+
+                    {contextualSearch && docsSearchVersionsHelpers.versioningEnabled && (
+                        <SearchVersionSelectList docsSearchVersionsHelpers={docsSearchVersionsHelpers} />
+                    )}
+                </form>
+
+                <SearchFilterPills active={activeFilter} onChange={handleFilterChange} className="margin-bottom--md" />
+
+                <div className="row">
+                    <div className={clsx("col", "col--12", styles.searchResultsColumn)}>
+                        {!!searchResultState.totalResults && documentsFoundPlural(searchResultState.totalResults)}
+                    </div>
+                </div>
+
+                {searchResultState.items.length > 0 ? (
+                    <main>
+                        {searchResultState.items.map((item, i) => (
+                            <article key={i} className={styles.searchResultItem}>
+                                <Heading
+                                    as="h2"
+                                    className={clsx(
+                                        styles.searchResultItemHeading,
+                                        "flex flex-wrap items-center gap-x-2 gap-y-1"
+                                    )}
+                                >
+                                    <Link to={item.url} dangerouslySetInnerHTML={{ __html: item.title }} />
+                                    <SearchResultBadge source={item.source} />
+                                    {item.external && <SearchResultBadge source="external" />}
+                                </Heading>
+
+                                {item.breadcrumbs.length > 0 && (
+                                    <nav aria-label="breadcrumbs">
+                                        <ul className={clsx("breadcrumbs", styles.searchResultItemPath)}>
+                                            {item.breadcrumbs.map((html, index) => (
+                                                <li
+                                                    key={index}
+                                                    className="breadcrumbs__item"
+                                                    // Markup comes from Algolia highlighting and is trusted.
+                                                    dangerouslySetInnerHTML={{ __html: html }}
+                                                />
+                                            ))}
+                                        </ul>
+                                    </nav>
+                                )}
+
+                                {item.summary && (
+                                    <p
+                                        className={styles.searchResultItemSummary}
+                                        // Markup comes from Algolia highlighting and is trusted.
+                                        dangerouslySetInnerHTML={{ __html: item.summary }}
+                                    />
+                                )}
+                            </article>
+                        ))}
+                    </main>
+                ) : (
+                    [
+                        searchQuery && !searchResultState.loading && (
+                            <p key="no-results">
+                                <Translate
+                                    id="theme.SearchPage.noResultsText"
+                                    description="The paragraph for empty search result"
+                                >
+                                    No results were found
+                                </Translate>
+                            </p>
+                        ),
+                        !!searchResultState.loading && <div key="spinner" className={styles.loadingSpinner} />,
+                    ]
+                )}
+
+                {searchResultState.hasMore && (
+                    <div className={styles.loader} ref={setLoaderRef}>
+                        <Translate
+                            id="theme.SearchPage.fetchingNewResults"
+                            description="The paragraph for fetching new search results"
+                        >
+                            Fetching new results...
+                        </Translate>
+                    </div>
+                )}
+            </div>
+        </Layout>
+    );
+}
+
+export default function SearchPage(): ReactNode {
+    return (
+        <HtmlClassNameProvider className="search-page-wrapper">
+            <SearchPageContent />
+        </HtmlClassNameProvider>
+    );
+}

--- a/src/theme/SearchPage/index.tsx
+++ b/src/theme/SearchPage/index.tsx
@@ -26,7 +26,7 @@ import Heading from "@theme/Heading";
 import SearchResultBadge from "@site/src/components/Search/SearchResultBadge";
 import SearchFilterPills from "@site/src/components/Search/SearchFilterPills";
 import {
-    ALL_SCOPE_EXCLUDED_TAGS,
+    ALL_SCOPE_EXCLUDED_PLUGIN_IDS,
     getSearchResultSource,
     SEARCH_ATTRIBUTES_TO_RETRIEVE,
     SEARCH_FILTERS,
@@ -303,9 +303,11 @@ function SearchPageContent(): ReactNode {
                 // "All": every instance except separated scopes (samples).
                 algoliaHelper.addDisjunctiveFacetRefinement("docusaurus_tag", "default");
                 Object.entries(docsSearchVersionsHelpers.searchVersions).forEach(([pluginId, searchVersion]) => {
-                    const tag = `docs-${pluginId}-${searchVersion}`;
-                    if (!ALL_SCOPE_EXCLUDED_TAGS.includes(tag)) {
-                        algoliaHelper.addDisjunctiveFacetRefinement("docusaurus_tag", tag);
+                    if (!ALL_SCOPE_EXCLUDED_PLUGIN_IDS.includes(pluginId)) {
+                        algoliaHelper.addDisjunctiveFacetRefinement(
+                            "docusaurus_tag",
+                            `docs-${pluginId}-${searchVersion}`
+                        );
                     }
                 });
             }

--- a/src/theme/SearchPage/styles.module.css
+++ b/src/theme/SearchPage/styles.module.css
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.searchQueryInput,
+.searchVersionInput {
+    border-radius: var(--ifm-global-radius);
+    border: 2px solid var(--ifm-toc-border-color);
+    font: var(--ifm-font-size-base) var(--ifm-font-family-base);
+    padding: 0.8rem;
+    width: 100%;
+    background: var(--docsearch-searchbox-focus-background);
+    color: var(--docsearch-text-color);
+    margin-bottom: 0.5rem;
+    transition: border var(--ifm-transition-fast) ease;
+}
+
+.searchQueryInput:focus,
+.searchVersionInput:focus {
+    border-color: var(--docsearch-primary-color);
+    outline: none;
+}
+
+.searchQueryInput::placeholder {
+    color: var(--docsearch-muted-color);
+}
+
+.searchResultsColumn {
+    font-size: 0.9rem;
+    font-weight: bold;
+}
+
+.searchResultItem {
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
+.searchResultItemHeading {
+    font-weight: 400;
+    margin-bottom: 0;
+}
+
+.searchResultItemPath {
+    font-size: 0.8rem;
+    color: var(--ifm-color-content-secondary);
+    --ifm-breadcrumb-separator-size-multiplier: 1;
+}
+
+.searchResultItemSummary {
+    margin: 0.5rem 0 0;
+    font-style: italic;
+}
+
+@media only screen and (max-width: 996px) {
+    .searchQueryColumn {
+        max-width: 60% !important;
+    }
+
+    .searchVersionColumn {
+        max-width: 40% !important;
+    }
+}
+
+@media screen and (max-width: 576px) {
+    .searchQueryColumn {
+        max-width: 100% !important;
+    }
+
+    .searchVersionColumn {
+        max-width: 100% !important;
+        padding-left: var(--ifm-spacing-horizontal) !important;
+    }
+}
+
+.loadingSpinner {
+    width: 3rem;
+    height: 3rem;
+    border: 0.4em solid #eee;
+    border-top-color: var(--ifm-color-primary);
+    border-radius: 50%;
+    animation: loading-spin 1s linear infinite;
+    margin: 0 auto;
+}
+
+@keyframes loading-spin {
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.loader {
+    margin-top: 2rem;
+}
+
+:global(.search-result-match) {
+    color: var(--docsearch-hit-color);
+    background: rgb(255 215 142 / 25%);
+    padding: 0.09em 0;
+}

--- a/src/theme/SearchPage/styles.module.css
+++ b/src/theme/SearchPage/styles.module.css
@@ -1,9 +1,4 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+/* Swizzled from @docusaurus/theme-search-algolia, kept close to upstream for diffing. */
 
 .searchQueryInput,
 .searchVersionInput {


### PR DESCRIPTION
### Issue link
[RDoc-3439](https://issues.hibernatingrhinos.com/issue/RDoc-3439) New documentation search results improvements

### Additional description
Improves the documentation search experience. Adds new components. Needs frontend code review @kalczur 🙏
Passed it through the superpowers code review on ultracode. 

<img width="1427" height="773" alt="image" src="https://github.com/user-attachments/assets/bd80e721-a01e-49fd-a4e0-f75e40c1ef7a" />
<img width="1620" height="748" alt="image" src="https://github.com/user-attachments/assets/6c9b2583-3b80-4a47-9b38-be220ab25583" />
<img width="1899" height="621" alt="image" src="https://github.com/user-attachments/assets/126bef20-452b-4955-9cf3-352fa1f987ca" />
<img width="792" height="658" alt="image" src="https://github.com/user-attachments/assets/22bafcfc-3753-4330-a01d-2f70ac2432d4" />


### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [x] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [x] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [ ] No changes in UX/UI
- [x] Changes in UX/UI (include screenshots and description)

