### PR TITLE
RDoc-3984 Rendering of expressions like `!=` in the documentation

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -197,6 +197,19 @@ pre[class*="language-"] {
     font-display: swap;
 }
 
+/* Disable coding ligatures so operators like != and <= render literally, not as glyphs (≠, ≤). */
+code,
+kbd,
+samp,
+pre,
+.prism-code,
+[class*="language-"] {
+    font-variant-ligatures: none;
+    font-feature-settings:
+        "liga" 0,
+        "calt" 0;
+}
+
 /* Custom border for sidebar and navbar */
 [class*="docSidebarContainer"] {
     @apply !border-black/10 dark:!border-white/10;


### PR DESCRIPTION


### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3984/Rendering-of-expressions-like-in-the-documentation

### Additional description
The monospace code font (JetBrains Mono) applied coding ligatures, so operator sequences in code and query examples rendered as single glyphs (for example "!=" as "≠" and "<=" as "≤"), hiding the exact characters readers must type in RQL/SQL queries.

Disable ligatures on code elements in src/css/custom.css using font-variant-ligatures and font-feature-settings so operators render exactly as written. The properties inherit, so Prism token spans are covered too; body text (Inter) is unaffected.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

