### PR TITLE
Update Quill link to point to the current version

### DIFF
--- a/src/theme/Navbar/Logo/index.tsx
+++ b/src/theme/Navbar/Logo/index.tsx
@@ -48,7 +48,7 @@ export default function NavbarLogo(): ReactNode {
             ) : isQuillPath ? (
                 <>
                     <Link
-                        to="https://ravendb.net/quill-beta"
+                        to="https://ravendb.net/quill"
                         aria-label="Quill"
                         className="inline-block !transition-all hover:opacity-75 group"
                     >


### PR DESCRIPTION
Quill should link no longer to `/quill-beta` and use `/quill` instead

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [x] Content - Quill
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

