### PR TITLE
RDoc-3916 Document behavior of IndexCreation.CreateIndexes and storeExecuteIndexes

### DIFF
--- a/docs/indexes/content/_creating-and-deploying-csharp.mdx
+++ b/docs/indexes/content/_creating-and-deploying-csharp.mdx
@@ -1,7 +1,8 @@
 import Admonition from '@theme/Admonition';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import ContentFrame from '@site/src/components/ContentFrame';
+import Panel from '@site/src/components/Panel';
 
 <Admonition type="note" title="">
 
@@ -14,8 +15,9 @@ import CodeBlock from '@theme/CodeBlock';
 
 * Static-indexes can be created:
     * using the Client API, as outlined in this article, or
-    * from the [Indexes list view](../../studio/database/indexes/indexes-list-view.mdx) in the Studio.
-* In this page:
+    * from the [Indexes list view](../../studio/database/indexes/indexes-list-view.mdx) in Studio.
+    
+* In this article:
   * [Static-indexes](../../indexes/creating-and-deploying.mdx#static-indexes)
       * [Define a static-index](../../indexes/creating-and-deploying.mdx#define-a-static-index)
       * [Deploy a static-index](../../indexes/creating-and-deploying.mdx#deploy-a-static-index)
@@ -31,22 +33,25 @@ import CodeBlock from '@theme/CodeBlock';
 
 </Admonition>
 
-<a id="static-indexes"/>
-## Define a static-index
+## Static-indexes
 
-<Admonition type="note" title="">
+<Panel heading="Define a static-index">
 
-##### Static-indexes
+<ContentFrame>
+
+### Static-indexes
+    
 * Indexes that are explicitly **created by the user** are called `static` indexes.
 * Static-indexes can perform calculations, data conversions, and other processes behind the scenes.  
   This reduces the workload at query time by offloading these costly operations to the indexing phase.
 * To query with a static-index, you must explicitly specify the index in the query definition.  
   For more details, see [Querying an index](../../indexes/querying/query-index.mdx).
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
+<ContentFrame>
 
-##### Define a static-index using a custom class
+### Define a static-index using a custom class
+    
 * To define a static-index using a custom class inherit from `AbstractIndexCreationTask`.
 * This method is recommended over the [Creating an index using an operation](../../indexes/creating-and-deploying.mdx#create-a-static-index---using-an-operation) method  
   for its simplicity and the following advantages:  
@@ -54,114 +59,115 @@ import CodeBlock from '@theme/CodeBlock';
     Provides strong typing when defining the index, making it easier to work with.
   * **Ease of querying**:  
     Lets you use the index class name in a query, instead of hard-coding the index name.
-<TabItem value="indexes_1" label="indexes_1">
-<CodeBlock language="csharp">
-{`// Define a static-index
+
+```csharp
+// Define a static-index
 // Inherit from 'AbstractIndexCreationTask'
 public class Orders_ByTotal : AbstractIndexCreationTask<Order>
-\{
+{
     // ...
-\}
-`}
-</CodeBlock>
-</TabItem>
+}
+```
+<br/>
+    
 * A complete example of creating a static-index is provided [below](../../indexes/creating-and-deploying.mdx#create-a-static-index---example).
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
+<ContentFrame>
 
-##### Naming convention
+### Naming convention
+    
 * Static-index class names follow a single naming convention:  
   Each `_` in the class name is translated to `/` in the index name on the server.
 * In the above example, the index class name is `Orders_ByTotal`.  
   The name of the index that will be generated on the server will be: `Orders/ByTotal`.  
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
+<ContentFrame>
 
-##### Customizing configuration
+### Customizing configuration
+    
 * You can set various [indexing configuration](../../server/configuration/indexing-configuration.mdx) values within the index definition.
 * Setting a configuration value within the index will override the matching indexing configuration values set at the server or database level.
-<TabItem value="indexes_2" label="indexes_2">
-<CodeBlock language="csharp">
-{`public class Orders_ByTotal : AbstractIndexCreationTask<Order>
-\{
+
+```csharp
+public class Orders_ByTotal : AbstractIndexCreationTask<Order>
+{
     public Orders_ByTotal()
-    \{
+    {
         // ...
         // Set an indexing configuration value for this index:
         Configuration["Indexing.MapTimeoutInSec"] = "30";
-    \}
-\}
-`}
-</CodeBlock>
-</TabItem>
+    }
+}
+```
 
-</Admonition>
+</ContentFrame>
 
+</Panel>
 
-## Deploy a static-index
+<Panel heading="Deploy a static-index">
 
 * To begin indexing data, the index must be deployed to the server.
 * This section provides options for deploying indexes that inherit from `AbstractIndexCreationTask`.
 * To create and deploy an index using the `IndexDefinition` class via `PutIndexesOperation`,  
   see [Creating a static-index - using an Operation](../../indexes/creating-and-deploying.mdx#create-a-static-index---using-an-operation).
-<Admonition type="note" title="">
 
-##### Deploy single index
+<ContentFrame>
+
+### Deploy single index
+    
 * Use `Execute()` or `ExecuteIndex()` to deploy a single index.
 * The following examples deploy index `Ordes/ByTotal` to the default database defined in your _DocumentStore_ object.
   See the [syntax](../../indexes/creating-and-deploying.mdx#deploy-syntax) section below for all available overloads.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="Execute" label="Execute">
-<CodeBlock language="csharp">
-{`// Call 'Execute' directly on the index instance
+```csharp
+// Call 'Execute' directly on the index instance
 new Orders_ByTotal().Execute(store);
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="Execute_async" label="Execute_async">
-<CodeBlock language="csharp">
-{`// Call 'ExecuteAsync' directly on the index instance
+```csharp
+// Call 'ExecuteAsync' directly on the index instance
 await new Orders_ByTotal().ExecuteAsync(store);
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="ExecuteIndex" label="ExecuteIndex">
-<CodeBlock language="csharp">
-{`// Call 'ExecuteIndex' on your store object
+```csharp
+// Call 'ExecuteIndex' on your store object
 store.ExecuteIndex(new Orders_ByTotal());
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="ExecuteIndex_async" label="ExecuteIndex_async">
-<CodeBlock language="csharp">
-{`// Call 'ExecuteIndexAsync' on your store object
+```csharp
+// Call 'ExecuteIndexAsync' on your store object
 await store.ExecuteIndexAsync(new Orders_ByTotal());
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
+<ContentFrame>
 
-##### Deploy multiple indexes
+### Deploy multiple indexes
+    
 * Use `ExecuteIndexes()` or `IndexCreation.CreateIndexes()` to deploy multiple indexes.
-* The `IndexCreation.CreateIndexes` method attempts to create all indexes in a single request.  
-  If it fails, it will repeat the execution by calling the `Execute` method for each index, one by one,  
-  in separate requests.
+* Both methods send all index definitions to the server in a single request, and behave identically.
+* If any index in the batch fails to compile, the entire batch fails and none of the indexes are created.  
+  An `IndexCompilationException` is thrown, naming the index that caused the failure.
+* Deploying an empty list of indexes is a no-op: no request is sent to the server and no exception is thrown.
 * The following examples deploy indexes `Ordes/ByTotal` and `Employees/ByLastName` to the default database defined in your _DocumentStore_ object.  
   See the [syntax](../../indexes/creating-and-deploying.mdx#deploy-syntax) section below for all available overloads.
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="ExecuteIndexes" label="ExecuteIndexes">
-<CodeBlock language="csharp">
-{`var indexesToDeploy = new List<AbstractIndexCreationTask>
+```csharp
+var indexesToDeploy = new List<AbstractIndexCreationTask>
 {
     new Orders_ByTotal(),
     new Employees_ByLastName()
@@ -169,12 +175,11 @@ await store.ExecuteIndexAsync(new Orders_ByTotal());
 
 // Call 'ExecuteIndexes' on your store object
 store.ExecuteIndexes(indexesToDeploy);
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="ExecuteIndexes_async" label="ExecuteIndexes_async">
-<CodeBlock language="csharp">
-{`var indexesToDeploy = new List<AbstractIndexCreationTask>
+```csharp
+var indexesToDeploy = new List<AbstractIndexCreationTask>
 {
     new Orders_ByTotal(),
     new Employees_ByLastName()
@@ -182,15 +187,14 @@ store.ExecuteIndexes(indexesToDeploy);
 
 // Call 'ExecuteIndexesAsync' on your store object
 await store.ExecuteIndexesAsync(indexesToDeploy);
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="CreateIndexes" label="CreateIndexes">
-<CodeBlock language="csharp">
-{`var indexesToDeploy = new List<AbstractIndexCreationTask>
+```csharp
+var indexesToDeploy = new List<AbstractIndexCreationTask>
 {
     new Orders_ByTotal(),
     new Employees_ByLastName()
@@ -198,12 +202,11 @@ await store.ExecuteIndexesAsync(indexesToDeploy);
 
 // Call the static method 'CreateIndexes' on the IndexCreation class
 IndexCreation.CreateIndexes(indexesToDeploy, store);
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="CreateIndexes_async" label="CreateIndexes_async">
-<CodeBlock language="csharp">
-{`var indexesToDeploy = new List<AbstractIndexCreationTask>
+```csharp
+var indexesToDeploy = new List<AbstractIndexCreationTask>
 {
     new Orders_ByTotal(),
     new Employees_ByLastName()
@@ -211,39 +214,41 @@ IndexCreation.CreateIndexes(indexesToDeploy, store);
 
 // Call the static method 'CreateIndexesAsync' on the IndexCreation class
 await IndexCreation.CreateIndexesAsync(indexesToDeploy, store);
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
-###### Deploy ALL indexes from an assembly
+
+</ContentFrame>
+<ContentFrame>    
+    
+### Deploy ALL indexes from an assembly
 
 * The following overload allows you to deploy ALL indexes from a specified assembly:
 
 <Tabs groupId='languageSyntax'>
 <TabItem value="CreateIndexes" label="CreateIndexes">
-<CodeBlock language="csharp">
-{`// Deploy ALL indexes from the assembly containing the \`Orders_ByTotal\` class
+```csharp
+// Deploy ALL indexes from the assembly containing the `Orders_ByTotal` class
 IndexCreation.CreateIndexes(typeof(Orders_ByTotal).Assembly, store);
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="CreateIndexes_async" label="CreateIndexes_async">
-<CodeBlock language="csharp">
-{`// Deploy ALL indexes from the assembly containing the \`Orders_ByTotal\` class
+```csharp
+// Deploy ALL indexes from the assembly containing the `Orders_ByTotal` class
 await IndexCreation.CreateIndexesAsync(typeof(Orders_ByTotal).Assembly, store);
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
+<ContentFrame>
 
-##### Deploy syntax
+### Deploy syntax
+    
 <Tabs groupId='languageSyntax'>
 <TabItem value="Deploy_methods" label="Deploy_methods">
-<CodeBlock language="csharp">
-{`// Call this method directly on the index instance
+```csharp
+// Call this method directly on the index instance
 void Execute(IDocumentStore store, DocumentConventions conventions = null, 
     string database = null);
 
@@ -257,12 +262,11 @@ void CreateIndexes(IEnumerable<IAbstractIndexCreationTask> indexes, IDocumentSto
     DocumentConventions conventions = null, string database = null);
 void CreateIndexes(Assembly assemblyToScan, IDocumentStore store,
     DocumentConventions conventions = null, string database = null);
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="Deploy_methods_async" label="Deploy_methods_async">
-<CodeBlock language="csharp">
-{`// Call this method directly on the index instance
+```csharp
+// Call this method directly on the index instance
 Task ExecuteAsync(IDocumentStore store, DocumentConventions conventions = null,
     string database = null, CancellationToken token = default);
 
@@ -271,6 +275,12 @@ Task ExecuteIndexAsync(IAbstractIndexCreationTask index, string database = null,
     CancellationToken token = default(CancellationToken));
 Task ExecuteIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
     string database = null, CancellationToken token = default(CancellationToken));
+    
+// In this overload, `conventions` and `database` have no default values.
+// Pass `null` to use the store's conventions or the store's default database.    
+Task ExecuteIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
+    DocumentConventions conventions, string database,
+    CancellationToken token = default(CancellationToken));    
 
 // Call these static methods on the IndexCreation class
 Task CreateIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
@@ -279,27 +289,28 @@ Task CreateIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
 Task CreateIndexesAsync(Assembly assemblyToScan, IDocumentStore store,
     DocumentConventions conventions = null, string database = null,
     CancellationToken token = default(CancellationToken));
-`}
-</CodeBlock>
+```
 </TabItem>
 </Tabs>
 
 | Parameter          | Type                                      | Description                                                                                                       |
 |--------------------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
 | **store**          | `IDocumentStore`                          | Your document store object.                                                                                       |
-| **conventions**    | `DocumentConventions`                     | The [Conventions](../../client-api/configuration/conventions.mdx) used by the document store.                            |
+| **conventions**    | `DocumentConventions`                     | The [Conventions](../../client-api/configuration/conventions.mdx) used by the document store.                     |
 | **database**       | `string`                                  | The target database to deploy the index to. If not specified, the default database set on the store will be used. |
 | **index**          | `IAbstractIndexCreationTask`              | The index object to deploy.                                                                                       |
 | **indexes**        | `IEnumerable<IAbstractIndexCreationTask>` | A list of index objects to deploy.                                                                                |
 | **assemblyToScan** | `Assembly `                               | Deploy all indexes that are contained in this assembly.                                                           |
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
+<ContentFrame>
 
-##### Deployment behavior
+### Deployment behavior
+    
 <Admonition type="info" title="">
 
-###### Deployment mode:
+#### Deployment mode:
+    
 * When your database spans multiple nodes,  
   you can choose between **Rolling** index deployment or **Parallel** index deployment.
 * Rolling deployment applies the index to one node at a time,  
@@ -307,69 +318,70 @@ Task CreateIndexesAsync(Assembly assemblyToScan, IDocumentStore store,
 * Learn more in [Rolling index deployment](../../indexes/rolling-index-deployment.mdx).
 
 </Admonition>
-
 <Admonition type="note" title="">
 
-###### When the index you are deploying already exists on the server:
+#### When the index you are deploying already exists on the server:
+    
 * **If the index definition is updated**:
     * RavenDB uses a side-by-side strategy for all index updates.
     * When an existing index definition is modified, RavenDB creates a new index with the updated definition.
       The new index will replace the existing index once it becomes non-stale.
     * If you want to swap the indexes immediately, you can do so through the Studio.  
       For more details, see [Side by side indexing](../../studio/database/indexes/indexes-list-view.mdx#indexes-list-view---side-by-side-indexing).
+    
 * **If the index definition is unchanged**:
     * If the definition of the index being deployed is identical to the one on the server,  
       the existing index will not be overwritten.
     * The indexed data will remain intact, and the indexing process will not restart.
 
-</Admonition>
-</Admonition>
+</Admonition>  
+</ContentFrame>
 
+</Panel>
 
-## Create a static-index - Example
+<Panel heading="Creating a static-index - Example">
 
-<TabItem value="indexes_13" label="indexes_13">
-<CodeBlock language="csharp">
-{`// Define a static-index:
+```csharp
+// Define a static-index:
 // ======================
 public class Orders_ByTotal : AbstractIndexCreationTask<Order>
-\{
+{
     public class IndexEntry
-    \{
+    {
         // The index-fields:
-        public string Employee \{ get; set; \}
-        public string Company \{ get; set; \}
-        public decimal Total \{ get; set; \}
-    \}
+        public string Employee { get; set; }
+        public string Company { get; set; }
+        public decimal Total { get; set; }
+    }
     
     public Orders_ByTotal()
-    \{
+    {
         Map = orders => from order in orders
                         select new IndexEntry
-                        \{
+                        {
                             // Set the index-fields:
                             Employee = order.Employee,
                             Company = order.Company,
                             Total = order.Lines.Sum(l => 
                                 (l.Quantity * l.PricePerUnit) * (1 - l.Discount))
-                        \};
+                        };
         
         // Customize the index as needed, for example:
         DeploymentMode = IndexDeploymentMode.Rolling;
         Configuration["Indexing.MapTimeoutInSec"] = "30";
         Indexes.Add(x => x.Company, FieldIndexing.Search);
         // ...
-    \}
-\}
+    }
+}
 
 public static void Main(string[] args)
-\{
+{
     using (DocumentStore store = new DocumentStore
-    \{
-        Urls = new[] \{ "http://localhost:8080" \},
+    {
+        Urls = new[] { "http://localhost:8080" },
         Database = "Northwind"
-    \})
-    \{
+    })
+    {
         store.Initialize();
         
         // Deploy the index:
@@ -377,7 +389,7 @@ public static void Main(string[] args)
         new Orders_ByTotal().Execute(store);
         
         using (IDocumentSession session = store.OpenSession())
-        \{
+        {
             // Query the index:
             // ================
             IList<Order> orders = session
@@ -386,16 +398,14 @@ public static void Main(string[] args)
                 .Where(x => x.Total > 100)
                 .OfType<Order>()
                 .ToList();
-        \}
-    \}
-\}
-`}
-</CodeBlock>
-</TabItem>
+        }
+    }
+}
+```
 
+</Panel>    
 
-
-## Create a static-index - using an Operation
+<Panel heading="Creating a static-index - using an Operation">
 
 * An index can also be defined and deployed using the [PutIndexesOperation](../../client-api/operations/maintenance/indexes/put-indexes.mdx) maintenance operation.  
 
@@ -412,77 +422,90 @@ public static void Main(string[] args)
 
 * For a detailed explanation and examples, refer to the dedicated article: [Put Indexes Operation](../../client-api/operations/maintenance/indexes/put-indexes.mdx).
 
+</Panel>    
+    
+## Auto-indexes
 
+<Panel heading="Creating auto-indexes">
 
-<a id="auto-indexes"/>
-## Creating auto-indexes
+<ContentFrame>
 
-<Admonition type="note" title="">
-
-##### Auto-indexes creation
+### Auto-indexes creation
+    
 * Indexes **created by the server** are called `dynamic` or `auto` indexes.
+    
 * Auto-indexes are created when all of the following conditions are met:  
     * A query is issued without specifying an index (a dynamic query).
     * The query includes a filtering condition.
     * No suitable auto-index exists that can satisfy the query.
     * Creation of auto-indexes has not been disabled.
+    
 * For such queries, RavenDB's Query Optimizer searches for an existing auto-index that can satisfy the query.
   If no suitable auto-index is found, RavenDB will either create a new auto-index or optimize an existing auto-index.
   (Static-indexes are not taken into account when determining which auto-index should handle the query).
 * Note: dynamic queries can be issued either when [querying](../../studio/database/queries/query-view.mdx#query-view) or when [patching](../../documents/patching-documents/patch-multiple-documents/patch-view.mdx#patch-configuration).
+    
 * Over time, RavenDB automatically adjusts and merges auto-indexes to efficiently serve your queries.  
   For more details, see [Query a collection - with filtering (dynamic query)](../../querying/overview.mdx#dynamicQuery).
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
+<ContentFrame>
 
-##### Naming convention
+### Naming convention
+    
 * Auto-indexes are easily identified by their names, which start with the `Auto/` prefix.
 * Their name also includes the name of the queried collection and a list of fields used in the query predicate to filter matching results.
 * For example, issuing the following query:
+    
 <Tabs groupId='languageSyntax'>
 <TabItem value="Query" label="Query">
-<CodeBlock language="csharp">
-{`List<Employee> employees = session
+```csharp
+List<Employee> employees = session
     .Query<Employee>()
     .Where(x => x.FirstName == "Robert" && x.LastName == "King")
     .ToList();
-`}
-</CodeBlock>
+```
 </TabItem>
 <TabItem value="RQL" label="RQL">
-<CodeBlock language="sql">
-{`from Employees
+```sql
+from Employees
 where FirstName = "Robert" and LastName = "King"
-`}
-</CodeBlock>
+```
 </TabItem>
-    </Tabs>
-    will result in the creation of an auto-index named `Auto/Employees/ByFirstNameAndLastName`.
+</Tabs>
+    
+will result in the creation of an auto-index named `Auto/Employees/ByFirstNameAndLastName`.
 
-</Admonition>
-<Admonition type="note" title="">
+</ContentFrame>
 
-##### Auto-index idle state
+<ContentFrame>
+
+### Auto-index idle state
+    
 * To reduce server load, an auto-index is marked as `idle` when it hasn't been used for a while.  
   Specifically, if the time difference between the last time the auto-index was queried
   and the last time a query was made on the database (using any index) exceeds the configured threshold (30 minutes by default),
   the auto-index will be marked as `idle`.
+    
 * This is done in order to avoid marking indexes as idle for databases that were offline for a long period of time,
   as well as for databases that were just restored from a snapshot or a backup.
+    
 * To set the time before marking an index as idle, use the
   [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration.mdx#indexingtimetowaitbeforedeletingautoindexmarkedasidleinhrs) configuration key.  
   Setting this value too high is not recommended, as it may lead to performance degradation by causing unnecessary and redundant work for the indexes.
+    
 * An `idle` auto-index will resume its work and return to `normal` state upon its next query,  
   or when resetting the index.
+    
 * If not resumed, the idle auto-index will be deleted by the server after the time period defined in the 
   [Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdleInHrs](../../server/configuration/indexing-configuration.mdx#indexingtimetowaitbeforedeletingautoindexmarkedasidleinhrs) configuration key  
   (72 hours by default).
 
-</Admonition>
+</ContentFrame>
 
+</Panel>
 
-## Disabling auto-indexes
+<Panel heading="Disabling auto-indexes">
 
 **Why disable**:  
 
@@ -501,6 +524,4 @@ where FirstName = "Robert" and LastName = "King"
    * To disable auto-index creation for a specific query made from the patch view, see these [Patch settings](../../documents/patching-documents/patch-multiple-documents/patch-view.mdx#patch-settings).
    * Disabling auto-index creation for ALL queries made on a database can be configured in the [Studio configuration view](../../studio/database/settings/studio-configuration.mdx#disabling-auto-index-creation-on-studio-queries-or-patches).
 
-
-
-
+</Panel>

--- a/docs/migration/client-api/client-migration.mdx
+++ b/docs/migration/client-api/client-migration.mdx
@@ -17,6 +17,7 @@ import LanguageContent from "@site/src/components/LanguageContent";
 
 * In this article:
    * [Client migration to RavenDB `7.x`](../../migration/client-api/client-migration.mdx#client-migration-to-ravendb-7x)
+   * [Deploying multiple indexes is now atomic](../../migration/client-api/client-migration.mdx#deploying-multiple-indexes-is-now-atomic)
 
 </Admonition>
 ## Client migration to RavenDB 7.x
@@ -33,5 +34,23 @@ Version `7.0`'s client API ability to connect to a server depends on the
   <Admonition type="info" title="">
   [See how to switch the algorithm to Gzip](../../migration/client-api/previous-versions-client-breaking-changes.mdx#http-compression-algorithm-is-now-zstd-by-default)
   </Admonition>
+
+## Deploying multiple indexes is now atomic
+
+This change applies to the **.NET client** only.  
+
+Prior to version `7.0`, `IndexCreation.CreateIndexes` retried the deployment index-by-index after a 
+failed batch, so valid indexes were still created and the failures were reported as an 
+`AggregateException`.  
+From version `7.0` on, `IndexCreation.CreateIndexes` and `DocumentStore.ExecuteIndexes` behave 
+identically and the batch is atomic: if any index fails to compile, none of the indexes in the batch 
+are created, and an `IndexCompilationException` naming the offending index is thrown.  
+
+If your deployment flow relied on the valid indexes being created despite one of them failing, 
+deploy the indexes in separate calls, or call `Execute` on each index individually.  
+
+<Admonition type="info" title="">
+[See the full description of this breaking change](../../migration/client-api/previous-versions-client-breaking-changes.mdx#deploying-multiple-indexes-is-now-atomic)
+</Admonition>
 
 

--- a/docs/migration/client-api/previous-versions-client-breaking-changes.mdx
+++ b/docs/migration/client-api/previous-versions-client-breaking-changes.mdx
@@ -26,6 +26,7 @@ Each breaking change indicates a behavior change or a function that is no longer
       * [Removed irrelevant `SingleNodeBatchCommand` parameters](../../migration/client-api/previous-versions-client-breaking-changes.mdx#removed-irrelevant-singlenodebatchcommand-parameters)  
       * [Removed obsolete methods](../../migration/client-api/previous-versions-client-breaking-changes.mdx#removed-obsolete-methods)  
       * [`FromEtl` is now internal](../../migration/client-api/previous-versions-client-breaking-changes.mdx#frometl-is-now-internal)  
+      * [Deploying multiple indexes is now atomic](../../migration/client-api/previous-versions-client-breaking-changes.mdx#deploying-multiple-indexes-is-now-atomic)  
    * [RavenDB 6.2 client breaking changes](../../migration/client-api/previous-versions-client-breaking-changes.mdx#ravendb-6-2-client-breaking-changes)  
       * [`CounterBatchOperation` default increment Delta is 1](../../migration/client-api/previous-versions-client-breaking-changes.mdx#counterbatchoperation-default-increment-delta-is-1)  
       * [CmpXchg item can only be created with an index of 0](../../migration/client-api/previous-versions-client-breaking-changes.mdx#cmpxchg-item-can-only-be-created-with-an-index-of-0)  
@@ -221,6 +222,40 @@ The following methods are no longer used and have been removed from RavenDB `7.0
 ## `FromEtl` is now internal
 The `CounterBatch` class `FromEtl` property is now **internal**.  
 `FromEtl` is used internally to get or set a value indicating whether a counters batch originated from an ETL process.
+</ContentFrame>
+
+<ContentFrame>
+
+## Deploying multiple indexes is now atomic
+This change applies to the **.NET client** only.  
+
+In RavenDB versions earlier than `7.0`, [IndexCreation.CreateIndexes](../../indexes/creating-and-deploying.mdx#deploy-multiple-indexes) 
+sent all index definitions in a single request, and if that request failed it retried the deployment 
+index-by-index. Indexes that were valid were therefore still created, and the indexes that failed were 
+reported together in an `AggregateException`.  
+
+From `7.0` on, `IndexCreation.CreateIndexes` delegates to 
+[DocumentStore.ExecuteIndexes](../../indexes/creating-and-deploying.mdx#deploy-multiple-indexes) and the 
+two methods behave identically. The batch is now atomic:  
+
+* If any index in the batch fails to compile, the entire batch fails and **none** of the indexes 
+  in it are created.  
+* The failure is reported as an `IndexCompilationException` naming the index that caused it, 
+  instead of an `AggregateException`.  
+
+<Admonition type="note" title="">
+
+If your deployment flow relied on the valid indexes being created despite one of them failing, 
+deploy the indexes in separate calls, or call `Execute` on each index individually.  
+
+</Admonition>
+
+<Admonition type="info" title="">
+
+Deploying an empty list of indexes is a no-op from `7.0` on: no request is sent to the server 
+and no exception is thrown.  
+
+</Admonition>
 </ContentFrame>
 
 

--- a/versioned_docs/version-7.0/indexes/content/_creating-and-deploying-csharp.mdx
+++ b/versioned_docs/version-7.0/indexes/content/_creating-and-deploying-csharp.mdx
@@ -152,9 +152,10 @@ await store.ExecuteIndexAsync(new Orders_ByTotal());
 
 ##### Deploy multiple indexes
 * Use `ExecuteIndexes()` or `IndexCreation.CreateIndexes()` to deploy multiple indexes.
-* The `IndexCreation.CreateIndexes` method attempts to create all indexes in a single request.  
-  If it fails, it will repeat the execution by calling the `Execute` method for each index, one by one,  
-  in separate requests.
+* Both methods send all index definitions to the server in a single request, and behave identically.
+* If any index in the batch fails to compile, the entire batch fails and none of the indexes are created.  
+  An `IndexCompilationException` is thrown, naming the index that caused the failure.
+* Deploying an empty list of indexes is a no-op: no request is sent to the server and no exception is thrown.
 * The following examples deploy indexes `Ordes/ByTotal` and `Employees/ByLastName` to the default database defined in your _DocumentStore_ object.  
   See the [syntax](../../indexes/creating-and-deploying.mdx#deploy-syntax) section below for all available overloads.
 
@@ -271,6 +272,12 @@ Task ExecuteIndexAsync(IAbstractIndexCreationTask index, string database = null,
     CancellationToken token = default(CancellationToken));
 Task ExecuteIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
     string database = null, CancellationToken token = default(CancellationToken));
+
+// In this overload, 'conventions' and 'database' have no default values.
+// Pass null to use the store's conventions or the store's default database.
+Task ExecuteIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
+    DocumentConventions conventions, string database,
+    CancellationToken token = default(CancellationToken));
 
 // Call these static methods on the IndexCreation class
 Task CreateIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,

--- a/versioned_docs/version-7.0/migration/client-api/client-breaking-changes.mdx
+++ b/versioned_docs/version-7.0/migration/client-api/client-breaking-changes.mdx
@@ -24,6 +24,7 @@ with their behavior in previous versions.
    * [Removed irrelevant `SingleNodeBatchCommand` parameters](../../migration/client-api/client-breaking-changes.mdx#removed-irrelevant-singlenodebatchcommand-parameters)  
    * [Removed obsolete methods](../../migration/client-api/client-breaking-changes.mdx#removed-obsolete-methods)  
    * [`FromEtl` is now internal](../../migration/client-api/client-breaking-changes.mdx#frometl-is-now-internal)  
+   * [Deploying multiple indexes is now atomic](../../migration/client-api/client-breaking-changes.mdx#deploying-multiple-indexes-is-now-atomic)  
 
 </Admonition>
 
@@ -214,5 +215,36 @@ The following methods are no longer used and have been removed from RavenDB `7.0
 ## `FromEtl` is now internal
 The `CounterBatch` class `FromEtl` property is now **internal**.  
 `FromEtl` is used internally to get or set a value indicating whether a counters batch originated from an ETL process.
+
+## Deploying multiple indexes is now atomic
+This change applies to the **.NET client** only.  
+
+In earlier versions, [IndexCreation.CreateIndexes](../../indexes/creating-and-deploying.mdx#deploy-multiple-indexes) 
+sent all index definitions in a single request, and if that request failed it retried the deployment 
+index-by-index. Indexes that were valid were therefore still created, and the indexes that failed were 
+reported together in an `AggregateException`.  
+
+`IndexCreation.CreateIndexes` now delegates to 
+[DocumentStore.ExecuteIndexes](../../indexes/creating-and-deploying.mdx#deploy-multiple-indexes), 
+and the two methods behave identically. The batch is now atomic:  
+
+* If any index in the batch fails to compile, the entire batch fails and **none** of the indexes 
+  in it are created.  
+* The failure is reported as an `IndexCompilationException` naming the index that caused it, 
+  instead of an `AggregateException`.  
+
+<Admonition type="note" title="">
+
+If your deployment flow relied on the valid indexes being created despite one of them failing, 
+deploy the indexes in separate calls, or call `Execute` on each index individually.  
+
+</Admonition>
+
+<Admonition type="info" title="">
+
+Deploying an empty list of indexes is now a no-op: no request is sent to the server 
+and no exception is thrown.  
+
+</Admonition>
 
 

--- a/versioned_docs/version-7.1/indexes/content/_creating-and-deploying-csharp.mdx
+++ b/versioned_docs/version-7.1/indexes/content/_creating-and-deploying-csharp.mdx
@@ -152,9 +152,10 @@ await store.ExecuteIndexAsync(new Orders_ByTotal());
 
 ##### Deploy multiple indexes
 * Use `ExecuteIndexes()` or `IndexCreation.CreateIndexes()` to deploy multiple indexes.
-* The `IndexCreation.CreateIndexes` method attempts to create all indexes in a single request.  
-  If it fails, it will repeat the execution by calling the `Execute` method for each index, one by one,  
-  in separate requests.
+* Both methods send all index definitions to the server in a single request, and behave identically.
+* If any index in the batch fails to compile, the entire batch fails and none of the indexes are created.  
+  An `IndexCompilationException` is thrown, naming the index that caused the failure.
+* Deploying an empty list of indexes is a no-op: no request is sent to the server and no exception is thrown.
 * The following examples deploy indexes `Ordes/ByTotal` and `Employees/ByLastName` to the default database defined in your _DocumentStore_ object.  
   See the [syntax](../../indexes/creating-and-deploying.mdx#deploy-syntax) section below for all available overloads.
 
@@ -271,6 +272,12 @@ Task ExecuteIndexAsync(IAbstractIndexCreationTask index, string database = null,
     CancellationToken token = default(CancellationToken));
 Task ExecuteIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
     string database = null, CancellationToken token = default(CancellationToken));
+
+// In this overload, 'conventions' and 'database' have no default values.
+// Pass null to use the store's conventions or the store's default database.
+Task ExecuteIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,
+    DocumentConventions conventions, string database,
+    CancellationToken token = default(CancellationToken));
 
 // Call these static methods on the IndexCreation class
 Task CreateIndexesAsync(IEnumerable<IAbstractIndexCreationTask> indexes,

--- a/versioned_docs/version-7.1/migration/client-api/client-breaking-changes.mdx
+++ b/versioned_docs/version-7.1/migration/client-api/client-breaking-changes.mdx
@@ -24,6 +24,7 @@ with their behavior in previous versions.
    * [Removed irrelevant `SingleNodeBatchCommand` parameters](../../migration/client-api/client-breaking-changes.mdx#removed-irrelevant-singlenodebatchcommand-parameters)  
    * [Removed obsolete methods](../../migration/client-api/client-breaking-changes.mdx#removed-obsolete-methods)  
    * [`FromEtl` is now internal](../../migration/client-api/client-breaking-changes.mdx#frometl-is-now-internal)  
+   * [Deploying multiple indexes is now atomic](../../migration/client-api/client-breaking-changes.mdx#deploying-multiple-indexes-is-now-atomic)  
 
 </Admonition>
 ## Subscription creation overload modification
@@ -227,5 +228,36 @@ The following methods are no longer used and have been removed from RavenDB `7.0
 ## `FromEtl` is now internal
 The `CounterBatch` class `FromEtl` property is now **internal**.  
 `FromEtl` is used internally to get or set a value indicating whether a counters batch originated from an ETL process.
+
+## Deploying multiple indexes is now atomic
+This change applies to the **.NET client** only.  
+
+In earlier versions, [IndexCreation.CreateIndexes](../../indexes/creating-and-deploying.mdx#deploy-multiple-indexes) 
+sent all index definitions in a single request, and if that request failed it retried the deployment 
+index-by-index. Indexes that were valid were therefore still created, and the indexes that failed were 
+reported together in an `AggregateException`.  
+
+`IndexCreation.CreateIndexes` now delegates to 
+[DocumentStore.ExecuteIndexes](../../indexes/creating-and-deploying.mdx#deploy-multiple-indexes), 
+and the two methods behave identically. The batch is now atomic:  
+
+* If any index in the batch fails to compile, the entire batch fails and **none** of the indexes 
+  in it are created.  
+* The failure is reported as an `IndexCompilationException` naming the index that caused it, 
+  instead of an `AggregateException`.  
+
+<Admonition type="note" title="">
+
+If your deployment flow relied on the valid indexes being created despite one of them failing, 
+deploy the indexes in separate calls, or call `Execute` on each index individually.  
+
+</Admonition>
+
+<Admonition type="info" title="">
+
+Deploying an empty list of indexes is now a no-op: no request is sent to the server 
+and no exception is thrown.  
+
+</Admonition>
 
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3916/Document-behavior-of-IndexCreation.CreateIndexes-and-store.ExecuteIndexes

### Additional description
Documents the RavenDB-24077 change aligning `IndexCreation.CreateIndexes` with `store.ExecuteIndexes` (**.NET** client only):

- Index batches are now atomic — one bad index fails the whole batch, 
   throwing `IndexCompilationException` instead of `AggregateException`.
- Empty index list is now a no-op.
- Added the `ExecuteIndexesAsync` overload taking `DocumentConventions`.

Applied to v7.2, v7.1, v7.0. (.NET-only) Node.js/Java/Python partials unchanged. 
Also reformatted the v7.2 C# partial to fenced code + added panels.

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

