### PR TITLE
RDoc-4006 Expose recent guides as an API endpoint

### DIFF
--- a/scripts/handle_redirects.js
+++ b/scripts/handle_redirects.js
@@ -24,7 +24,7 @@ const kvsHandle = cf.kvs();
 const defaultVersion = CURRENT_VERSION;
 
 const staticAssetRegex =
-    /\.(html|css|js|jpg|jpeg|png|gif|webp|svg|ico|ttf|otf|woff|woff2|eot|mp4|mp3|webm|avi|mov|pdf|txt|xml)$/i;
+    /\.(html|css|js|json|jpg|jpeg|png|gif|webp|svg|ico|ttf|otf|woff|woff2|eot|mp4|mp3|webm|avi|mov|pdf|txt|xml)$/i;
 
 const versionRegex = /^\/(\d+\.\d+)(\/.*)?/;
 

--- a/src/plugins/recent-guides-plugin.ts
+++ b/src/plugins/recent-guides-plugin.ts
@@ -160,5 +160,24 @@ export default function recentGuidesPlugin(context, _options): Plugin {
             const { setGlobalData } = actions;
             setGlobalData(content);
         },
+        async postBuild({ content, outDir }) {
+            // Static /api/guides.json for external consumers; native guides only.
+            // Absolute url — the widget is embedded off-site, so a relative path won't resolve.
+            const siteUrl = context.siteConfig.url.replace(/\/+$/, "");
+            const toApiGuide = (guide: Guide) => ({
+                title: guide.title,
+                url: siteUrl + guide.permalink,
+                description: guide.description,
+                tags: guide.tags.map((tag) => tag.label),
+                lastUpdatedAt: guide.lastUpdatedAt,
+            });
+
+            const data = content as PluginData | undefined;
+            const guides = (data?.guides ?? []).filter((guide) => !guide.external_url).map(toApiGuide);
+
+            const apiDir = path.join(outDir, "api");
+            fs.mkdirSync(apiDir, { recursive: true });
+            fs.writeFileSync(path.join(apiDir, "guides.json"), JSON.stringify({ guides }), "utf8");
+        },
     };
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-4006/Expose-recent-guides-as-an-API-endpoint

### Additional description
Added recent guides `/api/guides.json` route for external widgets e.g. ravendb.net


### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [x] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

