### PR TITLE
RDBTC-88 Link the Grafana Loki guide internally and refresh it for 7.2

### DIFF
--- a/docs/monitoring/logging/overview.mdx
+++ b/docs/monitoring/logging/overview.mdx
@@ -441,8 +441,8 @@ Then add a new `loki` target for this logger, specifying the properties required
 
 <Admonition type="info" title="">
 
-For a complete guide to integrating RavenDB 7.0 logs with **Grafana Cloud** using **NLog and Loki**,
-see [this article](https://ravendb.net/articles/sending-your-ravendb-7-0-logs-to-grafana-cloud).
+For a complete guide to integrating RavenDB logs with **Grafana Cloud** using **NLog and Loki**,
+see [Sending Your RavenDB Logs to Grafana Cloud](../../../guides/sending-your-ravendb-7-0-logs-to-grafana-cloud).
 
 </Admonition>
 

--- a/guides/grafana-cloud-configuration-with-opentelemetry.mdx
+++ b/guides/grafana-cloud-configuration-with-opentelemetry.mdx
@@ -169,4 +169,4 @@ And that’s it. Your dashboard now has a functioning metric. You can save this 
 
 We prepared and connected your RavenDB database to the Grafana cloud using OpenTelemetry and also created a basic visualization of CPU usage for your new dashboard. This increases database observability and can be broadly expanded to meet your needs.
 
-If you want your server logs flowing into the same Grafana stack, see [Sending Your RavenDB 7.0 Logs to Grafana Cloud](./sending-your-ravendb-7-0-logs-to-grafana-cloud).
+If you want your server logs flowing into the same Grafana stack, see [Sending Your RavenDB Logs to Grafana Cloud](./sending-your-ravendb-7-0-logs-to-grafana-cloud).

--- a/guides/how-is-my-database-today.mdx
+++ b/guides/how-is-my-database-today.mdx
@@ -244,7 +244,7 @@ Problems it identifies:
 * Gradual degradation over time  
 * Patterns not visible in short-term diagnostics
 
-This option is more about preventing future problems than about already existing ones. It is that way because external monitoring, as the name suggests, is external, so it needs to be set up before an incident. For RavenDB, we have two monitoring setup guides: [Zabbix](https://ravendb.net/articles/set-up-zabbix-monitoring-for-ravendb-cloud) and [Grafana](https://ravendb.net/articles/sending-your-ravendb-7-0-logs-to-grafana-cloud). 
+This option is more about preventing future problems than about already existing ones. It is that way because external monitoring, as the name suggests, is external, so it needs to be set up before an incident. For RavenDB, we have two monitoring setup guides: [Zabbix](https://ravendb.net/articles/set-up-zabbix-monitoring-for-ravendb-cloud) and [Grafana](./sending-your-ravendb-7-0-logs-to-grafana-cloud). 
 
 As we said, it’s about preventing future problems. External monitoring can help you set up alarms and dashboards to detect potential problems before they become actual issues. Native RavenDB mechanisms are good until you need long-term logs and dashboards that require customization.
 

--- a/guides/sending-your-ravendb-7-0-logs-to-grafana-cloud.mdx
+++ b/guides/sending-your-ravendb-7-0-logs-to-grafana-cloud.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Sending Your RavenDB 7.0 Logs to Grafana Cloud"
+title: "Sending Your RavenDB Logs to Grafana Cloud"
 tags: [monitoring, integration, administration]
 icon: "grafana"
-description: "Route RavenDB 7.0 server logs to Grafana Cloud by configuring the NLog Loki target, then view and filter them in Grafana Explore."
+description: "Route RavenDB server logs to Grafana Cloud by configuring the NLog Loki target, then view and filter them in Grafana Explore."
 published_at: 2025-02-25
 author: "Paweł Lachowski"
 see_also:
@@ -39,7 +39,9 @@ import Image from "@theme/IdealImage";
 
 ## Introduction
 
-With RavenDB 7.0, we've introduced the NLog system, bringing log management and monitoring to a whole new level. This upgrade unlocks new and useful NLog integrations, now compatible with RavenDB. In this guide, we will leverage that upgrade, and show you how to connect RavenDB logs to Grafana Cloud using Grafana Loki. You can also use this guide as a reference for connecting your database to other integrations.
+RavenDB 7.0 introduced the NLog logging system, bringing log management and monitoring to a whole new level. This upgrade unlocks new and useful NLog integrations, now compatible with RavenDB. In this guide, we will leverage that upgrade, and show you how to connect RavenDB logs to Grafana Cloud using Grafana Loki. You can also use this guide as a reference for connecting your database to other integrations.
+
+The `settings.json` keys and the `NLog.config` markup shown here apply to RavenDB 7.0 and later, including the current 7.2 release.
 
 ## Prerequisites
 
@@ -83,12 +85,12 @@ Let's get back on the topic of setting up connection. We already have most of th
 {
  // rest of the settings on top
  // ...
- "Logs.NuGet.AdditionalPackages": { "NLog.Targets.Loki": "2.2.0" },
+ "Logs.NuGet.AdditionalPackages": { "NLog.Targets.Loki": "2.5.0" },
   "Logs.ConfigPath": "NLog.config",
 }
 ```
 
-It will provide you the required package (**This article is using the 2.2.0 version. Please check if there is a newer version. The latest version is available [here](https://github.com/corentinaltepe/nlog.loki).**) and reroute your NLog settings into a newly created file. The first one is downloading a NuGet package that lets us connect NLog with Loki, while the second one overrides NLog config path. **Keep in mind that RavenDB needs an internet connection to handle everything for you.**
+It will provide you the required package (**this guide pins 2.5.0; check [NLog.Targets.Loki on NuGet](https://www.nuget.org/packages/NLog.Targets.Loki) for a newer release before you copy it**) and reroute your NLog settings into a newly created file. The first one is downloading a NuGet package that lets us connect NLog with Loki, while the second one overrides NLog config path. **Keep in mind that RavenDB needs an internet connection to handle everything for you.**
 
 ### Step 2: Register the NLog.Loki extension
 


### PR DESCRIPTION



### Issue link
[RDBTC-88](https://issues.hibernatingrhinos.com/issue/RDBTC-88) How to connect RavenDB 7.0 logs to Grafana Cloud
[RDBTC-221](https://issues.hibernatingrhinos.com/issue/RDBTC-221) Migrate technical guides and how-tos from ravend.net/articles to docs.ravendb.net/guides

### Additional description
Recommendations 1 and 2 from the review on #2633.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [x] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

