### PR TITLE
RDoc-3454 Persist selected language in URL

### DIFF
--- a/docs/ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx
+++ b/docs/ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx
@@ -3,6 +3,7 @@ title: "Creating AI agents: API"
 sidebar_label: "Client API"
 description: "Create and configure RavenDB AI agents programmatically using the Client API with connection strings, tools, and conversation management."
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -12,9 +13,7 @@ import CreatingAiAgentsApiCsharp from './content/_creating-ai-agents_api-csharp.
 import CreatingAiAgentsApiPython from './content/_creating-ai-agents_api-python.mdx';
 import CreatingAiAgentsApiNodejs from './content/_creating-ai-agents_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <CreatingAiAgentsApiCsharp />

--- a/docs/ai-integration/ai-agents/reading-conversation-history.mdx
+++ b/docs/ai-integration/ai-agents/reading-conversation-history.mdx
@@ -3,6 +3,7 @@ title: "AI agents: Reading conversation history"
 sidebar_label: "Reading conversation history"
 description: "Read back the messages of a stored AI agent conversation using the Client API, with timestamp-based paging and a selectable level of detail."
 sidebar_position: 3
+supported_languages: ["csharp"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -10,9 +11,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 import ReadingConversationHistoryCsharp from './content/_reading-conversation-history-csharp.mdx';
 
-export const supportedLanguages = ["csharp"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <ReadingConversationHistoryCsharp />

--- a/docs/ai-integration/gen-ai-integration/create-gen-ai-task/create-gen-ai-task_api.mdx
+++ b/docs/ai-integration/gen-ai-integration/create-gen-ai-task/create-gen-ai-task_api.mdx
@@ -3,6 +3,7 @@ title: "Create GenAI Task: API"
 sidebar_label: "Client API"
 description: "Create and deploy GenAI tasks programmatically using the RavenDB Client API to process documents with generative AI models."
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -12,9 +13,7 @@ import CreateGenAiTaskApiCsharp from './content/_create-gen-ai-task_api-csharp.m
 import CreateGenAiTaskApiPython from './content/_create-gen-ai-task_api-python.mdx';
 import CreateGenAiTaskApiNodejs from './content/_create-gen-ai-task_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <CreateGenAiTaskApiCsharp />

--- a/docs/ai-integration/gen-ai-integration/modify-gen-ai-task/modify-gen-ai-task_api.mdx
+++ b/docs/ai-integration/gen-ai-integration/modify-gen-ai-task/modify-gen-ai-task_api.mdx
@@ -3,6 +3,7 @@ title: "Modify GenAI Task: API"
 sidebar_label: "Client API"
 description: "Update existing GenAI task configurations programmatically using the RavenDB Client API to change prompts, collections, or settings."
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -12,9 +13,7 @@ import ModifyGenAiTaskApiCsharp from './content/_modify-gen-ai-task_api-csharp.m
 import ModifyGenAiTaskApiPython from './content/_modify-gen-ai-task_api-python.mdx';
 import ModifyGenAiTaskApiNodejs from './content/_modify-gen-ai-task_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <ModifyGenAiTaskApiCsharp />

--- a/docs/ai-integration/gen-ai-integration/process-attachments/processing-attachments_api.mdx
+++ b/docs/ai-integration/gen-ai-integration/process-attachments/processing-attachments_api.mdx
@@ -3,6 +3,7 @@ title: "Process attachments: API"
 sidebar_label: "Client API"
 description: "Send document attachments to AI models alongside documents using the RavenDB Client API for image analysis and file processing."
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -12,9 +13,7 @@ import ProcessingAttachmentsApiCsharp from './content/_processing-attachments_ap
 import ProcessingAttachmentsApiPython from './content/_processing-attachments_api-python.mdx';
 import ProcessingAttachmentsApiNodejs from './content/_processing-attachments_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <ProcessingAttachmentsApiCsharp />

--- a/src/components/LanguageContent.tsx
+++ b/src/components/LanguageContent.tsx
@@ -7,6 +7,6 @@ interface LanguageContentProps {
 }
 
 export default function LanguageContent({ language, children }: LanguageContentProps) {
-    const { language: current } = useLanguage();
+    const current = useLanguage();
     return current === language ? <>{children}</> : null;
 }

--- a/src/components/LanguageStore.tsx
+++ b/src/components/LanguageStore.tsx
@@ -1,18 +1,41 @@
-﻿import { useSyncExternalStore, useCallback } from "react";
+import { useSyncExternalStore, useCallback } from "react";
+import { useHistory } from "@docusaurus/router";
+import { languageConfig } from "./languageConfig";
 
 export type DocsLanguage = "csharp" | "java" | "python" | "php" | "nodejs";
 
-const DEFAULT_LANGUAGE: DocsLanguage = "csharp";
+export const DEFAULT_LANGUAGE: DocsLanguage = "csharp";
+export const LANGUAGE_QUERY_PARAM = "lang";
+
 const LANGUAGE_STORAGE_KEY = "docs-language";
 
-const getLanguageFromLocalStorage = (): DocsLanguage => {
-    return (window.localStorage.getItem(LANGUAGE_STORAGE_KEY) as DocsLanguage) || DEFAULT_LANGUAGE;
+// Same-tab only (not the native cross-tab "storage" event) so two tabs can show different languages side-by-side.
+const LANGUAGE_CHANGE_EVENT = "docs-language-change";
+
+export const isDocsLanguage = (value: string | null | undefined): value is DocsLanguage =>
+    !!value && languageConfig.some((lang) => lang.value === value);
+
+export const getLanguageFromSearch = (search: string): DocsLanguage | null => {
+    const value = new URLSearchParams(search).get(LANGUAGE_QUERY_PARAM);
+    return isDocsLanguage(value) ? value : null;
 };
 
+export const getStoredLanguage = (): DocsLanguage => {
+    const value = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    return isDocsLanguage(value) ? value : DEFAULT_LANGUAGE;
+};
+
+// URL wins (per-tab), then the stored cross-session default. Server snapshot is the default so the
+// first client render matches the query-less prerendered HTML; the URL/stored value applies after hydration.
+const getSnapshot = (): DocsLanguage => getLanguageFromSearch(window.location.search) ?? getStoredLanguage();
+const getServerSnapshot = (): DocsLanguage => DEFAULT_LANGUAGE;
+
 const subscribe = (callback: () => void): (() => void) => {
-    window.addEventListener("storage", callback);
+    window.addEventListener(LANGUAGE_CHANGE_EVENT, callback);
+    window.addEventListener("popstate", callback);
     return () => {
-        window.removeEventListener("storage", callback);
+        window.removeEventListener(LANGUAGE_CHANGE_EVENT, callback);
+        window.removeEventListener("popstate", callback);
     };
 };
 
@@ -20,12 +43,28 @@ export const useLanguage = (): {
     language: DocsLanguage;
     setLanguage: (newLanguage: DocsLanguage) => void;
 } => {
-    const language = useSyncExternalStore(subscribe, getLanguageFromLocalStorage, () => DEFAULT_LANGUAGE);
+    const history = useHistory();
+    const language = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-    const setLanguage = useCallback((newLanguage: DocsLanguage) => {
-        window.localStorage.setItem(LANGUAGE_STORAGE_KEY, newLanguage);
-        window.dispatchEvent(new window.Event("storage"));
-    }, []);
+    const setLanguage = useCallback(
+        (newLanguage: DocsLanguage) => {
+            const { pathname, search, hash } = history.location;
+            const params = new URLSearchParams(search);
+            // Keep the default language out of the URL; stamp everything else.
+            if (newLanguage === DEFAULT_LANGUAGE) {
+                params.delete(LANGUAGE_QUERY_PARAM);
+            } else {
+                params.set(LANGUAGE_QUERY_PARAM, newLanguage);
+            }
+
+            const newSearch = params.toString();
+            window.localStorage.setItem(LANGUAGE_STORAGE_KEY, newLanguage);
+            history.replace({ pathname, search: newSearch ? `?${newSearch}` : "", hash });
+            // Notify after storage and URL are both updated so getSnapshot re-reads fresh values.
+            window.dispatchEvent(new window.Event(LANGUAGE_CHANGE_EVENT));
+        },
+        [history]
+    );
 
     return { language, setLanguage };
 };

--- a/src/components/LanguageStore.tsx
+++ b/src/components/LanguageStore.tsx
@@ -9,7 +9,7 @@ export const LANGUAGE_QUERY_PARAM = "lang";
 
 const LANGUAGE_STORAGE_KEY = "docs-language";
 
-// Same-tab only (not the native cross-tab "storage" event) so two tabs can show different languages side-by-side.
+// Same-tab event (not the cross-tab "storage" event) so two tabs can hold different languages.
 const LANGUAGE_CHANGE_EVENT = "docs-language-change";
 
 export const isDocsLanguage = (value: string | null | undefined): value is DocsLanguage =>
@@ -25,8 +25,7 @@ export const getStoredLanguage = (): DocsLanguage => {
     return isDocsLanguage(value) ? value : DEFAULT_LANGUAGE;
 };
 
-// URL wins (per-tab), then the stored cross-session default. Server snapshot is the default so the
-// first client render matches the query-less prerendered HTML; the URL/stored value applies after hydration.
+// URL (per-tab) wins over the stored default; server snapshot is the default to avoid a hydration mismatch.
 const getSnapshot = (): DocsLanguage => getLanguageFromSearch(window.location.search) ?? getStoredLanguage();
 const getServerSnapshot = (): DocsLanguage => DEFAULT_LANGUAGE;
 
@@ -39,18 +38,16 @@ const subscribe = (callback: () => void): (() => void) => {
     };
 };
 
-export const useLanguage = (): {
-    language: DocsLanguage;
-    setLanguage: (newLanguage: DocsLanguage) => void;
-} => {
-    const history = useHistory();
-    const language = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+// Store-only (no router) so consumers don't re-render on unrelated location changes.
+export const useLanguage = (): DocsLanguage => useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-    const setLanguage = useCallback(
+export const useSetLanguage = (): ((newLanguage: DocsLanguage) => void) => {
+    const history = useHistory();
+
+    return useCallback(
         (newLanguage: DocsLanguage) => {
             const { pathname, search, hash } = history.location;
             const params = new URLSearchParams(search);
-            // Keep the default language out of the URL; stamp everything else.
             if (newLanguage === DEFAULT_LANGUAGE) {
                 params.delete(LANGUAGE_QUERY_PARAM);
             } else {
@@ -60,11 +57,9 @@ export const useLanguage = (): {
             const newSearch = params.toString();
             window.localStorage.setItem(LANGUAGE_STORAGE_KEY, newLanguage);
             history.replace({ pathname, search: newSearch ? `?${newSearch}` : "", hash });
-            // Notify after storage and URL are both updated so getSnapshot re-reads fresh values.
+            // Dispatch after storage + URL are updated so getSnapshot re-reads fresh values.
             window.dispatchEvent(new window.Event(LANGUAGE_CHANGE_EVENT));
         },
         [history]
     );
-
-    return { language, setLanguage };
 };

--- a/src/components/LanguageStore.tsx
+++ b/src/components/LanguageStore.tsx
@@ -1,4 +1,4 @@
-import { useSyncExternalStore, useCallback } from "react";
+import { useSyncExternalStore, useCallback, createContext, useContext } from "react";
 import { useHistory } from "@docusaurus/router";
 import { languageConfig } from "./languageConfig";
 
@@ -38,8 +38,20 @@ const subscribe = (callback: () => void): (() => void) => {
     };
 };
 
+// The current page's supported_languages, used to clamp the displayed language (see useLanguage).
+export const SupportedLanguagesContext = createContext<DocsLanguage[] | undefined>(undefined);
+
 // Store-only (no router) so consumers don't re-render on unrelated location changes.
-export const useLanguage = (): DocsLanguage => useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+export const useLanguage = (): DocsLanguage => {
+    const language = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+    const supportedLanguages = useContext(SupportedLanguagesContext);
+
+    // Clamp to a language the page offers, for display only (the stored preference is untouched).
+    if (supportedLanguages && supportedLanguages.length > 0 && !supportedLanguages.includes(language)) {
+        return supportedLanguages[0];
+    }
+    return language;
+};
 
 export const useSetLanguage = (): ((newLanguage: DocsLanguage) => void) => {
     const history = useHistory();

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useLocation } from "@docusaurus/router";
-import { useLanguage, LANGUAGE_QUERY_PARAM, type DocsLanguage } from "./LanguageStore";
+import { useLanguage, useSetLanguage, LANGUAGE_QUERY_PARAM, type DocsLanguage } from "./LanguageStore";
 import { languageConfig } from "./languageConfig";
 import clsx from "clsx";
 
@@ -10,7 +10,8 @@ type LanguageSwitcherProps = {
 };
 
 export default function LanguageSwitcher({ supportedLanguages, flush = false }: LanguageSwitcherProps) {
-    const { language, setLanguage } = useLanguage();
+    const language = useLanguage();
+    const setLanguage = useSetLanguage();
     const location = useLocation();
 
     const isCurrentLanguageSupported = supportedLanguages.includes(language);
@@ -22,7 +23,7 @@ export default function LanguageSwitcher({ supportedLanguages, flush = false }: 
         }
     }, [isCurrentLanguageSupported, firstSupportedLanguage, setLanguage]);
 
-    // Explicit "?lang=" (incl. the default) so Ctrl/Cmd/middle-click opens that language in a new tab (RDoc-3454).
+    // Explicit ?lang= (incl. default) so Ctrl/Cmd/middle-click opens that language in a new tab.
     const buildHref = (value: DocsLanguage): string => {
         const params = new URLSearchParams(location.search);
         params.set(LANGUAGE_QUERY_PARAM, value);

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useLocation } from "@docusaurus/router";
 import { useLanguage, useSetLanguage, LANGUAGE_QUERY_PARAM, type DocsLanguage } from "./LanguageStore";
 import { languageConfig } from "./languageConfig";
@@ -13,15 +13,6 @@ export default function LanguageSwitcher({ supportedLanguages, flush = false }: 
     const language = useLanguage();
     const setLanguage = useSetLanguage();
     const location = useLocation();
-
-    const isCurrentLanguageSupported = supportedLanguages.includes(language);
-    const firstSupportedLanguage = supportedLanguages[0];
-
-    useEffect(() => {
-        if (!isCurrentLanguageSupported) {
-            setLanguage(firstSupportedLanguage);
-        }
-    }, [isCurrentLanguageSupported, firstSupportedLanguage, setLanguage]);
 
     // Explicit ?lang= (incl. default) so Ctrl/Cmd/middle-click opens that language in a new tab.
     const buildHref = (value: DocsLanguage): string => {

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
-﻿import React, { useEffect } from "react";
-import { useLanguage, type DocsLanguage } from "./LanguageStore";
+import React, { useEffect } from "react";
+import { useLocation } from "@docusaurus/router";
+import { useLanguage, LANGUAGE_QUERY_PARAM, type DocsLanguage } from "./LanguageStore";
 import { languageConfig } from "./languageConfig";
 import clsx from "clsx";
 
@@ -10,6 +11,7 @@ type LanguageSwitcherProps = {
 
 export default function LanguageSwitcher({ supportedLanguages, flush = false }: LanguageSwitcherProps) {
     const { language, setLanguage } = useLanguage();
+    const location = useLocation();
 
     const isCurrentLanguageSupported = supportedLanguages.includes(language);
     const firstSupportedLanguage = supportedLanguages[0];
@@ -20,6 +22,13 @@ export default function LanguageSwitcher({ supportedLanguages, flush = false }: 
         }
     }, [isCurrentLanguageSupported, firstSupportedLanguage, setLanguage]);
 
+    // Explicit "?lang=" (incl. the default) so Ctrl/Cmd/middle-click opens that language in a new tab (RDoc-3454).
+    const buildHref = (value: DocsLanguage): string => {
+        const params = new URLSearchParams(location.search);
+        params.set(LANGUAGE_QUERY_PARAM, value);
+        return `${location.pathname}?${params.toString()}${location.hash}`;
+    };
+
     return (
         <div className={clsx("flex flex-wrap gap-2", { "mb-8": !flush })}>
             {languageConfig
@@ -28,12 +37,28 @@ export default function LanguageSwitcher({ supportedLanguages, flush = false }: 
                     const isActive = language === lang.value;
 
                     return (
-                        <button
+                        <a
                             key={lang.value}
-                            type="button"
-                            onClick={() => setLanguage(lang.value)}
+                            href={buildHref(lang.value)}
+                            aria-current={isActive ? "true" : undefined}
+                            onClick={(e) => {
+                                // Let modified clicks through (new tab/window); intercept only a plain left click.
+                                if (
+                                    e.defaultPrevented ||
+                                    e.button !== 0 ||
+                                    e.metaKey ||
+                                    e.ctrlKey ||
+                                    e.shiftKey ||
+                                    e.altKey
+                                ) {
+                                    return;
+                                }
+                                e.preventDefault();
+                                setLanguage(lang.value);
+                            }}
                             className={clsx(
-                                "px-3 py-1.5 rounded-md border text-sm transition-colors cursor-pointer",
+                                "px-3 py-1.5 rounded-md border text-sm transition-colors",
+                                "no-underline hover:no-underline",
                                 "border-black/10 text-gray-500 hover:bg-black/5 hover:border-black/15 hover:text-gray-600",
                                 "dark:text-gray-300 dark:border-white/10 dark:hover:text-gray-200 dark:hover:border-white/15 dark:hover:bg-white/5"
                             )}
@@ -48,7 +73,7 @@ export default function LanguageSwitcher({ supportedLanguages, flush = false }: 
                             }
                         >
                             {lang.label}
-                        </button>
+                        </a>
                     );
                 })}
         </div>

--- a/src/components/LanguageUrlSync.tsx
+++ b/src/components/LanguageUrlSync.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useLocation } from "@docusaurus/router";
 import {
     type DocsLanguage,
-    useLanguage,
+    useSetLanguage,
     getStoredLanguage,
     getLanguageFromSearch,
     DEFAULT_LANGUAGE,
@@ -12,10 +12,9 @@ type LanguageUrlSyncProps = {
     supportedLanguages?: DocsLanguage[];
 };
 
-// Renders nothing. Keeps "?lang=" in sync with the active language (re-stamped after navigation)
-// and persists an incoming "?lang=" so the choice carries across navigation and future sessions.
+// Renders nothing. Keeps ?lang= in sync with the active language and persists an incoming ?lang=.
 export default function LanguageUrlSync({ supportedLanguages }: LanguageUrlSyncProps): null {
-    const { setLanguage } = useLanguage();
+    const setLanguage = useSetLanguage();
     const location = useLocation();
 
     useEffect(() => {
@@ -23,14 +22,12 @@ export default function LanguageUrlSync({ supportedLanguages }: LanguageUrlSyncP
             return;
         }
 
-        // Resolve from the real sources (URL then storage), not the store's hydration-unstable `language`,
-        // which briefly reports the default and would clobber a stored non-default preference.
+        // Resolve from the real sources (URL then storage), not the hydration-unstable store value.
         const urlLanguage = getLanguageFromSearch(location.search);
         const active = urlLanguage ?? getStoredLanguage();
         const desired = supportedLanguages.includes(active) ? active : supportedLanguages[0];
         const expectedUrlLanguage = desired === DEFAULT_LANGUAGE ? null : desired;
 
-        // Guards make this a no-op once URL and storage agree, so there is no render loop.
         if (urlLanguage !== expectedUrlLanguage || getStoredLanguage() !== desired) {
             setLanguage(desired);
         }

--- a/src/components/LanguageUrlSync.tsx
+++ b/src/components/LanguageUrlSync.tsx
@@ -22,14 +22,19 @@ export default function LanguageUrlSync({ supportedLanguages }: LanguageUrlSyncP
             return;
         }
 
-        // Resolve from the real sources (URL then storage), not the hydration-unstable store value.
+        // Read the real sources (URL then storage), not the store's hydration-unstable `language`.
         const urlLanguage = getLanguageFromSearch(location.search);
-        const active = urlLanguage ?? getStoredLanguage();
-        const desired = supportedLanguages.includes(active) ? active : supportedLanguages[0];
-        const expectedUrlLanguage = desired === DEFAULT_LANGUAGE ? null : desired;
+        const activeLanguage = urlLanguage ?? getStoredLanguage();
 
-        if (urlLanguage !== expectedUrlLanguage || getStoredLanguage() !== desired) {
-            setLanguage(desired);
+        // Page doesn't offer the active language: leave the preference and URL alone (display clamps it).
+        if (!supportedLanguages.includes(activeLanguage)) {
+            return;
+        }
+
+        // Persist a ?lang arrival and keep it in the URL; guarded so it doesn't loop.
+        const expectedUrlLanguage = activeLanguage === DEFAULT_LANGUAGE ? null : activeLanguage;
+        if (urlLanguage !== expectedUrlLanguage || getStoredLanguage() !== activeLanguage) {
+            setLanguage(activeLanguage);
         }
     }, [location.pathname, location.search, supportedLanguages, setLanguage]);
 

--- a/src/components/LanguageUrlSync.tsx
+++ b/src/components/LanguageUrlSync.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useLocation } from "@docusaurus/router";
+import {
+    type DocsLanguage,
+    useLanguage,
+    getStoredLanguage,
+    getLanguageFromSearch,
+    DEFAULT_LANGUAGE,
+} from "./LanguageStore";
+
+type LanguageUrlSyncProps = {
+    supportedLanguages?: DocsLanguage[];
+};
+
+// Renders nothing. Keeps "?lang=" in sync with the active language (re-stamped after navigation)
+// and persists an incoming "?lang=" so the choice carries across navigation and future sessions.
+export default function LanguageUrlSync({ supportedLanguages }: LanguageUrlSyncProps): null {
+    const { setLanguage } = useLanguage();
+    const location = useLocation();
+
+    useEffect(() => {
+        if (!supportedLanguages || supportedLanguages.length === 0) {
+            return;
+        }
+
+        // Resolve from the real sources (URL then storage), not the store's hydration-unstable `language`,
+        // which briefly reports the default and would clobber a stored non-default preference.
+        const urlLanguage = getLanguageFromSearch(location.search);
+        const active = urlLanguage ?? getStoredLanguage();
+        const desired = supportedLanguages.includes(active) ? active : supportedLanguages[0];
+        const expectedUrlLanguage = desired === DEFAULT_LANGUAGE ? null : desired;
+
+        // Guards make this a no-op once URL and storage agree, so there is no render loop.
+        if (urlLanguage !== expectedUrlLanguage || getStoredLanguage() !== desired) {
+            setLanguage(desired);
+        }
+    }, [location.pathname, location.search, supportedLanguages, setLanguage]);
+
+    return null;
+}

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -20,7 +20,7 @@ const getEditUrlWithLanguage = (url: string, language: DocsLanguage, supportedLa
 };
 
 export default function DocItemFooter(): ReactNode {
-    const { language } = useLanguage();
+    const language = useLanguage();
     const { metadata } = useDoc();
     const { editUrl, lastUpdatedAt, lastUpdatedBy, tags, permalink, frontMatter } = metadata;
     const { see_also } = frontMatter;

--- a/src/theme/DocItem/TOC/useFilteredToc.ts
+++ b/src/theme/DocItem/TOC/useFilteredToc.ts
@@ -13,7 +13,7 @@ import { useEffect, useState } from "react";
 // https://github.com/facebook/docusaurus/issues/6201
 
 export default function useFilteredToc(originalToc: readonly TOCItem[]): readonly TOCItem[] {
-    const { language } = useLanguage();
+    const language = useLanguage();
     const [filteredToc, setFilteredToc] = useState<readonly TOCItem[]>([]);
 
     useEffect(() => {

--- a/src/theme/DocItem/index.tsx
+++ b/src/theme/DocItem/index.tsx
@@ -4,6 +4,7 @@ import type DocItemType from "@theme/DocItem";
 import type { WrapperProps } from "@docusaurus/types";
 import DocsTopbar from "@site/src/components/DocsTopbar";
 import LanguageUrlSync from "@site/src/components/LanguageUrlSync";
+import { SupportedLanguagesContext } from "@site/src/components/LanguageStore";
 import { CustomDocFrontMatter } from "@site/src/typescript/docMetadata";
 import { useActivePlugin } from "@docusaurus/plugin-content-docs/client";
 import Head from "@docusaurus/Head";
@@ -33,7 +34,7 @@ export default function DocItemWrapper(props: Props): ReactNode {
     const isTemplatesPlugin = pluginId === "templates";
 
     return (
-        <>
+        <SupportedLanguagesContext.Provider value={supportedLanguages}>
             {isTemplatesPlugin && (
                 <Head>
                     <meta name="robots" content="noindex, nofollow" />
@@ -46,6 +47,6 @@ export default function DocItemWrapper(props: Props): ReactNode {
                     <DocItem {...props} />
                 </div>
             </div>
-        </>
+        </SupportedLanguagesContext.Provider>
     );
 }

--- a/src/theme/DocItem/index.tsx
+++ b/src/theme/DocItem/index.tsx
@@ -3,6 +3,7 @@ import DocItem from "@theme-original/DocItem";
 import type DocItemType from "@theme/DocItem";
 import type { WrapperProps } from "@docusaurus/types";
 import DocsTopbar from "@site/src/components/DocsTopbar";
+import LanguageUrlSync from "@site/src/components/LanguageUrlSync";
 import { CustomDocFrontMatter } from "@site/src/typescript/docMetadata";
 import { useActivePlugin } from "@docusaurus/plugin-content-docs/client";
 import Head from "@docusaurus/Head";
@@ -38,6 +39,7 @@ export default function DocItemWrapper(props: Props): ReactNode {
                     <meta name="robots" content="noindex, nofollow" />
                 </Head>
             )}
+            {supportedLanguages?.length ? <LanguageUrlSync supportedLanguages={supportedLanguages} /> : null}
             {showTopbar && <DocsTopbar title={title} supportedLanguages={supportedLanguages} />}
             <div className="wrapper row">
                 <div className="col flex-1 min-w-0">

--- a/versioned_docs/version-7.1/ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx
+++ b/versioned_docs/version-7.1/ai-integration/ai-agents/creating-ai-agents/creating-ai-agents_api.mdx
@@ -2,6 +2,7 @@
 title: "Creating AI agents: API"
 sidebar_label: "Client API"
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -11,9 +12,7 @@ import CreatingAiAgentsApiCsharp from './content/_creating-ai-agents_api-csharp.
 import CreatingAiAgentsApiPython from './content/_creating-ai-agents_api-python.mdx';
 import CreatingAiAgentsApiNodejs from './content/_creating-ai-agents_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <CreatingAiAgentsApiCsharp />

--- a/versioned_docs/version-7.1/ai-integration/gen-ai-integration/create-gen-ai-task/create-gen-ai-task_api.mdx
+++ b/versioned_docs/version-7.1/ai-integration/gen-ai-integration/create-gen-ai-task/create-gen-ai-task_api.mdx
@@ -2,6 +2,7 @@
 title: "Create GenAI Task: API"
 sidebar_label: "Client API"
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -11,9 +12,7 @@ import CreateGenAiTaskApiCsharp from './content/_create-gen-ai-task_api-csharp.m
 import CreateGenAiTaskApiPython from './content/_create-gen-ai-task_api-python.mdx';
 import CreateGenAiTaskApiNodejs from './content/_create-gen-ai-task_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <CreateGenAiTaskApiCsharp />

--- a/versioned_docs/version-7.1/ai-integration/gen-ai-integration/modify-gen-ai-task/modify-gen-ai-task_api.mdx
+++ b/versioned_docs/version-7.1/ai-integration/gen-ai-integration/modify-gen-ai-task/modify-gen-ai-task_api.mdx
@@ -2,6 +2,7 @@
 title: "Modify GenAI Task: API"
 sidebar_label: "Client API"
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -11,9 +12,7 @@ import ModifyGenAiTaskApiCsharp from './content/_modify-gen-ai-task_api-csharp.m
 import ModifyGenAiTaskApiPython from './content/_modify-gen-ai-task_api-python.mdx';
 import ModifyGenAiTaskApiNodejs from './content/_modify-gen-ai-task_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <ModifyGenAiTaskApiCsharp />

--- a/versioned_docs/version-7.1/ai-integration/gen-ai-integration/process-attachments/processing-attachments_api.mdx
+++ b/versioned_docs/version-7.1/ai-integration/gen-ai-integration/process-attachments/processing-attachments_api.mdx
@@ -2,6 +2,7 @@
 title: "Process attachments: API"
 sidebar_label: "Client API"
 sidebar_position: 1
+supported_languages: ["csharp", "python", "nodejs"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
@@ -11,9 +12,7 @@ import ProcessingAttachmentsApiCsharp from './content/_processing-attachments_ap
 import ProcessingAttachmentsApiPython from './content/_processing-attachments_api-python.mdx';
 import ProcessingAttachmentsApiNodejs from './content/_processing-attachments_api-nodejs.mdx';
 
-export const supportedLanguages = ["csharp", "python", "nodejs"];
-
-<LanguageSwitcher supportedLanguages={supportedLanguages} />
+<LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <ProcessingAttachmentsApiCsharp />


### PR DESCRIPTION
### Issue link
[RDoc-3583](https://issues.hibernatingrhinos.com/issue/RDoc-3583) Persist selected language state in the URL
[RDoc-3454](https://issues.hibernatingrhinos.com/issue/RDoc-3454) Language switcher should open the article in a new tab on Ctrl+Click

### Additional description
Make the "?lang=" query parameter the per-tab source of truth for the selected API language, so a page can be shared/linked in a specific language and two tabs can show different languages side-by-side. On Ctrl+Click, a new tab appears with the clicked language.
 
### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [x] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

