### PR TITLE
RDoc-3631 Panel headings are missing from TOC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ versions.json                # Active version list
 ## Custom Docusaurus Plugins (`src/plugins/`)
 - `tailwind-config` — registers Tailwind CSS 4 via PostCSS.
 - `recent-guides-plugin` — indexes `guides/*.mdx`, exposes sorted list + tag counts.
+- `remark-panel-headings` — runs as `beforeDefaultRemarkPlugins` on every content instance and hoists `<Panel heading="...">` into a real Markdown heading node, so panel headings reach the compile-time TOC (Docusaurus' `remark/toc` only sees Markdown headings, never JSX props). It also pre-sets the legacy anchor id, which `remark/headings` honours, so existing panel anchors stay valid. Heading ids are a build-time concern: `Panel` just renders the hoisted heading it receives as its first child.
 - `versioned-seo-plugin` — two responsibilities, both running during `postBuild` on the same walk of versioned HTML files:
   - rewrites `<link rel="canonical">` in built HTML to the current-version URL, resolving redirect chains from `scripts/redirects.json`. Legacy-version files get a self-canonical. Verifies every rewritten canonical against the Docusaurus route universe.
   - asserts every legacy-version page carries `<meta name="robots" content="noindex,...">`. The injection itself is delegated to Docusaurus' native per-version `noIndex` config (see `docusaurus.config.ts`); the plugin only audits.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
+import remarkPanelHeadings from "./src/plugins/remark-panel-headings";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { CURRENT_VERSION, ACTIVE_VERSIONS, LEGACY_VERSIONS } = require("./scripts/lib/version-policy.js") as {
     CURRENT_VERSION: string;
@@ -97,6 +98,7 @@ const config: Config = {
             {
                 docs: {
                     sidebarPath: "sidebars.ts",
+                    beforeDefaultRemarkPlugins: [remarkPanelHeadings],
                     routeBasePath: "/",
                     includeCurrentVersion: true,
                     lastVersion: "current",
@@ -129,6 +131,7 @@ const config: Config = {
             "content-docs",
             {
                 id: "cloud",
+                beforeDefaultRemarkPlugins: [remarkPanelHeadings],
                 path: "cloud",
                 routeBasePath: "cloud",
                 sidebarPath: require.resolve("./sidebarsCloud.js"),
@@ -139,6 +142,7 @@ const config: Config = {
             "content-docs",
             {
                 id: "quill",
+                beforeDefaultRemarkPlugins: [remarkPanelHeadings],
                 path: "quill",
                 routeBasePath: "quill",
                 sidebarPath: require.resolve("./sidebarsQuill.js"),
@@ -149,6 +153,7 @@ const config: Config = {
             "content-docs",
             {
                 id: "guides",
+                beforeDefaultRemarkPlugins: [remarkPanelHeadings],
                 path: "guides",
                 routeBasePath: "guides",
                 sidebarPath: require.resolve("./sidebarsGuides.js"),
@@ -159,6 +164,7 @@ const config: Config = {
             "content-docs",
             {
                 id: "templates",
+                beforeDefaultRemarkPlugins: [remarkPanelHeadings],
                 path: "templates",
                 routeBasePath: "templates",
                 sidebarPath: require.resolve("./sidebarsTemplates.js"),
@@ -169,6 +175,7 @@ const config: Config = {
             "content-docs",
             {
                 id: "samples",
+                beforeDefaultRemarkPlugins: [remarkPanelHeadings],
                 path: "samples",
                 routeBasePath: "samples",
                 sidebarPath: require.resolve("./sidebarsSamples.js"),

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,29 +1,29 @@
 import clsx from "clsx";
 import React from "react";
-import Heading from "@theme/Heading";
 
 export type PanelProps = {
     children: React.ReactNode;
     className?: string;
     flush?: boolean;
-    heading: string;
-    headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+    /** Set by the remark-panel-headings plugin: the heading arrives as the first child. */
+    headingInContent?: boolean;
 };
 
+function splitHeadingFromBody(children: React.ReactNode): [React.ReactNode, React.ReactNode] {
+    const [first, ...rest] = React.Children.toArray(children);
+    return React.isValidElement(first) ? [first, rest] : [null, children];
+}
+
 export function Panel(props: PanelProps) {
-    const { children, className, flush, heading, headingLevel = 2 } = props;
-    const headingTag = `h${headingLevel}` as any;
-    const id = heading
-        .toLowerCase()
-        .replace(/[^\w]+/g, "-")
-        .replace(/^-|-$/g, "");
+    const { children, className, flush, headingInContent } = props;
+    const [heading, body]: [React.ReactNode, React.ReactNode] = headingInContent
+        ? splitHeadingFromBody(children)
+        : [null, children];
 
     return (
         <section className={clsx("panel", flush ? "" : "my-4", className)}>
-            <Heading as={headingTag} id={id} className="panel__heading">
-                {heading}
-            </Heading>
-            <div className="panel__body">{children}</div>
+            {heading}
+            <div className="panel__body">{body}</div>
         </section>
     );
 }

--- a/src/plugins/remark-panel-headings/__tests__/remark-panel-headings.test.ts
+++ b/src/plugins/remark-panel-headings/__tests__/remark-panel-headings.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import remarkPanelHeadings, { type MdastNode } from "../index";
+
+type Attribute = NonNullable<MdastNode["attributes"]>[number];
+
+function attribute(name: string, value: Attribute["value"] = null): Attribute {
+    return { type: "mdxJsxAttribute", name, value };
+}
+
+function expression(source: string): Attribute["value"] {
+    return { value: source };
+}
+
+function panel(attributes: Attribute[], children: MdastNode[] = []): MdastNode {
+    return { type: "mdxJsxFlowElement", name: "Panel", attributes, children };
+}
+
+function paragraph(text: string): MdastNode {
+    return { type: "paragraph", children: [{ type: "text", value: text }] };
+}
+
+function runPlugin(...children: MdastNode[]): MdastNode {
+    const root: MdastNode = { type: "root", children };
+    remarkPanelHeadings()(root, { path: "test.mdx" });
+    return root;
+}
+
+function captureWarnings(run: () => void): string[] {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message: string) => warnings.push(message);
+    try {
+        run();
+    } finally {
+        console.warn = originalWarn;
+    }
+    return warnings;
+}
+
+describe("remark-panel-headings", () => {
+    it("hoists the heading prop into a Markdown heading with the legacy anchor id", () => {
+        const root = runPlugin(panel([attribute("heading", "Sample data")], [paragraph("body")]));
+
+        const [hoisted] = root.children!;
+        assert.deepEqual(hoisted.attributes, [attribute("headingInContent")]);
+        assert.deepEqual(hoisted.children, [
+            {
+                type: "heading",
+                depth: 2,
+                children: [{ type: "text", value: "Sample data" }],
+                data: { hProperties: { id: "sample-data", className: "panel__heading" } },
+            },
+            paragraph("body"),
+        ]);
+    });
+
+    it("keeps ids that github-slugger would rewrite", () => {
+        const root = runPlugin(panel([attribute("heading", "Define the connection string - from Studio")]));
+
+        assert.equal(root.children![0].children![0].data!.hProperties!.id, "define-the-connection-string-from-studio");
+    });
+
+    it("honours headingLevel, written as an expression or as a string", () => {
+        const root = runPlugin(
+            panel([attribute("heading", "Expression"), attribute("headingLevel", expression("3"))]),
+            panel([attribute("heading", "String"), attribute("headingLevel", "4")]),
+            panel([attribute("heading", "Out of range"), attribute("headingLevel", "9")])
+        );
+
+        assert.deepEqual(
+            root.children!.map((node) => node.children![0].depth),
+            [3, 4, 2]
+        );
+    });
+
+    it("hoists nested panels and leaves other components alone", () => {
+        const root = runPlugin(
+            {
+                type: "mdxJsxFlowElement",
+                name: "Admonition",
+                attributes: [],
+                children: [panel([attribute("heading", "Nested")])],
+            },
+            {
+                type: "mdxJsxFlowElement",
+                name: "ContentFrame",
+                attributes: [attribute("heading", "Not a panel")],
+                children: [],
+            }
+        );
+
+        assert.equal(root.children![0].children![0].children![0].data!.hProperties!.id, "nested");
+        assert.deepEqual(root.children![1].children, []);
+        assert.deepEqual(root.children![1].attributes, [attribute("heading", "Not a panel")]);
+    });
+
+    it("warns and leaves the panel alone when the heading cannot become an anchor", () => {
+        let root: MdastNode;
+        const warnings = captureWarnings(() => {
+            root = runPlugin(
+                panel([attribute("heading", expression("title"))]),
+                panel([attribute("heading", "   ")]),
+                panel([attribute("heading", "***")])
+            );
+        });
+
+        assert.equal(warnings.length, 3);
+        assert.match(warnings[0], /test\.mdx/);
+        for (const node of root!.children!) {
+            assert.deepEqual(node.children, []);
+            assert.equal(
+                node.attributes!.some(({ name }) => name === "headingInContent"),
+                false
+            );
+        }
+    });
+
+    it("leaves a panel without a heading untouched", () => {
+        const root = runPlugin(panel([attribute("flush")], [paragraph("body")]));
+
+        assert.deepEqual(root.children![0].attributes, [attribute("flush")]);
+        assert.deepEqual(root.children![0].children, [paragraph("body")]);
+    });
+
+    it("is idempotent", () => {
+        const root = runPlugin(panel([attribute("heading", "Syntax")], [paragraph("body")]));
+        remarkPanelHeadings()(root, { path: "test.mdx" });
+
+        assert.equal(root.children![0].children!.length, 2);
+        assert.deepEqual(root.children![0].attributes, [attribute("headingInContent")]);
+    });
+});

--- a/src/plugins/remark-panel-headings/index.ts
+++ b/src/plugins/remark-panel-headings/index.ts
@@ -1,0 +1,95 @@
+// Docusaurus builds the TOC at MDX compile time from Markdown heading nodes only, never from JSX
+// props, so <Panel heading="..."> never reached it (RDoc-3631). Registered as a
+// beforeDefaultRemarkPlugins entry, so the default headings/toc plugins see an ordinary heading.
+// Hand-rolled walk: unist-util-visit is only a transitive Docusaurus dependency.
+
+type MdxAttributeExpression = { value?: string };
+
+type JsxAttribute = {
+    type: string;
+    name?: string;
+    value?: string | MdxAttributeExpression | null;
+};
+
+export type MdastNode = {
+    type: string;
+    name?: string | null;
+    attributes?: JsxAttribute[];
+    children?: MdastNode[];
+    depth?: number;
+    value?: string;
+    data?: { hProperties?: Record<string, unknown> };
+};
+
+const DEFAULT_HEADING_DEPTH = 2;
+
+export default function remarkPanelHeadings() {
+    return (root: MdastNode, file?: { path?: string }) => {
+        const filePath = file?.path ?? "unknown file";
+        forEachPanel(root, (panel) => hoistHeadingIntoContent(panel, filePath));
+    };
+}
+
+function forEachPanel(node: MdastNode, visitPanel: (panel: MdastNode) => void): void {
+    for (const child of node.children ?? []) {
+        if (child.type === "mdxJsxFlowElement" && child.name === "Panel") {
+            visitPanel(child);
+        }
+        forEachPanel(child, visitPanel);
+    }
+}
+
+function hoistHeadingIntoContent(panel: MdastNode, filePath: string): void {
+    const attributes = panel.attributes ?? [];
+    const headingAttribute = attributes.find(({ name }) => name === "heading");
+    if (!headingAttribute) {
+        return;
+    }
+
+    const text = plainString(headingAttribute.value).trim();
+    const anchorId = panelAnchorId(text);
+    if (!anchorId) {
+        console.warn(
+            `[remark-panel-headings] ${filePath}: a <Panel> heading is not a plain string that can become an anchor, so it will neither render nor reach the TOC.`
+        );
+        return;
+    }
+
+    panel.attributes = [
+        ...attributes.filter((attribute) => attribute !== headingAttribute),
+        { type: "mdxJsxAttribute", name: "headingInContent", value: null },
+    ];
+    panel.children = [markdownHeading(text, anchorId, headingDepth(attributes)), ...(panel.children ?? [])];
+}
+
+function markdownHeading(text: string, anchorId: string, depth: number): MdastNode {
+    return {
+        type: "heading",
+        depth,
+        children: [{ type: "text", value: text }],
+        data: { hProperties: { id: anchorId, className: "panel__heading" } },
+    };
+}
+
+// Identical to the id the component used to compute at render time, so that live anchors keep
+// working: github-slugger, which Docusaurus would otherwise apply, rewrites 175 of them.
+function panelAnchorId(heading: string): string {
+    return heading
+        .toLowerCase()
+        .replace(/[^\w]+/g, "-")
+        .replace(/^-|-$/g, "");
+}
+
+function headingDepth(attributes: JsxAttribute[]): number {
+    const value = attributes.find(({ name }) => name === "headingLevel")?.value;
+    const depth = Number.parseInt(plainString(value) || expressionSource(value), 10);
+    return depth >= 1 && depth <= 6 ? depth : DEFAULT_HEADING_DEPTH;
+}
+
+function plainString(value: JsxAttribute["value"]): string {
+    return typeof value === "string" ? value : "";
+}
+
+function expressionSource(value: JsxAttribute["value"]): string {
+    return typeof value === "string" ? "" : (value?.value ?? "");
+}

--- a/src/theme/DocItem/TOC/useFilteredToc.ts
+++ b/src/theme/DocItem/TOC/useFilteredToc.ts
@@ -11,6 +11,9 @@ import { useEffect, useState } from "react";
 //
 // Docusaurus team has an open issue for this problem:
 // https://github.com/facebook/docusaurus/issues/6201
+//
+// Panel headings reach this TOC only because src/plugins/remark-panel-headings hoists them into
+// real Markdown headings at build time.
 
 export default function useFilteredToc(originalToc: readonly TOCItem[]): readonly TOCItem[] {
     const language = useLanguage();

--- a/templates/frames.mdx
+++ b/templates/frames.mdx
@@ -109,7 +109,7 @@ Use `headingLevel` (1–6) to control the semantic level. Default is 2.
   Content...
 </Panel>
 
-The heading renders via `@theme/Heading`, so it automatically gets the anchor link. The id is generated from the `heading` text.
+The `heading` prop is hoisted into a real Markdown heading at build time, so it gets the anchor link and appears in the right-hand "In this article" TOC. The id is generated from the `heading` text.
 
 ### Flush variant (removes the outer vertical margin)
 ```mdx
@@ -216,7 +216,7 @@ Keep the heading hierarchy consistent using `headingLevel` to preserve a correct
 
 | Prop         | Type                      | Default | Description                                                            |
 | ------------ | ------------------------- | ------- | ---------------------------------------------------------------------- |
-| heading      | string                    | —       | Panel heading text. Used to generate the anchor id (slug).             |
+| heading      | string                    | —       | Panel heading text. Becomes a real heading: anchor id (slug) + TOC entry. |
 | headingLevel | 1 \| 2 \| 3 \| 4 \| 5 \| 6 | 2       | Semantic level of the heading (`h1`..`h6`).                             |
 | children     | React.ReactNode           | —       | Content placed inside the panel body.                                   |
 | className    | string                    | —       | Additional classes for custom styling.                       |


### PR DESCRIPTION

### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-3631

### Additional description

Docusaurus builds the "In this article" list at compile time and only looks at Markdown headings. `<Panel heading="...">` is a JSX prop, so panel headings were invisible to it. On 70 current-version pages that box was completely empty, and on the rest the panel sections were missing while their subheadings showed up flat, with no hint of which panel they belonged to.

 A new `remark-panel-headings` plugin turns the prop into a real Markdown heading before Docusaurus collects the TOC, and `Panel` renders that heading instead of the prop. The rendered markup and CSS are identical to before, so panels look exactly the same.

The plugin assigns the id itself, reusing the rule the component used at render time. Every panel link that works today keeps working; letting Docusaurus' slugger recompute the ids would have changed a lot of live anchors.


Before vs After

<img width="1417" height="777" alt="image" src="https://github.com/user-attachments/assets/67ed5bf7-be70-46f8-bfca-a0b11036ce18" />
<img width="1368" height="849" alt="image" src="https://github.com/user-attachments/assets/2702cc54-926f-43ef-ad79-e51e5c9c0ff5" />


### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [ ] Content - guides
- [ ] Content - start pages/other
- [x] New docs feature (consider updating `/templates` or readme) 
- [x] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [ ] No changes in UX/UI
- [x] Changes in UX/UI (include screenshots and description)
