### PR TITLE
RDBTC-237 Handle GA4 (docs side)

### DIFF
--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -7,13 +7,16 @@ import isInternalUrl from "@docusaurus/isInternalUrl";
 
 export type ButtonVariant = "default" | "outline" | "ghost" | "destructive" | "secondary";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
     children: React.ReactNode;
     url?: string;
     className?: string;
     variant?: ButtonVariant;
     size?: "xs" | "sm";
     iconName?: IconName;
+    onClick?: React.MouseEventHandler<HTMLElement>;
+    target?: string;
+    rel?: string;
 }
 
 const variantClasses: Record<ButtonVariant, string> = {
@@ -38,6 +41,9 @@ export default function Button({
     variant = "secondary",
     size = "sm",
     iconName,
+    onClick,
+    target,
+    rel,
     ...props
 }: ButtonProps) {
     const baseClasses = clsx(
@@ -52,14 +58,20 @@ export default function Button({
     if (url) {
         const isExternal = !isInternalUrl(url);
         return (
-            <Link {...(isExternal ? { href: url } : { to: url })} className={baseClasses}>
+            <Link
+                {...(isExternal ? { href: url } : { to: url })}
+                className={baseClasses}
+                onClick={onClick}
+                target={target}
+                rel={rel}
+            >
                 {children} {iconName && <Icon icon={iconName} className="ms-1" size="xs" />}
             </Link>
         );
     }
 
     return (
-        <button className={baseClasses} {...props}>
+        <button className={baseClasses} onClick={onClick} {...props}>
             {children} {iconName && <Icon icon={iconName} className="ms-1" size="xs" />}
         </button>
     );

--- a/src/components/Samples/Hub/Partials/SampleCard.tsx
+++ b/src/components/Samples/Hub/Partials/SampleCard.tsx
@@ -22,6 +22,7 @@ export interface SampleCardProps {
     url: string;
     tags?: TagWithCategory[];
     onTagClick?: (tagKey: string) => void;
+    onCardClick?: () => void;
     selectedTags?: Set<string>;
     /** Eager-load + high fetch priority for above-the-fold cards (LCP). */
     priority?: boolean;
@@ -37,6 +38,7 @@ export default function SampleCard({
     url,
     tags = [],
     onTagClick,
+    onCardClick,
     selectedTags,
     priority = false,
 }: SampleCardProps) {
@@ -125,7 +127,12 @@ export default function SampleCard({
                 )}
             </div>
             <article className="p-4">
-                <Link to={url} aria-label={title} className={clsx("absolute inset-0 z-1", "!transition-all")} />
+                <Link
+                    to={url}
+                    aria-label={title}
+                    onClick={onCardClick}
+                    className={clsx("absolute inset-0 z-1", "!transition-all")}
+                />
                 <div>
                     <div className="flex flex-col gap-0.5">
                         <Heading as="h4" className="!mb-0 !text-base !font-bold !leading-5 !break-normal">

--- a/src/components/Samples/Hub/Partials/SamplesGrid.tsx
+++ b/src/components/Samples/Hub/Partials/SamplesGrid.tsx
@@ -3,6 +3,14 @@ import clsx from "clsx";
 import { SampleCard } from "@site/src/components/Samples";
 import Heading from "@theme/Heading";
 import type { Sample } from "../../types";
+import { sampleSlugFromPermalink, trackSampleCardClick } from "../../analytics";
+
+function techStackOf(sample: Sample): string {
+    return sample.tags
+        .filter((tag) => tag.category === "tech-stack")
+        .map((tag) => tag.label)
+        .join(", ");
+}
 
 interface SamplesGridProps {
     samples: Sample[];
@@ -67,6 +75,13 @@ export default function SamplesGrid({ samples, selectedTags, matchLogic, onTagCl
                         priority={index < 2}
                         tags={sample.tags as any}
                         onTagClick={onTagClick}
+                        onCardClick={() =>
+                            trackSampleCardClick({
+                                sample_name: sampleSlugFromPermalink(sample.permalink),
+                                tech_stack: techStackOf(sample),
+                                card_position: index + 1,
+                            })
+                        }
                         selectedTags={selectedTags}
                     />
                 ))}

--- a/src/components/Samples/Hub/SamplesHomePage.tsx
+++ b/src/components/Samples/Hub/SamplesHomePage.tsx
@@ -9,6 +9,7 @@ import Drawer from "@site/src/components/Common/Drawer";
 import useBoolean from "@site/src/hooks/useBoolean";
 import Button from "@site/src/components/Common/Button";
 import clsx from "clsx";
+import { trackFilterApplied } from "../analytics";
 
 const categoryLabels: Record<string, string> = {
     "tech-stack": "Tech Stack",
@@ -89,6 +90,13 @@ export default function SamplesHomePage() {
             newSelected.add(tagKey);
         }
         setSelectedTags(newSelected);
+
+        const tag = allTags.find((t) => t.key === tagKey);
+        trackFilterApplied({
+            filter_category: categoryLabels[tag?.category || "other"] || "Other",
+            filter_value: tagKey,
+            match_logic: matchLogic,
+        });
     };
 
     const { value: isFilterDrawerOpen, setTrue: openFilterDrawer, setFalse: closeFilterDrawer } = useBoolean(false);

--- a/src/components/Samples/Overview/Partials/ActionsCard.tsx
+++ b/src/components/Samples/Overview/Partials/ActionsCard.tsx
@@ -1,14 +1,20 @@
 import React from "react";
 import clsx from "clsx";
 import Button from "@site/src/components/Common/Button";
+import { trackSampleOutboundClick, trackSampleRepoClick, withSamplesUtm } from "@site/src/components/Samples/analytics";
 
 export interface ActionsCardProps {
     className?: string;
     githubUrl?: string;
     demoUrl?: string;
+    sampleName?: string;
+    techStack?: string;
 }
 
-export default function ActionsCard({ className, githubUrl, demoUrl }: ActionsCardProps) {
+export default function ActionsCard({ className, githubUrl, demoUrl, sampleName, techStack }: ActionsCardProps) {
+    const githubHref = withSamplesUtm(githubUrl, sampleName);
+    const demoHref = withSamplesUtm(demoUrl, sampleName);
+
     return (
         <div
             className={clsx(
@@ -20,13 +26,43 @@ export default function ActionsCard({ className, githubUrl, demoUrl }: ActionsCa
             )}
         >
             <div className="flex flex-col gap-2">
-                {githubUrl && (
-                    <Button url={githubUrl} variant="secondary" size="sm" iconName="github" className="w-full">
+                {githubHref && (
+                    <Button
+                        url={githubHref}
+                        variant="secondary"
+                        size="sm"
+                        iconName="github"
+                        className="w-full"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() =>
+                            trackSampleRepoClick({
+                                sample_name: sampleName || "",
+                                tech_stack: techStack || "",
+                                destination_url: githubHref,
+                            })
+                        }
+                    >
                         Browse code
                     </Button>
                 )}
-                {demoUrl && (
-                    <Button url={demoUrl} variant="outline" size="sm" iconName="newtab" className="w-full">
+                {demoHref && (
+                    <Button
+                        url={demoHref}
+                        variant="outline"
+                        size="sm"
+                        iconName="newtab"
+                        className="w-full"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() =>
+                            trackSampleOutboundClick({
+                                destination_url: demoHref,
+                                link_text: "View demo",
+                                sample_name: sampleName,
+                            })
+                        }
+                    >
                         View demo
                     </Button>
                 )}

--- a/src/components/Samples/Overview/Partials/SampleMetadataColumn.tsx
+++ b/src/components/Samples/Overview/Partials/SampleMetadataColumn.tsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import Heading from "@theme/Heading";
 import Tag from "@site/src/theme/Tag";
 import type { PluginData } from "@site/src/components/Samples/types";
+import { sampleSlugFromPermalink } from "@site/src/components/Samples/analytics";
 import ActionsCard from "./ActionsCard";
 import RelatedResource from "./RelatedResource";
 
@@ -60,7 +61,7 @@ function TagSection({ title, tags }: TagSectionProps) {
 }
 
 export default function SampleMetadataColumn({ className }: SampleMetadataColumnProps) {
-    const { frontMatter } = useDoc();
+    const { frontMatter, metadata } = useDoc();
     const pluginData = usePluginData("recent-samples-plugin") as PluginData | undefined;
 
     const { challengesSolutionsTagsData, featureTagsData, techStackTagsData } = useMemo(() => {
@@ -102,9 +103,19 @@ export default function SampleMetadataColumn({ className }: SampleMetadataColumn
     const featureTags = getTagsWithLabels(featureTagKeys, featureTagsData);
     const techStackTags = getTagsWithLabels(techStackTagKeys, techStackTagsData);
 
+    const sampleName = sampleSlugFromPermalink(metadata.permalink);
+    const techStack = techStackTags.map((tag) => tag.label).join(", ");
+
     return (
         <div className={clsx("sticky top-[90px] flex flex-col gap-4", className)}>
-            {(repositoryUrl || demoUrl) && <ActionsCard githubUrl={repositoryUrl} demoUrl={demoUrl} />}
+            {(repositoryUrl || demoUrl) && (
+                <ActionsCard
+                    githubUrl={repositoryUrl}
+                    demoUrl={demoUrl}
+                    sampleName={sampleName}
+                    techStack={techStack}
+                />
+            )}
 
             <TagSection title="Challenges & Solutions" tags={challengesSolutionsTags} />
             <TagSection title="Feature" tags={featureTags} />

--- a/src/components/Samples/analytics.ts
+++ b/src/components/Samples/analytics.ts
@@ -1,0 +1,90 @@
+const UTM_SOURCE = "docs";
+const UTM_MEDIUM = "samples";
+const UTM_CAMPAIGN = "sample_apps";
+
+export function withSamplesUtm(url: string | undefined, sampleName?: string): string | undefined {
+    if (!url) {
+        return url;
+    }
+
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return url;
+    }
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return url;
+    }
+
+    parsed.searchParams.set("utm_source", UTM_SOURCE);
+    parsed.searchParams.set("utm_medium", UTM_MEDIUM);
+    parsed.searchParams.set("utm_campaign", UTM_CAMPAIGN);
+    if (sampleName) {
+        parsed.searchParams.set("utm_content", sampleName);
+    }
+    return parsed.toString();
+}
+
+export function sampleSlugFromPermalink(permalink: string | undefined): string {
+    if (!permalink) {
+        return "";
+    }
+    const segments = permalink.split("/").filter(Boolean);
+    if (segments[0] === "samples") {
+        segments.shift();
+    }
+    return segments.join("/");
+}
+
+type DataLayerPayload = Record<string, unknown> & { event: string };
+
+function pushEvent(payload: DataLayerPayload): void {
+    if (typeof window === "undefined") {
+        return;
+    }
+    const target = window as unknown as { dataLayer?: unknown[] };
+    target.dataLayer = target.dataLayer || [];
+    target.dataLayer.push(payload);
+}
+
+export interface SampleCardClickParams {
+    sample_name: string;
+    tech_stack: string;
+    card_position: number;
+}
+
+export function trackSampleCardClick(params: SampleCardClickParams): void {
+    pushEvent({ event: "sample_card_click", ...params });
+}
+
+export interface SampleRepoClickParams {
+    sample_name: string;
+    tech_stack: string;
+    destination_url: string;
+}
+
+export function trackSampleRepoClick(params: SampleRepoClickParams): void {
+    pushEvent({ event: "sample_repo_click", ...params });
+}
+
+export interface FilterAppliedParams {
+    filter_category: string;
+    filter_value: string;
+    match_logic: string;
+}
+
+export function trackFilterApplied(params: FilterAppliedParams): void {
+    pushEvent({ event: "filter_applied", ...params });
+}
+
+export interface SampleOutboundClickParams {
+    destination_url: string;
+    link_text: string;
+    sample_name?: string;
+}
+
+export function trackSampleOutboundClick(params: SampleOutboundClickParams): void {
+    pushEvent({ event: "sample_outbound_click", ...params });
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDBTC-237

### Additional description
Client-side GA4/GTM tracking for the samples hub: UTM tagging on outbound links plus four dataLayer events.

| File | Change |
|---|---|
| `src/components/Samples/analytics.ts` | New. UTM helper + dataLayer event pushers |
| `src/components/Samples/Hub/SamplesHomePage.tsx` | Fire `filter_applied` on filter toggle |
| `src/components/Samples/Hub/Partials/SamplesGrid.tsx` | Fire `sample_card_click` per card |
| `src/components/Samples/Hub/Partials/SampleCard.tsx` | `onCardClick` hook on the card link |
| `src/components/Samples/Overview/Partials/SampleMetadataColumn.tsx` | Pass sample slug + tech stack to the actions card |
| `src/components/Samples/Overview/Partials/ActionsCard.tsx` | UTM-tag repo/demo links; fire `sample_repo_click` / `sample_outbound_click`; open them in a new tab so the outbound event isn't lost to same-tab navigation |
| `src/components/Common/Button.tsx` | Forward `onClick` / `target` / `rel` to the link branch |

Note: forwarding `onClick` to the link branch also affects the existing `DocVersionBanner` "See latest version" button, whose `onClick` (persisting the preferred version) was previously dropped on the anchor path and now fires as intended.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [x] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)
