### PR TITLE
RDoc-4039 Fix sidebar section detection to match path segments instead of substrings

### DIFF
--- a/src/typescript/pathUtils.ts
+++ b/src/typescript/pathUtils.ts
@@ -20,7 +20,8 @@ const SECTIONS: readonly { segment: string; type: PathTypeValue }[] = [
 ];
 
 export function getPathType(path: string): PathTypeValue {
-    return SECTIONS.find((section) => path.includes(`/${section.segment}`))?.type ?? PathType.Documentation;
+    const [firstSegment] = path.replace(/^\/+/, "").split("/");
+    return SECTIONS.find((section) => section.segment === firstSegment)?.type ?? PathType.Documentation;
 }
 
 export function getLandingPagePath(pathType: PathTypeValue, versionLabel: string): string {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-4039/Fix-sidebar-section-detection-to-match-path-segments-instead-of-substrings

### Additional description

`getPathType` in `src/typescript/pathUtils.ts` detects the content area with `path.includes("/<segment>")`, so any page whose slug contains another section's name gets the wrong type and the wrong sidebar: `/guides/quill-guide` is treated as Quill Docs, while `/7.2/start/guides/*` and `/start/guides/cloudflare-workers/*` are treated as Guides and Cloud. On production this affects 83 URLs, 82 of them documentation pages that lose their entire navigation tree and the version dropdown and instead show a "switch to RavenDB Docs" link on a page that is already in RavenDB Docs.

The fix matches the first path segment instead of a substring, which also makes the result independent of the order of entries in `SECTIONS`. No URLs change.

Affected URLs before the fix, across all versions (8679 URLs checked):

| Wrong type | URLs | Cause |
|---|---|---|
| docs -> `GUIDES` | 54 | `/<version>/start/guides/aws-lambda/*`, `/azure-functions/*` |
| docs -> `CLOUD` | 18 | `/<version>/start/guides/cloudflare-workers/*`, `/cloudflare` contains `/cloud` |
| docs -> `SAMPLES` | 10 | legacy `/2.0/samples/*`, `/3.5/samples/mvc-starter-kit` and similar |
| guides -> `QUILL` | 1 | `/guides/quill-guide` |

All 83 resolve to the correct type after the change.

Verified on a local dev server:

- `/guides/quill-guide` renders the Guides sidebar again (no article tree, "Quill Docs" switch link back in the list, Start points to `/guides`).
- `/7.2/start/guides/aws-lambda/overview` and `/7.2/start/guides/cloudflare-workers/overview` get their full documentation tree and the 7.2.x version dropdown back, Start points to `/7.2`.
- `/quill` and `/cloud` are unchanged.

`npm run typecheck`, `npm run lint` and Prettier pass.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [ ] No changes in UX/UI
- [x] Changes in UX/UI (include screenshots and description)

The sidebar on the 83 affected URLs goes back to the layout intended for their section, as described above. No intentional design change, only pages that were rendering the wrong section's sidebar.
