### PR TITLE
RDoc-4075 Remove Link Copied entries from docs search bar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -267,6 +267,10 @@ pre,
     @apply opacity-100;
 }
 
+.hash-link__copied::before {
+    content: attr(data-copied-label);
+}
+
 /* Custom breadcrumbs styling */
 .breadcrumbsContainer {
     --ifm-breadcrumb-size-multiplier: 0.8;

--- a/src/theme/Heading/index.tsx
+++ b/src/theme/Heading/index.tsx
@@ -79,8 +79,9 @@ export default function Heading({ as: As, id, ...props }: Props): ReactNode {
             >
                 &#8203;
                 <span
+                    data-copied-label={copiedTitle}
                     className={clsx(
-                        "pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2",
+                        "hash-link__copied pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2",
                         "whitespace-nowrap rounded-md border px-2.5 py-1 text-xs font-medium shadow-lg backdrop-blur",
                         "border-black/10 bg-white/90 text-gray-700",
                         "dark:border-white/10 dark:bg-[#1b1b1d]/90 dark:text-gray-200",
@@ -88,9 +89,7 @@ export default function Heading({ as: As, id, ...props }: Props): ReactNode {
                         copied ? "opacity-100" : "opacity-0"
                     )}
                     aria-hidden="true"
-                >
-                    {copiedTitle}
-                </span>
+                />
             </a>
         </As>
     );


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-4075

### Additional description
Fix: the label moves to a `data-copied-label` attribute and is painted with `content: attr(...)`. Generated content is not part of `textContent`, so it also stops leaking into text selection and Ctrl+F. Tooltip looks and behaves the same.


### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)