### PR TITLE
RDBTC-221 Migrate technical guides Migrating RDBTC-49

### DIFF
--- a/guides/dynamic-fields.mdx
+++ b/guides/dynamic-fields.mdx
@@ -1,10 +1,338 @@
 ---
 title: "Dynamic Fields in RavenDB"
-tags: [deep-dive, indexes]
-description: "Read about Dynamic Fields in RavenDB on the RavenDB.net news section"
-external_url: "https://ravendb.net/articles/dynamic-fields"
+tags: [indexes, querying, deep-dive]
+icon: "index-fields"
+description: "How to use dynamic fields in RavenDB static indexes to query on properties that aren't defined at index-creation time, plus the pitfalls to watch for with duplicate field names and stored projections."
 published_at: 2024-10-28
-image: "https://ravendb.net/wp-content/uploads/2024/10/dynamic-fields-cover.jpg"
+see_also:
+  - title: "Using Dynamic Fields"
+    link: "indexes/using-dynamic-fields"
+    source: "docs"
+    path: "Indexes > Using Dynamic Fields"
+  - title: "Indexing Nested Data"
+    link: "indexes/indexing-nested-data"
+    source: "docs"
+    path: "Indexes > Indexing Nested Data"
+  - title: "Storing Data in Index"
+    link: "indexes/storing-data-in-index"
+    source: "docs"
+    path: "Indexes > Storing Data in Index"
 proficiency_level: "Expert"
+author: "Maciej Aszyk"
 ---
 
+import Admonition from '@theme/Admonition';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import LanguageSwitcher from "@site/src/components/LanguageSwitcher";
+import LanguageContent from "@site/src/components/LanguageContent";
+import Image from "@theme/IdealImage";
+
+## Introduction
+
+RavenDB, as a schemaless database, gives you flexibility in how you persist data in the system, allowing the system to evolve freely over time, and it's not only restricted to the documents. Static indexes (written in C# or JavaScript) provide the possibility of producing/generating specialized data structures for efficient querying. At first glance, it might appear that the static indexes don't offer the flexibility in defining fields for querying, as they require static, compile-time binding of the index field to one or more document fields/properties. Adding an additional field necessitates changing the definition and rebuilding the indexes, which can be time-consuming for large datasets.
+
+Fortunately, it only *seems* that way.
+
+## Examples of use cases
+
+For our examples, let's assume we are developing an e-commerce site to make them more practical and understandable.
+
+### Product attributes
+
+Your e-commerce site has a product catalog. We know that some products have common attributes such as `Name` or `Price`, but often a product can have distinguishing properties like `Color`. It makes sense to filter, for example, T-Shirts by color, but does it make sense to filter software by colors? When building a catalog, it is hard to predict what we would filter on in the future, and we do not want to edit the definition each time something new appears.
+
+Normally, the definition of the ProductSearch index would probably look like this:
+
+```csharp
+from doc in docs.Products
+select new
+{
+    Name = doc.Name,
+    Price = doc.Price,
+}
+```
+
+Alternatively, in JavaScript:
+
+```javascript
+map("Products", (product) => {
+    return {
+        Name: product.Name,
+        Price: product.Price
+    };
+})
+```
+
+and when a new property appears, we explicitly add the field to the definition. However, this isn't very flexible. Yet, with a little help from the [dynamic fields](/7.2/indexes/using-dynamic-fields) feature we can make our index flexible.
+
+Depending on the document structure we have a couple of possibilities there. Let's assume we have a document in format like this:
+
+```javascript
+{
+    "Name": "Unique T-Shirt",
+    "Price": 20,
+    "Attributes": {
+        "Color": "Black"
+    }
+}
+```
+
+This is a win-win situation, so let's change our index definition:
+
+```csharp
+from doc in docs.Products
+select new
+{
+    Name = doc.Name,
+    Price = doc.Price,
+    _ = doc.Attributes.Select(attribute => CreateField(attribute.Key, attribute.Value))
+}
+```
+
+```javascript
+map("Products", (product) => {
+    return {
+        Name: product.Name,
+        Price: product.Price,
+        _: Object.entries(product.Attributes).map(([key, value]) => createField(key, value, {
+            indexing: 'Default',
+            storage: false,
+            termVector: null
+        }))
+    };
+})
+```
+
+The `CreateField` method creates an additional index field for document index entry with the name `Color` and pushes `Black` as a value.
+When we look into the raw index entry (the [docs](/7.2/indexes/indexing-nested-data#simple-index---single-index-entry-per-document) show you how to get one), our document has these fields:
+
+```javascript
+{
+    "Color": "black",
+    "Name": "unique t-shirt",
+    "Price": "20",
+    "id()": "products/1-a"
+}
+```
+
+Notice that the term is stored lowercased. A dynamic field created with `indexing: 'Default'` gets no explicit analyzer, so RavenDB falls back to the Default Analyzer, which is `LowerCaseKeywordAnalyzer`: the whole field value becomes a single, lowercased token. The query term goes through the same analyzer, which is why `'Black'` still matches the term `black`. If you need different behavior, for example full-text search or diacritic-sensitive matching on a dynamic field, you have to configure the analyzer explicitly. See [Configuring analyzers for dynamic fields](/7.2/indexes/using-dynamic-fields#configuring-analyzers-for-dynamic-fields) and [Using Analyzers](/7.2/indexes/using-analyzers), and the [Diacritic-Sensitive Search in RavenDB](./diacritic-sensitive-search-in-ravendb) guide for a worked example.
+
+This gives the possibility to query by color even though we do not have any explicit `Color` field in our index definition:
+
+```sql
+from index 'ProductSearch' where Color == 'Black'
+```
+
+Or from the client:
+
+```csharp
+session.Query<ProductIndexResult, ProductSearch>()
+    .Where(x => x.Color == "Black")
+    .ProjectInto<Product>()
+    .ToList();
+```
+
+Remember, no term is written under the `Color` field for documents that don't have a `Color` attribute.
+
+As always, you can have totally different document structures, like properties are not aggregated in the dictionary but stored in root (like the `Name`), what to do in such a case? You can always index all fields from document, e.g:
+
+```csharp
+from doc in docs.Products
+select new
+{
+    _ = AsJson(doc).Select(x => CreateField(x.Key, x.Value))
+}
+```
+
+```javascript
+map('Products', function (product) {
+    return {
+        _: Object.keys(product).map(key => createField(key, product[key], {
+            indexing: 'Default',
+            storage: false,
+            termVector: null
+        }))
+    };
+})
+```
+
+Let's analyze the example above. RavenDB offers AsJson() indexing method, which returns a document as a dictionary object, which gives a lot of flexibility in creating unbounded indexes, however such usage should be carefully considered and analyzed. The great advantage of such an approach is a schemaless index, so you will be able to automatically use new fields added to documents. On the other hand, you will probably index fields that are unnecessary, which means higher disk usage and slower indexing when your documents are big. If you go down this road, keep an eye on what the index actually costs you: see [Which Index Ate My Disk?](./troubleshooting-which-index-ate-my-disk).
+
+Secondly, when you have complex values (e.g. you store some class as value of property) the indexed term will be a JSON so querying it would be hard since you would have to match JSON.
+
+In such scenarios, it is simply better to have a field with the names of the attributes to be additionally indexed.
+
+```javascript
+{
+    "Name": "Unique T-Shirt",
+    "Price": 20,
+    "Color": "Black",
+    "ForSearch": ["Color"]
+}
+```
+
+```csharp
+from doc in docs.Products
+select new
+{
+    Name = doc.Name,
+    Price = doc.Price,
+    _ = AsJson(doc).Where(x => doc.ForSearch?.Contains(x.Key) ?? false)
+        .Select(field => CreateField(field.Key, field.Value))
+}
+```
+
+```javascript
+map("Products", (product) => {
+    return {
+        Name: product.Name,
+        Price: product.Price,
+        _: !Array.isArray(product.ForSearch)
+            ? null
+            : product.ForSearch
+                .filter(key => product.hasOwnProperty(key))
+                .map(key => createField(key, product[key], {
+                    indexing: 'Default',
+                    storage: false,
+                    termVector: null
+                }))
+    };
+})
+```
+
+Both versions read the field names from `ForSearch` and pull the values from the root of the document, which is where `Color` lives in the document above. If your attributes sit in a nested `Attributes` object instead, read from `doc.Attributes` / `product.Attributes` in both places.
+
+In such a scenario you control what you index per document and avoid unwanted fields.
+
+The `CreateField` method also lets you configure field options such as indexing behavior, storage, and term vectors. See [Using Dynamic Fields](/7.2/indexes/using-dynamic-fields) for the full set.
+
+A note on null-safety: all of the examples above assume the source property exists. `doc.Attributes.Select(...)` throws for a document that has no `Attributes` object at all, and RavenDB will record that as an index error rather than silently skipping the document. In a real catalog where the shape genuinely varies, guard first, the same way the `ForSearch` example does:
+
+```csharp
+_ = doc.Attributes == null
+    ? null
+    : ((IEnumerable<dynamic>)doc.Attributes).Select(attribute => CreateField(attribute.Key, attribute.Value))
+```
+
+## Dynamic fields: things to be aware of
+
+Dynamic fields give the possibility to make our index flexible, but we should be careful what and how we index. Let's discuss some scenarios that might happen to you.
+
+### Duplicated names
+
+Let's have an index definition like this:
+
+```csharp
+from doc in docs.Products
+select new
+{
+    CreationDate = doc.CreationDate,
+    _ = doc.Attributes.Select(x => CreateField(x.Key, x.Value))
+}
+```
+
+```javascript
+map("Products", (product) => {
+    return {
+        CreationDate: product.CreationDate,
+        _: Object.entries(product.Attributes).map(([key, value]) => createField(key, value, {
+            indexing: 'Default',
+            storage: false,
+            termVector: null
+        }))
+    };
+})
+```
+
+And our document has two properties with the same name, but one of them is nested.
+
+```javascript
+{
+    [...]
+    "CreationDate": "2022-02-01",
+    "Attributes": {
+        "CreationDate": "2023-01-01"
+    }
+    [...]
+}
+```
+
+Situations like this can happen. For example: the `CreationDate` in the root of the document can mean the creation of the product in our catalog, but the `CreationDate` in the `Attributes` can mean the creation date of the product itself.
+
+After indexing, we can query our document like this:
+
+```sql
+from index 'Index' where CreationDate == "2022-02-01"
+```
+
+or
+
+```sql
+from index 'Index' where CreationDate == "2023-01-01"
+```
+
+Both queries match our document, which can lead to mismatches in queries because terms can have different meanings.
+
+Please be careful when creating dynamic fields with non-unique naming conventions (e.g. prefixes/suffixes), as this may inadvertently push additional terms into fields we do not initially want.
+
+### Creating different projection
+
+The example above shows us how dangerous it could be if we've duplicated names, but there is another scenario. RavenDB lets us store data in the index, either for performance or to keep a transformed version of the data ready for projections. Normally a projection has to go back to disk and load the document. When the document is big and we know upfront that we only need a couple of properties out of it, we can store those in the index instead and skip loading the whole thing, which can cut query time significantly. Learn more about storing fields [here](/7.2/indexes/storing-data-in-index), and see the [Master RavenDB Projections Performance](./master-ravendb-projections-performance) guide for how stored fields compare to the other projection strategies.
+We can do a trick with a dynamic field and have stored different values than we index.
+
+Let's have document like this:
+
+```javascript
+{
+    "Name": "ProductOne",
+    "OrderedAt": "2023-03-01T12:00:00.0000000"
+}
+```
+
+We have a page where we show our salespeople all orders with the date, of course we would not show them the date as a raw string but with nice formatting.
+We could do this in our application or we could have all data already prepared and just stream the model from our index.
+
+```csharp
+from order in docs.Orders
+select new
+{
+    Name = order.ProductName,
+    OrderedAt = order.OrderedAt, // indexed as a sortable ISO 8601 string
+    _ = CreateField(
+        "OrderedAt",
+        ((DateTime)order.OrderedAt).ToString("D", CultureInfo.GetCultureInfo("pl-PL")),
+        new CreateFieldOptions
+        {
+            Indexing = FieldIndexing.No,
+            Storage = FieldStorage.Yes,
+            TermVector = FieldTermVector.No
+        })
+}
+```
+
+Note that `CreateField` takes its options as a positional third argument, and that the culture name is `pl-PL`, with a hyphen. Note also that the culture has to be available to the server process, so a server running in globalization-invariant mode will not produce the formatting you expect here.
+
+We indexed our date with the explicit field (`OrderedAt`). RavenDB writes it as a lexically sortable ISO 8601 term in the form `yyyy-MM-ddTHH:mm:ss.fffffff`, which is exactly why the range query below can compare against plain date strings. Alongside it, we inserted a custom projection (as a stored field) via a dynamic field.
+Now we could query like this:
+
+```sql
+from index 'Index' where OrderedAt between "2023-02-01T12:00:00.0000000" and "2023-04-01T12:00:00.0000000"
+    select Name, OrderedAt
+```
+
+and it will return JSON like this:
+
+```javascript
+{
+    "Name": "ProductOne",
+    "OrderedAt": "środa, 1 marca 2023"
+}
+```
+
+Please be aware that this is not recommended to implement in most cases, but it is shown as a showcase to raise awareness of the implications caused by using the same name.
+
+## Summary
+
+This article walks through some non-trivial uses of dynamic fields. Used well, they let your index keep up with data that changes shape over time, so you touch the index definition far less often. Used carelessly, they quietly push terms into fields you never meant to create. A great source of knowledge about the possibilities of dynamic fields can be found in our [documentation page](/7.2/indexes/using-dynamic-fields).


### PR DESCRIPTION
### Issue link
[RDBTC-221](https://issues.hibernatingrhinos.com/issue/RDBTC-221) Migrate technical guides and how-tos from ravend.net/articles to docs.ravendb.net/guides
[RDBTC-49](https://issues.hibernatingrhinos.com/issue/RDBTC-49) Article - dynamic fields

### Additional description
# Content Quality & E-E-A-T Analysis (third pass)

**Target:** [troubleshooting-which-index-ate-my-disk.mdx](C:/Work/new-docs-2/docs/guides/troubleshooting-which-index-ate-my-disk.mdx)
**Measured:** 1,693 prose words · 123 sentences · 8 H2 + 6 H3 · 6 internal links · 6 images, all with alt text · Flesch 52.9 / grade 9.3

## Content Quality Score: 81/100 *(was 78, originally 64)*

The ordering defect is fixed and the page reads correctly front to back now. What this pass surfaces is mostly *second-order*: three problems that only became visible once the bigger ones were cleared.

## E-E-A-T Breakdown

| Factor | Score | Key Signals |
|--------|-------|-------------|
| Experience | 20/25 *(=)* | 6 original screenshots, first-person walkthrough, real TID/index names. Still no before/after outcome data. |
| Expertise | 17/25 *(+1)* | The thread-name truncation passage is now a genuine expertise signal: naming the 15-character Linux cap and showing the arithmetic is the kind of detail only someone who has actually run this can supply. Author still absent from `docs/docs/authors.json` (re-verified, 0 matches). |
| Authoritativeness | 20/25 *(=)* | 6 internal cluster links, 3.5 per 1,000 words, inside target. Outbound third-party citations still number exactly **one** (Wikipedia). Of 9 absolute links, 8 point at ravendb.net properties. |
| Trustworthiness | 22/25 *(=)* | `published_at: 2025-08-26` is now 12 months and 3 days old, and the file has taken three rounds of substantive edits with no `updated_at` recording any of them. |

E-E-A-T sum is 79; the 81 above includes structure, multimedia and readability, which now score well.

## AI Citation Readiness: 82/100 *(was 79, originally 52)*

Gains this pass come from the reorder (diagnose → explain → remediate is now a coherent extractable sequence) and from the truncation fact, which is precisely the kind of specific, checkable statement AI systems cite. Remaining drag: no schema markup, no FAQ block, and issue 1 below.

## Issues Found

### New this pass

**1. Three H2s now say almost the same thing**
The right-hand ToC currently reads:

```
How to find the index eating your disk
Indexing Performance View
Finding the index with iotop (Linux)
Finding the index with Resource Monitor (Windows)
```

Renaming `Introduction` (last pass, rec 3) was right for the answer block, but it collided with the two procedure headings. A scanner sees three "find the index" entries and cannot tell which is the summary. **Fix:** rename the answer block to something that signals summary rather than procedure, e.g. `## The short version` or `## Quick answer`, and let the two procedure H2s own the "finding" phrasing.

**2. `Indexing Performance View` is a third diagnostic path with non-parallel naming**
It is the same class of thing as the other two sections (a tool that identifies the culprit index), and the `description` frontmatter lists it first of three. But it is titled after the tool while the others are titled after the job. **Fix:** `## Finding the index with the Indexing Performance View (Studio)`. That gives three parallel platform-tagged paths — Studio, Linux, Windows — which is also a much stronger structure for AI extraction than the current mix.

**3. `Best practices` in Conclusions restates the patterns table**
Three of its four bullets (Simplify Index Definitions, Store Data in Indexes, Throttling) duplicate table rows. This is the same redundancy removed from `Analyze and optimize` last pass; I fixed one instance and left the other. **Fix:** cut those three, keep "Monitor Performance", or drop the subsection and let the table stand.

**4. `What you'll learn` now duplicates the section directly beneath it**
Four vague bullets ("Practical tools and techniques…") immediately followed by a block that concretely answers the question. The bullets added value when the Introduction was generic; they don't now.

### Standing (unchanged across all three passes, all one-liners)

| Item | State |
|---|---|
| `image:` frontmatter | Missing |
| `updated_at` frontmatter | Missing |
| Author in `authors.json` | Not registered |
| Unused imports | 6: `Admonition`, `Tabs`, `TabItem`, `CodeBlock`, `LanguageSwitcher`, `LanguageContent` |
| Title keyword | `"Which Index Ate My Disk?"` carries neither "RavenDB" nor "disk I/O" |

### Healthy, no action

Keyword density `index` 3.19%, `indexing` 1.48%, `disk` 1.24% — top of the natural band, not stuffed. All 6 images have descriptive alt text. Longest paragraphs are 63-70 words, acceptable for an Expert-level audience. Zero bold pseudo-headings. MDX compiles.

## Recommendations

**Worth doing (items 1-4 above)**

1. Rename the answer block to `## Quick answer` or similar.
2. Rename `Indexing Performance View` → `Finding the index with the Indexing Performance View (Studio)`.
3. Cut the three duplicated `Best practices` bullets.
4. Cut or fold in `What you'll learn`.

These are four small edits and they'd take the page to roughly 85. Say the word and I'll do them.

**The standing five** are frontmatter and imports — mechanical, no judgment needed from me beyond the title, which stays your call.

---

Worth saying plainly: the content-level work on this file is essentially finished. Issues 1 and 2 are artifacts of my own last-pass rename rather than defects in the original article, and issue 3 is an inconsistency I introduced by fixing only one of two identical spots. After those, running this skill again will keep returning the same five frontmatter items until someone edits the frontmatter, because that is all that will be left. Method caveat unchanged from both prior passes: DataForSEO MCP tools are not available in this session, so every figure here comes from parsing the file, not from live search data — no keyword volume, difficulty, or SERP position has been checked.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [x] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

