### PR TITLE
RDoc-3966 [Python, Node.js, Java] Per-database connection string articles

### DIFF
--- a/docs/integrations/connection-strings/per-database/add-or-update-connection-string.mdx
+++ b/docs/integrations/connection-strings/per-database/add-or-update-connection-string.mdx
@@ -2,16 +2,31 @@
 title: "Add or Update a Per-Database Connection String"
 sidebar_label: "Add or Update Connection String"
 sidebar_position: 1
-supported_languages: ["csharp"]
+supported_languages: ["csharp", "java", "nodejs", "python"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
 import AddOrUpdateConnectionStringCsharp from './content/_add-or-update-connection-string-csharp.mdx';
+import AddOrUpdateConnectionStringJava from './content/_add-or-update-connection-string-java.mdx';
+import AddOrUpdateConnectionStringNodejs from './content/_add-or-update-connection-string-nodejs.mdx';
+import AddOrUpdateConnectionStringPython from './content/_add-or-update-connection-string-python.mdx';
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <AddOrUpdateConnectionStringCsharp />
+</LanguageContent>
+
+<LanguageContent language="java">
+   <AddOrUpdateConnectionStringJava />
+</LanguageContent>
+
+<LanguageContent language="nodejs">
+   <AddOrUpdateConnectionStringNodejs />
+</LanguageContent>
+
+<LanguageContent language="python">
+   <AddOrUpdateConnectionStringPython />
 </LanguageContent>

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-csharp.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-csharp.mdx
@@ -132,6 +132,10 @@ To apply it to a different database, see [switch operations to a different datab
 For every connection string type, create the matching connection string class  
 (e.g.: `RavenConnectionString`, `SqlConnectionString`, etc.) and pass it to `PutConnectionStringOperation`.
 
+For `QueueConnectionString`, you must set `BrokerType` and provide the matching connection settings.  
+For example, set `BrokerType` to `QueueBrokerType.Kafka` and assign a configured `KafkaConnectionSettings` object to `KafkaConnectionSettings`.
+The server rejects a queue connection string if no broker type is specified.
+
 For type-specific fields and links to full examples, see
 [Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).  
 The following example adds a `RavenDB` connection string.    

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-java.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-java.mdx
@@ -132,6 +132,10 @@ To apply it to a different database, see [switch operations to a different datab
 For every connection string type, create the matching connection string class  
 (e.g.: `RavenConnectionString`, `SqlConnectionString`, etc.) and pass it to `PutConnectionStringOperation`.
 
+For `QueueConnectionString`, you must set the broker type and provide the matching connection settings.
+For example, use `setBrokerType(QueueBrokerType.KAFKA)` together with a configured `KafkaConnectionSettings` object passed to `setKafkaConnectionSettings(...)`.
+The server rejects a queue connection string if no broker type is specified.
+
 For type-specific fields and links to full examples, see
 [Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).  
 The following example adds a `RavenDB` connection string.    
@@ -152,12 +156,14 @@ PutConnectionStringOperation<RavenConnectionString> putConnectionStringOp =
     new PutConnectionStringOperation<>(ravenDBConStr);
 PutConnectionStringResult connectionStringResult = store.maintenance().send(putConnectionStringOp);
 ```
-
+<br/>
+    
 <Admonition type="note" title="">
 
-The Java client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+The Java client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`  
 (Kafka, RabbitMQ, Azure Queue Storage, and Amazon SQS), and `Ai` types.  
-Connection string types that have no matching class in the Java client, such as `Snowflake`, can be defined from Studio.    
+Connection string configurations that are not supported by the Java client,  
+such as `Snowflake` and `Azure Service Bus` queue connection strings, can be defined from Studio.    
 
 </Admonition>
 

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-java.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-java.mdx
@@ -125,7 +125,7 @@ After making changes, test the connection and save it.
 Use [PutConnectionStringOperation](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#the-putconnectionstringoperation-operation)
 to add a connection string to a database.
 
-The operation is sent through the database maintenance store: `store.Maintenance.Send(...)`.  
+The operation is sent through the database maintenance store: `store.maintenance().send(...)`.  
 By default, it is applied to the [default database](../../../../client-api/setting-up-default-database.mdx).  
 To apply it to a different database, see [switch operations to a different database](../../../../client-api/operations/how-to/switch-operations-to-a-different-database.mdx).
 
@@ -138,42 +138,28 @@ The following example adds a `RavenDB` connection string.
 
 #### Example
 
-<Tabs groupId='languageSyntax'>
-<TabItem value="Sync" label="Sync">
-```csharp
+```java
 // Define a connection string to a RavenDB database destination
 // ============================================================
-var ravenDBConStr = new RavenConnectionString
-{
-    Name = "ravendb-connection-string-name",
-    Database = "target-database-name",
-    TopologyDiscoveryUrls = new[] { "https://rvn2:8080" }
-};
+RavenConnectionString ravenDBConStr = new RavenConnectionString();
+ravenDBConStr.setName("ravendb-connection-string-name");
+ravenDBConStr.setDatabase("target-database-name");
+ravenDBConStr.setTopologyDiscoveryUrls(new String[]{ "https://rvn2:8080" });
 
 // Deploy (send) the connection string to the server via the PutConnectionStringOperation
 // ======================================================================================
-var putConnectionStringOp = new PutConnectionStringOperation<RavenConnectionString>(ravenDBConStr);
-PutConnectionStringResult connectionStringResult = store.Maintenance.Send(putConnectionStringOp);
+PutConnectionStringOperation<RavenConnectionString> putConnectionStringOp =
+    new PutConnectionStringOperation<>(ravenDBConStr);
+PutConnectionStringResult connectionStringResult = store.maintenance().send(putConnectionStringOp);
 ```
-</TabItem>
-<TabItem value="Async" label="Async">
-```csharp
-// Define a connection string to a RavenDB database destination
-// ============================================================
-var ravenDBConStr = new RavenConnectionString
-{
-    Name = "ravendb-connection-string-name",
-    Database = "target-database-name",
-    TopologyDiscoveryUrls = new[] { "https://rvn2:8080" }
-};
 
-// Deploy (send) the connection string to the server via the PutConnectionStringOperation
-// ======================================================================================
-var putConnectionStringOp = new PutConnectionStringOperation<RavenConnectionString>(ravenDBConStr);
-PutConnectionStringResult connectionStringResult = await store.Maintenance.SendAsync(putConnectionStringOp);
-```
-</TabItem>
-</Tabs>
+<Admonition type="note" title="">
+
+The Java client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+(Kafka, RabbitMQ, Azure Queue Storage, and Amazon SQS), and `Ai` types.  
+Connection string types that have no matching class in the Java client, such as `Snowflake`, can be defined from Studio.    
+
+</Admonition>
 
 </Panel>
 
@@ -240,9 +226,9 @@ The specific fields and complete examples are documented in the relevant task or
 
 #### The `PutConnectionStringOperation` operation
 
-```csharp
+```java
 public PutConnectionStringOperation(T connectionString)
-    where T : ConnectionString
+    // where T extends ConnectionString
 ```
 <br/>    
 
@@ -250,43 +236,42 @@ public PutConnectionStringOperation(T connectionString)
 |----------------------|---------------------------------|----------------------------------------------------|
 | **connectionString** | `RavenConnectionString`         | Object that defines the RavenDB connection string. |
 | **connectionString** | `SqlConnectionString`           | Object that defines the SQL connection string. |
-| **connectionString** | `SnowflakeConnectionString`     | Object that defines the Snowflake connection string. |
 | **connectionString** | `OlapConnectionString`          | Object that defines the OLAP connection string. |
 | **connectionString** | `ElasticSearchConnectionString` | Object that defines the Elasticsearch connection string. |
-| **connectionString** | `QueueConnectionString`         | Object that defines the connection string for the queue broker tasks - Queue ETL (Kafka, RabbitMQ, Azure Queue Storage, Amazon SQS) and Queue Sink (Kafka, RabbitMQ, Azure Service Bus). |
+| **connectionString** | `QueueConnectionString`         | Object that defines the connection string for the queue broker tasks - Queue ETL (Kafka, RabbitMQ, Azure Queue Storage, Amazon SQS) and Queue Sink (Kafka, RabbitMQ). |
 | **connectionString** | `AiConnectionString`            | Object that defines the AI connection string. |    
 
 #### The `ConnectionString` base class
 
 All the connection string class types inherit from this abstract class:
 
-```csharp
-public abstract class ConnectionString
-{
+```java
+public abstract class ConnectionString {
     // A name for the connection string
-    public string Name { get; set; }
-    
+    private String name;
+
+    public String getName();
+    public void setName(String name);
+
     // The connection string type
-    public abstract ConnectionStringType Type { get; } 
+    public abstract ConnectionStringType getType();
 }
 
-public enum ConnectionStringType
-{
-    None,
-    Raven,
-    Sql,
-    Olap,
-    ElasticSearch,
-    Queue,
-    Snowflake,
-    Ai
+public enum ConnectionStringType {
+    NONE,
+    RAVEN,
+    SQL,
+    OLAP,
+    ELASTIC_SEARCH,
+    QUEUE,
+    AI
 }
 ```
 <br/>
     
 <Admonition type="note" title="">
     
-Connection string type-specific fields and complete examples are documented in the task or feature articles listed under
+Connection string type-specific fields and complete examples are documented in the task or feature articles listed under  
 [Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).
     
 </Admonition>

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-nodejs.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-nodejs.mdx
@@ -125,7 +125,7 @@ After making changes, test the connection and save it.
 Use [PutConnectionStringOperation](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#the-putconnectionstringoperation-operation)
 to add a connection string to a database.
 
-The operation is sent through the database maintenance store: `store.Maintenance.Send(...)`.  
+The operation is sent through the database maintenance store: `store.maintenance.send(...)`.  
 By default, it is applied to the [default database](../../../../client-api/setting-up-default-database.mdx).  
 To apply it to a different database, see [switch operations to a different database](../../../../client-api/operations/how-to/switch-operations-to-a-different-database.mdx).
 
@@ -138,42 +138,27 @@ The following example adds a `RavenDB` connection string.
 
 #### Example
 
-<Tabs groupId='languageSyntax'>
-<TabItem value="Sync" label="Sync">
-```csharp
+```js
 // Define a connection string to a RavenDB database destination
 // ============================================================
-var ravenDBConStr = new RavenConnectionString
-{
-    Name = "ravendb-connection-string-name",
-    Database = "target-database-name",
-    TopologyDiscoveryUrls = new[] { "https://rvn2:8080" }
-};
+const ravenDBConStr = new RavenConnectionString();
+ravenDBConStr.name = "ravendb-connection-string-name";
+ravenDBConStr.database = "target-database-name";
+ravenDBConStr.topologyDiscoveryUrls = ["https://rvn2:8080"];
 
 // Deploy (send) the connection string to the server via the PutConnectionStringOperation
 // ======================================================================================
-var putConnectionStringOp = new PutConnectionStringOperation<RavenConnectionString>(ravenDBConStr);
-PutConnectionStringResult connectionStringResult = store.Maintenance.Send(putConnectionStringOp);
+const putConnectionStringOp = new PutConnectionStringOperation(ravenDBConStr);
+const connectionStringResult = await store.maintenance.send(putConnectionStringOp);
 ```
-</TabItem>
-<TabItem value="Async" label="Async">
-```csharp
-// Define a connection string to a RavenDB database destination
-// ============================================================
-var ravenDBConStr = new RavenConnectionString
-{
-    Name = "ravendb-connection-string-name",
-    Database = "target-database-name",
-    TopologyDiscoveryUrls = new[] { "https://rvn2:8080" }
-};
 
-// Deploy (send) the connection string to the server via the PutConnectionStringOperation
-// ======================================================================================
-var putConnectionStringOp = new PutConnectionStringOperation<RavenConnectionString>(ravenDBConStr);
-PutConnectionStringResult connectionStringResult = await store.Maintenance.SendAsync(putConnectionStringOp);
-```
-</TabItem>
-</Tabs>
+<Admonition type="note" title="">
+
+The Node.js client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+(Kafka and RabbitMQ), and `Ai` types.  
+Connection string types that have no matching class in the Node.js client, such as `Snowflake`, can be defined from Studio.    
+
+</Admonition>
 
 </Panel>
 
@@ -181,7 +166,7 @@ PutConnectionStringResult connectionStringResult = await store.Maintenance.SendA
     
 Use the same `PutConnectionStringOperation` to update an existing per-database connection string.
 
-To update a connection string, send a connection string with the **same** `Name`.    
+To update a connection string, send a connection string with the **same** `name`.    
 The submitted definition replaces the existing per-database connection string with that name.  
 The change applies to every task or AI agent in the database that references this connection string.
 
@@ -240,9 +225,9 @@ The specific fields and complete examples are documented in the relevant task or
 
 #### The `PutConnectionStringOperation` operation
 
-```csharp
-public PutConnectionStringOperation(T connectionString)
-    where T : ConnectionString
+```js
+// T extends ConnectionString
+new PutConnectionStringOperation(connectionString);
 ```
 <br/>    
 
@@ -250,37 +235,27 @@ public PutConnectionStringOperation(T connectionString)
 |----------------------|---------------------------------|----------------------------------------------------|
 | **connectionString** | `RavenConnectionString`         | Object that defines the RavenDB connection string. |
 | **connectionString** | `SqlConnectionString`           | Object that defines the SQL connection string. |
-| **connectionString** | `SnowflakeConnectionString`     | Object that defines the Snowflake connection string. |
 | **connectionString** | `OlapConnectionString`          | Object that defines the OLAP connection string. |
 | **connectionString** | `ElasticSearchConnectionString` | Object that defines the Elasticsearch connection string. |
-| **connectionString** | `QueueConnectionString`         | Object that defines the connection string for the queue broker tasks - Queue ETL (Kafka, RabbitMQ, Azure Queue Storage, Amazon SQS) and Queue Sink (Kafka, RabbitMQ, Azure Service Bus). |
+| **connectionString** | `QueueConnectionString`         | Object that defines the connection string for the queue broker tasks - Queue ETL (Kafka, RabbitMQ) and Queue Sink (Kafka, RabbitMQ). |
 | **connectionString** | `AiConnectionString`            | Object that defines the AI connection string. |    
 
 #### The `ConnectionString` base class
 
 All the connection string class types inherit from this abstract class:
 
-```csharp
-public abstract class ConnectionString
+```js
+class ConnectionString
 {
     // A name for the connection string
-    public string Name { get; set; }
+    name; // string
     
     // The connection string type
-    public abstract ConnectionStringType Type { get; } 
+    type; // ConnectionStringType, set by each derived class
 }
 
-public enum ConnectionStringType
-{
-    None,
-    Raven,
-    Sql,
-    Olap,
-    ElasticSearch,
-    Queue,
-    Snowflake,
-    Ai
-}
+// The available connection string types
+ConnectionStringType = "None" | "Raven" | "Sql" | "Olap" | "ElasticSearch" | "Queue" | "Ai";
 ```
 <br/>
     

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-nodejs.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-nodejs.mdx
@@ -132,6 +132,10 @@ To apply it to a different database, see [switch operations to a different datab
 For every connection string type, create the matching connection string class  
 (e.g.: `RavenConnectionString`, `SqlConnectionString`, etc.) and pass it to `PutConnectionStringOperation`.
 
+For `QueueConnectionString`, you must set `brokerType` and provide the matching connection settings.
+For example, set `brokerType` to `"Kafka"` and assign a configured `KafkaConnectionSettings` object to `kafkaConnectionSettings`.
+The server rejects a queue connection string if no broker type is specified.
+
 For type-specific fields and links to full examples, see
 [Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).  
 The following example adds a `RavenDB` connection string.    
@@ -151,12 +155,14 @@ ravenDBConStr.topologyDiscoveryUrls = ["https://rvn2:8080"];
 const putConnectionStringOp = new PutConnectionStringOperation(ravenDBConStr);
 const connectionStringResult = await store.maintenance.send(putConnectionStringOp);
 ```
-
+<br/>
+    
 <Admonition type="note" title="">
 
-The Node.js client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+The Node.js client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`  
 (Kafka and RabbitMQ), and `Ai` types.  
-Connection string types that have no matching class in the Node.js client, such as `Snowflake`, can be defined from Studio.    
+Connection string configurations that are not supported by the Node.js client,
+such as `Snowflake` and queue connection strings for `Azure Queue Storage`, `Amazon SQS`, and `Azure Service Bus`, can be defined from Studio.
 
 </Admonition>
 

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-python.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-python.mdx
@@ -132,6 +132,10 @@ To apply it to a different database, see [switch operations to a different datab
 For every connection string type, create the matching connection string class  
 (e.g.: `RavenConnectionString`, `SqlConnectionString`, etc.) and pass it to `PutConnectionStringOperation`.
 
+For `QueueConnectionString`, you must provide `broker_type` and the matching connection settings.
+For example, pass `broker_type=QueueBrokerType.KAFKA` together with a configured `KafkaConnectionSettings` object in `kafka_settings`.
+The server rejects a queue connection string if no broker type is specified.
+
 For type-specific fields and links to full examples, see
 [Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).  
 The following example adds a `RavenDB` connection string.    
@@ -155,6 +159,14 @@ raven_db_con_str = RavenConnectionString(
 put_connection_string_op = PutConnectionStringOperation(raven_db_con_str)
 connection_string_result = store.maintenance.send(put_connection_string_op)
 ```
+<br/>
+    
+<Admonition type="note" title="">
+
+_Azure Service Bus_ queue connection strings are not supported by the Python client,  
+but they can be defined from Studio.
+
+</Admonition>
 
 </Panel>
 

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-python.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-python.mdx
@@ -125,7 +125,7 @@ After making changes, test the connection and save it.
 Use [PutConnectionStringOperation](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#the-putconnectionstringoperation-operation)
 to add a connection string to a database.
 
-The operation is sent through the database maintenance store: `store.Maintenance.Send(...)`.  
+The operation is sent through the database maintenance store: `store.maintenance.send(...)`.  
 By default, it is applied to the [default database](../../../../client-api/setting-up-default-database.mdx).  
 To apply it to a different database, see [switch operations to a different database](../../../../client-api/operations/how-to/switch-operations-to-a-different-database.mdx).
 
@@ -138,42 +138,23 @@ The following example adds a `RavenDB` connection string.
 
 #### Example
 
-<Tabs groupId='languageSyntax'>
-<TabItem value="Sync" label="Sync">
-```csharp
-// Define a connection string to a RavenDB database destination
-// ============================================================
-var ravenDBConStr = new RavenConnectionString
-{
-    Name = "ravendb-connection-string-name",
-    Database = "target-database-name",
-    TopologyDiscoveryUrls = new[] { "https://rvn2:8080" }
-};
+```python
+from ravendb.documents.operations.connection_string.put_connection_string_operation import PutConnectionStringOperation
+from ravendb.documents.operations.etl.configuration import RavenConnectionString
 
-// Deploy (send) the connection string to the server via the PutConnectionStringOperation
-// ======================================================================================
-var putConnectionStringOp = new PutConnectionStringOperation<RavenConnectionString>(ravenDBConStr);
-PutConnectionStringResult connectionStringResult = store.Maintenance.Send(putConnectionStringOp);
-```
-</TabItem>
-<TabItem value="Async" label="Async">
-```csharp
-// Define a connection string to a RavenDB database destination
-// ============================================================
-var ravenDBConStr = new RavenConnectionString
-{
-    Name = "ravendb-connection-string-name",
-    Database = "target-database-name",
-    TopologyDiscoveryUrls = new[] { "https://rvn2:8080" }
-};
+# Define a connection string to a RavenDB database destination
+# ============================================================
+raven_db_con_str = RavenConnectionString(
+    name="ravendb-connection-string-name",
+    database="target-database-name",
+    topology_discovery_urls=["https://rvn2:8080"],
+)
 
-// Deploy (send) the connection string to the server via the PutConnectionStringOperation
-// ======================================================================================
-var putConnectionStringOp = new PutConnectionStringOperation<RavenConnectionString>(ravenDBConStr);
-PutConnectionStringResult connectionStringResult = await store.Maintenance.SendAsync(putConnectionStringOp);
+# Deploy (send) the connection string to the server via the PutConnectionStringOperation
+# ======================================================================================
+put_connection_string_op = PutConnectionStringOperation(raven_db_con_str)
+connection_string_result = store.maintenance.send(put_connection_string_op)
 ```
-</TabItem>
-</Tabs>
 
 </Panel>
 
@@ -181,7 +162,7 @@ PutConnectionStringResult connectionStringResult = await store.Maintenance.SendA
     
 Use the same `PutConnectionStringOperation` to update an existing per-database connection string.
 
-To update a connection string, send a connection string with the **same** `Name`.    
+To update a connection string, send a connection string with the **same** `name`.    
 The submitted definition replaces the existing per-database connection string with that name.  
 The change applies to every task or AI agent in the database that references this connection string.
 
@@ -240,47 +221,48 @@ The specific fields and complete examples are documented in the relevant task or
 
 #### The `PutConnectionStringOperation` operation
 
-```csharp
-public PutConnectionStringOperation(T connectionString)
-    where T : ConnectionString
+```python
+class PutConnectionStringOperation(MaintenanceOperation[PutConnectionStringResult]):
+    def __init__(self, connection_string: ConnectionString = None): ...
 ```
 <br/>    
 
-| Parameter            | Type                            | Description                                        |
-|----------------------|---------------------------------|----------------------------------------------------|
-| **connectionString** | `RavenConnectionString`         | Object that defines the RavenDB connection string. |
-| **connectionString** | `SqlConnectionString`           | Object that defines the SQL connection string. |
-| **connectionString** | `SnowflakeConnectionString`     | Object that defines the Snowflake connection string. |
-| **connectionString** | `OlapConnectionString`          | Object that defines the OLAP connection string. |
-| **connectionString** | `ElasticSearchConnectionString` | Object that defines the Elasticsearch connection string. |
-| **connectionString** | `QueueConnectionString`         | Object that defines the connection string for the queue broker tasks - Queue ETL (Kafka, RabbitMQ, Azure Queue Storage, Amazon SQS) and Queue Sink (Kafka, RabbitMQ, Azure Service Bus). |
-| **connectionString** | `AiConnectionString`            | Object that defines the AI connection string. |    
+| Parameter                | Type                            | Description                                        |
+|--------------------------|---------------------------------|----------------------------------------------------|
+| **connection_string**    | `RavenConnectionString`         | Object that defines the RavenDB connection string. |
+| **connection_string**    | `SqlConnectionString`           | Object that defines the SQL connection string. |
+| **connection_string**    | `SnowflakeConnectionString`     | Object that defines the Snowflake connection string. |
+| **connection_string**    | `OlapConnectionString`          | Object that defines the OLAP connection string. |
+| **connection_string**    | `ElasticSearchConnectionString` | Object that defines the Elasticsearch connection string. |
+| **connection_string**    | `QueueConnectionString`         | Object that defines the connection string for the queue broker tasks - Queue ETL (Kafka, RabbitMQ, Azure Queue Storage, Amazon SQS) and Queue Sink (Kafka, RabbitMQ). |
+| **connection_string**    | `AiConnectionString`            | Object that defines the AI connection string. |    
 
 #### The `ConnectionString` base class
 
 All the connection string class types inherit from this abstract class:
 
-```csharp
-public abstract class ConnectionString
-{
-    // A name for the connection string
-    public string Name { get; set; }
-    
-    // The connection string type
-    public abstract ConnectionStringType Type { get; } 
-}
+```python
+class ConnectionString:
+    def __init__(self, name: str):
+        # A name for the connection string
+        self.name = name
 
-public enum ConnectionStringType
-{
-    None,
-    Raven,
-    Sql,
-    Olap,
-    ElasticSearch,
-    Queue,
-    Snowflake,
-    Ai
-}
+    @property
+    @abstractmethod
+    def get_type(self):
+        # The connection string type
+        ...
+
+
+class ConnectionStringType(enum.Enum):
+    NONE = "None"
+    RAVEN = "Raven"
+    SQL = "Sql"
+    OLAP = "Olap"
+    AI = "Ai"
+    ELASTIC_SEARCH = "ElasticSearch"
+    QUEUE = "Queue"
+    SNOWFLAKE = "Snowflake"
 ```
 <br/>
     

--- a/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-python.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_add-or-update-connection-string-python.mdx
@@ -134,7 +134,7 @@ For every connection string type, create the matching connection string class
 
 For `QueueConnectionString`, you must provide `broker_type` and the matching connection settings.
 For example, pass `broker_type=QueueBrokerType.KAFKA` together with a configured `KafkaConnectionSettings` object in `kafka_settings`.
-The server rejects a queue connection string if no broker type is specified.
+The Python client raises `AttributeError: 'NoneType' object has no attribute 'value'` if no broker type is specified.
 
 For type-specific fields and links to full examples, see
 [Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).  
@@ -266,6 +266,7 @@ class ConnectionString:
         ...
 
 
+# from ravendb.serverwide.server_operation_executor import ConnectionStringType
 class ConnectionStringType(enum.Enum):
     NONE = "None"
     RAVEN = "Raven"

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-csharp.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-csharp.mdx
@@ -41,12 +41,17 @@ using (var store = new DocumentStore())
     // ===============
     Dictionary<string, RavenConnectionString> ravenConnectionStrings = 
         connectionStrings.RavenConnectionStrings;
-    
-    var numberOfRavenConnectionStrings = ravenConnectionStrings.Count;
-    var ravenConStr = ravenConnectionStrings["ravendb-connection-string-name"];
-    
-    var targetUrls = ravenConStr.TopologyDiscoveryUrls;
-    var targetDatabase = ravenConStr.Database;
+
+    // If no connection string matches the specified name and type, 
+    // the result dictionary is null.
+    if (ravenConnectionStrings != null)
+    {
+        var numberOfRavenConnectionStrings = ravenConnectionStrings.Count;
+        var ravenConStr = ravenConnectionStrings["ravendb-connection-string-name"];
+
+        var targetUrls = ravenConStr.TopologyDiscoveryUrls;
+        var targetDatabase = ravenConStr.Database;
+    }
 }
 ```
 </TabItem>
@@ -65,12 +70,16 @@ using (var store = new DocumentStore())
     // ===============
     Dictionary<string, RavenConnectionString> ravenConnectionStrings = 
         connectionStrings.RavenConnectionStrings;
-    
-    var numberOfRavenConnectionStrings = ravenConnectionStrings.Count;
-    var ravenConStr = ravenConnectionStrings["ravendb-connection-string-name"];
-    
-    var targetUrls = ravenConStr.TopologyDiscoveryUrls;
-    var targetDatabase = ravenConStr.Database;
+
+    // If no connection string matches the specified name and type, the result dictionary is null.
+    if (ravenConnectionStrings != null)
+    {
+        var numberOfRavenConnectionStrings = ravenConnectionStrings.Count;
+        var ravenConStr = ravenConnectionStrings["ravendb-connection-string-name"];
+
+        var targetUrls = ravenConStr.TopologyDiscoveryUrls;
+        var targetDatabase = ravenConStr.Database;
+    }
 }
 ```
 </TabItem>

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-java.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-java.mdx
@@ -1,0 +1,151 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+import Panel from "@site/src/components/Panel";
+
+<Admonition type="note" title="">
+
+* Use `GetConnectionStringsOperation` to retrieve a specific connection string,  
+  or all connection strings defined in the database.
+
+* This operation reads connection strings from a single database's record.   
+  To get connection strings defined at the cluster level, see [Get server-wide connection strings](../../../../integrations/connection-strings/server-wide/get-connection-strings.mdx).
+
+* Learn more about per-database connection strings in [Per-database connection strings - Overview](../../../../integrations/connection-strings/per-database/overview.mdx).  
+  To create or update a connection string, see [Add or update a connection string](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx).
+
+* In this article:
+  * [Get connection string by name and type](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#get-connection-string-by-name-and-type)
+  * [Get all connection strings](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#get-all-connection-strings)
+  * [Syntax](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#syntax)
+
+</Admonition>
+
+<Panel heading="Get connection string by name and type">
+
+The following example retrieves a `Raven` connection string in the current database:
+
+```java
+try (IDocumentStore store = new DocumentStore()) {
+    // Request a specific connection string, pass its name and type:
+    // =============================================================
+    GetConnectionStringsOperation getRavenConStrOp = new GetConnectionStringsOperation(
+        "ravendb-connection-string-name", ConnectionStringType.RAVEN);
+
+    GetConnectionStringsResult connectionStrings = store.maintenance().send(getRavenConStrOp);
+
+    // Access results:
+    // ===============
+    Map<String, RavenConnectionString> ravenConnectionStrings =
+        connectionStrings.getRavenConnectionStrings();
+
+    int numberOfRavenConnectionStrings = ravenConnectionStrings.size();
+    RavenConnectionString ravenConStr = ravenConnectionStrings.get("ravendb-connection-string-name");
+
+    String[] targetUrls = ravenConStr.getTopologyDiscoveryUrls();
+    String targetDatabase = ravenConStr.getDatabase();
+}
+```
+
+</Panel>
+
+<Panel heading="Get all connection strings">
+    
+The following example retrieves all connection strings defined in the database:    
+
+```java
+try (IDocumentStore store = new DocumentStore()) {
+    // Get all connection strings:
+    // ===========================
+    GetConnectionStringsOperation getAllConStrOp = new GetConnectionStringsOperation();
+    GetConnectionStringsResult allConnectionStrings = store.maintenance().send(getAllConStrOp);
+
+    // Access results by connection string type:
+    // =========================================
+
+    // Raven
+    Map<String, RavenConnectionString> ravenConnectionStrings =
+        allConnectionStrings.getRavenConnectionStrings();
+
+    // SQL
+    Map<String, SqlConnectionString> sqlConnectionStrings =
+        allConnectionStrings.getSqlConnectionStrings();
+
+    // OLAP
+    Map<String, OlapConnectionString> olapConnectionStrings =
+        allConnectionStrings.getOlapConnectionStrings();
+
+    // Elasticsearch
+    Map<String, ElasticSearchConnectionString> elasticsearchConnectionStrings =
+        allConnectionStrings.getElasticSearchConnectionStrings();
+
+    // Queue
+    Map<String, QueueConnectionString> queueConnectionStrings =
+        allConnectionStrings.getQueueConnectionStrings();
+
+    // AI
+    Map<String, AiConnectionString> aiConnectionStrings =
+        allConnectionStrings.getAiConnectionStrings();
+}
+```
+
+</Panel>
+
+<Panel heading="Syntax">
+
+```java
+public GetConnectionStringsOperation()
+public GetConnectionStringsOperation(String connectionStringName, ConnectionStringType type)
+```
+<br/>    
+
+| Parameter                | Type                   | Description                                                                    |
+|--------------------------|------------------------|--------------------------------------------------------------------------------|
+| **connectionStringName** | `String`               | Connection string name                                                         |
+| **type**                 | `ConnectionStringType` | Connection string type:<br/>`RAVEN`, `SQL`, `OLAP`, `ELASTIC_SEARCH`, `QUEUE`, or `AI` |
+
+```java
+public enum ConnectionStringType {
+    NONE,
+    RAVEN,
+    SQL,
+    OLAP,
+    ELASTIC_SEARCH,
+    QUEUE,
+    AI
+}
+```
+<br/>    
+
+| Operation result             | Description                                                   |
+|------------------------------|---------------------------------------------------------------|
+| `GetConnectionStringsResult` | Class holding all connection strings defined in the database. |
+
+```java
+public class GetConnectionStringsResult {
+    private Map<String, RavenConnectionString> ravenConnectionStrings;
+    private Map<String, SqlConnectionString> sqlConnectionStrings;
+    private Map<String, OlapConnectionString> olapConnectionStrings;
+    private Map<String, ElasticSearchConnectionString> elasticSearchConnectionStrings;
+    private Map<String, QueueConnectionString> queueConnectionStrings;
+    private Map<String, AiConnectionString> aiConnectionStrings;
+
+    // Getters and setters are available for each of the above
+}
+```
+<br/>
+
+<Admonition type="note" title="">
+
+The Java client returns connection strings of the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+(Kafka, RabbitMQ, Azure Queue Storage, and Amazon SQS), and `Ai` types.  
+Connection string types that have no matching class in the Java client, such as `Snowflake`, can be viewed from Studio.
+
+</Admonition>
+    
+<Admonition type="note" title="">
+Connection string type-specific fields and complete examples are documented in the task or feature articles listed under
+[Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).
+</Admonition>
+
+</Panel>

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-java.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-java.mdx
@@ -39,11 +39,16 @@ try (IDocumentStore store = new DocumentStore()) {
     Map<String, RavenConnectionString> ravenConnectionStrings =
         connectionStrings.getRavenConnectionStrings();
 
-    int numberOfRavenConnectionStrings = ravenConnectionStrings.size();
-    RavenConnectionString ravenConStr = ravenConnectionStrings.get("ravendb-connection-string-name");
-
-    String[] targetUrls = ravenConStr.getTopologyDiscoveryUrls();
-    String targetDatabase = ravenConStr.getDatabase();
+    // If no connection string matches the specified name and type, 
+    // the result map is null.
+    if (ravenConnectionStrings != null) {
+        int numberOfRavenConnectionStrings = ravenConnectionStrings.size();
+        RavenConnectionString ravenConStr =
+            ravenConnectionStrings.get("ravendb-connection-string-name");
+    
+        String[] targetUrls = ravenConStr.getTopologyDiscoveryUrls();
+        String targetDatabase = ravenConStr.getDatabase();
+    }
 }
 ```
 

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-nodejs.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-nodejs.mdx
@@ -37,11 +37,15 @@ const connectionStrings = await store.maintenance.send(getRavenConStrOp);
 // ===============
 const ravenConnectionStrings = connectionStrings.ravenConnectionStrings;
 
-const numberOfRavenConnectionStrings = Object.keys(ravenConnectionStrings).length;
-const ravenConStr = ravenConnectionStrings["ravendb-connection-string-name"];
+// If no connection string matches the specified name and type, 
+// the result object is null.
+if (ravenConnectionStrings) {
+    const numberOfRavenConnectionStrings = Object.keys(ravenConnectionStrings).length;
+    const ravenConStr = ravenConnectionStrings["ravendb-connection-string-name"];
 
-const targetUrls = ravenConStr.topologyDiscoveryUrls;
-const targetDatabase = ravenConStr.database;
+    const targetUrls = ravenConStr.topologyDiscoveryUrls;
+    const targetDatabase = ravenConStr.database;
+}
 ```
 
 </Panel>

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-nodejs.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-nodejs.mdx
@@ -1,0 +1,131 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+import Panel from "@site/src/components/Panel";
+
+<Admonition type="note" title="">
+
+* Use `GetConnectionStringsOperation` to retrieve a specific connection string,  
+  or all connection strings defined in the database.
+
+* This operation reads connection strings from a single database's record.   
+  To get connection strings defined at the cluster level, see [Get server-wide connection strings](../../../../integrations/connection-strings/server-wide/get-connection-strings.mdx).
+
+* Learn more about per-database connection strings in [Per-database connection strings - Overview](../../../../integrations/connection-strings/per-database/overview.mdx).  
+  To create or update a connection string, see [Add or update a connection string](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx).
+
+* In this article:
+  * [Get connection string by name and type](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#get-connection-string-by-name-and-type)
+  * [Get all connection strings](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#get-all-connection-strings)
+  * [Syntax](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#syntax)
+
+</Admonition>
+
+<Panel heading="Get connection string by name and type">
+
+The following example retrieves a `Raven` connection string in the current database:
+
+```js
+// Request a specific connection string, pass its name and type:
+// =============================================================
+const getRavenConStrOp = new GetConnectionStringsOperation(
+    "ravendb-connection-string-name", "Raven");
+
+const connectionStrings = await store.maintenance.send(getRavenConStrOp);
+
+// Access results:
+// ===============
+const ravenConnectionStrings = connectionStrings.ravenConnectionStrings;
+
+const numberOfRavenConnectionStrings = Object.keys(ravenConnectionStrings).length;
+const ravenConStr = ravenConnectionStrings["ravendb-connection-string-name"];
+
+const targetUrls = ravenConStr.topologyDiscoveryUrls;
+const targetDatabase = ravenConStr.database;
+```
+
+</Panel>
+
+<Panel heading="Get all connection strings">
+    
+The following example retrieves all connection strings defined in the database:    
+
+```js
+// Get all connection strings:
+// ===========================
+const getAllConStrOp = new GetConnectionStringsOperation();
+const allConnectionStrings = await store.maintenance.send(getAllConStrOp);
+
+// Access results by connection string type:
+// =========================================
+
+// Raven
+const ravenConnectionStrings = allConnectionStrings.ravenConnectionStrings;
+
+// SQL
+const sqlConnectionStrings = allConnectionStrings.sqlConnectionStrings;
+
+// OLAP
+const olapConnectionStrings = allConnectionStrings.olapConnectionStrings;
+
+// Elasticsearch
+const elasticsearchConnectionStrings = allConnectionStrings.elasticSearchConnectionStrings;
+
+// Queue
+const queueConnectionStrings = allConnectionStrings.queueConnectionStrings;
+
+// AI
+const aiConnectionStrings = allConnectionStrings.aiConnectionStrings;
+```
+
+</Panel>
+
+<Panel heading="Syntax">
+
+```js
+new GetConnectionStringsOperation();
+new GetConnectionStringsOperation(connectionStringName, type);
+```
+<br/>    
+
+| Parameter                | Type                   | Description                                                                    |
+|--------------------------|------------------------|--------------------------------------------------------------------------------|
+| **connectionStringName** | `string`               | Connection string name                                                         |
+| **type**                 | `ConnectionStringType` | Connection string type:<br/>`Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`, or `Ai` |
+
+```js
+// The available connection string types
+ConnectionStringType = "None" | "Raven" | "Sql" | "Olap" | "ElasticSearch" | "Queue" | "Ai";
+```
+<br/>    
+
+| Operation result             | Description                                                   |
+|------------------------------|---------------------------------------------------------------|
+| `GetConnectionStringsResult` | Object holding all connection strings defined in the database. |
+
+```js
+interface GetConnectionStringsResult {
+    ravenConnectionStrings; // Record<string, RavenConnectionString>
+    sqlConnectionStrings; // Record<string, SqlConnectionString>
+    olapConnectionStrings; // Record<string, OlapConnectionString>
+    elasticSearchConnectionStrings; // Record<string, ElasticSearchConnectionString>
+    queueConnectionStrings; // Record<string, QueueConnectionString>
+    aiConnectionStrings; // Record<string, AiConnectionString>
+}
+```
+<br/>
+
+<Admonition type="note" title="">
+
+The Node.js client returns connection strings of the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+(Kafka and RabbitMQ), and `Ai` types.  
+Connection string types that have no matching class in the Node.js client, such as `Snowflake`, can be viewed from Studio.
+
+</Admonition>
+    
+<Admonition type="note" title="">
+Connection string type-specific fields and complete examples are documented in the task or feature articles listed under
+[Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).
+</Admonition>
+
+</Panel>

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-python.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-python.mdx
@@ -40,11 +40,14 @@ connection_strings = store.maintenance.send(get_raven_con_str_op)
 # ===============
 raven_connection_strings = connection_strings.raven_connection_strings
 
-number_of_raven_connection_strings = len(raven_connection_strings)
-raven_con_str = raven_connection_strings["ravendb-connection-string-name"]
+# If no connection string matches the specified name and type, 
+# the result dictionary is None.
+if raven_connection_strings is not None:
+    number_of_raven_connection_strings = len(raven_connection_strings)
+    raven_con_str = raven_connection_strings["ravendb-connection-string-name"]
 
-target_urls = raven_con_str.topology_discovery_urls
-target_database = raven_con_str.database
+    target_urls = raven_con_str.topology_discovery_urls
+    target_database = raven_con_str.database
 ```
 
 </Panel>

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-python.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-python.mdx
@@ -116,7 +116,7 @@ class GetConnectionStringsOperation(MaintenanceOperation[GetConnectionStringsRes
 | Parameter                    | Type                   | Description                                                                    |
 |------------------------------|------------------------|--------------------------------------------------------------------------------|
 | **connection_string_name**   | `str`                  | Connection string name                                                         |
-| **connection_string_type**   | `ConnectionStringType` | Connection string type:<br/>`RAVEN`, `SQL`, `OLAP`, `ELASTIC_SEARCH`, `QUEUE`, `SNOWFLAKE`, or `AI` |
+| **connection_string_type**   | `ConnectionStringType` | Connection string type:<br/>`RAVEN`, `SQL`, `OLAP`, `ELASTIC_SEARCH`, `QUEUE`, `SNOWFLAKE`, or `AI`<br/>Required whenever `connection_string_name` is given. |
 
 ```python
 class ConnectionStringType(enum.Enum):

--- a/docs/integrations/connection-strings/per-database/content/_get-connection-strings-python.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_get-connection-strings-python.mdx
@@ -1,0 +1,155 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+import Panel from "@site/src/components/Panel";
+
+<Admonition type="note" title="">
+
+* Use `GetConnectionStringsOperation` to retrieve a specific connection string,  
+  or all connection strings defined in the database.
+
+* This operation reads connection strings from a single database's record.   
+  To get connection strings defined at the cluster level, see [Get server-wide connection strings](../../../../integrations/connection-strings/server-wide/get-connection-strings.mdx).
+
+* Learn more about per-database connection strings in [Per-database connection strings - Overview](../../../../integrations/connection-strings/per-database/overview.mdx).  
+  To create or update a connection string, see [Add or update a connection string](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx).
+
+* In this article:
+  * [Get connection string by name and type](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#get-connection-string-by-name-and-type)
+  * [Get all connection strings](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#get-all-connection-strings)
+  * [Syntax](../../../../integrations/connection-strings/per-database/get-connection-strings.mdx#syntax)
+
+</Admonition>
+
+<Panel heading="Get connection string by name and type">
+
+The following example retrieves a `Raven` connection string in the current database:
+
+```python
+from ravendb.documents.operations.connection_string.get_connection_string_operation import GetConnectionStringsOperation
+from ravendb.serverwide.server_operation_executor import ConnectionStringType
+
+# Request a specific connection string, pass its name and type:
+# =============================================================
+get_raven_con_str_op = GetConnectionStringsOperation(
+    "ravendb-connection-string-name", ConnectionStringType.RAVEN)
+
+connection_strings = store.maintenance.send(get_raven_con_str_op)
+
+# Access results:
+# ===============
+raven_connection_strings = connection_strings.raven_connection_strings
+
+number_of_raven_connection_strings = len(raven_connection_strings)
+raven_con_str = raven_connection_strings["ravendb-connection-string-name"]
+
+target_urls = raven_con_str.topology_discovery_urls
+target_database = raven_con_str.database
+```
+
+</Panel>
+
+<Panel heading="Get all connection strings">
+    
+The following example retrieves all connection strings defined in the database:    
+
+```python
+from ravendb.documents.operations.connection_string.get_connection_string_operation import GetConnectionStringsOperation
+
+# Get all connection strings:
+# ===========================
+get_all_con_str_op = GetConnectionStringsOperation()
+all_connection_strings = store.maintenance.send(get_all_con_str_op)
+
+# Access results by connection string type:
+# =========================================
+
+# Raven
+raven_connection_strings = all_connection_strings.raven_connection_strings
+
+# SQL
+sql_connection_strings = all_connection_strings.sql_connection_strings
+
+# OLAP
+olap_connection_strings = all_connection_strings.olap_connection_strings
+
+# Elasticsearch
+elasticsearch_connection_strings = all_connection_strings.elastic_search_connection_strings
+
+# Queue
+queue_connection_strings = all_connection_strings.queue_connection_strings
+
+# Snowflake
+snowflake_connection_strings = all_connection_strings.snowflake_connection_strings
+
+# AI
+ai_connection_strings = all_connection_strings.ai_connection_strings
+```
+
+<Admonition type="note" title="">
+
+A connection string type that has no connection strings defined for it is returned as `None`, not as an empty dictionary.
+Check for `None` before iterating over a result, for example:
+
+```python
+if all_connection_strings.sql_connection_strings:
+    for name, con_str in all_connection_strings.sql_connection_strings.items():
+        print(name)
+```
+
+</Admonition>
+
+</Panel>
+
+<Panel heading="Syntax">
+
+```python
+class GetConnectionStringsOperation(MaintenanceOperation[GetConnectionStringsResult]):
+    def __init__(self, connection_string_name: str = None,
+                 connection_string_type: ConnectionStringType = None): ...
+```
+<br/>    
+
+| Parameter                    | Type                   | Description                                                                    |
+|------------------------------|------------------------|--------------------------------------------------------------------------------|
+| **connection_string_name**   | `str`                  | Connection string name                                                         |
+| **connection_string_type**   | `ConnectionStringType` | Connection string type:<br/>`RAVEN`, `SQL`, `OLAP`, `ELASTIC_SEARCH`, `QUEUE`, `SNOWFLAKE`, or `AI` |
+
+```python
+class ConnectionStringType(enum.Enum):
+    NONE = "None"
+    RAVEN = "Raven"
+    SQL = "Sql"
+    OLAP = "Olap"
+    AI = "Ai"
+    ELASTIC_SEARCH = "ElasticSearch"
+    QUEUE = "Queue"
+    SNOWFLAKE = "Snowflake"
+```
+<br/>    
+
+| Operation result             | Description                                                   |
+|------------------------------|---------------------------------------------------------------|
+| `GetConnectionStringsResult` | Class holding all connection strings defined in the database. |
+
+```python
+class GetConnectionStringsResult:
+    def __init__(
+        self,
+        raven_connection_strings: Dict[str, RavenConnectionString] = None,
+        sql_connection_strings: Dict[str, SqlConnectionString] = None,
+        olap_connection_strings: Dict[str, OlapConnectionString] = None,
+        ai_connection_strings: Dict[str, AiConnectionString] = None,
+        elastic_search_connection_strings: Dict[str, ElasticSearchConnectionString] = None,
+        queue_connection_strings: Dict[str, QueueConnectionString] = None,
+        snowflake_connection_strings: Dict[str, SnowflakeConnectionString] = None,
+    ): ...
+```
+<br/>
+    
+<Admonition type="note" title="">
+Connection string type-specific fields and complete examples are documented in the task or feature articles listed under
+[Connection string per type](../../../../integrations/connection-strings/per-database/add-or-update-connection-string.mdx#connection-string-per-type).
+</Admonition>
+
+</Panel>

--- a/docs/integrations/connection-strings/per-database/content/_remove-connection-string-java.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_remove-connection-string-java.mdx
@@ -1,0 +1,83 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+import Panel from "@site/src/components/Panel";
+
+<Admonition type="note" title="">
+    
+* Use `RemoveConnectionStringOperation` to remove a per-database connection string from the current database.
+
+* A connection string **cannot** be removed while it is still used by an ongoing task.  
+  Before removing it, delete the task or update it to use a different connection string.
+
+* This operation **cannot** remove inherited server-wide connection strings.  
+  To remove a cluster-level definition, use [Remove a server-wide connection string](../../../../integrations/connection-strings/server-wide/remove-connection-string.mdx).
+    
+* To remove a per-database connection string from Studio, open **Settings > Connection Strings** and use the remove action in the list view.
+  See [Managing per-database connection strings](../../../../integrations/connection-strings/per-database/overview.mdx#managing-per-database-connection-strings).    
+
+* In this article:
+  * [Remove a per-database connection string](../../../../integrations/connection-strings/per-database/remove-connection-string.mdx#remove-a-per-database-connection-string)
+  * [Syntax](../../../../integrations/connection-strings/per-database/remove-connection-string.mdx#syntax)
+    
+</Admonition>    
+
+<Panel heading="Remove a per-database connection string">    
+
+The following example removes a RavenDB per-database connection string.  
+Only the `Name` property is required; the type is inferred from the connection string class.
+
+```java
+RavenConnectionString ravenConnectionString = new RavenConnectionString();
+
+// Note:
+// Only the 'Name' property of the connection string is needed for the remove operation.
+// Other properties are not considered.
+ravenConnectionString.setName("ravendb-connection-string-name");
+
+// Define the remove connection string operation,
+// pass the connection string to be removed.
+RemoveConnectionStringOperation<RavenConnectionString> removeConStrOp =
+    new RemoveConnectionStringOperation<>(ravenConnectionString);
+
+// Execute the operation by passing it to maintenance().send
+store.maintenance().send(removeConStrOp);
+```
+
+</Panel>
+
+<Panel heading="Syntax">
+
+```java
+public RemoveConnectionStringOperation(T connectionString)
+    // where T extends ConnectionString
+```
+<br/>
+
+| Parameter            | Type | Description |
+|----------------------|------|-------------|
+| **connectionString** | `T`  | Connection string to remove (only `Name` is required):<br/>`RavenConnectionString`<br/>`SqlConnectionString`<br/>`OlapConnectionString`<br/>`ElasticSearchConnectionString`<br/>`QueueConnectionString`<br/>`AiConnectionString` |
+
+| Return value | Description |
+|--------------|-------------|
+| `RemoveConnectionStringResult` | Contains `raftCommandIndex` - the Raft index assigned to the operation. |
+
+```java
+public class RemoveConnectionStringResult {
+    private long raftCommandIndex;
+
+    public long getRaftCommandIndex();
+    public void setRaftCommandIndex(long raftCommandIndex);
+}
+```
+<br/>
+
+<Admonition type="note" title="">
+
+The Java client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+(Kafka, RabbitMQ, Azure Queue Storage, and Amazon SQS), and `Ai` types.  
+Connection string types that have no matching class in the Java client, such as `Snowflake`, can be removed from Studio.
+
+</Admonition>
+
+</Panel>

--- a/docs/integrations/connection-strings/per-database/content/_remove-connection-string-java.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_remove-connection-string-java.mdx
@@ -73,10 +73,9 @@ public class RemoveConnectionStringResult {
 <br/>
 
 <Admonition type="note" title="">
-
-The Java client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
-(Kafka, RabbitMQ, Azure Queue Storage, and Amazon SQS), and `Ai` types.  
-Connection string types that have no matching class in the Java client, such as `Snowflake`, can be removed from Studio.
+    
+To remove a queue connection string, including one for Azure Service Bus, pass a `QueueConnectionString` with only its `Name` to `RemoveConnectionStringOperation`; broker-specific settings are not required.  
+Connection string types that have no matching Java class, such as `Snowflake`, can be removed from Studio.    
 
 </Admonition>
 

--- a/docs/integrations/connection-strings/per-database/content/_remove-connection-string-nodejs.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_remove-connection-string-nodejs.mdx
@@ -1,0 +1,74 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+import Panel from "@site/src/components/Panel";
+
+<Admonition type="note" title="">
+    
+* Use `RemoveConnectionStringOperation` to remove a per-database connection string from the current database.
+
+* A connection string **cannot** be removed while it is still used by an ongoing task.  
+  Before removing it, delete the task or update it to use a different connection string.
+
+* This operation **cannot** remove inherited server-wide connection strings.  
+  To remove a cluster-level definition, use [Remove a server-wide connection string](../../../../integrations/connection-strings/server-wide/remove-connection-string.mdx).
+    
+* To remove a per-database connection string from Studio, open **Settings > Connection Strings** and use the remove action in the list view.
+  See [Managing per-database connection strings](../../../../integrations/connection-strings/per-database/overview.mdx#managing-per-database-connection-strings).    
+
+* In this article:
+  * [Remove a per-database connection string](../../../../integrations/connection-strings/per-database/remove-connection-string.mdx#remove-a-per-database-connection-string)
+  * [Syntax](../../../../integrations/connection-strings/per-database/remove-connection-string.mdx#syntax)
+    
+</Admonition>    
+
+<Panel heading="Remove a per-database connection string">    
+
+The following example removes a RavenDB per-database connection string.  
+Only the `name` property is required; the type is inferred from the connection string class.
+
+```js
+const ravenConnectionString = new RavenConnectionString();
+
+// Note:
+// Only the 'name' property of the connection string is needed for the remove operation.
+// Other properties are not considered.
+ravenConnectionString.name = "ravendb-connection-string-name";
+
+// Define the remove connection string operation,
+// pass the connection string to be removed.
+const removeConStrOp = new RemoveConnectionStringOperation(ravenConnectionString);
+
+// Execute the operation by passing it to maintenance.send
+await store.maintenance.send(removeConStrOp);
+```
+
+</Panel>
+
+<Panel heading="Syntax">
+
+```js
+// T extends ConnectionString
+new RemoveConnectionStringOperation(connectionString);
+```
+<br/>
+
+| Parameter            | Type | Description |
+|----------------------|------|-------------|
+| **connectionString** | `T`  | Connection string to remove (only `name` is required):<br/>`RavenConnectionString`<br/>`SqlConnectionString`<br/>`OlapConnectionString`<br/>`ElasticSearchConnectionString`<br/>`QueueConnectionString`<br/>`AiConnectionString` |
+
+| Return value | Description |
+|--------------|-------------|
+| `RemoveConnectionStringResult` | Contains `raftCommandIndex` - the Raft index assigned to the operation. |
+
+<br/>
+
+<Admonition type="note" title="">
+
+The Node.js client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
+(Kafka and RabbitMQ), and `Ai` types.  
+Connection string types that have no matching class in the Node.js client, such as `Snowflake`, can be removed from Studio.
+
+</Admonition>
+
+</Panel>

--- a/docs/integrations/connection-strings/per-database/content/_remove-connection-string-nodejs.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_remove-connection-string-nodejs.mdx
@@ -65,9 +65,8 @@ new RemoveConnectionStringOperation(connectionString);
 
 <Admonition type="note" title="">
 
-The Node.js client provides connection string classes for the `Raven`, `Sql`, `Olap`, `ElasticSearch`, `Queue`
-(Kafka and RabbitMQ), and `Ai` types.  
-Connection string types that have no matching class in the Node.js client, such as `Snowflake`, can be removed from Studio.
+To remove a queue connection string, including one for Azure Service Bus, pass a `QueueConnectionString` with only its `name` to `RemoveConnectionStringOperation`; broker-specific settings are not required.  
+Connection string types without a matching Node.js class, such as `Snowflake`, can be removed from Studio.
 
 </Admonition>
 

--- a/docs/integrations/connection-strings/per-database/content/_remove-connection-string-python.mdx
+++ b/docs/integrations/connection-strings/per-database/content/_remove-connection-string-python.mdx
@@ -1,0 +1,91 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+import Panel from "@site/src/components/Panel";
+
+<Admonition type="note" title="">
+    
+* Use `RemoveConnectionStringOperation` to remove a per-database connection string from the current database.
+
+* A connection string **cannot** be removed while it is still used by an ongoing task.  
+  Before removing it, delete the task or update it to use a different connection string.
+
+* This operation **cannot** remove inherited server-wide connection strings.  
+  To remove a cluster-level definition, use [Remove a server-wide connection string](../../../../integrations/connection-strings/server-wide/remove-connection-string.mdx).
+    
+* To remove a per-database connection string from Studio, open **Settings > Connection Strings** and use the remove action in the list view.
+  See [Managing per-database connection strings](../../../../integrations/connection-strings/per-database/overview.mdx#managing-per-database-connection-strings).    
+
+* In this article:
+  * [Remove a per-database connection string](../../../../integrations/connection-strings/per-database/remove-connection-string.mdx#remove-a-per-database-connection-string)
+  * [Syntax](../../../../integrations/connection-strings/per-database/remove-connection-string.mdx#syntax)
+    
+</Admonition>    
+
+<Panel heading="Remove a per-database connection string">    
+
+The following example removes a RavenDB per-database connection string.  
+Only the `name` property is required; the type is inferred from the connection string class.
+
+```python
+from ravendb.documents.operations.connection_string.remove_connection_string_operation import RemoveConnectionStringOperation
+from ravendb.documents.operations.etl.configuration import RavenConnectionString
+
+# Note:
+# Only the 'name' property of the connection string is needed for the remove operation.
+# Other properties are not considered.
+raven_connection_string = RavenConnectionString(name="ravendb-connection-string-name")
+
+# Define the remove connection string operation,
+# pass the connection string to be removed.
+remove_con_str_op = RemoveConnectionStringOperation(raven_connection_string)
+
+# Execute the operation by passing it to maintenance.send
+store.maintenance.send(remove_con_str_op)
+```
+
+</Panel>
+
+<Panel heading="Syntax">
+
+```python
+class RemoveConnectionStringOperation(MaintenanceOperation[RemoveConnectionStringResult]):
+    def __init__(self, connection_string: ConnectionString = None): ...
+```
+<br/>
+
+| Parameter             | Type               | Description |
+|-----------------------|--------------------|-------------|
+| **connection_string** | `ConnectionString` | Connection string to remove (only `name` is required):<br/>`RavenConnectionString`<br/>`SqlConnectionString`<br/>`SnowflakeConnectionString`<br/>`OlapConnectionString`<br/>`ElasticSearchConnectionString`<br/>`QueueConnectionString`<br/>`AiConnectionString` |
+
+| Return value | Description |
+|--------------|-------------|
+| `RemoveConnectionStringResult` | Contains `raft_command_index` - the Raft index assigned to the operation. |
+
+```python
+class RemoveConnectionStringResult:
+    def __init__(self, raft_command_index: int = None):
+        self.raft_command_index = raft_command_index
+```
+<br/>
+
+<Admonition type="note" title="">
+
+If you don't have a connection string object at hand, you can remove a connection string by passing its name and type
+to `RemoveConnectionStringByNameOperation`:
+
+```python
+class RemoveConnectionStringByNameOperation(MaintenanceOperation[RemoveConnectionStringByNameResult]):
+    def __init__(self, connection_string_name: str,
+                 connection_string_type: ConnectionStringType): ...
+```
+<br/>    
+
+| Parameter                    | Type                   | Description |
+|------------------------------|------------------------|-------------|
+| **connection_string_name**   | `str`                  | Name of the connection string to remove |
+| **connection_string_type**   | `ConnectionStringType` | Connection string type:<br/>`RAVEN`, `SQL`, `OLAP`, `ELASTIC_SEARCH`, `QUEUE`, `SNOWFLAKE`, or `AI` |
+
+</Admonition>
+
+</Panel>

--- a/docs/integrations/connection-strings/per-database/get-connection-strings.mdx
+++ b/docs/integrations/connection-strings/per-database/get-connection-strings.mdx
@@ -2,16 +2,31 @@
 title: "Get a Per-Database Connection String"
 sidebar_label: "Get connection strings"
 sidebar_position: 2
-supported_languages: ["csharp"]
+supported_languages: ["csharp", "java", "nodejs", "python"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
 import GetConnectionStringsCsharp from './content/_get-connection-strings-csharp.mdx';
+import GetConnectionStringsJava from './content/_get-connection-strings-java.mdx';
+import GetConnectionStringsNodejs from './content/_get-connection-strings-nodejs.mdx';
+import GetConnectionStringsPython from './content/_get-connection-strings-python.mdx';
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <GetConnectionStringsCsharp />
+</LanguageContent>
+
+<LanguageContent language="java">
+   <GetConnectionStringsJava />
+</LanguageContent>
+
+<LanguageContent language="nodejs">
+   <GetConnectionStringsNodejs />
+</LanguageContent>
+
+<LanguageContent language="python">
+   <GetConnectionStringsPython />
 </LanguageContent>

--- a/docs/integrations/connection-strings/per-database/remove-connection-string.mdx
+++ b/docs/integrations/connection-strings/per-database/remove-connection-string.mdx
@@ -2,16 +2,31 @@
 title: "Remove a Per-Database Connection String"
 sidebar_label: "Remove connection string"
 sidebar_position: 3
-supported_languages: ["csharp"]
+supported_languages: ["csharp", "java", "nodejs", "python"]
 ---
 
 import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
 import LanguageContent from "@site/src/components/LanguageContent";
 
 import RemoveConnectionStringCsharp from './content/_remove-connection-string-csharp.mdx';
+import RemoveConnectionStringJava from './content/_remove-connection-string-java.mdx';
+import RemoveConnectionStringNodejs from './content/_remove-connection-string-nodejs.mdx';
+import RemoveConnectionStringPython from './content/_remove-connection-string-python.mdx';
 
 <LanguageSwitcher supportedLanguages={frontMatter.supported_languages} />
 
 <LanguageContent language="csharp">
    <RemoveConnectionStringCsharp />
+</LanguageContent>
+
+<LanguageContent language="java">
+   <RemoveConnectionStringJava />
+</LanguageContent>
+
+<LanguageContent language="nodejs">
+   <RemoveConnectionStringNodejs />
+</LanguageContent>
+
+<LanguageContent language="python">
+   <RemoveConnectionStringPython />
 </LanguageContent>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3966/Python-Node.js-Java-Per-database-connection-string-articles

### Additional description
Added Python, Node.js, and Java versions for the per-database connection string articles under:
`../integrations/connection-strings/per-database`

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

