### PR TITLE
Exclude third-party context7.json from the Prettier check (fixes CI)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,6 @@ src/data/guides-metadata.json
 src/typescript/iconName.ts
 
 /.github
+
+# Third-party tool config (managed in main, not ours to format)
+/context7.json


### PR DESCRIPTION
`context7.json` (added to `main` in #2542) isn't Prettier-compliant, it has no trailing newline, so the CI `prettier --check .` step fails on every PR that merges `main`.
