### PR TITLE
reference to cert registration explanation via client API; explain that deleting a DB removes it from cert permissions; updates to pages layout

### DIFF
--- a/docs/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
+++ b/docs/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
@@ -1,13 +1,13 @@
 import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
@@ -15,12 +15,14 @@ import CodeBlock from '@theme/CodeBlock';
   * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
+
+<Panel heading="Put client certificate example">
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Sync" label="Sync">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -31,12 +33,13 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.Send
 store.Maintenance.Server.Send(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="Async" label="Async">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -47,25 +50,23 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.SendAsync
 await store.Maintenance.Server.SendAsync(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="put_syntax" label="put_syntax">
-<CodeBlock language="csharp">
-{`public PutClientCertificateOperation(
+```csharp
+public PutClientCertificateOperation(
     string name, 
     X509Certificate2 certificate, 
     Dictionary<string, DatabaseAccess> permissions, 
     SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                                 | Description                                                                                         |
 |-----------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -74,32 +75,26 @@ await store.Maintenance.Server.SendAsync(putClientCertificateOp);
 | **permissions** | `Dictionary<string, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `ValidUser`. |
 | **clearance**   | `SecurityClearance`                  | Access level (role) assigned to the certificate.                                                    |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="csharp">
-{`// The role assigned to the certificate:
+```csharp
+// The role assigned to the certificate:
 public enum SecurityClearance
-\{
+{
     ClusterAdmin,
     ClusterNode,
     Operator,
     ValidUser
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="csharp">
-{`// The access level for a 'ValidUser' security clearance:
+}
+```
+<br />
+
+```csharp
+// The access level for a 'ValidUser' security clearance:
 public enum DatabaseAccess
-\{
+{
     Read,
     ReadWrite,
     Admin
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/docs/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
+++ b/docs/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
@@ -1,25 +1,23 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="java">
-{`byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
+<Panel heading="Put client certificate example">
+
+```java
+byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
 String certificateAsBase64 = Base64.getEncoder().encodeToString(rawCert);                
 
 store.maintenance().server().send(
@@ -28,23 +26,19 @@ store.maintenance().server().send(
         certificateAsBase64,
         new HashMap<>(),
         SecurityClearance.CLUSTER_ADMIN));
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="cert_put_1" label="cert_put_1">
-<CodeBlock language="java">
-{`public PutClientCertificateOperation(String name,
+```java
+public PutClientCertificateOperation(String name,
                                      String certificate,
                                      Map<String, DatabaseAccess> permissions,
                                      SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                          | Description                                                                                          |
 |-----------------|-------------------------------|------------------------------------------------------------------------------------------------------|
@@ -53,28 +47,22 @@ store.maintenance().server().send(
 | **permissions** | `Map<String, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `VALID_USER`. |
 | **clearance**   | `SecurityClearance`           | Access level (role) assigned to the certificate.                                                     |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="java">
-{`public enum SecurityClearance \{
+```java
+public enum SecurityClearance {
     CLUSTER_ADMIN,
     CLUSTER_NODE,
     OPERATOR,
     VALID_USER
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="java">
-{`public enum DatabaseAccess \{
+}
+```
+<br />
+
+```java
+public enum DatabaseAccess {
     READ,
     READ_WRITE,
     ADMIN
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/docs/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
+++ b/docs/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
@@ -1,49 +1,43 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="js">
-{`const rawCert = fs.readFileSync("<path-to-certificate.crt>");
+<Panel heading="Put client certificate example">
+
+```js
+const rawCert = fs.readFileSync("<path-to-certificate.crt>");
 const certificateAsBase64 = rawCert.toString("base64");
 
 const putClientCertificateOp = new PutClientCertificateOperation(
     "certificateName",
     certificateAsBase64,
-    \{\},
+    {},
     "ClusterAdmin");
 
 await store.maintenance.server.send(putClientCertificateOp);
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="syntax" label="syntax">
-<CodeBlock language="js">
-{`const putOperation = 
+```js
+const putOperation = 
     new PutClientCertificateOperation(name, certificate, permissions, clearance);
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                             | Description                                                                                         |
 |-----------------|----------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -58,11 +52,9 @@ await store.maintenance.server.send(putClientCertificateOp);
   * `Operator`  
   * `ValidUser`  
 
-* `DatabaseAccess ` options:
+* `DatabaseAccess` options:
   * `Read`
   * `ReadWrite`  
   * `Admin`
 
-
-
-
+</Panel>

--- a/docs/client-api/operations/server-wide/certificates/put-client-certificate.mdx
+++ b/docs/client-api/operations/server-wide/certificates/put-client-certificate.mdx
@@ -13,6 +13,10 @@ see_also:
        link: "client-api/operations/server-wide/certificates/create-client-certificate"
        source: "docs"
        path: "Client API > Operations > Server-Maintenance > Certificates"
+     - title: "Certificates Management"
+       link: "server/security/authentication/certificate-management#enabling-communication-between-servers-importing-and-exporting-certificates"
+       source: "docs"
+       path: "Server > Security > Authentication"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/docs/server/security/authentication/certificate-management.mdx
+++ b/docs/server/security/authentication/certificate-management.mdx
@@ -32,7 +32,7 @@ In this page:
   * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
   * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
   * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers:-importing-and-exporting-certificates)  
+* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
   * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
   * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
   * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
@@ -343,6 +343,12 @@ This information is used by RavenDB internally and is not stored in the certific
 <Admonition type="note" title="">
 
 Expiration for client certificates is set to 5 years by default.
+
+</Admonition>
+
+<Admonition type="note" title="">
+
+To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
 ### Certificate Collections

--- a/docs/server/security/authentication/certificate-management.mdx
+++ b/docs/server/security/authentication/certificate-management.mdx
@@ -315,6 +315,14 @@ Expiration for client certificates is set to 5 years by default.
 
 </ContentFrame>
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">

--- a/docs/server/security/authentication/certificate-management.mdx
+++ b/docs/server/security/authentication/certificate-management.mdx
@@ -11,6 +11,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authentication: Certificate Management
 <Admonition type="note" title="">
@@ -22,25 +24,27 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * See the API article for integrating a client certificate into an application via the [document store](../../../client-api/creating-document-store.mdx).  
 
-In this page:  
-
-* [Studio Certificate Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)  
-* [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)  
-  * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)  
-  * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)  
-* [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)  
-  * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
-  * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
-  * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
-  * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
-  * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
-  * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
-  * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)  
-  * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)  
+* In this article:
+   * [Studio Certificates Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)
+   * [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)
+      * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)
+      * [Full Access to Database](../../../server/security/authentication/certificate-management.mdx#full-access-to-database)
+      * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)
+   * [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)
+      * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)
+      * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)
+      * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+   * [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)
+      * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)
+      * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)
+      * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)
+      * [Generating Client Certificates Via Command Line Interface](../../../server/security/authentication/certificate-management.mdx#generating-client-certificates-via-command-line-interface)
+      * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)
+      * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)
 
 </Admonition>
-## Studio Certificates Management View
+
+<Panel heading="Studio Certificates Management View">
 
 ![Figure 1. Studio Certificates Management View](./assets/studio-certificates-overview.png)
 
@@ -72,14 +76,19 @@ Client certificates are managed by RavenDB directly and not by any [Public Key I
 
 
 
-## The RavenDB Security Authorization Approach
+</Panel>
+
+<Panel heading="The RavenDB Security Authorization Approach">
 
 In general, RavenDB assumes that an application will implement its own logic and business rules, limiting 
 itself to protect the data from unauthorized access. Applications operate on behalf of developers, and as such, they are in a better position than RavenDB to determine what is
 allowed.  This is why access levels of RavenDB databases in each cluster are highly customizable by [cluster admins](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) 
 and [operators](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator).  
 
+<ContentFrame>
+
 ### Authorization Levels in Client Certificates
+
 The security system in RavenDB does not make assumptions about which types of users should access which type of database. The concept of a user
 does not really exist within RavenDB in this manner. Instead, cluster admins or operators create various client certificates and configure each one with a custom set of permissions. 
 
@@ -93,16 +102,19 @@ does not really exist within RavenDB in this manner. Instead, cluster admins or 
   * "User" certificates are configured to specify which databases people can access with each certificate.  
   * ["User" authorization levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels) are also configured per database.  
 
+**Access is through your applications, not individual users**  
 In most cases, users do not access RavenDB directly. Aside from admins and developers during the development process, all access to 
 the data inside RavenDB is expected to be done through your applications. A security mechanism on a per-user basis is not practical in complex systems 
 because each user (employee or customer) may need different access levels to different portions of the data. 
 Also, the same application usually needs to access the same data on behalf of different types of users with different levels of access.  
 
-**Most organizations have fairly complex architectures.** In most systems, the access level
+**Most organizations have fairly complex architectures**  
+In most systems, the access level
 and operations allowed are never simple enough to be able to express them as an Access Control List. They are highly dependent on business rules and
 processes, the state of the system, etc. 
 
-**How can authorization levels efficiently handle complex systems?**  By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
+**How can authorization levels efficiently handle complex systems?**  
+By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
 is not permitted to approve their own vacation. The HR manager, on the other hand, may approve the vacation.  
 
 From the point of view of RavenDB, the act of editing a vacation request document or approving it looks very much the same, it's a simple document edit.
@@ -112,12 +124,20 @@ but not to development-oriented data, whereas developers might have read/write o
 Meanwhile, customers likely have read/write certification to their user account, but read-only access to the catalog.  
 
 Thus, RavenDB is designed so that **each client certificate has specific and customizable permissions for various databases as well as configurable authorization levels**.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Full Access to Database
 RavenDB expects the applications and systems using it to utilize the security infrastructure it provides to prevent unauthorized access, such as a different
 application trying to access the HR database. However, once access is granted, the access is complete.  
 
 RavenDB security infrastructure operates at the level of the entire database. If you are granted access to a database, you can access 
 any and all documents in that database unless protection is explicitly configured.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Partial Access to Database
 
 There are two approaches to giving partial access to a database:
@@ -125,7 +145,7 @@ There are two approaches to giving partial access to a database:
  * [Using ETL for selective, one-way data transfer](../../../server/security/authentication/certificate-management.mdx#using-etl-for-selective-one-way-data-transfer)  
  * [Setting "User" Access Levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels)  
 
-####  *Using ETL for selective, one-way data transfer*  
+#### Using ETL for selective, one-way data transfer
 
 Some developers need to provide partial access to a database that also contains sensitive data. One approach is to set up an [Extract, Transform, Load (ETL) task](../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx):  
 
@@ -153,7 +173,9 @@ Together, ETL and dedicated databases can be used for fine-grained filtration, b
 
 </Admonition>
 
-####  *Setting "User" Access Levels*  
+---
+
+#### Setting "User" Access Levels
 
 You can also control access by giving a client certificate a [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user) security clearance. 
 With this clearance, you can set a different access level to each database. The three "User" access levels are:  
@@ -178,7 +200,13 @@ It enables developers to control access levels by configuring client certificate
 
 
 
-## Create and Configure Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Create and Configure Certificates">
+
+<ContentFrame>
 
 ### List of Registered Certificates 
 
@@ -207,6 +235,10 @@ Each client certificate contains the following:
 6. **Edit Certificate**  
    Configure which databases it can access (applicable for User-level) and its authorization clearance level.  
 7. **Delete Certificate**  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generate Client Certificate 
 
 Using this view, you can generate client certificates directly via RavenDB.  
@@ -242,6 +274,10 @@ This information is used by RavenDB internally and is not stored in the certific
 Expiration for client certificates is set to 5 years by default.
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Edit Certificate
 
 To edit existing certificates:
@@ -277,7 +313,11 @@ Expiration for client certificates is set to 5 years by default.
 
 
 
-## Enabling Communication Between Servers: Importing and Exporting Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">
 
 There are various situations where developers need to create a database with partial access to another server.  
 For example, a source server may contain sensitive information that should not be exposed to the public, but also contain databases that need to be exposed with limited access.  
@@ -306,12 +346,18 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
    * **Upload client certificate**  
      [Import a client certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate) 
      that was exported from another server so that the two can communicate.  
+<ContentFrame>
+
 ### Export Server Certificates
 
 ![Figure 6. Export Server Certificates](./assets/export-server-certificates.png)
 
 This option allows you to export the server certificate as a .pfx file. In the case of a cluster which contains several different server certificates, 
 a .pfx [collection](../../../server/security/authentication/certificate-management.mdx#certificate-collections) will be exported.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Upload an Existing Certificate
 
 Click the **Client certificate** button, select **Upload client certificate** and you will see the following window.  
@@ -351,12 +397,20 @@ Expiration for client certificates is set to 5 years by default.
 To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Certificate Collections
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all of the certificates to the list of registered certificates as one entry 
 and will allow access to all these certificates explicitly by their thumbprint.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generating Client Certificates Via Command Line Interface
 
 * RavenDB provides an intuitive certificates management GUI in Studio.  
@@ -365,6 +419,10 @@ and will allow access to all these certificates explicitly by their thumbprint.
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
   - There are CLI-based means to [generate](../../../server/security/authentication/client-certificate-usage.mdx#example-i---using-the-ravendb-cli) and [configure client certificates in Windows](../../../server/security/authentication/client-certificate-usage.mdx#example-ii---using-powershell-and-wget-in-windows).  
   - [Linux](../../../server/security/authentication/client-certificate-usage.mdx#example-iii--using-curl-in-linux) developers can use this cURL command sample.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Private Keys
 
 It's important to note that RavenDB does _not_ keep track of the certificate's private key. Whether you generate a client certificate
@@ -376,6 +434,10 @@ If two different RavenDB clusters are communicating securely, and the source clu
 still trust this new certificate - provided that the new certificate is signed with the same private key as the original, and was issued by the 
 same certificate authority. This is accomplished using a [public key pinning hash](../../../server/security/authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash).  
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Client Certificate Chain of Trust
 
 As mentioned above, RavenDB generates client certificates by signing them using the server certificate. 
@@ -394,6 +456,10 @@ and is explained here only to show how to view the full chain in Windows. The ri
 Because client certificates are managed by RavenDB directly and [not through any PKI infrastructure](../overview.mdx#important) **this is perfectly acceptable**. 
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
+
+</ContentFrame>
+
+</Panel>
 
 
 

--- a/docs/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/docs/server/security/authorization/security-clearance-and-permissions.mdx
@@ -11,28 +11,37 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authorization: Security Clearance and Permissions
 
-* X.509 certificates are used for authentication - validating that users are who they say they are. 
-  Once a connection is authenticated, RavenDB uses the certificate for authorization as well. 
+<Admonition type="note" title="">
+
+* X.509 certificates are used for authentication - validating that users are who they say they are.  
+  Once a connection is authenticated, RavenDB uses the certificate for authorization as well.
 
 * Each certificate is associated with a security clearance and access permissions per database.
 
-* It is the administrator's responsibility to generate client certificates and assign permissions. 
+* It is the administrator's responsibility to generate client certificates and assign permissions.  
   Read more in the [Certificate Management](../authentication/certificate-management.mdx) page.
 
-* A client certificate's security clearance can be one of the following: Cluster Admin, Operator, User.
+* A client certificate's security clearance can be one of the following:
+   * Cluster Admin
+   * Operator
+   * User
 
-* In this page:
+* In this article:
    * [Cluster Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin)
    * [Operator](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator)
-   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)  
-      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#section)  
-      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-1) 
-      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-2)
+   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)
+      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#admin)
+      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#readwrite)
+      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#read-only)
 
-## Cluster Admin
+</Admonition>
+
+<Panel heading="Cluster Admin">
 
 `Cluster Admin` is the highest security clearance. There are no restrictions. A `Cluster Admin` certificate has admin permissions to all databases. It also has the ability to modify the cluster itself.
 
@@ -47,7 +56,9 @@ The following operations are allowed **only** for `Cluster Admin` certificates:
 
 
 
-## Operator
+</Panel>
+
+<Panel heading="Operator">
 
 A client certificate with an `Operator` security clearance has admin access to all databases 
 but is unable to modify the cluster. It cannot perform operations such as 
@@ -78,7 +89,9 @@ The following operations are allowed for **both** `Operator` and `Cluster Admin`
 
 
 
-## User
+</Panel>
+
+<Panel heading="User">
 
 A client certificate with a `User` security clearance cannot perform any admin operations at the cluster level.  
 Unlike the other clearance levels, a `User` client certificate can grant different access levels to different databases.  
@@ -89,6 +102,9 @@ These access levels are, from highest to lowest:
 * **Read Only**  
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
+
+<ContentFrame>
+
 ### `Admin`
 
 The following operations are permitted at the `Admin` access level but not for `Read/Write` or `Read Only`:
@@ -102,6 +118,11 @@ The following operations are permitted at the `Admin` access level but not for `
 - Put client configuration for the database (Max number of requests per session, Read balance behavior)
 - Get transaction info
 - Perform SQL migration
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read/Write`
 
 A `User` certificate with a `Read/Write` access level can perform all operations **except** for those listed above in the 'Admin' and 'Operator'sections.  
@@ -110,6 +131,11 @@ A `User` certificate with a `Read/Write` access level can perform all operations
     To configure a server or database so that only Admin certificates will be able to deploy JavaScript static indexes,  
     set [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../../server/configuration/indexing-configuration.mdx#indexingstaticrequireadmintodeployjavascriptindexes) 
     to `true`.
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read Only`
 
 The `ReadOnly` access level **allows** clients to: 
@@ -136,6 +162,10 @@ The following operations are **forbidden**:
 </Admonition>
 
 Learn more about the `Read Only` access level [here](../../../studio/server/certificates/read-only-access-level.mdx).
+
+</ContentFrame>
+
+</Panel>
 
 
 

--- a/docs/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/docs/server/security/authorization/security-clearance-and-permissions.mdx
@@ -103,6 +103,14 @@ These access levels are, from highest to lowest:
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 <ContentFrame>
 
 ### `Admin`

--- a/docs/studio/server/certificates/server-management-certificates-view.mdx
+++ b/docs/studio/server/certificates/server-management-certificates-view.mdx
@@ -11,6 +11,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Certificates View
 <Admonition type="note" title="">
@@ -28,7 +30,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 </Admonition>
 
-## The Certificates view
+<Panel heading="The Certificates view">
 
 To open the certificates view: **Manage Server** `>` **Certificates**
 
@@ -74,7 +76,9 @@ To open the certificates view: **Manage Server** `>` **Certificates**
    Client certificates registered with this server are used to authenticate users and applications connecting to the database.  
    Each client certificate can be assigned specific permissions and security clearance levels, such as Cluster Administrator (ClusterAdmin), Operator, or User.
 
-## View and edit certificates
+</Panel>
+
+<Panel heading="View and edit certificates">
 
 In the image below, the client certificates have different 
 **security clearance** and **database permissions** configurations.  
@@ -110,7 +114,9 @@ by using different client certificates, each with its own set of permissions.
 10. **Delete Certificate**  
     Deleting a certificate will revoke access for all clients using this certificate.
 
-## Generate a client certificate 
+</Panel>
+
+<Panel heading="Generate a client certificate">
 
 Use this view to generate a client certificate directly via RavenDB.  
 Newly generated certificates will be added to the list of registered certificates.  
@@ -143,18 +149,24 @@ Newly generated certificates will be added to the list of registered certificate
          * **B. Additional Settings**  
            You can limit the session duration here.  
            You can also grant access only to this browser, or use this clearance screen to open Studio for other clients as well.  
+         * **C. Proceed**  
+           Click to enter Studio using the authentication code you provided.  
 7. **Generate** the certificate or **Cancel**.  
    
 <Admonition type="note" title="">
 The information collected in this view is used by RavenDB internally, and will not be stored in the certificate itself.
 </Admonition>
 
-## Enable communication between secure servers 
+</Panel>
+
+<Panel heading="Enable communication between secure servers">
 
 To enable communication between two secure servers, you need to:
 
 1. **Export** ([download](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)) the `.pfx` certificate from the destination server.  
 2. **Upload** (import) the downloaded certificate into the source server.  
+
+<ContentFrame>
 
 ### Upload an existing client certificate
 
@@ -169,7 +181,11 @@ While uploading the client certificate you can modify its settings.
 
 See the [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view.mdx#generate-a-client-certificate) section to learn about the available settings.  
 
-## Export server certificates
+</ContentFrame>
+
+<ContentFrame>
+
+### Export server certificates
 
 ![Export Server Certificates](./assets/export-server-certificates.png)
 
@@ -177,11 +193,17 @@ This option allows you to export the server certificate as a `.pfx` file.
 In the case of a cluster that contains several different server certificates, a `.pfx` [collection](../../../server/security/authentication/certificate-management.mdx#certificate-collections) will be exported.
 
 
-## Certificate collections 
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Certificate collections">
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all certificates to the list of registered certificates as a single entry, and explicitly allow access to all certificates by their thumbprint.
+
+</Panel>
 
 
 

--- a/docs/studio/server/certificates/server-management-certificates-view.mdx
+++ b/docs/studio/server/certificates/server-management-certificates-view.mdx
@@ -114,6 +114,14 @@ by using different client certificates, each with its own set of permissions.
 10. **Delete Certificate**  
     Deleting a certificate will revoke access for all clients using this certificate.
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Generate a client certificate">

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
@@ -1,13 +1,13 @@
 import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
@@ -15,12 +15,14 @@ import CodeBlock from '@theme/CodeBlock';
   * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
+
+<Panel heading="Put client certificate example">
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Sync" label="Sync">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -31,12 +33,13 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.Send
 store.Maintenance.Server.Send(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="Async" label="Async">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -47,25 +50,23 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.SendAsync
 await store.Maintenance.Server.SendAsync(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="put_syntax" label="put_syntax">
-<CodeBlock language="csharp">
-{`public PutClientCertificateOperation(
+```csharp
+public PutClientCertificateOperation(
     string name, 
     X509Certificate2 certificate, 
     Dictionary<string, DatabaseAccess> permissions, 
     SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                                 | Description                                                                                         |
 |-----------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -74,32 +75,26 @@ await store.Maintenance.Server.SendAsync(putClientCertificateOp);
 | **permissions** | `Dictionary<string, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `ValidUser`. |
 | **clearance**   | `SecurityClearance`                  | Access level (role) assigned to the certificate.                                                    |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="csharp">
-{`// The role assigned to the certificate:
+```csharp
+// The role assigned to the certificate:
 public enum SecurityClearance
-\{
+{
     ClusterAdmin,
     ClusterNode,
     Operator,
     ValidUser
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="csharp">
-{`// The access level for a 'ValidUser' security clearance:
+}
+```
+<br />
+
+```csharp
+// The access level for a 'ValidUser' security clearance:
 public enum DatabaseAccess
-\{
+{
     Read,
     ReadWrite,
     Admin
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
@@ -1,25 +1,23 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="java">
-{`byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
+<Panel heading="Put client certificate example">
+
+```java
+byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
 String certificateAsBase64 = Base64.getEncoder().encodeToString(rawCert);                
 
 store.maintenance().server().send(
@@ -28,23 +26,19 @@ store.maintenance().server().send(
         certificateAsBase64,
         new HashMap<>(),
         SecurityClearance.CLUSTER_ADMIN));
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="cert_put_1" label="cert_put_1">
-<CodeBlock language="java">
-{`public PutClientCertificateOperation(String name,
+```java
+public PutClientCertificateOperation(String name,
                                      String certificate,
                                      Map<String, DatabaseAccess> permissions,
                                      SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                          | Description                                                                                          |
 |-----------------|-------------------------------|------------------------------------------------------------------------------------------------------|
@@ -53,28 +47,22 @@ store.maintenance().server().send(
 | **permissions** | `Map<String, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `VALID_USER`. |
 | **clearance**   | `SecurityClearance`           | Access level (role) assigned to the certificate.                                                     |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="java">
-{`public enum SecurityClearance \{
+```java
+public enum SecurityClearance {
     CLUSTER_ADMIN,
     CLUSTER_NODE,
     OPERATOR,
     VALID_USER
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="java">
-{`public enum DatabaseAccess \{
+}
+```
+<br />
+
+```java
+public enum DatabaseAccess {
     READ,
     READ_WRITE,
     ADMIN
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
@@ -1,49 +1,43 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="js">
-{`const rawCert = fs.readFileSync("<path-to-certificate.crt>");
+<Panel heading="Put client certificate example">
+
+```js
+const rawCert = fs.readFileSync("<path-to-certificate.crt>");
 const certificateAsBase64 = rawCert.toString("base64");
 
 const putClientCertificateOp = new PutClientCertificateOperation(
     "certificateName",
     certificateAsBase64,
-    \{\},
+    {},
     "ClusterAdmin");
 
 await store.maintenance.server.send(putClientCertificateOp);
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="syntax" label="syntax">
-<CodeBlock language="js">
-{`const putOperation = 
+```js
+const putOperation = 
     new PutClientCertificateOperation(name, certificate, permissions, clearance);
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                             | Description                                                                                         |
 |-----------------|----------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -58,11 +52,9 @@ await store.maintenance.server.send(putClientCertificateOp);
   * `Operator`  
   * `ValidUser`  
 
-* `DatabaseAccess ` options:
+* `DatabaseAccess` options:
   * `Read`
   * `ReadWrite`  
   * `Admin`
 
-
-
-
+</Panel>

--- a/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/put-client-certificate.mdx
+++ b/versioned_docs/version-6.2/client-api/operations/server-wide/certificates/put-client-certificate.mdx
@@ -12,6 +12,10 @@ see_also:
        link: "client-api/operations/server-wide/certificates/create-client-certificate"
        source: "docs"
        path: "Client API > Operations > Server-Maintenance > Certificates"
+     - title: "Certificates Management"
+       link: "server/security/authentication/certificate-management#enabling-communication-between-servers-importing-and-exporting-certificates"
+       source: "docs"
+       path: "Server > Security > Authentication"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
@@ -31,7 +31,7 @@ In this page:
   * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
   * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
   * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers:-importing-and-exporting-certificates)  
+* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
   * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
   * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
   * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
@@ -342,6 +342,12 @@ This information is used by RavenDB internally and is not stored in the certific
 <Admonition type="note" title="">
 
 Expiration for client certificates is set to 5 years by default.
+
+</Admonition>
+
+<Admonition type="note" title="">
+
+To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
 ### Certificate Collections

--- a/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Authentication: Certificate Management"
 sidebar_label: Certificate Management
+description: "Manage client and server certificates in RavenDB including generation, registration, permissions assignment, and revocation procedures."
 sidebar_position: 1
 ---
 
@@ -10,6 +11,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authentication: Certificate Management
 <Admonition type="note" title="">
@@ -21,25 +24,27 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * See the API article for integrating a client certificate into an application via the [document store](../../../client-api/creating-document-store.mdx).  
 
-In this page:  
-
-* [Studio Certificate Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)  
-* [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)  
-  * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)  
-  * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)  
-* [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)  
-  * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
-  * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
-  * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
-  * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
-  * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
-  * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
-  * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)  
-  * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)  
+* In this article:
+   * [Studio Certificates Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)
+   * [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)
+      * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)
+      * [Full Access to Database](../../../server/security/authentication/certificate-management.mdx#full-access-to-database)
+      * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)
+   * [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)
+      * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)
+      * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)
+      * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+   * [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)
+      * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)
+      * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)
+      * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)
+      * [Generating Client Certificates Via Command Line Interface](../../../server/security/authentication/certificate-management.mdx#generating-client-certificates-via-command-line-interface)
+      * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)
+      * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)
 
 </Admonition>
-## Studio Certificates Management View
+
+<Panel heading="Studio Certificates Management View">
 
 ![Figure 1. Studio Certificates Management View](./assets/studio-certificates-overview.png)
 
@@ -71,14 +76,19 @@ Client certificates are managed by RavenDB directly and not by any [Public Key I
 
 
 
-## The RavenDB Security Authorization Approach
+</Panel>
+
+<Panel heading="The RavenDB Security Authorization Approach">
 
 In general, RavenDB assumes that an application will implement its own logic and business rules, limiting 
 itself to protect the data from unauthorized access. Applications operate on behalf of developers, and as such, they are in a better position than RavenDB to determine what is
 allowed.  This is why access levels of RavenDB databases in each cluster are highly customizable by [cluster admins](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) 
 and [operators](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator).  
 
+<ContentFrame>
+
 ### Authorization Levels in Client Certificates
+
 The security system in RavenDB does not make assumptions about which types of users should access which type of database. The concept of a user
 does not really exist within RavenDB in this manner. Instead, cluster admins or operators create various client certificates and configure each one with a custom set of permissions. 
 
@@ -92,16 +102,19 @@ does not really exist within RavenDB in this manner. Instead, cluster admins or 
   * "User" certificates are configured to specify which databases people can access with each certificate.  
   * ["User" authorization levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels) are also configured per database.  
 
+**Access is through your applications, not individual users**  
 In most cases, users do not access RavenDB directly. Aside from admins and developers during the development process, all access to 
 the data inside RavenDB is expected to be done through your applications. A security mechanism on a per-user basis is not practical in complex systems 
 because each user (employee or customer) may need different access levels to different portions of the data. 
 Also, the same application usually needs to access the same data on behalf of different types of users with different levels of access.  
 
-**Most organizations have fairly complex architectures.** In most systems, the access level
+**Most organizations have fairly complex architectures**  
+In most systems, the access level
 and operations allowed are never simple enough to be able to express them as an Access Control List. They are highly dependent on business rules and
 processes, the state of the system, etc. 
 
-**How can authorization levels efficiently handle complex systems?**  By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
+**How can authorization levels efficiently handle complex systems?**  
+By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
 is not permitted to approve their own vacation. The HR manager, on the other hand, may approve the vacation.  
 
 From the point of view of RavenDB, the act of editing a vacation request document or approving it looks very much the same, it's a simple document edit.
@@ -111,12 +124,20 @@ but not to development-oriented data, whereas developers might have read/write o
 Meanwhile, customers likely have read/write certification to their user account, but read-only access to the catalog.  
 
 Thus, RavenDB is designed so that **each client certificate has specific and customizable permissions for various databases as well as configurable authorization levels**.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Full Access to Database
 RavenDB expects the applications and systems using it to utilize the security infrastructure it provides to prevent unauthorized access, such as a different
 application trying to access the HR database. However, once access is granted, the access is complete.  
 
 RavenDB security infrastructure operates at the level of the entire database. If you are granted access to a database, you can access 
 any and all documents in that database unless protection is explicitly configured.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Partial Access to Database
 
 There are two approaches to giving partial access to a database:
@@ -124,7 +145,7 @@ There are two approaches to giving partial access to a database:
  * [Using ETL for selective, one-way data transfer](../../../server/security/authentication/certificate-management.mdx#using-etl-for-selective-one-way-data-transfer)  
  * [Setting "User" Access Levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels)  
 
-####  *Using ETL for selective, one-way data transfer*  
+#### Using ETL for selective, one-way data transfer
 
 Some developers need to provide partial access to a database that also contains sensitive data. One approach is to set up an [Extract, Transform, Load (ETL) task](../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx):  
 
@@ -152,7 +173,9 @@ Together, ETL and dedicated databases can be used for fine-grained filtration, b
 
 </Admonition>
 
-####  *Setting "User" Access Levels*  
+---
+
+#### Setting "User" Access Levels
 
 You can also control access by giving a client certificate a [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user) security clearance. 
 With this clearance, you can set a different access level to each database. The three "User" access levels are:  
@@ -177,7 +200,13 @@ It enables developers to control access levels by configuring client certificate
 
 
 
-## Create and Configure Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Create and Configure Certificates">
+
+<ContentFrame>
 
 ### List of Registered Certificates 
 
@@ -206,6 +235,10 @@ Each client certificate contains the following:
 6. **Edit Certificate**  
    Configure which databases it can access (applicable for User-level) and its authorization clearance level.  
 7. **Delete Certificate**  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generate Client Certificate 
 
 Using this view, you can generate client certificates directly via RavenDB.  
@@ -241,6 +274,10 @@ This information is used by RavenDB internally and is not stored in the certific
 Expiration for client certificates is set to 5 years by default.
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Edit Certificate
 
 To edit existing certificates:
@@ -276,7 +313,11 @@ Expiration for client certificates is set to 5 years by default.
 
 
 
-## Enabling Communication Between Servers: Importing and Exporting Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">
 
 There are various situations where developers need to create a database with partial access to another server.  
 For example, a source server may contain sensitive information that should not be exposed to the public, but also contain databases that need to be exposed with limited access.  
@@ -305,12 +346,18 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
    * **Upload client certificate**  
      [Import a client certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate) 
      that was exported from another server so that the two can communicate.  
+<ContentFrame>
+
 ### Export Server Certificates
 
 ![Figure 6. Export Server Certificates](./assets/export-server-certificates.png)
 
 This option allows you to export the server certificate as a .pfx file. In the case of a cluster which contains several different server certificates, 
 a .pfx [collection](../../../server/security/authentication/certificate-management.mdx#certificate-collections) will be exported.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Upload an Existing Certificate
 
 Click the **Client certificate** button, select **Upload client certificate** and you will see the following window.  
@@ -350,12 +397,20 @@ Expiration for client certificates is set to 5 years by default.
 To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Certificate Collections
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all of the certificates to the list of registered certificates as one entry 
 and will allow access to all these certificates explicitly by their thumbprint.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generating Client Certificates Via Command Line Interface
 
 * RavenDB provides an intuitive certificates management GUI in Studio.  
@@ -364,6 +419,10 @@ and will allow access to all these certificates explicitly by their thumbprint.
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
   - There are CLI-based means to [generate](../../../server/security/authentication/client-certificate-usage.mdx#example-i---using-the-ravendb-cli) and [configure client certificates in Windows](../../../server/security/authentication/client-certificate-usage.mdx#example-ii---using-powershell-and-wget-in-windows).  
   - [Linux](../../../server/security/authentication/client-certificate-usage.mdx#example-iii--using-curl-in-linux) developers can use this cURL command sample.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Private Keys
 
 It's important to note that RavenDB does _not_ keep track of the certificate's private key. Whether you generate a client certificate
@@ -375,6 +434,10 @@ If two different RavenDB clusters are communicating securely, and the source clu
 still trust this new certificate - provided that the new certificate is signed with the same private key as the original, and was issued by the 
 same certificate authority. This is accomplished using a [public key pinning hash](../../../server/security/authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash).  
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Client Certificate Chain of Trust
 
 As mentioned above, RavenDB generates client certificates by signing them using the server certificate. 
@@ -394,5 +457,6 @@ Because client certificates are managed by RavenDB directly and [not through any
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
 
+</ContentFrame>
 
-
+</Panel>

--- a/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-6.2/server/security/authentication/certificate-management.mdx
@@ -315,6 +315,14 @@ Expiration for client certificates is set to 5 years by default.
 
 </ContentFrame>
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">

--- a/versioned_docs/version-6.2/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/versioned_docs/version-6.2/server/security/authorization/security-clearance-and-permissions.mdx
@@ -102,6 +102,14 @@ These access levels are, from highest to lowest:
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 <ContentFrame>
 
 ### `Admin`

--- a/versioned_docs/version-6.2/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/versioned_docs/version-6.2/server/security/authorization/security-clearance-and-permissions.mdx
@@ -10,28 +10,37 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authorization: Security Clearance and Permissions
 
-* X.509 certificates are used for authentication - validating that users are who they say they are. 
-  Once a connection is authenticated, RavenDB uses the certificate for authorization as well. 
+<Admonition type="note" title="">
+
+* X.509 certificates are used for authentication - validating that users are who they say they are.  
+  Once a connection is authenticated, RavenDB uses the certificate for authorization as well.
 
 * Each certificate is associated with a security clearance and access permissions per database.
 
-* It is the administrator's responsibility to generate client certificates and assign permissions. 
+* It is the administrator's responsibility to generate client certificates and assign permissions.  
   Read more in the [Certificate Management](../authentication/certificate-management.mdx) page.
 
-* A client certificate's security clearance can be one of the following: Cluster Admin, Operator, User.
+* A client certificate's security clearance can be one of the following:
+   * Cluster Admin
+   * Operator
+   * User
 
-* In this page:
+* In this article:
    * [Cluster Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin)
    * [Operator](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator)
-   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)  
-      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#section)  
-      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-1) 
-      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-2)
+   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)
+      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#admin)
+      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#readwrite)
+      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#read-only)
 
-## Cluster Admin
+</Admonition>
+
+<Panel heading="Cluster Admin">
 
 `Cluster Admin` is the highest security clearance. There are no restrictions. A `Cluster Admin` certificate has admin permissions to all databases. It also has the ability to modify the cluster itself.
 
@@ -46,7 +55,9 @@ The following operations are allowed **only** for `Cluster Admin` certificates:
 
 
 
-## Operator
+</Panel>
+
+<Panel heading="Operator">
 
 A client certificate with an `Operator` security clearance has admin access to all databases 
 but is unable to modify the cluster. It cannot perform operations such as 
@@ -77,7 +88,9 @@ The following operations are allowed for **both** `Operator` and `Cluster Admin`
 
 
 
-## User
+</Panel>
+
+<Panel heading="User">
 
 A client certificate with a `User` security clearance cannot perform any admin operations at the cluster level.  
 Unlike the other clearance levels, a `User` client certificate can grant different access levels to different databases.  
@@ -88,6 +101,9 @@ These access levels are, from highest to lowest:
 * **Read Only**  
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
+
+<ContentFrame>
+
 ### `Admin`
 
 The following operations are permitted at the `Admin` access level but not for `Read/Write` or `Read Only`:
@@ -101,6 +117,11 @@ The following operations are permitted at the `Admin` access level but not for `
 - Put client configuration for the database (Max number of requests per session, Read balance behavior)
 - Get transaction info
 - Perform SQL migration
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read/Write`
 
 A `User` certificate with a `Read/Write` access level can perform all operations **except** for those listed above in the 'Admin' and 'Operator'sections.  
@@ -109,6 +130,11 @@ A `User` certificate with a `Read/Write` access level can perform all operations
     To configure a server or database so that only Admin certificates will be able to deploy JavaScript static indexes,  
     set [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../../server/configuration/indexing-configuration.mdx#indexingstaticrequireadmintodeployjavascriptindexes) 
     to `true`.
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read Only`
 
 The `ReadOnly` access level **allows** clients to: 
@@ -135,6 +161,10 @@ The following operations are **forbidden**:
 </Admonition>
 
 Learn more about the `Read Only` access level [here](../../../studio/server/certificates/read-only-access-level.mdx).
+
+</ContentFrame>
+
+</Panel>
 
 
 

--- a/versioned_docs/version-6.2/studio/server/certificates/server-management-certificates-view.mdx
+++ b/versioned_docs/version-6.2/studio/server/certificates/server-management-certificates-view.mdx
@@ -89,7 +89,13 @@ by using different client certificates, each with its own set of permissions.
    Configure which databases it can access (applicable for User level) and its authorization clearance level.  
 8. **Delete Certificate**  
 
+<Admonition type="info" title="">
 
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
 
 </Panel>
 

--- a/versioned_docs/version-6.2/studio/server/certificates/server-management-certificates-view.mdx
+++ b/versioned_docs/version-6.2/studio/server/certificates/server-management-certificates-view.mdx
@@ -10,6 +10,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Certificates View
 <Admonition type="note" title="">
@@ -26,7 +28,8 @@ import LanguageContent from "@site/src/components/LanguageContent";
    * [Certificate collections](../../../studio/server/certificates/server-management-certificates-view.mdx#certificate-collections)
 
 </Admonition>
-## The certificates view
+
+<Panel heading="The certificates view">
 
 ![Studio Certificates Management View](./assets/studio-certificates-overview.png)
 
@@ -53,7 +56,9 @@ the permissions entirely using this view.
 
 
 
-## View and edit certificates
+</Panel>
+
+<Panel heading="View and edit certificates">
 
 In the image below, the client certificates (`sampledom.client.certificate` and `Booking`) have different 
 **security clearance** and **database permissions** configurations.  
@@ -86,7 +91,9 @@ by using different client certificates, each with its own set of permissions.
 
 
 
-## Generate a client certificate 
+</Panel>
+
+<Panel heading="Generate a client certificate">
 
 Use this view to generate a client certificate directly via RavenDB.  
 Newly generated certificates will be added to the list of registered certificates.  
@@ -122,6 +129,8 @@ Newly generated certificates will be added to the list of registered certificate
            You can limit the session duration here.  
            You can also grant access only to this browser, or use this 
            clearance screen to open Studio for other clients as well.  
+         * **C. Proceed**  
+           Click to enter Studio using the authentication code you provided.  
 7. **Generate** the certificate or **Cancel**.  
    
 <Admonition type="note" title="">
@@ -131,13 +140,18 @@ and will not be stored in the certificate itself.
 
 
 
-## Enable communication between secure servers 
+</Panel>
+
+<Panel heading="Enable communication between secure servers">
 
 To enable communication between two secure databases, you need to:
 
 1. **Export** ([download](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)) 
    the `.pfx` certificate from the destination cluster.  
 2. **Upload** (import) the downloaded certificate into the source server.  
+
+<ContentFrame>
+
 ### Upload an existing client certificate
 
 Use this option to upload an existing client certificate.  
@@ -151,6 +165,11 @@ While uploading the client certificate you can modify its settings.
 
 See the [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view.mdx#generate-a-client-certificate) 
 section to learn about the available settings.  
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### Export server certificates
 
 ![Export Server Certificates](./assets/export-server-certificates.png)
@@ -162,13 +181,19 @@ will be exported.
 
 
 
-## Certificate collections 
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Certificate collections">
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all certificates 
 to the list of registered certificates as a single entry, and explicitly allow access to 
 all certificates by their thumbprint.
+
+</Panel>
 
 
 

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
@@ -1,13 +1,13 @@
 import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
@@ -15,12 +15,14 @@ import CodeBlock from '@theme/CodeBlock';
   * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
+
+<Panel heading="Put client certificate example">
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Sync" label="Sync">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -31,12 +33,13 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.Send
 store.Maintenance.Server.Send(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="Async" label="Async">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -47,25 +50,23 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.SendAsync
 await store.Maintenance.Server.SendAsync(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="put_syntax" label="put_syntax">
-<CodeBlock language="csharp">
-{`public PutClientCertificateOperation(
+```csharp
+public PutClientCertificateOperation(
     string name, 
     X509Certificate2 certificate, 
     Dictionary<string, DatabaseAccess> permissions, 
     SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                                 | Description                                                                                         |
 |-----------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -74,32 +75,26 @@ await store.Maintenance.Server.SendAsync(putClientCertificateOp);
 | **permissions** | `Dictionary<string, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `ValidUser`. |
 | **clearance**   | `SecurityClearance`                  | Access level (role) assigned to the certificate.                                                    |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="csharp">
-{`// The role assigned to the certificate:
+```csharp
+// The role assigned to the certificate:
 public enum SecurityClearance
-\{
+{
     ClusterAdmin,
     ClusterNode,
     Operator,
     ValidUser
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="csharp">
-{`// The access level for a 'ValidUser' security clearance:
+}
+```
+<br />
+
+```csharp
+// The access level for a 'ValidUser' security clearance:
 public enum DatabaseAccess
-\{
+{
     Read,
     ReadWrite,
     Admin
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
@@ -1,25 +1,23 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="java">
-{`byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
+<Panel heading="Put client certificate example">
+
+```java
+byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
 String certificateAsBase64 = Base64.getEncoder().encodeToString(rawCert);                
 
 store.maintenance().server().send(
@@ -28,23 +26,19 @@ store.maintenance().server().send(
         certificateAsBase64,
         new HashMap<>(),
         SecurityClearance.CLUSTER_ADMIN));
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="cert_put_1" label="cert_put_1">
-<CodeBlock language="java">
-{`public PutClientCertificateOperation(String name,
+```java
+public PutClientCertificateOperation(String name,
                                      String certificate,
                                      Map<String, DatabaseAccess> permissions,
                                      SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                          | Description                                                                                          |
 |-----------------|-------------------------------|------------------------------------------------------------------------------------------------------|
@@ -53,28 +47,22 @@ store.maintenance().server().send(
 | **permissions** | `Map<String, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `VALID_USER`. |
 | **clearance**   | `SecurityClearance`           | Access level (role) assigned to the certificate.                                                     |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="java">
-{`public enum SecurityClearance \{
+```java
+public enum SecurityClearance {
     CLUSTER_ADMIN,
     CLUSTER_NODE,
     OPERATOR,
     VALID_USER
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="java">
-{`public enum DatabaseAccess \{
+}
+```
+<br />
+
+```java
+public enum DatabaseAccess {
     READ,
     READ_WRITE,
     ADMIN
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
@@ -1,49 +1,43 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="js">
-{`const rawCert = fs.readFileSync("<path-to-certificate.crt>");
+<Panel heading="Put client certificate example">
+
+```js
+const rawCert = fs.readFileSync("<path-to-certificate.crt>");
 const certificateAsBase64 = rawCert.toString("base64");
 
 const putClientCertificateOp = new PutClientCertificateOperation(
     "certificateName",
     certificateAsBase64,
-    \{\},
+    {},
     "ClusterAdmin");
 
 await store.maintenance.server.send(putClientCertificateOp);
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="syntax" label="syntax">
-<CodeBlock language="js">
-{`const putOperation = 
+```js
+const putOperation = 
     new PutClientCertificateOperation(name, certificate, permissions, clearance);
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                             | Description                                                                                         |
 |-----------------|----------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -58,11 +52,9 @@ await store.maintenance.server.send(putClientCertificateOp);
   * `Operator`  
   * `ValidUser`  
 
-* `DatabaseAccess ` options:
+* `DatabaseAccess` options:
   * `Read`
   * `ReadWrite`  
   * `Admin`
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/put-client-certificate.mdx
+++ b/versioned_docs/version-7.0/client-api/operations/server-wide/certificates/put-client-certificate.mdx
@@ -12,6 +12,10 @@ see_also:
        link: "client-api/operations/server-wide/certificates/create-client-certificate"
        source: "docs"
        path: "Client API > Operations > Server-Maintenance > Certificates"
+     - title: "Certificates Management"
+       link: "server/security/authentication/certificate-management#enabling-communication-between-servers-importing-and-exporting-certificates"
+       source: "docs"
+       path: "Server > Security > Authentication"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
@@ -31,7 +31,7 @@ In this page:
   * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
   * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
   * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers:-importing-and-exporting-certificates)  
+* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
   * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
   * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
   * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
@@ -342,6 +342,12 @@ This information is used by RavenDB internally and is not stored in the certific
 <Admonition type="note" title="">
 
 Expiration for client certificates is set to 5 years by default.
+
+</Admonition>
+
+<Admonition type="note" title="">
+
+To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
 ### Certificate Collections

--- a/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Authentication: Certificate Management"
 sidebar_label: Certificate Management
+description: "Manage client and server certificates in RavenDB including generation, registration, permissions assignment, and revocation procedures."
 sidebar_position: 1
 ---
 
@@ -10,6 +11,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authentication: Certificate Management
 <Admonition type="note" title="">
@@ -21,25 +24,27 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * See the API article for integrating a client certificate into an application via the [document store](../../../client-api/creating-document-store.mdx).  
 
-In this page:  
-
-* [Studio Certificate Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)  
-* [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)  
-  * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)  
-  * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)  
-* [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)  
-  * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
-  * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
-  * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
-  * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
-  * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
-  * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
-  * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)  
-  * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)  
+* In this article:
+   * [Studio Certificates Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)
+   * [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)
+      * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)
+      * [Full Access to Database](../../../server/security/authentication/certificate-management.mdx#full-access-to-database)
+      * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)
+   * [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)
+      * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)
+      * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)
+      * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+   * [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)
+      * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)
+      * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)
+      * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)
+      * [Generating Client Certificates Via Command Line Interface](../../../server/security/authentication/certificate-management.mdx#generating-client-certificates-via-command-line-interface)
+      * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)
+      * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)
 
 </Admonition>
-## Studio Certificates Management View
+
+<Panel heading="Studio Certificates Management View">
 
 ![Figure 1. Studio Certificates Management View](./assets/studio-certificates-overview.png)
 
@@ -71,14 +76,19 @@ Client certificates are managed by RavenDB directly and not by any [Public Key I
 
 
 
-## The RavenDB Security Authorization Approach
+</Panel>
+
+<Panel heading="The RavenDB Security Authorization Approach">
 
 In general, RavenDB assumes that an application will implement its own logic and business rules, limiting 
 itself to protect the data from unauthorized access. Applications operate on behalf of developers, and as such, they are in a better position than RavenDB to determine what is
 allowed.  This is why access levels of RavenDB databases in each cluster are highly customizable by [cluster admins](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) 
 and [operators](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator).  
 
+<ContentFrame>
+
 ### Authorization Levels in Client Certificates
+
 The security system in RavenDB does not make assumptions about which types of users should access which type of database. The concept of a user
 does not really exist within RavenDB in this manner. Instead, cluster admins or operators create various client certificates and configure each one with a custom set of permissions. 
 
@@ -92,16 +102,19 @@ does not really exist within RavenDB in this manner. Instead, cluster admins or 
   * "User" certificates are configured to specify which databases people can access with each certificate.  
   * ["User" authorization levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels) are also configured per database.  
 
+**Access is through your applications, not individual users**  
 In most cases, users do not access RavenDB directly. Aside from admins and developers during the development process, all access to 
 the data inside RavenDB is expected to be done through your applications. A security mechanism on a per-user basis is not practical in complex systems 
 because each user (employee or customer) may need different access levels to different portions of the data. 
 Also, the same application usually needs to access the same data on behalf of different types of users with different levels of access.  
 
-**Most organizations have fairly complex architectures.** In most systems, the access level
+**Most organizations have fairly complex architectures**  
+In most systems, the access level
 and operations allowed are never simple enough to be able to express them as an Access Control List. They are highly dependent on business rules and
 processes, the state of the system, etc. 
 
-**How can authorization levels efficiently handle complex systems?**  By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
+**How can authorization levels efficiently handle complex systems?**  
+By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
 is not permitted to approve their own vacation. The HR manager, on the other hand, may approve the vacation.  
 
 From the point of view of RavenDB, the act of editing a vacation request document or approving it looks very much the same, it's a simple document edit.
@@ -111,12 +124,20 @@ but not to development-oriented data, whereas developers might have read/write o
 Meanwhile, customers likely have read/write certification to their user account, but read-only access to the catalog.  
 
 Thus, RavenDB is designed so that **each client certificate has specific and customizable permissions for various databases as well as configurable authorization levels**.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Full Access to Database
 RavenDB expects the applications and systems using it to utilize the security infrastructure it provides to prevent unauthorized access, such as a different
 application trying to access the HR database. However, once access is granted, the access is complete.  
 
 RavenDB security infrastructure operates at the level of the entire database. If you are granted access to a database, you can access 
 any and all documents in that database unless protection is explicitly configured.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Partial Access to Database
 
 There are two approaches to giving partial access to a database:
@@ -124,7 +145,7 @@ There are two approaches to giving partial access to a database:
  * [Using ETL for selective, one-way data transfer](../../../server/security/authentication/certificate-management.mdx#using-etl-for-selective-one-way-data-transfer)  
  * [Setting "User" Access Levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels)  
 
-####  *Using ETL for selective, one-way data transfer*  
+#### Using ETL for selective, one-way data transfer
 
 Some developers need to provide partial access to a database that also contains sensitive data. One approach is to set up an [Extract, Transform, Load (ETL) task](../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx):  
 
@@ -152,7 +173,9 @@ Together, ETL and dedicated databases can be used for fine-grained filtration, b
 
 </Admonition>
 
-####  *Setting "User" Access Levels*  
+---
+
+#### Setting "User" Access Levels
 
 You can also control access by giving a client certificate a [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user) security clearance. 
 With this clearance, you can set a different access level to each database. The three "User" access levels are:  
@@ -177,7 +200,13 @@ It enables developers to control access levels by configuring client certificate
 
 
 
-## Create and Configure Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Create and Configure Certificates">
+
+<ContentFrame>
 
 ### List of Registered Certificates 
 
@@ -206,6 +235,10 @@ Each client certificate contains the following:
 6. **Edit Certificate**  
    Configure which databases it can access (applicable for User-level) and its authorization clearance level.  
 7. **Delete Certificate**  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generate Client Certificate 
 
 Using this view, you can generate client certificates directly via RavenDB.  
@@ -241,6 +274,10 @@ This information is used by RavenDB internally and is not stored in the certific
 Expiration for client certificates is set to 5 years by default.
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Edit Certificate
 
 To edit existing certificates:
@@ -276,7 +313,11 @@ Expiration for client certificates is set to 5 years by default.
 
 
 
-## Enabling Communication Between Servers: Importing and Exporting Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">
 
 There are various situations where developers need to create a database with partial access to another server.  
 For example, a source server may contain sensitive information that should not be exposed to the public, but also contain databases that need to be exposed with limited access.  
@@ -305,12 +346,18 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
    * **Upload client certificate**  
      [Import a client certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate) 
      that was exported from another server so that the two can communicate.  
+<ContentFrame>
+
 ### Export Server Certificates
 
 ![Figure 6. Export Server Certificates](./assets/export-server-certificates.png)
 
 This option allows you to export the server certificate as a .pfx file. In the case of a cluster which contains several different server certificates, 
 a .pfx [collection](../../../server/security/authentication/certificate-management.mdx#certificate-collections) will be exported.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Upload an Existing Certificate
 
 Click the **Client certificate** button, select **Upload client certificate** and you will see the following window.  
@@ -350,12 +397,20 @@ Expiration for client certificates is set to 5 years by default.
 To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Certificate Collections
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all of the certificates to the list of registered certificates as one entry 
 and will allow access to all these certificates explicitly by their thumbprint.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generating Client Certificates Via Command Line Interface
 
 * RavenDB provides an intuitive certificates management GUI in Studio.  
@@ -364,6 +419,10 @@ and will allow access to all these certificates explicitly by their thumbprint.
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
   - There are CLI-based means to [generate](../../../server/security/authentication/client-certificate-usage.mdx#example-i---using-the-ravendb-cli) and [configure client certificates in Windows](../../../server/security/authentication/client-certificate-usage.mdx#example-ii---using-powershell-and-wget-in-windows).  
   - [Linux](../../../server/security/authentication/client-certificate-usage.mdx#example-iii--using-curl-in-linux) developers can use this cURL command sample.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Private Keys
 
 It's important to note that RavenDB does _not_ keep track of the certificate's private key. Whether you generate a client certificate
@@ -375,6 +434,10 @@ If two different RavenDB clusters are communicating securely, and the source clu
 still trust this new certificate - provided that the new certificate is signed with the same private key as the original, and was issued by the 
 same certificate authority. This is accomplished using a [public key pinning hash](../../../server/security/authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash).  
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Client Certificate Chain of Trust
 
 As mentioned above, RavenDB generates client certificates by signing them using the server certificate. 
@@ -394,5 +457,6 @@ Because client certificates are managed by RavenDB directly and [not through any
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
 
+</ContentFrame>
 
-
+</Panel>

--- a/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.0/server/security/authentication/certificate-management.mdx
@@ -315,6 +315,14 @@ Expiration for client certificates is set to 5 years by default.
 
 </ContentFrame>
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">

--- a/versioned_docs/version-7.0/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/versioned_docs/version-7.0/server/security/authorization/security-clearance-and-permissions.mdx
@@ -102,6 +102,14 @@ These access levels are, from highest to lowest:
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 <ContentFrame>
 
 ### `Admin`

--- a/versioned_docs/version-7.0/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/versioned_docs/version-7.0/server/security/authorization/security-clearance-and-permissions.mdx
@@ -10,28 +10,37 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authorization: Security Clearance and Permissions
 
-* X.509 certificates are used for authentication - validating that users are who they say they are. 
-  Once a connection is authenticated, RavenDB uses the certificate for authorization as well. 
+<Admonition type="note" title="">
+
+* X.509 certificates are used for authentication - validating that users are who they say they are.  
+  Once a connection is authenticated, RavenDB uses the certificate for authorization as well.
 
 * Each certificate is associated with a security clearance and access permissions per database.
 
-* It is the administrator's responsibility to generate client certificates and assign permissions. 
+* It is the administrator's responsibility to generate client certificates and assign permissions.  
   Read more in the [Certificate Management](../authentication/certificate-management.mdx) page.
 
-* A client certificate's security clearance can be one of the following: Cluster Admin, Operator, User.
+* A client certificate's security clearance can be one of the following:
+   * Cluster Admin
+   * Operator
+   * User
 
-* In this page:
+* In this article:
    * [Cluster Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin)
    * [Operator](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator)
-   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)  
-      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#section)  
-      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-1) 
-      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-2)
+   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)
+      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#admin)
+      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#readwrite)
+      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#read-only)
 
-## Cluster Admin
+</Admonition>
+
+<Panel heading="Cluster Admin">
 
 `Cluster Admin` is the highest security clearance. There are no restrictions. A `Cluster Admin` certificate has admin permissions to all databases. It also has the ability to modify the cluster itself.
 
@@ -46,7 +55,9 @@ The following operations are allowed **only** for `Cluster Admin` certificates:
 
 
 
-## Operator
+</Panel>
+
+<Panel heading="Operator">
 
 A client certificate with an `Operator` security clearance has admin access to all databases 
 but is unable to modify the cluster. It cannot perform operations such as 
@@ -77,7 +88,9 @@ The following operations are allowed for **both** `Operator` and `Cluster Admin`
 
 
 
-## User
+</Panel>
+
+<Panel heading="User">
 
 A client certificate with a `User` security clearance cannot perform any admin operations at the cluster level.  
 Unlike the other clearance levels, a `User` client certificate can grant different access levels to different databases.  
@@ -88,6 +101,9 @@ These access levels are, from highest to lowest:
 * **Read Only**  
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
+
+<ContentFrame>
+
 ### `Admin`
 
 The following operations are permitted at the `Admin` access level but not for `Read/Write` or `Read Only`:
@@ -101,6 +117,11 @@ The following operations are permitted at the `Admin` access level but not for `
 - Put client configuration for the database (Max number of requests per session, Read balance behavior)
 - Get transaction info
 - Perform SQL migration
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read/Write`
 
 A `User` certificate with a `Read/Write` access level can perform all operations **except** for those listed above in the 'Admin' and 'Operator'sections.  
@@ -109,6 +130,11 @@ A `User` certificate with a `Read/Write` access level can perform all operations
     To configure a server or database so that only Admin certificates will be able to deploy JavaScript static indexes,  
     set [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../../server/configuration/indexing-configuration.mdx#indexingstaticrequireadmintodeployjavascriptindexes) 
     to `true`.
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read Only`
 
 The `ReadOnly` access level **allows** clients to: 
@@ -135,6 +161,10 @@ The following operations are **forbidden**:
 </Admonition>
 
 Learn more about the `Read Only` access level [here](../../../studio/server/certificates/read-only-access-level.mdx).
+
+</ContentFrame>
+
+</Panel>
 
 
 

--- a/versioned_docs/version-7.0/studio/server/certificates/server-management-certificates-view.mdx
+++ b/versioned_docs/version-7.0/studio/server/certificates/server-management-certificates-view.mdx
@@ -113,6 +113,14 @@ by using different client certificates, each with its own set of permissions.
 10. **Delete Certificate**  
     Deleting a certificate will revoke access for all clients using this certificate.
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Generate a client certificate">

--- a/versioned_docs/version-7.0/studio/server/certificates/server-management-certificates-view.mdx
+++ b/versioned_docs/version-7.0/studio/server/certificates/server-management-certificates-view.mdx
@@ -10,6 +10,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Certificates View
 <Admonition type="note" title="">
@@ -27,7 +29,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 </Admonition>
 
-## The Certificates view
+<Panel heading="The Certificates view">
 
 To open the certificates view: **Manage Server** `>` **Certificates**
 
@@ -73,7 +75,9 @@ To open the certificates view: **Manage Server** `>` **Certificates**
    Client certificates registered with this server are used to authenticate users and applications connecting to the database.  
    Each client certificate can be assigned specific permissions and security clearance levels, such as Cluster Administrator (ClusterAdmin), Operator, or User.
 
-## View and edit certificates
+</Panel>
+
+<Panel heading="View and edit certificates">
 
 In the image below, the client certificates have different 
 **security clearance** and **database permissions** configurations.  
@@ -109,7 +113,9 @@ by using different client certificates, each with its own set of permissions.
 10. **Delete Certificate**  
     Deleting a certificate will revoke access for all clients using this certificate.
 
-## Generate a client certificate 
+</Panel>
+
+<Panel heading="Generate a client certificate">
 
 Use this view to generate a client certificate directly via RavenDB.  
 Newly generated certificates will be added to the list of registered certificates.  
@@ -142,18 +148,24 @@ Newly generated certificates will be added to the list of registered certificate
          * **B. Additional Settings**  
            You can limit the session duration here.  
            You can also grant access only to this browser, or use this clearance screen to open Studio for other clients as well.  
+         * **C. Proceed**  
+           Click to enter Studio using the authentication code you provided.  
 7. **Generate** the certificate or **Cancel**.  
    
 <Admonition type="note" title="">
 The information collected in this view is used by RavenDB internally, and will not be stored in the certificate itself.
 </Admonition>
 
-## Enable communication between secure servers 
+</Panel>
+
+<Panel heading="Enable communication between secure servers">
 
 To enable communication between two secure servers, you need to:
 
 1. **Export** ([download](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)) the `.pfx` certificate from the destination server.  
 2. **Upload** (import) the downloaded certificate into the source server.  
+
+<ContentFrame>
 
 ### Upload an existing client certificate
 
@@ -168,7 +180,11 @@ While uploading the client certificate you can modify its settings.
 
 See the [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view.mdx#generate-a-client-certificate) section to learn about the available settings.  
 
-## Export server certificates
+</ContentFrame>
+
+<ContentFrame>
+
+### Export server certificates
 
 ![Export Server Certificates](./assets/export-server-certificates.png)
 
@@ -176,11 +192,17 @@ This option allows you to export the server certificate as a `.pfx` file.
 In the case of a cluster that contains several different server certificates, a `.pfx` [collection](../../../server/security/authentication/certificate-management.mdx#certificate-collections) will be exported.
 
 
-## Certificate collections 
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Certificate collections">
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all certificates to the list of registered certificates as a single entry, and explicitly allow access to all certificates by their thumbprint.
+
+</Panel>
 
 
 

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/content/_put-client-certificate-csharp.mdx
@@ -1,13 +1,13 @@
 import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
@@ -15,12 +15,14 @@ import CodeBlock from '@theme/CodeBlock';
   * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
+
+<Panel heading="Put client certificate example">
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Sync" label="Sync">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -31,12 +33,13 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.Send
 store.Maintenance.Server.Send(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 <TabItem value="Async" label="Async">
-<CodeBlock language="csharp">
-{`X509Certificate2 certificate = new X509Certificate2("c:\\\\path_to_pfx_file");
+
+```csharp
+X509Certificate2 certificate = new X509Certificate2("c:\\path_to_pfx_file");
 
 // Define the put client certificate operation 
 var putClientCertificateOp = new PutClientCertificateOperation(
@@ -47,25 +50,23 @@ var putClientCertificateOp = new PutClientCertificateOperation(
 
 // Execute the operation by passing it to Maintenance.Server.SendAsync
 await store.Maintenance.Server.SendAsync(putClientCertificateOp);
-`}
-</CodeBlock>
+```
+
 </TabItem>
 </Tabs>
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="put_syntax" label="put_syntax">
-<CodeBlock language="csharp">
-{`public PutClientCertificateOperation(
+```csharp
+public PutClientCertificateOperation(
     string name, 
     X509Certificate2 certificate, 
     Dictionary<string, DatabaseAccess> permissions, 
     SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                                 | Description                                                                                         |
 |-----------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -74,32 +75,26 @@ await store.Maintenance.Server.SendAsync(putClientCertificateOp);
 | **permissions** | `Dictionary<string, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `ValidUser`. |
 | **clearance**   | `SecurityClearance`                  | Access level (role) assigned to the certificate.                                                    |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="csharp">
-{`// The role assigned to the certificate:
+```csharp
+// The role assigned to the certificate:
 public enum SecurityClearance
-\{
+{
     ClusterAdmin,
     ClusterNode,
     Operator,
     ValidUser
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="csharp">
-{`// The access level for a 'ValidUser' security clearance:
+}
+```
+<br />
+
+```csharp
+// The access level for a 'ValidUser' security clearance:
 public enum DatabaseAccess
-\{
+{
     Read,
     ReadWrite,
     Admin
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/content/_put-client-certificate-java.mdx
@@ -1,25 +1,23 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="java">
-{`byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
+<Panel heading="Put client certificate example">
+
+```java
+byte[] rawCert = Files.readAllBytes(Paths.get("<path-to-certificate.crt>"));
 String certificateAsBase64 = Base64.getEncoder().encodeToString(rawCert);                
 
 store.maintenance().server().send(
@@ -28,23 +26,19 @@ store.maintenance().server().send(
         certificateAsBase64,
         new HashMap<>(),
         SecurityClearance.CLUSTER_ADMIN));
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="cert_put_1" label="cert_put_1">
-<CodeBlock language="java">
-{`public PutClientCertificateOperation(String name,
+```java
+public PutClientCertificateOperation(String name,
                                      String certificate,
                                      Map<String, DatabaseAccess> permissions,
                                      SecurityClearance clearance)
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                          | Description                                                                                          |
 |-----------------|-------------------------------|------------------------------------------------------------------------------------------------------|
@@ -53,28 +47,22 @@ store.maintenance().server().send(
 | **permissions** | `Map<String, DatabaseAccess>` | A dictionary mapping database name to access level.<br/>Relevant only when clearance is `VALID_USER`. |
 | **clearance**   | `SecurityClearance`           | Access level (role) assigned to the certificate.                                                     |
 
-<TabItem value="cert_1_2" label="cert_1_2">
-<CodeBlock language="java">
-{`public enum SecurityClearance \{
+```java
+public enum SecurityClearance {
     CLUSTER_ADMIN,
     CLUSTER_NODE,
     OPERATOR,
     VALID_USER
-\}
-`}
-</CodeBlock>
-</TabItem>
-<TabItem value="cert_1_3" label="cert_1_3">
-<CodeBlock language="java">
-{`public enum DatabaseAccess \{
+}
+```
+<br />
+
+```java
+public enum DatabaseAccess {
     READ,
     READ_WRITE,
     ADMIN
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/content/_put-client-certificate-nodejs.mdx
@@ -1,49 +1,43 @@
 import Admonition from '@theme/Admonition';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Panel from "@site/src/components/Panel";
 
 <Admonition type="note" title="">
 
 * Use `PutClientCertificateOperation` to register an existing client certificate.
 
-* To register an existing client certificate from the Studio,
+* To register an existing client certificate from Studio,
   see [Upload an existing client certificate](../../../../../studio/server/certificates/server-management-certificates-view.mdx#upload-an-existing-client-certificate).
 
 * In this article:
-    * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
-    * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
+  * [Put client certificate example](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#put-client-certificate-example)
+  * [Syntax](../../../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx#syntax)
 
 </Admonition>
-## Put client certificate example
 
-<TabItem value="cert_put_2" label="cert_put_2">
-<CodeBlock language="js">
-{`const rawCert = fs.readFileSync("<path-to-certificate.crt>");
+<Panel heading="Put client certificate example">
+
+```js
+const rawCert = fs.readFileSync("<path-to-certificate.crt>");
 const certificateAsBase64 = rawCert.toString("base64");
 
 const putClientCertificateOp = new PutClientCertificateOperation(
     "certificateName",
     certificateAsBase64,
-    \{\},
+    {},
     "ClusterAdmin");
 
 await store.maintenance.server.send(putClientCertificateOp);
-`}
-</CodeBlock>
-</TabItem>
+```
 
+</Panel>
 
+<Panel heading="Syntax">
 
-## Syntax
-
-<TabItem value="syntax" label="syntax">
-<CodeBlock language="js">
-{`const putOperation = 
+```js
+const putOperation = 
     new PutClientCertificateOperation(name, certificate, permissions, clearance);
-`}
-</CodeBlock>
-</TabItem>
+```
+<br />
 
 | Parameter       | Type                             | Description                                                                                         |
 |-----------------|----------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -58,11 +52,9 @@ await store.maintenance.server.send(putClientCertificateOp);
   * `Operator`  
   * `ValidUser`  
 
-* `DatabaseAccess ` options:
+* `DatabaseAccess` options:
   * `Read`
   * `ReadWrite`  
   * `Admin`
 
-
-
-
+</Panel>

--- a/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/put-client-certificate.mdx
+++ b/versioned_docs/version-7.1/client-api/operations/server-wide/certificates/put-client-certificate.mdx
@@ -12,6 +12,10 @@ see_also:
        link: "client-api/operations/server-wide/certificates/create-client-certificate"
        source: "docs"
        path: "Client API > Operations > Server-Maintenance > Certificates"
+     - title: "Certificates Management"
+       link: "server/security/authentication/certificate-management#enabling-communication-between-servers-importing-and-exporting-certificates"
+       source: "docs"
+       path: "Server > Security > Authentication"
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";

--- a/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
@@ -31,7 +31,7 @@ In this page:
   * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
   * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
   * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers:-importing-and-exporting-certificates)  
+* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
   * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
   * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
   * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
@@ -342,6 +342,12 @@ This information is used by RavenDB internally and is not stored in the certific
 <Admonition type="note" title="">
 
 Expiration for client certificates is set to 5 years by default.
+
+</Admonition>
+
+<Admonition type="note" title="">
+
+To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
 ### Certificate Collections

--- a/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Authentication: Certificate Management"
 sidebar_label: Certificate Management
+description: "Manage client and server certificates in RavenDB including generation, registration, permissions assignment, and revocation procedures."
 sidebar_position: 1
 ---
 
@@ -10,6 +11,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authentication: Certificate Management
 <Admonition type="note" title="">
@@ -21,25 +24,27 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * See the API article for integrating a client certificate into an application via the [document store](../../../client-api/creating-document-store.mdx).  
 
-In this page:  
-
-* [Studio Certificate Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)  
-* [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)  
-  * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)  
-  * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)  
-* [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)  
-  * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)  
-  * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)  
-  * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)  
-* [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)  
-  * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)  
-  * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)  
-  * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)  
-  * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)  
-  * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)  
+* In this article:
+   * [Studio Certificates Management View](../../../server/security/authentication/certificate-management.mdx#studio-certificates-management-view)
+   * [The RavenDB Security Authorization Approach](../../../server/security/authentication/certificate-management.mdx#the-ravendb-security-authorization-approach)
+      * [Authorization Levels in Client Certificates](../../../server/security/authentication/certificate-management.mdx#authorization-levels-in-client-certificates)
+      * [Full Access to Database](../../../server/security/authentication/certificate-management.mdx#full-access-to-database)
+      * [Partial Access to Database](../../../server/security/authentication/certificate-management.mdx#partial-access-to-database)
+   * [Create and Configure Certificates](../../../server/security/authentication/certificate-management.mdx#create-and-configure-certificates)
+      * [List of Registered Certificates](../../../server/security/authentication/certificate-management.mdx#list-of-registered-certificates)
+      * [Generate Client Certificate](../../../server/security/authentication/certificate-management.mdx#generate-client-certificate)
+      * [Edit Certificate](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+   * [Enabling Communication Between Servers: Importing and Exporting Certificates](../../../server/security/authentication/certificate-management.mdx#enabling-communication-between-servers-importing-and-exporting-certificates)
+      * [Export Server Certificates](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)
+      * [Upload an Existing Certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate)
+      * [Certificate Collections](../../../server/security/authentication/certificate-management.mdx#certificate-collections)
+      * [Generating Client Certificates Via Command Line Interface](../../../server/security/authentication/certificate-management.mdx#generating-client-certificates-via-command-line-interface)
+      * [Private Keys](../../../server/security/authentication/certificate-management.mdx#private-keys)
+      * [Client Certificate Chain of Trust](../../../server/security/authentication/certificate-management.mdx#client-certificate-chain-of-trust)
 
 </Admonition>
-## Studio Certificates Management View
+
+<Panel heading="Studio Certificates Management View">
 
 ![Figure 1. Studio Certificates Management View](./assets/studio-certificates-overview.png)
 
@@ -71,14 +76,19 @@ Client certificates are managed by RavenDB directly and not by any [Public Key I
 
 
 
-## The RavenDB Security Authorization Approach
+</Panel>
+
+<Panel heading="The RavenDB Security Authorization Approach">
 
 In general, RavenDB assumes that an application will implement its own logic and business rules, limiting 
 itself to protect the data from unauthorized access. Applications operate on behalf of developers, and as such, they are in a better position than RavenDB to determine what is
 allowed.  This is why access levels of RavenDB databases in each cluster are highly customizable by [cluster admins](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) 
 and [operators](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator).  
 
+<ContentFrame>
+
 ### Authorization Levels in Client Certificates
+
 The security system in RavenDB does not make assumptions about which types of users should access which type of database. The concept of a user
 does not really exist within RavenDB in this manner. Instead, cluster admins or operators create various client certificates and configure each one with a custom set of permissions. 
 
@@ -92,16 +102,19 @@ does not really exist within RavenDB in this manner. Instead, cluster admins or 
   * "User" certificates are configured to specify which databases people can access with each certificate.  
   * ["User" authorization levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels) are also configured per database.  
 
+**Access is through your applications, not individual users**  
 In most cases, users do not access RavenDB directly. Aside from admins and developers during the development process, all access to 
 the data inside RavenDB is expected to be done through your applications. A security mechanism on a per-user basis is not practical in complex systems 
 because each user (employee or customer) may need different access levels to different portions of the data. 
 Also, the same application usually needs to access the same data on behalf of different types of users with different levels of access.  
 
-**Most organizations have fairly complex architectures.** In most systems, the access level
+**Most organizations have fairly complex architectures**  
+In most systems, the access level
 and operations allowed are never simple enough to be able to express them as an Access Control List. They are highly dependent on business rules and
 processes, the state of the system, etc. 
 
-**How can authorization levels efficiently handle complex systems?**  By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
+**How can authorization levels efficiently handle complex systems?**  
+By customizing access via client certificates.  For example, an employee may request a vacation day, but the employee
 is not permitted to approve their own vacation. The HR manager, on the other hand, may approve the vacation.  
 
 From the point of view of RavenDB, the act of editing a vacation request document or approving it looks very much the same, it's a simple document edit.
@@ -111,12 +124,20 @@ but not to development-oriented data, whereas developers might have read/write o
 Meanwhile, customers likely have read/write certification to their user account, but read-only access to the catalog.  
 
 Thus, RavenDB is designed so that **each client certificate has specific and customizable permissions for various databases as well as configurable authorization levels**.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Full Access to Database
 RavenDB expects the applications and systems using it to utilize the security infrastructure it provides to prevent unauthorized access, such as a different
 application trying to access the HR database. However, once access is granted, the access is complete.  
 
 RavenDB security infrastructure operates at the level of the entire database. If you are granted access to a database, you can access 
 any and all documents in that database unless protection is explicitly configured.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Partial Access to Database
 
 There are two approaches to giving partial access to a database:
@@ -124,7 +145,7 @@ There are two approaches to giving partial access to a database:
  * [Using ETL for selective, one-way data transfer](../../../server/security/authentication/certificate-management.mdx#using-etl-for-selective-one-way-data-transfer)  
  * [Setting "User" Access Levels](../../../server/security/authentication/certificate-management.mdx#setting-user-access-levels)  
 
-####  *Using ETL for selective, one-way data transfer*  
+#### Using ETL for selective, one-way data transfer
 
 Some developers need to provide partial access to a database that also contains sensitive data. One approach is to set up an [Extract, Transform, Load (ETL) task](../../../studio/database/tasks/ongoing-tasks/ravendb-etl-task.mdx):  
 
@@ -152,7 +173,9 @@ Together, ETL and dedicated databases can be used for fine-grained filtration, b
 
 </Admonition>
 
-####  *Setting "User" Access Levels*  
+---
+
+#### Setting "User" Access Levels
 
 You can also control access by giving a client certificate a [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user) security clearance. 
 With this clearance, you can set a different access level to each database. The three "User" access levels are:  
@@ -177,7 +200,13 @@ It enables developers to control access levels by configuring client certificate
 
 
 
-## Create and Configure Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Create and Configure Certificates">
+
+<ContentFrame>
 
 ### List of Registered Certificates 
 
@@ -206,6 +235,10 @@ Each client certificate contains the following:
 6. **Edit Certificate**  
    Configure which databases it can access (applicable for User-level) and its authorization clearance level.  
 7. **Delete Certificate**  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generate Client Certificate 
 
 Using this view, you can generate client certificates directly via RavenDB.  
@@ -241,6 +274,10 @@ This information is used by RavenDB internally and is not stored in the certific
 Expiration for client certificates is set to 5 years by default.
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Edit Certificate
 
 To edit existing certificates:
@@ -276,7 +313,11 @@ Expiration for client certificates is set to 5 years by default.
 
 
 
-## Enabling Communication Between Servers: Importing and Exporting Certificates
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">
 
 There are various situations where developers need to create a database with partial access to another server.  
 For example, a source server may contain sensitive information that should not be exposed to the public, but also contain databases that need to be exposed with limited access.  
@@ -305,12 +346,18 @@ b. **Upload** ([import](../../../server/security/authentication/certificate-mana
    * **Upload client certificate**  
      [Import a client certificate](../../../server/security/authentication/certificate-management.mdx#upload-an-existing-certificate) 
      that was exported from another server so that the two can communicate.  
+<ContentFrame>
+
 ### Export Server Certificates
 
 ![Figure 6. Export Server Certificates](./assets/export-server-certificates.png)
 
 This option allows you to export the server certificate as a .pfx file. In the case of a cluster which contains several different server certificates, 
 a .pfx [collection](../../../server/security/authentication/certificate-management.mdx#certificate-collections) will be exported.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Upload an Existing Certificate
 
 Click the **Client certificate** button, select **Upload client certificate** and you will see the following window.  
@@ -350,12 +397,20 @@ Expiration for client certificates is set to 5 years by default.
 To register the source server's certificate on the destination server from the client API, use [PutClientCertificateOperation](../../../client-api/operations/server-wide/certificates/put-client-certificate.mdx).
 
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Certificate Collections
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all of the certificates to the list of registered certificates as one entry 
 and will allow access to all these certificates explicitly by their thumbprint.
+</ContentFrame>
+
+<ContentFrame>
+
 ### Generating Client Certificates Via Command Line Interface
 
 * RavenDB provides an intuitive certificates management GUI in Studio.  
@@ -364,6 +419,10 @@ and will allow access to all these certificates explicitly by their thumbprint.
   - Be sure to configure the `SecurityClearance` for each client certificate because the default is [cluster admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin) which has full access.
   - There are CLI-based means to [generate](../../../server/security/authentication/client-certificate-usage.mdx#example-i---using-the-ravendb-cli) and [configure client certificates in Windows](../../../server/security/authentication/client-certificate-usage.mdx#example-ii---using-powershell-and-wget-in-windows).  
   - [Linux](../../../server/security/authentication/client-certificate-usage.mdx#example-iii--using-curl-in-linux) developers can use this cURL command sample.  
+</ContentFrame>
+
+<ContentFrame>
+
 ### Private Keys
 
 It's important to note that RavenDB does _not_ keep track of the certificate's private key. Whether you generate a client certificate
@@ -375,6 +434,10 @@ If two different RavenDB clusters are communicating securely, and the source clu
 still trust this new certificate - provided that the new certificate is signed with the same private key as the original, and was issued by the 
 same certificate authority. This is accomplished using a [public key pinning hash](../../../server/security/authentication/certificate-renewal-and-rotation.mdx#implicit-trust-by-public-key-pinning-hash).  
 </Admonition>
+</ContentFrame>
+
+<ContentFrame>
+
 ### Client Certificate Chain of Trust
 
 As mentioned above, RavenDB generates client certificates by signing them using the server certificate. 
@@ -394,5 +457,6 @@ Because client certificates are managed by RavenDB directly and [not through any
 Authenticating a client certificate is done explicitly by looking for the thumbprint in the registered certificates list in the server 
 and not by validating the chain of trust. 
 
+</ContentFrame>
 
-
+</Panel>

--- a/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
+++ b/versioned_docs/version-7.1/server/security/authentication/certificate-management.mdx
@@ -315,6 +315,14 @@ Expiration for client certificates is set to 5 years by default.
 
 </ContentFrame>
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Enabling Communication Between Servers: Importing and Exporting Certificates">

--- a/versioned_docs/version-7.1/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/versioned_docs/version-7.1/server/security/authorization/security-clearance-and-permissions.mdx
@@ -102,6 +102,14 @@ These access levels are, from highest to lowest:
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 <ContentFrame>
 
 ### `Admin`

--- a/versioned_docs/version-7.1/server/security/authorization/security-clearance-and-permissions.mdx
+++ b/versioned_docs/version-7.1/server/security/authorization/security-clearance-and-permissions.mdx
@@ -10,28 +10,37 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Authorization: Security Clearance and Permissions
 
-* X.509 certificates are used for authentication - validating that users are who they say they are. 
-  Once a connection is authenticated, RavenDB uses the certificate for authorization as well. 
+<Admonition type="note" title="">
+
+* X.509 certificates are used for authentication - validating that users are who they say they are.  
+  Once a connection is authenticated, RavenDB uses the certificate for authorization as well.
 
 * Each certificate is associated with a security clearance and access permissions per database.
 
-* It is the administrator's responsibility to generate client certificates and assign permissions. 
+* It is the administrator's responsibility to generate client certificates and assign permissions.  
   Read more in the [Certificate Management](../authentication/certificate-management.mdx) page.
 
-* A client certificate's security clearance can be one of the following: Cluster Admin, Operator, User.
+* A client certificate's security clearance can be one of the following:
+   * Cluster Admin
+   * Operator
+   * User
 
-* In this page:
+* In this article:
    * [Cluster Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#cluster-admin)
    * [Operator](../../../server/security/authorization/security-clearance-and-permissions.mdx#operator)
-   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)  
-      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#section)  
-      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-1) 
-      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#section-2)
+   * [User](../../../server/security/authorization/security-clearance-and-permissions.mdx#user)
+      * [Admin](../../../server/security/authorization/security-clearance-and-permissions.mdx#admin)
+      * [Read/Write](../../../server/security/authorization/security-clearance-and-permissions.mdx#readwrite)
+      * [Read Only](../../../server/security/authorization/security-clearance-and-permissions.mdx#read-only)
 
-## Cluster Admin
+</Admonition>
+
+<Panel heading="Cluster Admin">
 
 `Cluster Admin` is the highest security clearance. There are no restrictions. A `Cluster Admin` certificate has admin permissions to all databases. It also has the ability to modify the cluster itself.
 
@@ -46,7 +55,9 @@ The following operations are allowed **only** for `Cluster Admin` certificates:
 
 
 
-## Operator
+</Panel>
+
+<Panel heading="Operator">
 
 A client certificate with an `Operator` security clearance has admin access to all databases 
 but is unable to modify the cluster. It cannot perform operations such as 
@@ -77,7 +88,9 @@ The following operations are allowed for **both** `Operator` and `Cluster Admin`
 
 
 
-## User
+</Panel>
+
+<Panel heading="User">
 
 A client certificate with a `User` security clearance cannot perform any admin operations at the cluster level.  
 Unlike the other clearance levels, a `User` client certificate can grant different access levels to different databases.  
@@ -88,6 +101,9 @@ These access levels are, from highest to lowest:
 * **Read Only**  
 
 If no access level is defined for a particular database, the certificate doesn't grant access to that database at all.  
+
+<ContentFrame>
+
 ### `Admin`
 
 The following operations are permitted at the `Admin` access level but not for `Read/Write` or `Read Only`:
@@ -101,6 +117,11 @@ The following operations are permitted at the `Admin` access level but not for `
 - Put client configuration for the database (Max number of requests per session, Read balance behavior)
 - Get transaction info
 - Perform SQL migration
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read/Write`
 
 A `User` certificate with a `Read/Write` access level can perform all operations **except** for those listed above in the 'Admin' and 'Operator'sections.  
@@ -109,6 +130,11 @@ A `User` certificate with a `Read/Write` access level can perform all operations
     To configure a server or database so that only Admin certificates will be able to deploy JavaScript static indexes,  
     set [Indexing.Static.RequireAdminToDeployJavaScriptIndexes](../../../server/configuration/indexing-configuration.mdx#indexingstaticrequireadmintodeployjavascriptindexes) 
     to `true`.
+
+</ContentFrame>
+
+<ContentFrame>
+
 ### `Read Only`
 
 The `ReadOnly` access level **allows** clients to: 
@@ -135,6 +161,10 @@ The following operations are **forbidden**:
 </Admonition>
 
 Learn more about the `Read Only` access level [here](../../../studio/server/certificates/read-only-access-level.mdx).
+
+</ContentFrame>
+
+</Panel>
 
 
 

--- a/versioned_docs/version-7.1/studio/server/certificates/server-management-certificates-view.mdx
+++ b/versioned_docs/version-7.1/studio/server/certificates/server-management-certificates-view.mdx
@@ -113,6 +113,14 @@ by using different client certificates, each with its own set of permissions.
 10. **Delete Certificate**  
     Deleting a certificate will revoke access for all clients using this certificate.
 
+<Admonition type="info" title="">
+
+When a database is deleted, RavenDB removes its name from the permissions of every client certificate that was granted access to it.  
+If you later re-create a database with the same name, [reassign the relevant permissions](../../../server/security/authentication/certificate-management.mdx#edit-certificate)
+to each certificate that needs access to it.
+
+</Admonition>
+
 </Panel>
 
 <Panel heading="Generate a client certificate">

--- a/versioned_docs/version-7.1/studio/server/certificates/server-management-certificates-view.mdx
+++ b/versioned_docs/version-7.1/studio/server/certificates/server-management-certificates-view.mdx
@@ -10,6 +10,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
+import Panel from "@site/src/components/Panel";
+import ContentFrame from "@site/src/components/ContentFrame";
 
 # Certificates View
 <Admonition type="note" title="">
@@ -27,7 +29,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 </Admonition>
 
-## The Certificates view
+<Panel heading="The Certificates view">
 
 To open the certificates view: **Manage Server** `>` **Certificates**
 
@@ -73,7 +75,9 @@ To open the certificates view: **Manage Server** `>` **Certificates**
    Client certificates registered with this server are used to authenticate users and applications connecting to the database.  
    Each client certificate can be assigned specific permissions and security clearance levels, such as Cluster Administrator (ClusterAdmin), Operator, or User.
 
-## View and edit certificates
+</Panel>
+
+<Panel heading="View and edit certificates">
 
 In the image below, the client certificates have different 
 **security clearance** and **database permissions** configurations.  
@@ -109,7 +113,9 @@ by using different client certificates, each with its own set of permissions.
 10. **Delete Certificate**  
     Deleting a certificate will revoke access for all clients using this certificate.
 
-## Generate a client certificate 
+</Panel>
+
+<Panel heading="Generate a client certificate">
 
 Use this view to generate a client certificate directly via RavenDB.  
 Newly generated certificates will be added to the list of registered certificates.  
@@ -142,18 +148,24 @@ Newly generated certificates will be added to the list of registered certificate
          * **B. Additional Settings**  
            You can limit the session duration here.  
            You can also grant access only to this browser, or use this clearance screen to open Studio for other clients as well.  
+         * **C. Proceed**  
+           Click to enter Studio using the authentication code you provided.  
 7. **Generate** the certificate or **Cancel**.  
    
 <Admonition type="note" title="">
 The information collected in this view is used by RavenDB internally, and will not be stored in the certificate itself.
 </Admonition>
 
-## Enable communication between secure servers 
+</Panel>
+
+<Panel heading="Enable communication between secure servers">
 
 To enable communication between two secure servers, you need to:
 
 1. **Export** ([download](../../../server/security/authentication/certificate-management.mdx#export-server-certificates)) the `.pfx` certificate from the destination server.  
 2. **Upload** (import) the downloaded certificate into the source server.  
+
+<ContentFrame>
 
 ### Upload an existing client certificate
 
@@ -168,7 +180,11 @@ While uploading the client certificate you can modify its settings.
 
 See the [Generate a client certificate](../../../studio/server/certificates/server-management-certificates-view.mdx#generate-a-client-certificate) section to learn about the available settings.  
 
-## Export server certificates
+</ContentFrame>
+
+<ContentFrame>
+
+### Export server certificates
 
 ![Export Server Certificates](./assets/export-server-certificates.png)
 
@@ -176,11 +192,17 @@ This option allows you to export the server certificate as a `.pfx` file.
 In the case of a cluster that contains several different server certificates, a `.pfx` [collection](../../../server/security/authentication/certificate-management.mdx#certificate-collections) will be exported.
 
 
-## Certificate collections 
+</ContentFrame>
+
+</Panel>
+
+<Panel heading="Certificate collections">
 
 `.pfx` files may contain a single certificate or a collection of certificates.
 
 When uploading a `.pfx` file with multiple certificates, RavenDB will add all certificates to the list of registered certificates as a single entry, and explicitly allow access to all certificates by their thumbprint.
+
+</Panel>
 
 
 


### PR DESCRIPTION
### Issue link
[RDoc-2220](https://issues.hibernatingrhinos.com/issue/RDoc-2220)
[RDoc-3972](https://issues.hibernatingrhinos.com/issue/RDoc-3972)
[RDoc-3973](https://issues.hibernatingrhinos.com/issue/RDoc-3973)
[RDoc-3975](https://issues.hibernatingrhinos.com/issue/RDoc-3975)
[RDoc-3976](https://issues.hibernatingrhinos.com/issue/RDoc-3976)
[RDoc-3974](https://issues.hibernatingrhinos.com/issue/RDoc-3974)

### Additional description
RDoc-2220 - reference from certificate-management an explanation of registering certificates via client API
RDoc-3972, RDoc-3973 - update layout and broken links in put-client-certificate, certificate-management
RDoc-3975 - update `Authorization: Security Clearance and Permissions` page layout
RDoc-3976 - update the `Certificates View` page layout
RDoc-3974 - document that deleting a database removes its name from client certificate permissions

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

