### PR TITLE
RDoc-3573 Version dropdown links to the same article in the target version when it exists

### DIFF
--- a/src/components/SidebarVersionDropdown.tsx
+++ b/src/components/SidebarVersionDropdown.tsx
@@ -6,7 +6,10 @@ export default function CustomVersionDropdown() {
     const pluginId = "default";
     const versions = useVersions(pluginId);
     const latestVersion = useLatestVersion(pluginId);
-    const { activeVersion } = useActiveDocContext(pluginId);
+    const { activeVersion, alternateDocVersions } = useActiveDocContext(pluginId);
+
+    const getVersionTargetPath = (version: (typeof versions)[number]) =>
+        alternateDocVersions[version.name]?.path ?? version.path;
 
     const [open, setOpen] = useState(false);
     const wrapperRef = useRef<HTMLDivElement>(null);
@@ -69,7 +72,11 @@ export default function CustomVersionDropdown() {
                 <ul className="!p-0 !m-0">
                     {versions.map((version) => (
                         <li key={version.name} className="rounded-sm overflow-hidden">
-                            <Link to={version.path} className="menu__link" onClick={() => setOpen(false)}>
+                            <Link
+                                to={getVersionTargetPath(version)}
+                                className="menu__link"
+                                onClick={() => setOpen(false)}
+                            >
                                 {version.label}.x
                             </Link>
                         </li>

--- a/src/components/SidebarVersionDropdown.tsx
+++ b/src/components/SidebarVersionDropdown.tsx
@@ -1,15 +1,27 @@
 import React, { useState, useRef, useEffect } from "react";
 import Link from "@docusaurus/Link";
-import { useVersions, useLatestVersion, useActiveDocContext } from "@docusaurus/plugin-content-docs/client";
+import {
+    useVersions,
+    useLatestVersion,
+    useActiveDocContext,
+    useDocsPreferredVersion,
+    type GlobalVersion,
+} from "@docusaurus/plugin-content-docs/client";
+import { useHistorySelector } from "@docusaurus/theme-common";
 
 export default function CustomVersionDropdown() {
     const pluginId = "default";
     const versions = useVersions(pluginId);
     const latestVersion = useLatestVersion(pluginId);
     const { activeVersion, alternateDocVersions } = useActiveDocContext(pluginId);
+    const { savePreferredVersionName } = useDocsPreferredVersion(pluginId);
+    const queryString = useHistorySelector((history) => history.location.search);
+    const anchor = useHistorySelector((history) => history.location.hash);
 
-    const getVersionTargetPath = (version: (typeof versions)[number]) =>
-        alternateDocVersions[version.name]?.path ?? version.path;
+    const getVersionMainDoc = (version: GlobalVersion) => version.docs.find((doc) => doc.id === version.mainDocId)!;
+
+    const getVersionTargetPath = (version: GlobalVersion) =>
+        `${(alternateDocVersions[version.name] ?? getVersionMainDoc(version)).path}${queryString}${anchor}`;
 
     const [open, setOpen] = useState(false);
     const wrapperRef = useRef<HTMLDivElement>(null);
@@ -75,7 +87,10 @@ export default function CustomVersionDropdown() {
                             <Link
                                 to={getVersionTargetPath(version)}
                                 className="menu__link"
-                                onClick={() => setOpen(false)}
+                                onClick={() => {
+                                    savePreferredVersionName(version.name);
+                                    setOpen(false);
+                                }}
                             >
                                 {version.label}.x
                             </Link>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3573/Documentation-version-switching-behavior

### Additional description


### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [x] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

