### PR TITLE
RDoc-4091 Agentic Documentation & RDoc-4100

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ src/
   pages/                     # Custom standalone pages
   theme/                     # Docusaurus theme overrides
 scripts/                     # Build/deploy automation
+static/skills/ravendb/       # Agent skill served verbatim at /skills/ravendb/
 static/icons/                # SVG icon assets (source for icon type generation)
 sidebars.ts                  # Main docs sidebar config
 sidebarsCloud.js             # Cloud docs sidebar
@@ -71,6 +72,15 @@ versions.json                # Active version list
   - Both checks fail the build under `DOCUSAURUS_STRICT_SEO=true`. Registered **after** all `content-docs` instances so HTML is already emitted when it runs.
 
 Noindex for legacy versions is set declaratively in `docusaurus.config.ts` (`versions[v].noIndex: true`); template pages are marked `unlisted: true` in frontmatter. No custom plugin writes the meta tag — the versioned-seo-plugin only verifies it landed.
+
+---
+
+## Hosted Agent Skill
+
+`static/skills/ravendb/` is served verbatim at `/skills/ravendb/SKILL.md`, outside the version
+prefix. `SKILL.md` links to `references/` with relative paths, so moving or flattening the tree
+breaks navigation, and `md` must stay in `staticAssetRegex` in `scripts/handle_redirects.js` or
+these URLs 301 to a versioned path that does not exist.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,23 @@ these URLs 301 to a versioned path that does not exist.
 
 ---
 
+## CloudFront Configuration as Code
+
+Three pieces of CloudFront config are versioned here and do not travel with the S3 upload, so a
+local build never exercises them. `deploy.ps1` phase 3 pushes all three:
+
+| Source | Pushed by | Identifier |
+|---|---|---|
+| `scripts/redirects.json` | `Update-CloudFrontKVS` in `deploy.ps1` | `$env:KVS_ARN` |
+| `scripts/handle_redirects.js` | `scripts/sync-edge-function.ps1` | `-EdgeFunctionName` |
+| `scripts/lib/csp-policy.js` | `scripts/sync-csp.ps1` | `-ResponseHeadersPolicyId` |
+
+Both AWS APIs replace the whole config, so both sync scripts re-send it verbatim and verify
+afterwards: the response headers policy also holds CORS and HSTS, and the function config holds
+the KVS binding. `-Check` reports drift without writing, for CI.
+
+---
+
 ## Content Authoring
 
 ### File Format

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -14,7 +14,12 @@ Prerequisites
   `AWS_DEFAULT_REGION` (and optional `AWS_SESSION_TOKEN`)
 * Environment variable **`WHATS_NEW_URL`** set (only required when regenerating
   *What's New* for specific versions)
+* Environment variable **`KVS_ARN`** set (CloudFront KeyValueStore holding the
+  redirect table)
 * Project `package.json` includes `@docusaurus/core` and `@docusaurus/cli`
+
+Phase 3 also pushes the CloudFront config kept in this repo: the redirect table,
+the viewer-request function and the CSP. See CLAUDE.md.
 
 Example
 -------
@@ -25,6 +30,8 @@ $env:WHATS_NEW_URL = 'https://whats.new.api/v1/docs'
 pwsh deploy.ps1 \
      -S3BucketName my-docs-bucket \
      -CloudFrontDistributionId ABCD1234 \
+     -EdgeFunctionName <function> \
+     -ResponseHeadersPolicyId <policy-id> \
      -Versions "6.0,6.2,7.0,7.1,8.0"
 ```
 ------------------------------------------------------------------------------!#>
@@ -37,6 +44,12 @@ param(
     [Parameter(HelpMessage = 'CloudFront distribution ID to invalidate (optional)')]
     [string]$CloudFrontDistributionId,
 
+    [Parameter(HelpMessage = 'CloudFront function name for handle_redirects.js. Defaults to $env:EDGE_FUNCTION_NAME. Skipped when neither is set.')]
+    [string]$EdgeFunctionName = $env:EDGE_FUNCTION_NAME,
+
+    [Parameter(HelpMessage = 'CloudFront response headers policy ID carrying the CSP. Defaults to $env:RESPONSE_HEADERS_POLICY_ID. Skipped when neither is set.')]
+    [string]$ResponseHeadersPolicyId = $env:RESPONSE_HEADERS_POLICY_ID,
+
     [Parameter(HelpMessage = "Comma-separated versions to regenerate Whats New for e.g. '6.0,6.2,7.0'")]
     [string]$Versions = "",
 
@@ -46,6 +59,8 @@ param(
 
 $PythonWhatsNewPath = Join-Path $PSScriptRoot 'build_whats_new.py'
 $RedirectsFilePath = Join-Path $PSScriptRoot 'redirects.json'
+$SyncEdgeFunctionPath = Join-Path $PSScriptRoot 'sync-edge-function.ps1'
+$SyncCspPath = Join-Path $PSScriptRoot 'sync-csp.ps1'
 
 function ThrowIfEmpty {
     param (
@@ -156,6 +171,25 @@ function Update-CloudFrontKVS {
     }
 }
 
+# Neither script gets -CloudFrontDistributionId: the invalidation below covers all three. Both are
+# no-ops when the live config already matches, and are skipped when their identifier is absent so a
+# local deploy needs no CloudFront write access.
+function Sync-CloudFrontConfig {
+    if ($EdgeFunctionName) {
+        & $SyncEdgeFunctionPath -FunctionName $EdgeFunctionName -DryRun:$DryRun
+        if ($LASTEXITCODE) { throw "sync-edge-function.ps1 failed (exit $LASTEXITCODE)" }
+    } else {
+        Write-Host '  edge function: skipped, no EDGE_FUNCTION_NAME' -ForegroundColor Yellow
+    }
+
+    if ($ResponseHeadersPolicyId) {
+        & $SyncCspPath -ResponseHeadersPolicyId $ResponseHeadersPolicyId -DryRun:$DryRun
+        if ($LASTEXITCODE) { throw "sync-csp.ps1 failed (exit $LASTEXITCODE)" }
+    } else {
+        Write-Host '  CSP: skipped, no RESPONSE_HEADERS_POLICY_ID' -ForegroundColor Yellow
+    }
+}
+
 Ensure-Dependencies
 
 ThrowIfEmpty $Env:AWS_ACCESS_KEY_ID     'AWS_ACCESS_KEY_ID not set'
@@ -192,7 +226,7 @@ if ($empty) {
 }
 
 if ($DryRun) {
-    Write-Host "Dry run mode enabled. Skipping sync to s3://$S3BucketName/, CloudFront KeyValueStore update and CloudFront invalidation." -ForegroundColor Yellow
+    Write-Host "Dry run mode enabled. Skipping sync to s3://$S3BucketName/, CloudFront KeyValueStore update, edge function publish, CSP push and CloudFront invalidation." -ForegroundColor Yellow
 } else {
 
     Write-Host "Syncing to s3://$S3BucketName/ ..." -ForegroundColor Cyan
@@ -217,10 +251,14 @@ if ($DryRun) {
         --delete
     if ($LASTEXITCODE) { throw 'aws s3 sync (static files) failed' }
 
-    # Phase 3 — invalidate CloudFront so every edge location fetches the new
-    # index.html, which references the new hashed asset filenames
+    # Phase 3: push the CloudFront configuration that lives in this repo, then
+    # invalidate so every edge location fetches the new index.html, which
+    # references the new hashed asset filenames
     Write-Host "Updating CloudFront KeyValueStore" -ForegroundColor Cyan
     Update-CloudFrontKVS
+
+    Write-Host 'Syncing CloudFront configuration' -ForegroundColor Cyan
+    Sync-CloudFrontConfig
 
     if ($CloudFrontDistributionId) {
         Write-Host "Invalidating CloudFront distribution $CloudFrontDistributionId" -ForegroundColor Cyan

--- a/scripts/handle_redirects.js
+++ b/scripts/handle_redirects.js
@@ -23,8 +23,10 @@ const kvsHandle = cf.kvs();
 
 const defaultVersion = CURRENT_VERSION;
 
+// `md` is listed so the hosted agent skill under /skills/**.md reaches S3 instead of being
+// version-prefixed into a path that does not exist.
 const staticAssetRegex =
-    /\.(html|css|js|json|jpg|jpeg|png|gif|webp|svg|ico|ttf|otf|woff|woff2|eot|mp4|mp3|webm|avi|mov|pdf|txt|xml)$/i;
+    /\.(html|css|js|json|jpg|jpeg|png|gif|webp|svg|ico|ttf|otf|woff|woff2|eot|mp4|mp3|webm|avi|mov|pdf|txt|xml|md)$/i;
 
 const versionRegex = /^\/(\d+\.\d+)(\/.*)?/;
 

--- a/scripts/lib/cloudfront-common.ps1
+++ b/scripts/lib/cloudfront-common.ps1
@@ -1,0 +1,112 @@
+# Shared by sync-csp.ps1 and sync-edge-function.ps1.
+
+# CloudFront limits: CSP header value, and function code size.
+$script:MaxCspBytes = 1783
+$script:MaxFunctionBytes = 10240
+
+function Assert-CloudFrontPrerequisites {
+    foreach ($cmd in 'aws') {
+        if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) { throw "$cmd not found in PATH" }
+    }
+    foreach ($name in 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_DEFAULT_REGION') {
+        if (-not (Get-Item -Path Env:$name -ErrorAction SilentlyContinue).Value) { throw "$name not set" }
+    }
+}
+
+# Nested config shapes (KeyValueStoreAssociations, SecurityHeadersConfig) do not survive CLI
+# shorthand, so they are passed by file reference. Caller removes the file.
+function New-CloudFrontArgumentFile {
+    param(
+        [Parameter(Mandatory)] [string]$Content,
+        [string]$Extension = 'json'
+    )
+    $path = Join-Path ([IO.Path]::GetTempPath()) "cf-arg-$([guid]::NewGuid()).$Extension"
+    Set-Content -Path $path -Value $Content -Encoding utf8 -NoNewline
+    return $path
+}
+
+# Config is applied per request, but a response already in the edge cache keeps the headers and the
+# redirect it was stored with. deploy.ps1 runs its own single invalidation and skips this.
+function Invoke-CloudFrontInvalidation {
+    param([Parameter(Mandatory)] [string]$DistributionId)
+
+    Write-Host "Invalidating CloudFront distribution $DistributionId" -ForegroundColor Cyan
+    aws cloudfront create-invalidation --distribution-id $DistributionId --paths '/*' | Out-Null
+    if ($LASTEXITCODE) { throw 'CloudFront invalidation failed' }
+}
+
+# Paths where $Candidate differs from $Reference: node kind, array length, added or dropped
+# property, or scalar value. Proves a patch touched only the field it meant to.
+function Get-JsonDifference {
+    param(
+        [AllowNull()] $Reference,
+        [AllowNull()] $Candidate,
+        [string]$Path = ''
+    )
+
+    $here = if ($Path) { $Path } else { '(root)' }
+
+    $refNull = $null -eq $Reference
+    $canNull = $null -eq $Candidate
+    if ($refNull -or $canNull) {
+        if ($refNull -ne $canNull) { return @("$here : $(if ($refNull) { 'added' } else { 'removed' })") }
+        return @()
+    }
+
+    $refArr = $Reference -is [System.Collections.IEnumerable] -and $Reference -isnot [string]
+    $canArr = $Candidate -is [System.Collections.IEnumerable] -and $Candidate -isnot [string]
+    if ($refArr -ne $canArr) { return @("$here : kind changed (array vs scalar/object)") }
+
+    if ($refArr) {
+        $r = @($Reference); $c = @($Candidate)
+        if ($r.Count -ne $c.Count) { return @("$here : array length $($r.Count) -> $($c.Count)") }
+        $out = @()
+        for ($i = 0; $i -lt $r.Count; $i++) {
+            $out += Get-JsonDifference -Reference $r[$i] -Candidate $c[$i] -Path "$here[$i]"
+        }
+        return $out
+    }
+
+    $refObj = $Reference -is [System.Management.Automation.PSCustomObject]
+    $canObj = $Candidate -is [System.Management.Automation.PSCustomObject]
+    if ($refObj -ne $canObj) { return @("$here : kind changed (object vs scalar)") }
+
+    if ($refObj) {
+        $out = @()
+        $names = @($Reference.PSObject.Properties.Name) + @($Candidate.PSObject.Properties.Name) | Select-Object -Unique
+        foreach ($n in $names) {
+            $childPath = if ($Path) { "$Path.$n" } else { $n }
+            $out += Get-JsonDifference -Reference $Reference.$n -Candidate $Candidate.$n -Path $childPath
+        }
+        return $out
+    }
+
+    if ("$Reference" -cne "$Candidate") { return @("$here : value changed") }
+    return @()
+}
+
+# True when live already matches the repo. Line endings normalised so a CRLF checkout is not drift.
+function Compare-CloudFrontValue {
+    param(
+        [AllowNull()] [string]$Live,
+        [Parameter(Mandatory)] [string]$Local,
+        [string]$Noun = 'value'
+    )
+
+    $normalise = { param($s) if ($null -eq $s) { '' } else { ($s -replace "`r`n", "`n").Trim() } }
+    if ((& $normalise $Live) -eq (& $normalise $Local)) {
+        Write-Host "CloudFront already serves this $Noun. Nothing to do." -ForegroundColor Green
+        return $true
+    }
+
+    if ($null -eq $Live) {
+        Write-Host '  live: nothing published yet' -ForegroundColor DarkGray
+    } elseif ($Live.Length -lt 400 -and $Local.Length -lt 400) {
+        Write-Host "  live: $Live" -ForegroundColor DarkGray
+        Write-Host "  repo: $Local" -ForegroundColor Gray
+    } else {
+        Write-Host "  live: $($Live.Length) chars" -ForegroundColor DarkGray
+        Write-Host "  repo: $($Local.Length) chars" -ForegroundColor Gray
+    }
+    return $false
+}

--- a/scripts/lib/csp-policy.js
+++ b/scripts/lib/csp-policy.js
@@ -1,0 +1,172 @@
+/**
+ * Content-Security-Policy for docs.ravendb.net, pushed by scripts/sync-csp.ps1.
+ *
+ * Served by the CloudFront response headers policy, not by Docusaurus, so a local build never
+ * exercises it and a blocked tag only shows up as a console violation in production.
+ *
+ * Every host is justified by a tag that runs on the site: the GTM-TDH4JWF2 container, the Reo
+ * snippet in docusaurus.config.ts, and Algolia DocSearch. Several container tags are Custom HTML,
+ * i.e. arbitrary JavaScript published from the GTM console, and default-src carries
+ * 'unsafe-inline', so this policy constrains which hosts a tag can reach, not what it does to the
+ * page. Treat the allowlist as an inventory, not a sandbox, and update it in the same change that
+ * touches the container.
+ *
+ * Gotchas: `*.example.com` does not match the apex `example.com`; an absent directive falls back
+ * to default-src, which carries no third-party hosts; and a host source with no scheme does not
+ * cover a wss: URL in Chrome, even on an https document.
+ *
+ * CommonJS for cross-consumer interop.
+ */
+
+// Directive order is preserved in the emitted header, so keep related directives adjacent for
+// readability in the CloudFront console.
+const CSP_DIRECTIVES = {
+    // Site's own bundles. 'unsafe-inline'/'unsafe-eval' are inherited by
+    // script-src-attr and style-src: Docusaurus emits an inline theme bootstrap and
+    // GTM evaluates its container at runtime.
+    "default-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+
+    // Tracking pixels are images from arbitrary ad hosts. Enumerating them is not
+    // practical and an image is a low-value sink.
+    "img-src": ["'self'", "data:", "*"],
+
+    // <script src> elements. Anything missing here is a tag that never runs.
+    "script-src-elem": [
+        "'self'",
+        "'unsafe-inline'",
+        // Google Tag Manager loader + GA4 + the Google tag
+        "www.googletagmanager.com",
+        // Google Ads conversion tracking (conversion_async.js)
+        "www.googleadservices.com",
+        // Google Ads remarketing
+        "pagead2.googlesyndication.com",
+        // Google Ads view-through conversion pings, injected as <script> by the Google
+        // tag. The conversion tags raise script-src-elem violations without it.
+        "*.g.doubleclick.net",
+        // Google tag "taggy" agent (cross-domain conversion measurement)
+        "cct.google",
+        // CookieYes CMP: script.js, which in turn loads banner.js
+        "cdn-cookieyes.com",
+        // Meta Pixel: fbevents.js
+        "connect.facebook.net",
+        // Meta CAPI parameter builder, injected by the Meta Pixel template
+        "capi-automation.s3.us-east-2.amazonaws.com",
+        // Reo.dev (snippet lives in docusaurus.config.ts headTags)
+        "static.reo.dev",
+        // LinkedIn Insight Tag: insight.min.js
+        "snap.licdn.com",
+        // X/Twitter pixel: uwt.js
+        "static.ads-twitter.com",
+        // Reddit pixel: pixel.js
+        "www.redditstatic.com",
+        // Zoho SalesIQ chat widget and Marketing Automation, both Custom HTML tags.
+        // The widget URL is only a loader; its bundle comes from zohocdn.com, a
+        // separate registrable domain that the zoho.com wildcard does NOT cover.
+        "*.zoho.com",
+        "*.zohostatic.com",
+        "*.zohocdn.com",
+        // Common Room signals.js (Custom HTML tag, visitor identification)
+        "*.cr-relay.com",
+        // InfoQ beacon.min.js (Custom HTML tag, paid-placement measurement)
+        "*.infoq.com",
+    ],
+
+    // fetch / XHR / sendBeacon. This is where measurement hits actually land, so a
+    // gap here silently drops data rather than breaking a page.
+    "connect-src": [
+        "'self'",
+        // Algolia DocSearch. The client falls back from <appid>-dsn.algolia.net to
+        // <appid>-{1,2,3}.algolianet.com on error, so both apexes are needed.
+        "*.algolia.net",
+        "*.algolianet.com",
+        // GTM container fetches
+        "*.googletagmanager.com",
+        // GA4 collect (www. and region1. hosts)
+        "*.google-analytics.com",
+        // Google signals. The apex is a separate host from the wildcard.
+        "analytics.google.com",
+        "*.analytics.google.com",
+        // Google Ads / Floodlight measurement
+        "*.g.doubleclick.net",
+        "ad.doubleclick.net",
+        "pagead2.googlesyndication.com",
+        "ade.googlesyndication.com",
+        // Google Ads user lists, enhanced conversions, conversion linker
+        "www.google.com",
+        "www.googleadservices.com",
+        "adservice.google.com",
+        "cct.google",
+        // CookieYes: config/translation JSON, consent log, and the geo-IP lookup the
+        // banner awaits before it renders.
+        "cdn-cookieyes.com",
+        "log.cookieyes.com",
+        "directory.cookieyes.com",
+        // Meta Pixel event delivery
+        "connect.facebook.net",
+        "www.facebook.com",
+        // Reo.dev ingestion
+        "*.reo.dev",
+        // LinkedIn Insight Tag conversion beacons
+        "px.ads.linkedin.com",
+        "*.linkedin.com",
+        // X/Twitter pixel event delivery
+        "analytics.twitter.com",
+        "t.co",
+        // Reddit pixel event delivery
+        "*.reddit.com",
+        "*.redditstatic.com",
+        // Zoho SalesIQ. The chat holds a long-lived socket, which connect-src governs
+        // for ws:/wss: as well as fetch.
+        "*.zoho.com",
+        "*.zohopublic.com",
+        "*.zohostatic.com",
+        "*.zohocdn.com",
+        // SalesIQ's visitor-tracking socket (vts.zohopublic.com/watchws). A host
+        // source with no scheme does NOT cover a wss: URL in Chrome, even on an https
+        // document, so the socket needs its own scheme-qualified entry. Listing only
+        // `*.zohopublic.com` gets the connection refused with a connect-src violation.
+        "wss://*.zoho.com",
+        "wss://*.zohopublic.com",
+        // Common Room signal ingestion
+        "*.cr-relay.com",
+        // InfoQ beacon delivery
+        "*.infoq.com",
+    ],
+
+    // Iframes injected by tags: the GTM <noscript> fallback and the cookie-sync
+    // frames Google Ads remarketing and Meta drop after a conversion.
+    "frame-src": [
+        "'self'",
+        "www.googletagmanager.com",
+        "*.g.doubleclick.net",
+        "td.doubleclick.net",
+        "www.google.com",
+        "www.facebook.com",
+        // Zoho SalesIQ renders the chat panel in an iframe
+        "*.zoho.com",
+    ],
+
+    // Stylesheets, fonts and workers pulled in by third-party widgets (Zoho SalesIQ
+    // is the main one). These sinks are deliberately permissive: the controls that
+    // matter are script-src-elem and connect-src, and pinning every vendor's asset
+    // CDN buys little while guaranteeing console noise the next time one of them
+    // moves a file.
+    "style-src": ["'self'", "'unsafe-inline'", "*"],
+
+    "font-src": ["'self'", "data:", "*"],
+
+    "worker-src": ["'self'", "blob:"],
+};
+
+function buildCspHeader(directives = CSP_DIRECTIVES) {
+    return Object.entries(directives)
+        .map(([name, sources]) => `${name} ${sources.join(" ")}`)
+        .join("; ");
+}
+
+module.exports = { CSP_DIRECTIVES, buildCspHeader };
+
+// Runnable directly: `node scripts/lib/csp-policy.js` prints the header value.
+if (require.main === module) {
+    console.log(buildCspHeader());
+}

--- a/scripts/sync-csp.ps1
+++ b/scripts/sync-csp.ps1
@@ -1,0 +1,119 @@
+# Writes scripts/lib/csp-policy.js into the CloudFront response headers policy that serves the CSP
+# for docs.ravendb.net. Deploying the site cannot change it. Called by deploy.ps1 phase 3;
+# -Check reports drift without writing, for CI, and -Print renders the header without AWS access.
+#
+#   pwsh scripts/sync-csp.ps1 -ResponseHeadersPolicyId <id> [-Check] [-DryRun]
+#   pwsh scripts/sync-csp.ps1 -Print
+
+[CmdletBinding()]
+param(
+    [Parameter(HelpMessage = 'CloudFront response headers policy ID. Required unless -Print.')]
+    [string]$ResponseHeadersPolicyId,
+
+    [Parameter(HelpMessage = 'CloudFront distribution ID to invalidate (optional)')]
+    [string]$CloudFrontDistributionId,
+
+    [Parameter(HelpMessage = 'Report drift and exit non-zero. Writes nothing.')]
+    [switch]$Check,
+
+    [Parameter(HelpMessage = 'Print the header built from csp-policy.js and exit.')]
+    [switch]$Print,
+
+    [Parameter(HelpMessage = 'Print the diff without writing.')]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/cloudfront-common.ps1')
+
+$CspPolicyPath = Join-Path $PSScriptRoot 'lib/csp-policy.js'
+if (-not (Test-Path $CspPolicyPath)) { throw "CSP source not found: $CspPolicyPath" }
+if (-not (Get-Command 'node' -ErrorAction SilentlyContinue)) { throw 'node not found in PATH' }
+
+$csp = (& node $CspPolicyPath | Out-String).Trim()
+if ($LASTEXITCODE -or -not $csp) { throw "Failed to render the CSP from $CspPolicyPath" }
+if ($csp -notmatch '^[a-z-]+ ') { throw "$CspPolicyPath did not print a directive" }
+if ($csp.Length -gt $script:MaxCspBytes) {
+    throw "CSP is $($csp.Length) chars; CloudFront caps it at $script:MaxCspBytes"
+}
+
+if ($Print) {
+    Write-Output $csp
+    return
+}
+if (-not $ResponseHeadersPolicyId) { throw 'ResponseHeadersPolicyId is required unless -Print is used' }
+
+Assert-CloudFrontPrerequisites
+
+Write-Host "Reading response headers policy $ResponseHeadersPolicyId" -ForegroundColor Cyan
+$current = aws cloudfront get-response-headers-policy --id $ResponseHeadersPolicyId | ConvertFrom-Json
+if ($LASTEXITCODE) { throw 'aws get-response-headers-policy failed' }
+
+$etag = $current.ETag
+$config = $current.ResponseHeadersPolicy.ResponseHeadersPolicyConfig
+
+if (Compare-CloudFrontValue -Live $config.SecurityHeadersConfig.ContentSecurityPolicy.ContentSecurityPolicy -Local $csp -Noun 'policy') { return }
+
+if ($Check) {
+    Write-Error "The live CSP does not match $CspFilePath. Run without -Check to push it."
+    exit 1
+}
+
+# update-response-headers-policy replaces the whole config, and this policy also carries CORS with
+# a per-environment origin plus HSTS at a one-year max-age. So the patch is proved to touch one
+# field before writing, and the policy is read back after. Losing HSTS here would not surface until
+# someone reported a broken page.
+$CspPath = 'SecurityHeadersConfig.ContentSecurityPolicy'
+$before = $config | ConvertTo-Json -Depth 30 -Compress | ConvertFrom-Json
+
+if (-not $config.SecurityHeadersConfig) {
+    $config | Add-Member -NotePropertyName SecurityHeadersConfig -NotePropertyValue ([pscustomobject]@{}) -Force
+}
+$config.SecurityHeadersConfig | Add-Member -NotePropertyName ContentSecurityPolicy -NotePropertyValue ([pscustomobject]@{
+        Override              = $true
+        ContentSecurityPolicy = $csp
+    }) -Force
+
+$payload = $config | ConvertTo-Json -Depth 30 -Compress
+$diffs = @(Get-JsonDifference -Reference $before -Candidate ($payload | ConvertFrom-Json))
+$unexpected = @($diffs | Where-Object { $_ -notlike "$CspPath*" })
+
+foreach ($d in $diffs) {
+    Write-Host "  $d" -ForegroundColor $(if ($d -like "$CspPath*") { 'Gray' } else { 'Red' })
+}
+if ($unexpected.Count) {
+    throw "Refusing to write: $($unexpected.Count) field(s) outside the CSP would change. $($unexpected -join '; ')"
+}
+
+if ($DryRun) {
+    Write-Host 'Dry run. Skipping the CloudFront update.' -ForegroundColor Yellow
+    return
+}
+
+$configPath = New-CloudFrontArgumentFile -Content $payload
+try {
+    Write-Host 'Updating the response headers policy' -ForegroundColor Cyan
+    aws cloudfront update-response-headers-policy `
+        --id $ResponseHeadersPolicyId `
+        --if-match $etag `
+        --response-headers-policy-config "file://$configPath" | Out-Null
+    if ($LASTEXITCODE) { throw 'aws update-response-headers-policy failed' }
+} finally {
+    Remove-Item -Path $configPath -Force -ErrorAction SilentlyContinue
+}
+
+$reread = aws cloudfront get-response-headers-policy --id $ResponseHeadersPolicyId | ConvertFrom-Json
+if ($LASTEXITCODE) { throw 'aws get-response-headers-policy failed on re-read' }
+
+$now = $reread.ResponseHeadersPolicy.ResponseHeadersPolicyConfig | ConvertTo-Json -Depth 30 -Compress | ConvertFrom-Json
+$postDiffs = @(Get-JsonDifference -Reference $before -Candidate $now | Where-Object { $_ -notlike "$CspPath*" })
+if ($postDiffs.Count) {
+    throw "The policy changed outside the CSP: $($postDiffs -join '; '). Restore the affected headers from the CloudFront console."
+}
+if ($now.SecurityHeadersConfig.ContentSecurityPolicy.ContentSecurityPolicy -cne $csp) {
+    throw 'The CSP does not read back as written.'
+}
+
+if ($CloudFrontDistributionId) { Invoke-CloudFrontInvalidation -DistributionId $CloudFrontDistributionId }
+
+Write-Host 'CSP updated.' -ForegroundColor Green

--- a/scripts/sync-edge-function.ps1
+++ b/scripts/sync-edge-function.ps1
@@ -1,0 +1,86 @@
+# Publishes scripts/handle_redirects.js to the CloudFront function that runs on viewer-request.
+# Deploying the site does not touch it, so an edit there has no effect until this runs: the site
+# deploys cleanly while the edge keeps behaving like the previous release. Called by deploy.ps1
+# phase 3; -Check reports drift without writing, for CI.
+#
+#   pwsh scripts/sync-edge-function.ps1 -FunctionName <function> [-Check] [-DryRun]
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, HelpMessage = 'CloudFront function name')]
+    [string]$FunctionName,
+
+    [Parameter(HelpMessage = 'CloudFront distribution ID to invalidate (optional)')]
+    [string]$CloudFrontDistributionId,
+
+    [Parameter(HelpMessage = 'Report drift and exit non-zero. Writes nothing.')]
+    [switch]$Check,
+
+    [Parameter(HelpMessage = 'Print the diff without writing.')]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/cloudfront-common.ps1')
+
+$FunctionSourcePath = Join-Path $PSScriptRoot 'handle_redirects.js'
+if (-not (Test-Path $FunctionSourcePath)) { throw "Function source not found: $FunctionSourcePath" }
+
+Assert-CloudFrontPrerequisites
+
+$localBytes = (Get-Item $FunctionSourcePath).Length
+if ($localBytes -gt $script:MaxFunctionBytes) {
+    throw "handle_redirects.js is $localBytes bytes; CloudFront caps function code at $script:MaxFunctionBytes"
+}
+
+Write-Host "Reading function $FunctionName" -ForegroundColor Cyan
+$described = aws cloudfront describe-function --name $FunctionName --stage DEVELOPMENT | ConvertFrom-Json
+if ($LASTEXITCODE) { throw 'aws describe-function failed' }
+
+$etag = $described.ETag
+# update-function replaces the whole FunctionConfig, so it is re-sent verbatim. Dropping
+# KeyValueStoreAssociations would leave cf.kvs() unbound and break every redirect at runtime.
+$config = $described.FunctionSummary.FunctionConfig
+
+$livePath = Join-Path ([IO.Path]::GetTempPath()) "cf-live-fn-$([guid]::NewGuid()).js"
+try {
+    aws cloudfront get-function --name $FunctionName --stage LIVE $livePath | Out-Null
+    $liveCode = if ($LASTEXITCODE -eq 0) { Get-Content -Path $livePath -Raw } else { $null }
+} finally {
+    Remove-Item -Path $livePath -Force -ErrorAction SilentlyContinue
+}
+
+$localCode = Get-Content -Path $FunctionSourcePath -Raw
+if (Compare-CloudFrontValue -Live $liveCode -Local $localCode -Noun 'function') { return }
+
+if ($Check) {
+    Write-Error "The live function does not match $FunctionSourcePath. Run without -Check to publish it."
+    exit 1
+}
+if ($DryRun) {
+    Write-Host 'Dry run. Skipping the update and publish.' -ForegroundColor Yellow
+    return
+}
+
+# fileb:// because the code is sent as a binary blob.
+$configPath = New-CloudFrontArgumentFile -Content ($config | ConvertTo-Json -Depth 30 -Compress)
+try {
+    Write-Host 'Updating the function (DEVELOPMENT stage)' -ForegroundColor Cyan
+    $newEtag = aws cloudfront update-function `
+        --name $FunctionName `
+        --if-match $etag `
+        --function-code "fileb://$FunctionSourcePath" `
+        --function-config "file://$configPath" `
+        --query 'ETag' --output text
+    if ($LASTEXITCODE -or -not $newEtag) { throw 'aws update-function failed' }
+
+    Write-Host 'Publishing to LIVE' -ForegroundColor Cyan
+    aws cloudfront publish-function --name $FunctionName --if-match $newEtag | Out-Null
+    if ($LASTEXITCODE) { throw 'aws publish-function failed' }
+} finally {
+    Remove-Item -Path $configPath -Force -ErrorAction SilentlyContinue
+}
+
+if ($CloudFrontDistributionId) { Invoke-CloudFrontInvalidation -DistributionId $CloudFrontDistributionId }
+
+Write-Host 'Edge function published.' -ForegroundColor Green

--- a/static/skills/ravendb/README.md
+++ b/static/skills/ravendb/README.md
@@ -1,0 +1,41 @@
+# `ravendb` — agent skill
+
+RavenDB knowledge for coding agents: install a server, model documents, write client code (Node.js, .NET, Python), write RQL and indexes, use vector search and AI agents.
+
+## Install
+
+```bash
+npx skills add ravendb/skills --skill ravendb
+```
+
+Or copy this directory into the agent's skills path — `~/.claude/skills/` or `.claude/skills/` (Claude Code), `~/.cursor/skills/` or `.agents/skills/` (Cursor).
+
+## Shape
+
+`SKILL.md` is a router, not a manual: the agent reads it, picks the ONE topic file its task needs, and opens only that. Nothing but the front-matter description is in context until a RavenDB task shows up.
+
+```
+SKILL.md                    router — language table, topic table, version/license gate
+references/
+  install.md                find a server first, docker, database, version + licensing
+  install-native.md         download, extract, service, per-OS commands
+  license.md                free key request form, activation call, verification
+  windows.md                PowerShell probes, rvn windows-service, WSL2, firewall
+  structure.md              store singleton, startup order, session per unit of work
+  modeling.md               collections, ids, embed vs reference, metadata
+  http-api.md               docs / queries / bulk_docs over raw HTTP
+  ai-agents.md              agent configs + conversation endpoints (7.1+)
+  testing.md                route choice, staleness flakes, what to test, CI
+  diagnostics.md            wrong results, broken index, slow server, exceptions, logs
+  samples.md                official sample apps and what each one showcases
+  rql-*.md                  cheatsheet, reference, functions, fulltext, facets,
+                            advanced (suggest/MLT/vector), spatial, timeseries
+  nodejs/ dotnet/ python/   client.md · indexes.md · operations.md · testing.md ·
+                            ai-agents.md
+```
+
+Server baseline is **6.2+**. Version- and license-gated features carry an inline `(7.0+)` / `(license)` mark in the file that documents them, and the router requires three checks before using one: server version (`GET /build/version`), the client version pinned in the project, and `GET /license/status`.
+
+## Maintaining it
+
+Content is verified against the real client repos and a tri-language sample app, never written from recall — the same rule the skill imposes on its readers. When a client API changes, fix the language file; when RQL changes, fix the `rql-*.md` file. Adding a topic means adding a row to the router table in `SKILL.md`, otherwise the agent never finds it.

--- a/static/skills/ravendb/SKILL.md
+++ b/static/skills/ravendb/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: ravendb
+description: Read this before writing any RavenDB query, client call or /databases/ request. Covers server setup, document modelling, the Node.js, .NET and Python clients, RQL, indexes, vector search and AI agents. Code written from recall tends to run and return the wrong rows, because RQL resembles SQL and the clients take field names as plain strings.
+license: MIT
+metadata:
+  author: ravendb
+  version: "1.0.0"
+---
+
+# RavenDB
+
+RavenDB is a transactional (ACID) document database: JSON documents in collections, queries in RQL served by indexes that are always maintained, with a client library per language.
+
+**Your recall of RavenDB is stale. Do not write RQL, client code, or endpoint shapes from memory.**
+
+**Before you write any query, do both of these:**
+
+1. **Read `references/rql-cheatsheet.md`.** Every query, every time, including ones that look obvious. RQL resembles SQL closely enough that a query written from memory usually parses and then returns the wrong rows.
+2. **If the query names a static index, read that index off the server first:** `GET /databases/<db>/indexes?name=<index>`. `?name=` is a query string, so `/indexes/<index>` is not a route and returns `RouteNotFoundException`. The definition names the fields the index holds and which are analyzed, which decides whether `=` or `search()` matches. An index cannot answer on a field it does not hold.
+
+Then route from the tables below to the one further file your task needs and follow its syntax exactly. Read only what the tables route you to; unrouted files waste context. Use ravendb.net/docs only if no file covers it.
+
+**Find out what the database is before you write to it.** `GET /databases` reports an `Environment` per database:
+`Production`, `Testing`, `Development` or `None`. A server-wide default can be set separately, readable at
+`GET /configuration/studio` (404 when unset); a database does not inherit it, so check both. `None` is not an answer:
+it means nobody declared it, or that the server cannot declare it at all, since setting this is licensed and every
+database on a server whose `GET /license/status` reports `HasStudioConfiguration: false` reads `None` whatever it
+actually holds. Ask the user which it is, and never infer it from the database name.
+
+**Treat every write as a production write until you have an answer that says otherwise.** Reading is fine. Everything
+else needs the user to agree to that specific operation on that specific database. The test is not whether an
+operation appears in a list, it is whether the effect outlives your task: does it change state that was there before
+you started, or change behaviour for anyone but you? Either one, and you name the operation and the database it lands
+on, then stop.
+
+In RavenDB that catches more than it first looks like. Writing to or deleting a document that already exists. `update`
+or `delete` by query. Deleting or resetting an index. Hard-deleting a database. Expiration and refresh, which delete
+documents on a schedule. A revisions configuration, which rewrites history that is already there. A data subscription,
+and any other edit to the database record, which every client of that database sees and which can consume a licensed
+slot. Being told to build a feature is not agreement to run it against real data, and a connection string is not
+agreement either. To check your own work, write your own document or your own database and use that, never an existing
+one.
+
+## Getting a server
+
+**Before you write any connection code, do these three:**
+
+1. **Find the server the user already has.** Never assume `localhost:8080`, and never install RavenDB unasked. If more
+   than one server is running, ask which to use.
+2. **Confirm it answers and identify it.** `GET /build/version` for the version, `GET /databases` for the databases and each one's `Environment`.
+3. **Check the licence.** `GET /license/status`. Warn the user if unlicensed: such a server rejects some operations
+   outright and reports `HasStudioConfiguration: false`, which makes every database read back as `Environment: None`.
+
+`references/install.md` has the full discovery protocol and the version and licensing steps.
+
+| You need to… | Read |
+|---|---|
+| Find an existing server, or install one after asking: Docker, health check, create a database, server/client version check, license check, free Developer license | `references/install.md` |
+| Obtain and register a license: the free-key request form, activation, verification. Only **after** `install.md`'s license check has run and the user has agreed | `references/license.md` |
+| Install without Docker: download, extract, run as a service | `references/install-native.md` |
+| **Anything on Windows**: PowerShell probes, Docker Desktop, `rvn windows-service`, WSL2 port rules, firewall | `references/windows.md` |
+| Connect to a secured or Cloud server (`https://`, client certificate) | the "Secured server" section of your language's `client.md` |
+
+## Client code
+
+**Pick one language directory, then open exactly one file from it. Do not read the others.**
+
+| Target language | Directory |
+|---|---|
+| JavaScript / Node.js (`ravendb` npm) | `references/nodejs/` |
+| C# / .NET (`RavenDB.Client` NuGet) | `references/dotnet/` |
+| Python (`ravendb` pip) | `references/python/` |
+
+Every directory holds the same five files:
+
+| File | When your change involves… |
+|---|---|
+| `client.md` | store setup, sessions, CRUD, basic querying, includes, bulk insert |
+| `indexes.md` | static indexes, map-reduce, `LoadDocument`, full-text, vector search, waiting out staleness |
+| `operations.md` | creating/deleting a database in code, subscriptions, patching, attachments/counters/time-series/revisions, optimistic concurrency and cluster-wide transactions, facet/suggest/spatial query calls |
+| `testing.md` | test driver or database-per-test suite in that language, and the runtime it needs. Read `references/testing.md` first to pick the route |
+| `ai-agents.md` | the client's AI-agent wrapper |
+
+Writing a query is different: it always starts at the cheatsheet below, whichever language you are in.
+
+## Writing a query
+
+**Always start at `references/rql-cheatsheet.md`:** clause order, `where`/`select`/`group by`/paging, and the SQL
+habits that silently return wrong rows. Open one of these after it, only if your query needs it:
+
+| Your query needs… | Read |
+|---|---|
+| How querying works: dynamic vs named index, auto-indexes, staleness, parameters | `references/rql-reference.md` |
+| The exact signature of one method (`id` `exists` `regex` `startsWith` …) | `references/rql-functions.md` |
+| Full-text: `search` `boost` `fuzzy` `proximity` | `references/rql-fulltext.md` |
+| Facets, `avg`/`min`/`max` over a collection | `references/rql-facets.md` |
+| `suggest` `morelikethis` `highlight` `vector.search` (7.0+) | `references/rql-advanced.md` |
+| Spatial: `spatial.within` `circle` `wkt` distance | `references/rql-spatial.md` |
+| Time series query syntax | `references/rql-timeseries.md` |
+
+**Aggregation routes three ways, so pick one before reading.** Ad-hoc aggregate: `group by`, in `rql-cheatsheet.md`.
+Faceted breakdown of a filtered result set: `rql-facets.md`. Precomputed or large: map-reduce, in your language's
+`indexes.md`. `group by` is rejected on a named index; use a collection, or an index that is already map-reduce.
+
+## Everything else
+
+| You want… | Read |
+|---|---|
+| Wiring a codebase: store singleton, deploy indexes at startup, session per unit of work, where query code lives | `references/structure.md` |
+| Document shape: collections, ids, embed vs reference, `@metadata`, change vector | `references/modeling.md` |
+| AI agents (7.1+, license): concepts and the conversation HTTP surface | `references/ai-agents.md`, then your language's `ai-agents.md` |
+| Raw HTTP: `GET /docs`, `POST /queries`, `POST /bulk_docs`, index definitions, create database | `references/http-api.md` |
+| Can this deployment run a marked feature: server version, client package version, license | `references/version-gate.md` |
+| Testing: which route, staleness flakes, what to test, CI. Read before your language's `testing.md` | `references/testing.md` |
+| Something is wrong: empty or wrong results, broken or lagging index, slow server, an unfamiliar exception, logs | `references/diagnostics.md` |
+| A working app to copy: official sample apps per feature, minimal starters, client test suites, playground servers | `references/samples.md` |
+
+Files inside `references/` cross-link to each other with relative paths. Follow those links; they are part of the routing.
+
+Not covered here, so go to ravendb.net/docs or ask the user: sharding, backup/restore, ETL and external replication, production monitoring and SNMP, encryption at rest, cluster topology changes.
+
+## Version & license gate
+
+Baseline server is **6.2+**; older versions are out of support, so ignore them. Features above the baseline carry an
+inline mark where they are documented: `(7.0+)` or `(7.1+)` is a **server** requirement, `(client 7.2.2+)` names a
+**client package** version, and `(license)` means the license decides. Before writing code against a marked feature,
+run the matching check in `references/version-gate.md`.

--- a/static/skills/ravendb/references/ai-agents.md
+++ b/static/skills/ravendb/references/ai-agents.md
@@ -1,0 +1,58 @@
+# RavenDB AI Agents (7.1+)
+
+How to define an AI agent in RavenDB and run conversations with it — concepts and HTTP surface; client-library wrappers live in your language's directory (`nodejs/ai-agents.md`, `dotnet/ai-agents.md`, `python/ai-agents.md`).
+
+## Concepts
+
+| Piece | What it is |
+|---|---|
+| AI connection string | Named config pointing at one model provider (`type: "Ai"`, `modelType: "Chat"`). Exactly one of: `openAiSettings`, `azureOpenAiSettings`, `ollamaSettings`, `googleSettings`, `mistralAiSettings`, `huggingFaceSettings`, `vertexSettings`, `embeddedSettings`. |
+| Agent configuration | Server-stored: `name`, `connectionStringName`, `systemPrompt`, output shape (`sampleObject` or `outputSchema`), `parameters`, `queries`, `actions`, optional `subAgents`, `chatTrimming`, `maxModelIterationsPerCall`. Creating returns an `identifier` — use it for all later calls. |
+| Parameters | Values the caller must supply when opening a conversation; referenced by the agent's queries (`$param`). `sendToModel: false` hides a value from the LLM while queries can still use it. |
+| Queries | RQL the *server* runs when the model asks (database-side tools): `{ name, description, query, parametersSampleObject | parametersSchema }`. |
+| Actions | Client-side tools: the model calls them, *your app* computes the result and sends it back. Same shape minus `query`. |
+| Conversation | A document (id like `chats/dealadvisor/`... or `prefix|` for server-generated id) holding chat state; each run returns a `changeVector` for optimistic concurrency. |
+
+Requires v7.1 or later (endpoints absent in 7.0). **License-gated** (`HasAiAgent`) — verify with `GET /license/status` before use; a disabled license reports the feature unavailable. Embeddings generation is separately gated (`HasEmbeddingsGeneration`), as is GenAI (`HasGenAi`).
+
+**Agents are server-side objects: the connection string and every agent configuration must be PUT to the server, not just written into app code.** The run endpoint 404s on an agent that was never created. A stub model provider is fine for tests (`embeddedSettings` or a stub connection string), but it still has to exist on the server.
+
+Before inventing provider settings, look for a working connection string already on the server with the right `modelType` and provider — `GET /databases` for the names, then `GET /databases/{db}/admin/connection-strings` — and mirror it.
+
+## HTTP endpoints
+
+| Route | Verb | Purpose |
+|---|---|---|
+| `/databases/{db}/admin/connection-strings` | PUT | Store the AI connection string |
+| `/databases/{db}/admin/ai/agent` | PUT | Create/update agent (body = agent configuration); returns `{ Identifier, RaftCommandIndex }` |
+| `/databases/{db}/admin/ai/agent?agentId={id}` | GET / DELETE | Read (`{ AiAgents: [...] }`) / delete |
+| `/databases/{db}/ai/agent?conversationId={cid}&agentId={id}[&changeVector=..][&streaming=true&streamPropertyPath=..]` | POST | Run one conversation turn |
+
+Run-turn body / response:
+
+```json
+{ "UserPrompt": [{ "Type": "text", "Text": "..." }],
+  "ActionResponses": [{ "ToolId": "...", "Content": "json string" }],
+  "ArtificialActions": null,
+  "CreationOptions": { "Parameters": { "clientId": { "Value": "clients/1-A", "SendToModel": true } },
+                       "ExpirationInSec": null, "MaxModelIterationsPerCall": null } }
+```
+
+```json
+{ "ConversationId": "...", "ChangeVector": "...",
+  "Response": { "your output schema": "..." },
+  "ActionRequests": [{ "Name": "...", "ToolId": "...", "Arguments": "json string" }],
+  "Usage": {}, "TotalUsage": {}, "Elapsed": "00:00:02" }
+```
+
+`ActionRequests` non-empty means: run each action, POST again with matching `ActionResponses` and no new prompt. With `streaming=true` the response is line-delimited: JSON-string chunks of the streamed property, then one final `{...}` result object.
+
+## Embeddings + vector search (brief) — server 7.0+, embeddings generation license-gated (`HasEmbeddingsGeneration`)
+
+Same `AiConnectionString` with `modelType: "TextEmbeddings"` feeds an embeddings-generation task (`AddEmbeddingsGenerationOperation`, PUT `/databases/{db}/admin/etl`): `{ EtlType: "EmbeddingsGeneration", name, identifier, connectionStringName, collection, embeddingsPathConfigurations, quantization, chunkingOptionsForQuerying }`. Over raw HTTP the `EtlType` discriminator is mandatory — omit it and the PUT fails with `"ETL configuration must have EtlType field"`, and a wrong value gives `"Unknown ETL type"`. `"GenAi"` is a **different** feature on the same endpoint with its own licence flag (`HasGenAi`), so a 402 naming Gen AI means you sent the wrong type, not that embeddings generation is unavailable — that one is `HasEmbeddingsGeneration`. Query with RQL:
+
+```
+from "Deals" where vector.search(embedding.text(Summary, ai.task('deals-embeddings')), $q)
+```
+
+Working applications built on this surface — agents with sub-agents, GenAI tasks, streaming, conversation storage — are listed in [samples.md](samples.md); `samples-fit` and `samples-verity` are the deepest.

--- a/static/skills/ravendb/references/diagnostics.md
+++ b/static/skills/ravendb/references/diagnostics.md
@@ -1,0 +1,74 @@
+# Diagnosing a RavenDB problem
+
+Symptom → the one thing to look at. Every endpoint here is a plain `GET` on the server URL unless marked; `{db}` is the database name. Studio exposes all of it visually, but the endpoints work headlessly and in CI.
+
+## "The query returns nothing / the wrong rows"
+
+| Question | Check |
+|---|---|
+| Which index served it, and why that one? | `GET /databases/{db}/queries?query=<rql>&debug=explain` — returns the candidate indexes with the reason each was picked or rejected. **Dynamic queries only**: on `from index 'X'` it throws `InvalidOperationException: Explain can only work on dynamic indexes`, and the index is already named anyway |
+| What did the index actually store for these documents? | `GET /databases/{db}/queries?query=<rql>&debug=entries` — the raw index entries, not the documents. **Drop the `where` clause first**: entries are filtered by the same predicate, so the query that returns nothing also returns no entries. Fields you expected but do not see in the unfiltered entries were never indexed |
+| Which terms exist for a field? | `GET /databases/{db}/indexes/terms?name=<index>&field=<field>` — the answer to most "why doesn't `where` match" questions on an analyzed field |
+| Where did the time go? | Client-side `.Timings(out var timings)` (or `include timings()` in RQL) breaks the query into optimizer/retriever/query stages |
+| Is the result stale? | Every query response carries `IsStale` and `IndexTimestamp`; `GET /databases/{db}/indexes/staleness?name=<index>` asks directly |
+
+Field names are the literal stored JSON property names, and an analyzed (`Search`) field matches analyzed terms, not the exact string — those two account for most empty result sets. `debug=entries` distinguishes them in one call.
+
+The same field can be analyzed in one index and exact in another, so `where Field = 'Some Value'` legitimately returns nothing on a static index while the identical predicate works as a dynamic query against the collection (the auto-index indexes it exact unless full-text was asked for). That is not a contradiction and not a bug: use `search(Field, '…')` against the analyzed one. `indexes/terms` on each index shows which is which.
+
+## "The index is broken / never finishes"
+
+| Check | Endpoint |
+|---|---|
+| Errors per index (map/reduce exceptions, with document ids) | `GET /databases/{db}/indexes/errors` |
+| State, priority, indexed/errored counts, last indexing time | `GET /databases/{db}/indexes/stats` |
+| How far behind, and on which collection | `GET /databases/{db}/indexes/progress` |
+| Per-batch timings — which stage is slow | `GET /databases/{db}/indexes/performance` (`/performance/live` streams) |
+| The definition the server actually has | `GET /databases/{db}/indexes?name=<index>`, or `/indexes/source` for the compiled source |
+| Did my deploy change anything? | `POST /databases/{db}/indexes/has-changed` with the definition — a no-op deploy is not the problem |
+
+`ErrorsCount` and `State` are separate questions: a map that throws on a few documents leaves the index `Normal` and still indexing everything else. It flips to `Error` only when the map failure rate passes **15%** over at least 6 attempts, or when every attempt so far has failed — so a handful of poison documents in a large collection shows up as a rising `ErrorsCount`, never as a state change. Check both. An index in state `Error` stops indexing entirely; fix the map and redeploy, which rebuilds side-by-side. A single poison document usually shows up as a repeated error with the same id — patch or delete it. `GET /databases/{db}/indexes/suggest-index-merge` proposes consolidating near-duplicate indexes, which is the fix for "too many auto indexes".
+
+## "It's slow" / "it stopped responding"
+
+| Check | Endpoint |
+|---|---|
+| Queries running right now (with their RQL and duration) | `GET /databases/{db}/debug/queries/running` — kill one with `POST /databases/{db}/debug/queries/kill?id=<id>` using the id from that listing |
+| Database counts, index count, size on disk | `GET /databases/{db}/stats` (`/stats/essential` is cheaper, `/stats/detailed` adds identity and compare-exchange counts). Per-collection document counts and sizes are a different endpoint: `GET /databases/{db}/collections/stats/detailed` |
+| Disk I/O behavior over time | `GET /databases/{db}/debug/io-metrics` |
+| Storage layout and space per tree | `GET /databases/{db}/debug/storage/report` |
+| Oversized documents driving the cost | `GET /databases/{db}/debug/documents/huge` — documents seen over `PerformanceHints.Documents.HugeDocumentSizeInMb` (default 5 MB). It lists only what has been *read* since the server started, so it is empty on a fresh process. The threshold is the **stored** size, which for repetitive text is far below the JSON you sent — check one document with `GET /databases/{db}/docs/size?id=<id>` (`ActualSize`) before concluding the endpoint is broken |
+| Everything at once, for a support ticket | `GET /databases/{db}/debug/info-package` — a zip of the whole diagnostic set; attach this rather than pasting fragments |
+
+Cluster-level health lives at `GET /cluster/topology` and `GET /admin/cluster/log`; a node that is `Passive` or a cluster with no leader fails writes while reads keep working.
+
+## Exceptions and what they actually mean
+
+| Exception | Meaning | Response |
+|---|---|---|
+| `ConcurrencyException` | change-vector mismatch under optimistic concurrency, or a duplicate id on `store` | reload and retry, or drop optimistic concurrency for that path |
+| `ClusterTransactionConcurrencyException` | compare-exchange index moved under a cluster-wide transaction | retry the whole transaction; it is the expected outcome of a lost race |
+| `DocumentDoesNotExistException` | a patch/attachment op targeted a missing document (`Load` returns `null` instead) | check the id shape — `clients/1-A`, not `clients/1` |
+| `IndexDoesNotExistException` | query names an index that was never deployed | deploy indexes at startup, not on demand |
+| `InvalidQueryException` | the RQL is rejected by the server | read the message; it names the clause |
+| `DatabaseDoesNotExistException` | the store's `Database` does not exist on that server | create it explicitly, don't assume the server auto-creates |
+| `AllTopologyNodesDownException` | no node reachable — wrong URL/port, server down, or TLS refused | probe the URL as in `install.md`; with a certificate check the scheme is `https` |
+| `AuthorizationException` / 403 | the certificate is valid but not authorized for that database | check the certificate's database permissions |
+| `LicenseLimitException` | the feature or resource is beyond the license | `GET /license/status` and see `install.md` |
+| `IndexCompilationException` | the index definition does not compile server-side | the message carries the compiler error |
+| `NotSupportedInCoraxException` | the index uses a Lucene-only capability | rewrite it, or pin that index to Lucene |
+| `RavenTimeoutException` | server did not answer within the configured timeout | usually a slow query or a stale-wait, not a network fault |
+| `BulkInsertAbortedException` | the server ended the bulk-insert stream | look at the inner exception; the real error is there |
+
+Per-language shapes: .NET throws these as classes under `Raven.Client.Exceptions` (all deriving from `RavenException`). Python raises them from `ravendb.exceptions.exceptions`, and the missing-document one is spelled `DocumentDoesNotExistsException`. **Node.js has no exception classes** — every failure is a plain `Error` whose `name` is set to the string above, so branch on `err.name === "ConcurrencyException"`; `instanceof` cannot work.
+
+## Server-side logs
+
+Logs go to the configured `Logs.Path` (Docker image: `/var/log/ravendb/logs`; `docker logs <container>` for startup failures). Raise verbosity without a restart:
+
+```bash
+curl -s -X POST http://localhost:8080/admin/logs/configuration \
+  -H 'Content-Type: application/json' -d '{"Logs":{"MinLevel":"Debug"},"Persist":false}'
+```
+
+Lower it again afterwards — debug logging is expensive. `Persist: true` survives a restart. `GET /admin/logs/configuration` reads the current setting, `GET /admin/logs/watch` is a websocket tail, `GET /admin/logs/download` a zip. Startup problems (port in use, bad certificate, unaccepted EULA) only ever appear in stdout/`docker logs`, never in the HTTP API, because the server never got far enough to serve it.

--- a/static/skills/ravendb/references/dotnet/ai-agents.md
+++ b/static/skills/ravendb/references/dotnet/ai-agents.md
@@ -1,0 +1,109 @@
+# AI Agents from .NET (client 7.2+; sub-agents client 7.2.2+)
+
+The C# client wraps the AI-agent HTTP surface under `store.AI` (`AiOperations`) — prefer it over raw HTTP. Concepts, endpoint shapes, and embeddings setup: `../ai-agents.md`.
+
+## Connection string
+
+```csharp
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+
+await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(
+    new AiConnectionString
+    {
+        Name = "open-ai-chat",
+        ModelType = AiModelType.Chat,
+        OpenAiSettings = new OpenAiSettings(apiKey, "https://api.openai.com/v1", "gpt-4.1")
+    }));
+```
+
+Exactly one settings property may be set: `OpenAiSettings`, `AzureOpenAiSettings`, `OllamaSettings`, `EmbeddedSettings`, `GoogleSettings`, `HuggingFaceSettings`, `MistralAiSettings`, `VertexSettings`.
+
+## Define the agent
+
+```csharp
+using Raven.Client.Documents.Operations.AI.Agents;
+
+public class AnswerSchema
+{
+    public string Answer = "Answer to the user question";
+    public List<string> RelevantDealIds = ["Deal ids relevant to the answer"];
+}
+
+var agent = new AiAgentConfiguration("deal advisor", "open-ai-chat",
+    "You are a deal advisor. When discussing deals, include their ids.");
+
+agent.Parameters.Add(new AiAgentParameter("clientId", "Client document id"));
+agent.Queries =
+[
+    new AiAgentToolQuery
+    {
+        Name = "ClientDeals",
+        Description = "Open deals for the current client",
+        Query = "from Deals where ClientId == $clientId",
+        ParametersSampleObject = "{}"
+    }
+];
+agent.Actions =
+[
+    new AiAgentToolAction("SendQuote", "Send a quote to the client")
+    {
+        ParametersSampleObject = "{\"amount\": 100}"
+    }
+];
+
+var agentId = (await store.AI.CreateAgentAsync(agent, new AnswerSchema())).Identifier;
+```
+
+- The `sampleObject` argument serializes into the agent's output schema; every `RunAsync<T>` answer deserializes into that type. Alternatively set `agent.SampleObject` / `agent.OutputSchema` (JSON strings) and call `CreateAgentAsync(agent)`.
+- `new AiAgentParameter(name, description, sendToModel: false)` hides a sensitive value from the model while queries still use it.
+- Also on `AiOperations`: `GetAgentAsync(id)`, `GetAgentsAsync()`, `DeleteAgentAsync(id)`, `ForDatabase(name)`; sync twins of everything exist.
+- Extras on `AiAgentConfiguration`: `SubAgents`, `ChatTrimming`, `MaxModelIterationsPerCall`, `Disabled`. A sub-agent's action surfaces to your code as `"subAgentName/ActionName"`.
+
+## Converse
+
+```csharp
+using Raven.Client.Documents.AI;
+
+var chat = store.AI.Conversation(agentId, "chats/deals/",
+    new AiConversationCreationOptions().AddParameter("clientId", "clients/1-A"));
+
+chat.SetUserPrompt("Summarize this client's open deals and recommend next steps.");
+chat.Handle<SendQuoteArgs, SendQuoteResult>("SendQuote",
+    async args => new SendQuoteResult { Sent = true });
+
+var answer = await chat.RunAsync<AnswerSchema>();
+// answer.Status == AiConversationResult.Done; answer.Answer is a typed AnswerSchema
+// answer.Usage (tokens), answer.Elapsed; chat.Id, chat.ChangeVector
+
+chat.SetUserPrompt("What about pricing?");   // follow-up turn, same conversation document
+answer = await chat.RunAsync<AnswerSchema>();
+```
+
+- `RunAsync` loops model↔tool calls internally: registered `Handle` callbacks execute and their results go back to the model until `Done`. Sync `Run<T>()` exists.
+- Conversation id `"chats/deals/"` gets a server-assigned tail; a fixed id resumes that conversation. Pass the stored `ChangeVector` to the `Conversation(...)` overload for optimistic concurrency.
+- Deferred tools: `Receive<TArgs>(name, ...)` observes the call but leaves it open — `RunAsync` returns `Status == AiConversationResult.ActionRequired`; inspect `RequiredActions()`, later call `AddActionResponse(toolId, response)` (even from a new `Conversation` instance) and run again.
+- Unregistered action from the model → `OnUnhandledAction` event fires; with no subscriber it throws. Handler errors go back to the model by default (`AiHandleErrorStrategy.SendErrorsToModel`) or throw (`RaiseImmediately`).
+- Multimodal input: `AddAttachment(name, stream, contentType)`, `CopyAttachmentFrom(sourceDocumentId, fileName)`; multiple prompts via `AddUserPrompt(...)`.
+- `AddArtificialActionWithResponse(toolId, response)` injects a fake tool call + result into the context (programmatic prompting).
+
+## Streaming
+
+```csharp
+var answer = await chat.StreamAsync<AnswerSchema>(x => x.Answer,
+    async chunk => Console.Write(chunk));
+```
+
+Streams one string property while the turn runs; the full typed answer still returns. The streamed property should be a simple string, ideally the first in the schema.
+
+## Vector search (LINQ)
+
+```csharp
+var similar = await session.Query<Deal>()
+    .VectorSearch(f => f.WithText(x => x.Summary).UsingTask("deals-embeddings"),
+                  v => v.ByText("late delivery"),
+                  minimumSimilarity: 0.75f)
+    .ToListAsync();
+```
+
+`WithText` takes a property selector or field name; `.UsingTask(id)` points at a deployed embeddings-generation task (setup: `../ai-agents.md`). Value side: `ByText(text)` or `ByEmbedding(float[])`. Optional args: `minimumSimilarity`, `numberOfCandidates`, `isExact`.

--- a/static/skills/ravendb/references/dotnet/client.md
+++ b/static/skills/ravendb/references/dotnet/client.md
@@ -1,0 +1,149 @@
+# RavenDB .NET client — core usage
+
+Verified against `Raven.Client` v7.2 source (NuGet package `RavenDB.Client`). Covers store/session lifecycle, CRUD, querying, includes, bulk insert.
+
+## Setup
+
+```csharp
+using Raven.Client.Documents;
+
+var store = new DocumentStore
+{
+    Urls = new[] { "http://127.0.0.1:8080" },
+    Database = "ConsultingDeals"
+};
+store.Initialize();
+// on shutdown:
+store.Dispose();
+```
+
+- One `DocumentStore` per app (it is thread-safe and expensive). `Initialize()` is mandatory; conventions are frozen at that point.
+- Conventions live on `store.Conventions` (set before `Initialize()`): `MaxNumberOfRequestsPerSession`, `FindCollectionName`, `IdentityPartsSeparator`, etc. Collection name derives from the class name, pluralized (`Client` → `Clients`).
+
+In an ASP.NET Core app the store is a singleton and the session is scoped to the request:
+
+```csharp
+var store = new DocumentStore { Urls = new[] { cfg["Raven:Url"] }, Database = cfg["Raven:Database"] };
+store.Initialize();
+builder.Services.AddSingleton<IDocumentStore>(store);
+builder.Services.AddScoped<IAsyncDocumentSession>(sp => sp.GetRequiredService<IDocumentStore>().OpenAsyncSession());
+```
+
+The scoped session is one unit of work per request, disposed with the request. Inject `IDocumentStore` instead when a handler needs several sessions or a bulk insert. Index deployment and database creation belong in the startup path before `app.Run()` (`../structure.md`).
+
+## Secured server (certificate)
+
+```csharp
+using System.Security.Cryptography.X509Certificates;   // X509CertificateLoader lives here
+using Raven.Client.Documents;
+
+var store = new DocumentStore
+{
+    Urls = new[] { "https://a.myapp.ravendb.cloud" },
+    Database = "ConsultingDeals",
+    Certificate = X509CertificateLoader.LoadPkcs12FromFile(
+        Environment.GetEnvironmentVariable("RAVENDB_CERT_PATH"),
+        Environment.GetEnvironmentVariable("RAVENDB_CERT_PASSWORD"))
+};
+store.Initialize();
+```
+
+- `Certificate` is an `X509Certificate2` and must be set before `Initialize()`. On .NET 9+ use `X509CertificateLoader`; the `new X509Certificate2(path, password)` constructor is obsolete there but still the form on older targets. The loader is **pkcs12-only** — convert a `.pem` download first (`openssl pkcs12 -export -in client.pem -out client.pfx`) — and the file must be readable by the process uid.
+- **The client certificate is only half of it: the *server's* certificate must also be trusted.** Against RavenDB Cloud this is invisible because those chain to a public root, but a self-signed or private-CA server fails at `Initialize()` with `Failed to retrieve database topology from all known nodes` → `The remote certificate was rejected by the provided RemoteCertificateValidationCallback`. Trust the CA out of band — `SSL_CERT_FILE=/path/ca.crt` needs no code — or register `Raven.Client.Http.RequestExecutor.RemoteCertificateValidationCallback`, a public static event.
+- URL must be `https://`: a certificate against an `http://` url fails client-side before any request is sent — `InvalidOperationException: The url <url> is using HTTP, but a certificate is specified, which require us to use HTTPS` at `Initialize()`.
+- On Linux/containers load from a file or a mounted secret; `X509KeyStorageFlags.MachineKeySet` matters only on Windows service accounts. Never commit the `.pfx` or its password.
+
+## Session lifecycle
+
+```csharp
+using (var session = store.OpenSession())
+{
+    var client = new Client { Name = "Acme" };
+    session.Store(client);                 // id auto: "clients/1-A"
+    session.Store(client, "clients/42");   // explicit id
+    session.Store(client, "clients/");     // "/" suffix: server assigns the id tail
+    session.Store(client, "clients|");     // "|" suffix: cluster-wide identity number
+    session.SaveChanges();                 // one batch request; nothing hits the server before this
+}
+```
+
+Async mirror: `store.OpenAsyncSession()`, `session.StoreAsync(entity[, id])`, `session.SaveChangesAsync()`, `session.LoadAsync<T>(id)`, and `ToListAsync()`/`CountAsync()`/`FirstOrDefaultAsync()` from `Raven.Client.Documents` on queries. Prefer async in app code.
+
+- A session is a unit of work with an identity map. It holds every document it received in full (`Load`, an include, a query without a projection), keyed by id, with a copy of the JSON as it arrived. `SaveChanges()` diffs the tracked documents against those copies and sends the differences, plus anything stored or deleted, in one batch; nothing else reaches the server. Not thread-safe.
+- Not in the map, so not tracked: projections (`Select`), streams, aggregations, facets. Mutating one and calling `SaveChanges()` writes nothing and raises nothing; `GetDocumentId` and `GetMetadataFor` cannot see it either. To change documents without loading them in full, patch (`operations.md`).
+- Limit: 30 requests per session (`store.Conventions.MaxNumberOfRequestsPerSession`); exceeding throws. Open a new session instead of raising it.
+- `session.Delete(entity)` or `session.Delete("clients/1-A")`, then `SaveChanges()`.
+- `Load<T>(id)` returns `null` for a missing id; loading the same id twice in one session hits the session cache (no second request).
+- Load many: `session.Load<Client>(new[] { "clients/1-A", "clients/2-A" })` returns `Dictionary<string, Client>` (missing ids map to null).
+- A `public string Id` property on the entity is populated by the client after `Store()`; it is not stored inside the document body.
+- To read the id of a document you **queried** rather than stored, use `session.Advanced.GetDocumentId(entity)`. It works on any tracked entity, including one whose class has no `Id` property. Projections are not tracked, so project `id()` in the query instead.
+
+## Metadata
+
+```csharp
+var metadata = session.Advanced.GetMetadataFor(client);   // tracked entity only
+var collection = metadata[Constants.Documents.Metadata.Collection];   // "@collection"
+metadata["Custom-Key"] = "v";   // mutate + SaveChanges() persists
+```
+
+## Querying
+
+```csharp
+var page = session.Query<Client>()
+    .Where(x => x.Status == "active" && x.SignedAt >= cutoff)
+    .Search(x => x.Notes, "renewal risk")     // full-text; terms OR-ed within the field
+    .OrderBy(x => x.Name)
+    .Skip(20).Take(10)
+    .ToList();
+
+int total = session.Query<Client>().Count(x => x.Status == "active");
+```
+
+- `session.Query<T>()` is a dynamic query (server creates/reuses an auto index); `session.Query<T, TIndexCreator>()` or `session.Query<T>("Deals/ByClient")` targets a static index — see `indexes.md`.
+- That bare string overload is an **index** name, not a collection name: `session.Query<Deal>("Deals")` throws `IndexDoesNotExistException: Could not find index Deals`. To name a collection, pass the argument by name: `session.Query<Deal>(collectionName: "Deals")`.
+- **Declare a small class for the entity; do not query `dynamic` or `object`.** `Query<dynamic>()` breaks LINQ two ways: a lambda over it fails to compile with `CS1963: An expression tree may not contain a dynamic operation`, and the string-named operators return a plain `IOrderedQueryable<dynamic>`, which has lost `Statistics` and every other Raven extension. A three-property class costs less than working around either.
+- `string.Contains` does not translate: `.Where(x => x.Name.Contains("acme"))` throws `NotSupportedException: Could not understand expression`. Use `.Search(x => x.Name, "acme")` for an analyzed field, or `StartsWith`/`EndsWith`.
+- Searching **several fields at once** chains `Search` calls and passes the combining option on the later ones: `.Search(x => x.Name, q).Search(x => x.Email, q, options: SearchOptions.Or)`. The enum is `Raven.Client.Documents.SearchOptions` (`Or`/`And`/`Not`/`Guess`, default `Guess`) — not under `.Queries`. `OrElse()` exists only on `Advanced.DocumentQuery`, not on `IRavenQueryable<T>`, so it will not compile here.
+- Projections: `.Select(x => new { x.Name, x.Status })` or `.ProjectInto<ClientSummary>()` (matches fields by name; server-side, only projected fields travel).
+- Sorting: LINQ `.OrderBy(x => x.Amount)` carries the property type and sorts numerically. The **string-named** form on `Advanced.DocumentQuery` does not: `.OrderByDescending("Amount")` sorts as a string and puts `99952` above `243889170`. Pass the ordering type, from `Raven.Client.Documents.Session`: `.OrderByDescending("Amount", OrderingType.Double)`, and `Long` / `AlphaNumeric` likewise. This returns wrong rows with no error.
+- Query stats: `.Statistics(out QueryStatistics stats)` before the conditions (`stats.TotalResults` is a `long`, `stats.IsStale`). It is defined on `IRavenQueryable<T>`, so keep the query in a `var` and keep `T` a real class. Anything that drops it back to a plain `IQueryable<T>` / `IOrderedQueryable<T>` loses the method, and the compiler only says `CS1061: does not contain a definition for 'Statistics'`.
+- Raw RQL: `session.Advanced.RawQuery<T>("from Clients where Status = $s").AddParameter("s", "active")` (`AsyncRawQuery<T>` on an async session) — the escape hatch when the query is RQL text, e.g. copied from Studio. When the RQL projects, `T` is a class with the projected properties or `Dictionary<string, object>`; each row also carries an `@metadata` object, so `Dictionary<string, string>` fails to deserialize.
+- String-based alternative: `session.Advanced.DocumentQuery<T>(indexName, collectionName, isMapReduce)` with `WhereEquals`/`AndAlso`/`OpenSubclause` etc. — use it when field names are only known at runtime; otherwise stay in LINQ.
+- Large result sets: `session.Advanced.Stream(query)` (results not tracked).
+
+## Include — avoid N+1
+
+```csharp
+var client = session.Include<Client>(x => x.DealIds).Load("clients/1-A");
+var deal = session.Load<Deal>(client.DealIds[0]);   // already in session, no extra request
+```
+
+Query-side: `session.Query<Deal>().Include(x => x.ClientId)`.
+
+Include paths are resolved on what the query returns. On a projected query the include is silently dropped unless the field it walks is in the projection: `select DealName, AccountId include AccountId` includes the accounts, `select DealName include AccountId` includes nothing and every later load is a request.
+
+## Bulk insert
+
+```csharp
+using (var bulk = store.BulkInsert())
+{
+    foreach (var row in rows)
+        bulk.Store(row);          // or bulk.Store(entity, id); async: await bulk.StoreAsync(...)
+}
+```
+
+- Streams to the server in batches; orders of magnitude faster than session `Store` loops for seeding. Disposing flushes the remaining batch.
+- Ids ending in `|` are rejected in bulk insert. Metadata via `bulk.Store(entity, id, metadata)`.
+- An entity whose `Id` is initialized to `""` throws `BulkInsertInvalidOperationException: Document id must have a non empty value` — bulk insert treats a non-null id as explicit. Leave the property `null` (`string?`) and let the client assign it.
+
+## Staleness
+
+Queries run on indexes that update asynchronously; a query right after `SaveChanges()` may return stale results. Details and wait patterns: `indexes.md`. Test-suite discipline: `../testing.md`; the driver and per-test database call forms: `testing.md`.
+
+## Gotchas
+
+- Nothing persists without `SaveChanges()` (or disposing the bulk insert).
+- Field names in the database are the C# property names (PascalCase by default) — RQL/DocumentQuery strings must match exactly.
+- The session tracks entities by reference: mutate a loaded entity and `SaveChanges()` persists it; no second `Store` call needed.
+- `session.Advanced.NumberOfRequests` shows the current count against the 30-request cap.
+- Dispose sessions (`using`); an undisposed session leaks tracked entities, not connections — but treat it as a bug.

--- a/static/skills/ravendb/references/dotnet/indexes.md
+++ b/static/skills/ravendb/references/dotnet/indexes.md
@@ -1,0 +1,207 @@
+# RavenDB indexes from the .NET client
+
+Verified against `Raven.Client` v7.2 source. Covers auto vs static indexes, defining/deploying strongly-typed indexes, map-reduce, related documents, full-text, staleness.
+
+## Auto vs static
+
+| | Auto index | Static index |
+|---|---|---|
+| Created by | server, on first dynamic query (`session.Query<T>()` with a filter/order) | you, deployed from code |
+| Named | `Auto/Collection/By...` | class name, `_` → `/` (`Deals_ByClient` → `Deals/ByClient`) |
+| Capabilities | equality/range/basic search over stored fields | computed fields, map-reduce, `LoadDocument`, analyzers, stored fields |
+
+Dynamic queries are fine for simple filters — the server builds and reuses auto indexes. Write a static index when you need full-text analyzers, aggregation, or indexing across related documents.
+
+## Defining a static index
+
+Subclass `AbstractIndexCreationTask<TDocument>`; set `Map` in the constructor. The expression is translated and shipped to the server: it must be self-contained (no closure captures, no local method calls).
+
+```csharp
+using Raven.Client.Documents.Indexes;
+
+public class Deals_ByClientName : AbstractIndexCreationTask<Deal>
+{
+    public Deals_ByClientName()
+    {
+        Map = deals => from d in deals
+                       select new { d.ClientName, d.Value };
+
+        Index(x => x.ClientName, FieldIndexing.Search);   // full-text
+        Store(x => x.Value, FieldStorage.Yes);            // retrievable from index w/o doc load
+        Analyze(x => x.ClientName, "StandardAnalyzer");   // optional; Search implies a default analyzer
+    }
+}
+```
+
+**Reading a computed field takes two things — store it, and project it.** A field the map computes (`Total = Sum(...)`) does not exist on the source document, and a bare `Query<TResult, TIndex>()` **loads the document** and binds `TResult` by name — so `Total` comes back `0`/`null` for every row. Add `Store(x => x.Total, FieldStorage.Yes)` in the index *and* an explicit `.Select(x => new Result {...})` or `.ProjectInto<Result>()`, which is what makes the server answer from stored index fields. Filtering and sorting on the computed field work either way, which is why this reads as a client bug rather than a missing projection. Map-reduce indexes are exempt: reduce results always come from the index, stored or not.
+
+The stored value on the wire is a string (`"2479.0"`); a typed `decimal`/`int` property converts it silently, so this only bites when the projection target is `object`, `dynamic`, or a `string` property that then fails to parse. Give computed fields their real numeric type.
+
+Multi-map: subclass `AbstractMultiMapIndexCreationTask<TReduceResult>` and call `AddMap<TSource>(...)` once per collection; all maps must emit the same shape.
+
+## Deploying
+
+```csharp
+await store.ExecuteIndexAsync(new Deals_ByClientName());
+// or all at once:
+await IndexCreation.CreateIndexesAsync(new IAbstractIndexCreationTask[]
+    { new Deals_ByClientName(), new Deals_ByStatus() }, store);
+// or every index class in an assembly:
+await IndexCreation.CreateIndexesAsync(typeof(Deals_ByClientName).Assembly, store);
+```
+
+Idempotent: re-deploying an unchanged definition is a no-op; a changed one rebuilds side-by-side. Sync variants exist (`store.ExecuteIndex`, `IndexCreation.CreateIndexes`).
+
+## Querying a static index
+
+```csharp
+var hot = await session.Query<Deal, Deals_ByClientName>()
+    .Search(x => x.ClientName, "acme consulting")
+    .ToListAsync();
+// or by name: session.Query<Deal>("Deals/ByClientName")
+```
+
+Only fields emitted by the map are queryable. `Search()` on a field requires `FieldIndexing.Search` on it; equality on a Search field matches analyzed terms, not the exact string.
+
+## Map-reduce
+
+```csharp
+public class Deals_CountByStatus : AbstractIndexCreationTask<Deal, Deals_CountByStatus.Result>
+{
+    public class Result
+    {
+        public string Status { get; set; }
+        public int Count { get; set; }
+        public decimal Total { get; set; }
+    }
+
+    public Deals_CountByStatus()
+    {
+        Map = deals => from d in deals
+                       select new Result { Status = d.Status, Count = 1, Total = d.Value };
+
+        Reduce = results => from r in results
+                            group r by r.Status into g
+                            select new Result
+                            {
+                                Status = g.Key,
+                                Count = g.Sum(x => x.Count),
+                                Total = g.Sum(x => x.Total)
+                            };
+    }
+}
+
+var won = await session.Query<Deals_CountByStatus.Result, Deals_CountByStatus>()
+    .Where(x => x.Status == "won")
+    .ToListAsync();   // rows are aggregates, not documents
+```
+
+Map output shape and reduce output shape must match (`TReduceResult`). Optional: set `OutputReduceToCollection` to materialize results as documents.
+
+## Indexing related documents (LoadDocument)
+
+```csharp
+public class Deals_ByClientRegion : AbstractIndexCreationTask<Deal>
+{
+    public Deals_ByClientRegion()
+    {
+        Map = deals => from d in deals
+                       select new
+                       {
+                           Region = LoadDocument<Client>(d.ClientId).Region,
+                           d.Value
+                       };
+    }
+}
+```
+
+`LoadDocument<T>(id)` inside the map creates a reference: when the Client changes, affected Deal entries re-index automatically.
+
+## Full-text field, end to end
+
+```csharp
+Map = deals => from d in deals select new { d.Notes };
+Index(x => x.Notes, FieldIndexing.Search);
+```
+
+```csharp
+var risky = await session.Query<Deal, Deals_ByNotes>()
+    .Search(x => x.Notes, "renewal risk")   // any term matches
+    .ToListAsync();
+```
+
+## Vector / semantic search
+
+RavenDB 7.0+. Define a vector field in a (multi-)map static index; the app sends raw text and RavenDB embeds it with its built-in model (no external embedding service).
+
+```csharp
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Queries.Vector;
+
+public class Books_And_Authors_Vector_Search
+    : AbstractMultiMapIndexCreationTask<Books_And_Authors_Vector_Search.IndexEntry>
+{
+    public class IndexEntry { public object NameVector { get; set; } public string Name { get; set; } }
+
+    public Books_And_Authors_Vector_Search()
+    {
+        AddMap<Book>(books => from b in books
+            select new IndexEntry { NameVector = CreateVector(b.Title), Name = b.Title });
+        AddMap<Author>(authors => from a in authors
+            select new IndexEntry { NameVector = CreateVector(a.FirstName + " " + a.LastName), Name = a.FirstName + " " + a.LastName });
+
+        // CreateVector(text) in the map + Vector(...) marks a server-side text-embedding field.
+        Vector("NameVector", f => f.SourceEmbedding(VectorEmbeddingType.Text));
+
+        // Vector fields require the Corax engine (Lucene unsupported); scoped to this index only.
+        SearchEngineType = SearchEngineType.Corax;
+    }
+}
+```
+
+Query — target the static-index field with `WithField`:
+
+```csharp
+var hits = await session
+    .Query<Books_And_Authors_Vector_Search.IndexEntry, Books_And_Authors_Vector_Search>()
+    .VectorSearch(
+        f => f.WithField(x => x.NameVector),                              // → RQL vector.search(NameVector, $p)
+        v => ((IVectorEmbeddingTextFieldValueFactory)v).ByText(query),    // embeds the query server-side
+        minimumSimilarity: 0.2f)                                          // cosine, 0..1
+    .Take(20)
+    .ToListAsync();
+```
+
+`WithField` → static-index `vector.search(Field, $p)`; `WithText` → the auto-index `embedding.text(...)` form — use `WithField` against a static index. RQL background: `../rql-advanced.md`.
+
+Client gotcha (7.2.0): `AbstractMultiMapIndexCreationTask<T>` does not propagate `VectorIndexesStrings` to the `IndexDefinition`; override `CreateIndexDefinition()` to copy each entry into `def.Fields[key].Vector`.
+
+## Staleness
+
+Indexes (auto and static) update asynchronously after writes. A query immediately following `SaveChanges()` may return results from before the write — the response is marked stale (`stats.IsStale`), not delayed. Tests that write-then-query MUST wait:
+
+```csharp
+var won = await session.Query<Deal>()
+    .Customize(x => x.WaitForNonStaleResults(TimeSpan.FromSeconds(5)))
+    .Where(x => x.Status == "won")
+    .ToListAsync();
+```
+
+Global wait: tests built on `Raven.TestDriver` inherit `WaitForIndexing(store)` from `RavenTestDriver`. Without the test driver, poll:
+
+```csharp
+using Raven.Client.Documents.Operations;
+
+async Task WaitForIndexingAsync(IDocumentStore store)
+{
+    while (true)
+    {
+        var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+        if (stats.Indexes.All(i => i.State == IndexState.Disabled || i.IsStale == false))
+            return;
+        await Task.Delay(100);
+    }
+}
+```
+
+Never use `WaitForNonStaleResults` on hot production paths — it trades latency for consistency; design UIs to tolerate slightly stale query results instead.

--- a/static/skills/ravendb/references/dotnet/operations.md
+++ b/static/skills/ravendb/references/dotnet/operations.md
@@ -1,0 +1,151 @@
+# RavenDB .NET client — operations beyond CRUD/query
+
+Verified against `Raven.Client` v7.2 source. Covers database management, data subscriptions, patching, attachments/counters/time series/revisions, cluster-wide transactions & compare-exchange, and advanced-query call forms.
+
+## Database management from client
+
+```csharp
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Exceptions.Database;
+
+store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord("Reports")));
+
+store.Maintenance.Server.Send(new DeleteDatabasesOperation("Reports", hardDelete: true));
+```
+
+- `Maintenance.Server.Send(...)` runs server-level ops; `Maintenance.Send(...)` runs db-level ops (against `store.Database`).
+- `CreateDatabaseOperation(DatabaseRecord)` or `CreateDatabaseOperation(DatabaseRecord, int replicationFactor)`. `DatabaseRecord(string name)` sets the name; leave defaults for a single-node local db.
+- `DeleteDatabasesOperation(string databaseName, bool hardDelete, string fromNode = null, TimeSpan? timeToWaitForConfirmation = null)`, or pass a `DeleteDatabasesOperation.Parameters { DatabaseNames = [...], HardDelete = true }` for many.
+- `GetDatabaseNamesOperation(start, pageSize)` returns `string[]` of every database on the server — the way to find leftovers to clean up, or to check existence without pulling a whole record.
+- Ensure-exists / self-provision from app code — check the record, create if absent, swallow the create race:
+
+```csharp
+var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+if (record == null)
+{
+    try { store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(store.Database))); }
+    catch (Exception) { /* concurrent create; record now exists */ }
+}
+```
+
+`GetDatabaseRecordOperation(name)` returns `null` when the db does not exist. Operations against a missing db throw `DatabaseDoesNotExistException`.
+
+## Data subscriptions
+
+Server-side query defines a stream; a worker pulls acknowledged batches with at-least-once delivery and automatic resume from the last acknowledged position. A single worker per subscription needs no license; **concurrent** workers on one subscription are license-gated (`HasConcurrentDataSubscriptions` — verify via `GET /license/status`).
+
+A subscription worker connects over the server's **TCP** port, not HTTP: the client reads `GET /info/tcp` and dials the address the server advertises there, so a server whose TCP port is published on a different host port than it binds sends the worker to the wrong place — the fix is in `../install.md`. Unlicensed servers cap subscriptions per database — read `MaxNumberOfSubscriptionsPerDatabase` from `GET /license/status`.
+
+```csharp
+using Raven.Client.Documents.Subscriptions;
+
+string name = store.Subscriptions.Create<Order>(x => x.Total > 1000);
+// or full control: store.Subscriptions.Create(new SubscriptionCreationOptions { Name = "big-orders", Query = "from Orders where Total > 1000" });
+
+using var worker = store.Subscriptions.GetSubscriptionWorker<Order>(name);
+await worker.Run(batch =>
+{
+    foreach (SubscriptionBatch<Order>.Item item in batch.Items)
+    {
+        Order order = item.Result;   // item.Id, item.ChangeVector also available
+        Process(order);
+    }
+    // ack is automatic when the delegate returns; open batch.OpenSession() to write in the same unit
+});
+```
+
+- `Create<T>(Expression<Func<T,bool>> predicate, ...)`, `Create<T>(SubscriptionCreationOptions<T>)`, or `Create(SubscriptionCreationOptions)` (string `Query`). Returns the subscription name.
+- **A named subscription is create-once, not upsert.** `Create` with a `Name` that already exists is rejected by the server (the name is "already in use in a subscription with different Id"), so startup code that reruns must check `GetSubscriptions` first and create only when missing. An unnamed `Create` sidesteps this by letting the server generate the name, at the cost of not being able to find it again.
+- `GetSubscriptionWorker<T>(name)` or `GetSubscriptionWorker<T>(SubscriptionWorkerOptions)`. `worker.Run(Action<SubscriptionBatch<T>>)` or `Run(Func<SubscriptionBatch<T>, Task>)`; both return a `Task` that completes only on a terminal error.
+- `batch.OpenSession()` gives a session already scoped to the batch — writes there commit together with the ack.
+- Reconnection: the worker reconnects automatically on transient drops (`SubscriptionWorkerOptions.TimeToWaitBeforeConnectionRetry`). The returned `Task` faults on terminal conditions — `SubscriptionClosedException`, `SubscriptionInvalidStateException`, `SubscriptionDoesNotExistException`; loop-and-recreate only for those. Only one worker processes a subscription at a time unless `SubscriptionWorkerOptions.Strategy` allows concurrency.
+
+## Patching (server-side, no load)
+
+```csharp
+session.Advanced.Patch<Order, string>("orders/1-A", x => x.Status, "shipped");
+session.Advanced.Increment<Order, int>("orders/1-A", x => x.Version, 1);
+session.SaveChanges();   // patches batch with the rest of the unit of work
+```
+
+- Signatures: `Patch<T,U>(string id | T entity, Expression<Func<T,U>> path, U value)`; array form `Patch<T,U>(id, Expression<Func<T,IEnumerable<U>>> path, Expression<Func<JavaScriptArray<U>,object>> arrayAdder)`. `Increment<T,U>(string id | T entity, Expression<Func<T,U>> path, U valToAdd)`. Also `AddOrPatch<T,TU>(id, entity, path, value)` / `AddOrIncrement<T,TU>(id, entity, path, valToAdd)` for upsert semantics.
+- Bulk conditional update across a collection — run a JS patch script server-side (no documents travel to the client):
+
+```csharp
+using Raven.Client.Documents.Operations;
+
+var op = store.Operations.Send(new PatchByQueryOperation(
+    "from Orders as o where o.Status = 'pending' update { o.Status = 'stale'; }"));
+op.WaitForCompletion();   // PatchByQueryOperation returns an Operation; await/WaitForCompletion for the result
+```
+
+`PatchByQueryOperation(string queryToUpdate)` or `PatchByQueryOperation(IndexQuery, QueryOperationOptions)`. The `update { ... }` clause is JavaScript; parameterize via `IndexQuery.QueryParameters` rather than string-concatenating values.
+
+## Attachments, counters, time series, revisions
+
+All accessed off `session.Advanced` (or directly on the session for counters/time series); changes flush on `SaveChanges()`.
+
+```csharp
+// Attachments — binary streams attached to a document
+session.Advanced.Attachments.Store("orders/1-A", "invoice.pdf", stream, "application/pdf");
+AttachmentResult a = session.Advanced.Attachments.Get("orders/1-A", "invoice.pdf");   // a.Stream, a.Details
+bool has = session.Advanced.Attachments.Exists("orders/1-A", "invoice.pdf");
+
+// Counters — distributed, conflict-free numeric values
+session.CountersFor("orders/1-A").Increment("views", 1);
+long? views = session.CountersFor("orders/1-A").Get("views");
+Dictionary<string, long?> all = session.CountersFor("orders/1-A").GetAll();
+
+// Time series — timestamped numeric measurements per named series
+session.TimeSeriesFor("orders/1-A", "Heartrate").Append(DateTime.UtcNow, 72, tag: "watch/1");
+TimeSeriesEntry[] entries = session.TimeSeriesFor("orders/1-A", "Heartrate").Get(from: DateTime.UtcNow.AddHours(-1), to: DateTime.UtcNow);
+
+// Revisions — read-only history (requires revisions configured for the collection)
+List<Order> history = session.Advanced.Revisions.GetFor<Order>("orders/1-A", start: 0, pageSize: 25);
+Order at = session.Advanced.Revisions.Get<Order>("orders/1-A", DateTime.UtcNow.AddDays(-1));
+List<IMetadataDictionary> meta = session.Advanced.Revisions.GetMetadataFor("orders/1-A");
+```
+
+- Attachments: `Store(documentId|entity, name, Stream, contentType = null)`; `Get(...)` returns `AttachmentResult` (dispose it — it holds the stream); `GetRange`, `GetRevision`, `Exists` also available.
+- Counters `Increment(counter, delta = 1)` / `Delete(counter)`; deltas merge across nodes.
+- Time series `Append(DateTime, double | IEnumerable<double>, tag = null)`, `Delete(from, to)` / `Delete(at)`; `Get(from, to, start, pageSize)` returns `TimeSeriesEntry[]`. Typed variants via `TimeSeriesFor<T>`.
+- Revision retention is license-capped: a configuration above `MaxNumberOfRevisionsToKeep` / `MaxNumberOfRevisionAgeToKeepInDays` is refused with HTTP 402 and `Raven.Client.Exceptions.Commercial.LicenseLimitException` — read both from `GET /license/status` before choosing numbers. A database-wide `Default` configuration is refused outright on an unlicensed server whatever the numbers (`CanSetupDefaultRevisionsConfiguration` is `false` there); configure per collection instead.
+- Revisions `GetFor<T>` defaults to `pageSize: 25`; `Get<T>(changeVector)` or `Get<T>(id, DateTime)` fetch one point-in-time version.
+
+## Cluster-wide transactions & concurrency
+
+```csharp
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Operations.CompareExchange;
+
+using var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+
+// atomic reservation — succeeds only if the key does not already exist cluster-wide
+CompareExchangeValue<string> reserved =
+    session.Advanced.ClusterTransaction.CreateCompareExchangeValue("emails/jane@acme.com", "users/1-A");
+
+session.Store(new User { Email = "jane@acme.com" }, "users/1-A");
+session.SaveChanges();   // throws ClusterTransactionConcurrencyException if the key was taken
+```
+
+- `TransactionMode.ClusterWide` routes the batch through Raft consensus — all-or-nothing across nodes, at the cost of latency. `TransactionMode.SingleNode` is the default.
+- Compare-exchange (the cluster's concurrency primitive): `CreateCompareExchangeValue<T>(key, value)`, `GetCompareExchangeValueAsync<T>(key)`, `DeleteCompareExchangeValue(key, long index)` / `DeleteCompareExchangeValue<T>(CompareExchangeValue<T>)`. `CompareExchangeValue<T>` exposes `Key`, `Value`, and `Index` (the version — 0 means "must not exist yet").
+- **Optimistic concurrency** (single-node mode) makes `SaveChanges()` fail on a stale change vector — `ConcurrencyException`. Which API you get depends on the **client package version**, so read it off the manifest first:
+  - `session.Advanced.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes` — the current API, **(client 7.2.2+)**. Also `WritesAndReads` (tracks loaded entities too); default `None`.
+  - `session.Advanced.UseOptimisticConcurrency = true` — use only on a client older than 7.2.2. From 7.2.2 it still compiles but is `[Obsolete]` and fails the build under `TreatWarningsAsErrors` (`CS0618`), and setting both on one session throws.
+
+  Neither combines with `ClusterWide` (compare-exchange is the cluster-wide equivalent).
+
+## Advanced queries — call form only
+
+RQL semantics and full syntax live in the shared files; from C# these are LINQ extensions on `IQueryable<T>` / `IDocumentQuery<T>`:
+
+| Feature | Call form | RQL |
+|---|---|---|
+| Facets / aggregation | `query.AggregateBy(builder)` or `.AggregateUsing(facetSetupId)` → `.Execute()` returns `Dictionary<string, FacetResult>` | `../rql-facets.md` |
+| Suggestions | `query.SuggestUsing(builder)` → `ISuggestionQuery<T>` | `../rql-advanced.md` |
+| More-like-this | `query.MoreLikeThis(builder)` → `IRavenQueryable<T>` | `../rql-advanced.md` |
+| Spatial | `query.Spatial(x => x.Location, c => c.WithinRadius(km, lat, lng))` | `../rql-spatial.md` |
+
+`AggregateBy` chains `AndAggregateBy(...)` for multiple facets; both facet paths terminate in `Execute()`/`ExecuteAsync()`. Do not hand-write RQL for these when the strongly-typed builder covers the case.

--- a/static/skills/ravendb/references/dotnet/testing.md
+++ b/static/skills/ravendb/references/dotnet/testing.md
@@ -1,0 +1,55 @@
+# Testing RavenDB code — .NET
+
+Routes and the language-neutral discipline (staleness, what to test, CI): `../testing.md`.
+
+## Route 1 — test driver
+
+```csharp
+// NuGet: RavenDB.TestDriver
+public class DealTests : RavenTestDriver
+{
+    [Fact]
+    public void Won_deals_are_queryable()
+    {
+        using var store = GetDocumentStore();      // database named after the test method
+        new Deals_ByStatus().Execute(store);
+        using (var s = store.OpenSession()) { s.Store(new Deal { Status = "won" }); s.SaveChanges(); }
+
+        WaitForIndexing(store);
+
+        using var session = store.OpenSession();
+        Assert.Single(session.Query<Deal, Deals_ByStatus>().Where(d => d.Status == "won"));
+    }
+}
+```
+
+- Database per call to `GetDocumentStore()` — no cross-test leakage, no cleanup code.
+- Override `PreConfigureDatabase` / `SetupDatabase` to seed or configure revisions once per database.
+- `WaitForIndexing(store)` before any assertion that queries. `WaitForUserToContinueTheTest(store)` opens Studio against the live test database — the fastest way to see why an assertion failed.
+- `ConfigureServer(new TestServerOptions { ... })` must be called before the first `GetDocumentStore()`; after that the server is up and it throws.
+- The driver pulls a server via `RavenDB.Embedded` and starts it as a real process, not an in-memory fake.
+
+### The bundled server pins an exact runtime patch, and a lower one on the machine will not do
+
+`RavenDB.Embedded`'s `RavenDBServer/Raven.Server.runtimeconfig.json` names the `Microsoft.NETCore.App` *and* `Microsoft.AspNetCore.App` version it requires; framework roll-forward only moves up, so a machine one patch behind fails at first use with `Could not find a matching runtime for '<version>+'`. Read the required version out of that file, then either install a matching ASP.NET Core runtime — `dotnet-install.sh --runtime aspnetcore --version <v> --install-dir <dir>` needs no root — and point the driver at it, or use a CI image that already has it:
+
+```csharp
+RavenTestDriver.ConfigureServer(new TestServerOptions { DotNetPath = "<dir>/dotnet" });
+```
+
+`FrameworkVersion` on the same options object becomes `--fx-version`, which covers only `Microsoft.NETCore.App` — it cannot satisfy the ASP.NET Core half, so it is not the fix for a too-old runtime.
+
+## Route 2 — one server, database per test
+
+`CreateDatabaseOperation` / `DeleteDatabasesOperation` from `operations.md`, one uniquely named database per test, hard-deleted on teardown. Take this route when the machine cannot get a matching runtime, or when the suite must run against the same server the app uses.
+
+## Route 3 — embedded server, driven directly
+
+When the test needs to own server configuration or survive across many tests:
+
+```csharp
+EmbeddedServer.Instance.StartServer(new ServerOptions { DataDirectory = tempDir });
+using var store = EmbeddedServer.Instance.GetDocumentStore("Tests");
+```
+
+Same trade-off as Route 1 — real server process, matching runtime required — but you control lifetime and settings. `EmbeddedServer.Instance.OpenStudioInBrowser()` for a look inside.

--- a/static/skills/ravendb/references/http-api.md
+++ b/static/skills/ravendb/references/http-api.md
@@ -1,0 +1,54 @@
+# Raw HTTP API
+
+Talking to RavenDB with plain HTTP — for apps or scripts that don't use a client library. Base: `http://<host>:<port>/databases/<db>`.
+
+Prefer the official client for application code (your language's `client.md`: `nodejs/`, `dotnet/`, `python/`); raw HTTP fits load scripts, proxies, and pass-through endpoints.
+
+## Documents
+
+| Call | Shape |
+|---|---|
+| `GET /docs?id=clients/1-A` | `{ "Results": [ { ...doc, "@metadata": {...} } ] }`; 404 when missing |
+| `GET /docs?id=a&id=b` | Multiple ids in one round-trip |
+| `PUT /docs?id=clients/1-A` | Body = the document JSON; creates or overwrites. Include `"@metadata": {"@collection": "Clients"}` — without it the write still returns 201 but the document lands in no named collection, so `from Clients` and `/collections/docs?name=Clients` never see it |
+| `DELETE /docs?id=clients/1-A` | Deletes |
+
+## Queries (RQL)
+
+```
+POST /queries
+{ "Query": "from Clients where region = $r limit 25",
+  "QueryParameters": { "r": "EU" },
+  "Start": 0, "PageSize": 25 }
+
+Send the body from a file (`curl --data-binary @body.json`) rather than inlining it in a shell argument. RQL string literals need quotes inside a JSON string inside a shell quote, and hand-escaping that nest is where `\x27` appears and the server answers `Invalid escape char, numeric value is 120`. Parameters keep literals out of the query text entirely.
+```
+
+Response: `{ "Results": [...], "TotalResults": n, "IsStale": bool, "IndexName": "..." }`. Always pass values via `QueryParameters`, never string-interpolate. RQL syntax: `rql-cheatsheet.md`.
+
+## Batch writes
+
+```
+POST /bulk_docs
+{ "Commands": [
+    { "Type": "PUT", "Id": "clients/1-A", "ChangeVector": null, "Document": { ..., "@metadata": { "@collection": "Clients" } } },
+    { "Type": "DELETE", "Id": "clients/2-A", "ChangeVector": null } ] }
+```
+
+One transaction. `ChangeVector: null` = unconditional write; pass a document's current change vector to fail on concurrent modification. Suits seeding in batches (a few hundred commands per call); for very large loads the client library's bulk insert streams instead.
+
+## Database & health
+
+| Call | Purpose |
+|---|---|
+| `GET /databases/<db>/stats` | Exists + document/index counts (non-2xx → database missing) |
+| `GET /databases/<db>/indexes` | Static + auto index definitions. A single index is `?name=<n>`, a **query string, not a path segment**: `/indexes/<n>` returns `RouteNotFoundException`. The response carries each field's `Indexing` mode, which is what tells you whether `=` or `search()` will match |
+| `DELETE /databases/<db>/indexes?name=<n>` | Delete an index, including an `Auto/…` one. The path is **not** symmetric with the `PUT` below: there is no `admin/indexes` DELETE handler, and asking for one returns `RouteNotFoundException` |
+| `PUT /databases/<db>/admin/indexes` | Define a static index: `{"Indexes":[{"Name":"<n>","Maps":["from d in docs.<Collection> select new { … }"],"Fields":{"<field>":{"Indexing":"Search","Storage":"Yes"}}}]}`. The non-admin `/indexes` path rejects a C# map with `UnauthorizedAccessException`, so use `admin`. A field the map computes needs `"Storage":"Yes"` to be projectable at all — without it the projection returns `null` — and it comes back as a **string** (`"113.598"`), so cast before arithmetic |
+| `PUT /admin/databases` (server root) | Create database: `{ "DatabaseName": "<db>" }`; an existing name returns 409 `ConcurrencyException` |
+| `GET /setup/alive` (server root) | Server responds (204); the readiness probe — see `install.md` |
+
+## Notes
+
+- Unsecured servers take no auth headers; secured servers require the client certificate — plain `http.request` won't do.
+- Responses use PascalCase envelope keys (`Results`, `TotalResults`); your document fields keep their stored casing.

--- a/static/skills/ravendb/references/install-native.md
+++ b/static/skills/ravendb/references/install-native.md
@@ -1,0 +1,77 @@
+# Native installation
+
+No Docker: download the server archive, extract, run the binary. Health check, database creation, and licensing are identical to the Docker path — see `install.md`. Commands here are POSIX; on Windows read `windows.md` instead.
+
+## Download
+
+`/latest` redirects to the current stable build, so follow redirects (`curl -L`; `Invoke-WebRequest` already does).
+
+| Platform | URL under `https://hibernatingrhinos.com/downloads/` | Archive |
+|---|---|---|
+| Windows x64 | `RavenDB%20for%20Windows%20x64/latest` | `.zip` |
+| Linux x64 | `RavenDB%20for%20Linux%20x64/latest` | `.tar.bz2` |
+| Linux ARM64 | `RavenDB%20for%20Linux%20ARM64/latest` | `.tar.bz2` |
+| Ubuntu 24.04 x64 | `RavenDB%20for%20Ubuntu%2024.04%20x64%20DEB/latest` | `.deb` |
+| macOS Intel (`uname -m` = `x86_64`) | `RavenDB%20for%20macOS%20x64/latest` | `.tar.bz2` |
+| macOS Apple Silicon (`uname -m` = `arm64`) | `RavenDB%20for%20macOS%20arm64/latest` | `.tar.bz2` |
+| Raspberry Pi | `RavenDB%20for%20Raspberry%20Pi/latest` | `.tar.bz2` |
+
+Labels are case- and word-exact — `macOS%20ARM` or an Ubuntu label without `%20DEB` returns 404. When one does, read the current list off <https://ravendb.net/download>. Other Ubuntu releases (18.04 / 20.04 / 22.04) and arm32/arm64 DEBs follow the same pattern.
+
+```bash
+curl -L --progress-bar -o ravendb.tar.bz2 "https://hibernatingrhinos.com/downloads/RavenDB%20for%20Linux%20x64/latest"
+mkdir -p ~/ravendb && tar xjf ravendb.tar.bz2 -C ~/ravendb --strip-components=1 && rm ravendb.tar.bz2
+```
+
+Windows download, extraction, and service registration: `windows.md`.
+
+Everything sits under a single top-level `RavenDB/` directory in the archive — hence `--strip-components=1` above — with the binary at `Server/Raven.Server` (`Server\Raven.Server.exe` on Windows) and `run.sh` / `install-daemon.sh` next to it. Inside a project, `./support/RavenDB` (gitignored) keeps the install with the code; otherwise `~/ravendb` or `C:\RavenDB`.
+
+## Run (development, unsecured)
+
+```bash
+~/ravendb/Server/Raven.Server --Setup.Mode=None \
+  --ServerUrl=http://127.0.0.1:8080 --ServerUrl.Tcp=tcp://127.0.0.1:38888 \
+  --DataDir=/srv/ravendata
+```
+
+Both ports are picked here rather than remapped as in Docker, and both must be free — substitute any pair (`8099` / `38899`) when another server already holds them, and report the HTTP one you settled on. `--DataDir` decides where databases land before the first one is created; adding it later leaves the earlier tree behind and the server comes up empty.
+
+No unsecured-access flag is needed for a loopback bind: `Security.UnsecuredAccessAllowed` defaults to `Local`, which is exactly `127.0.0.1`. Widening it (`PrivateNetwork`, `PublicNetwork`) is only for a server that must answer on a LAN or routable address — and an unsecured server should not. Background it with `nohup … &`. Then health-check and create the database as in `install.md`.
+
+## Run as a service
+
+- **Windows:** `rvn.exe windows-service register` from an elevated shell — there is no `Raven.Server.exe` service flag. Commands, service naming, and the rest of the Windows specifics: `windows.md`.
+- **Linux:** a systemd unit; `sudo` is needed for the install steps, so print them for the user rather than running them.
+
+```ini
+[Unit]
+Description=RavenDB
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/USER/ravendb/Server/Raven.Server --Setup.Mode=None --ServerUrl=http://127.0.0.1:8080 --ServerUrl.Tcp=tcp://127.0.0.1:38888
+WorkingDirectory=/home/USER/ravendb/Server
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=65536
+User=USER
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo cp ravendb.service /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now ravendb
+```
+
+`LimitNOFILE=65536` matters: RavenDB memory-maps its data files and hits the default 1024 descriptor cap under load.
+
+## Stopping / cleanup
+
+`systemctl stop ravendb`, or kill the process on the port (`kill $(lsof -t -i:8080)`). Data lives where `DataDir` points; without it, `Databases/{database-name}` **relative to the server directory** — `~/ravendb/Server/Databases/<name>`, with settings at `Server/settings.json`. Deleting that tree resets every database, and an upgrade replaces the install directory, so keep the data outside it.
+
+## Reaching it from another machine
+
+Only for a secured server. A firewall usually needs the port opened: `sudo ufw allow 8080/tcp`, or `sudo firewall-cmd --add-port=8080/tcp --permanent && sudo firewall-cmd --reload`.

--- a/static/skills/ravendb/references/install.md
+++ b/static/skills/ravendb/references/install.md
@@ -1,0 +1,177 @@
+# Getting a RavenDB server running
+
+## Find a server before installing one
+
+**Never install RavenDB unasked.** A machine that already runs one — a container, a service, a colleague's shared server — must be reused, and the user is the only authority on which server their app should talk to. Probe, then ask. On Windows, run the equivalents in `windows.md`; the commands below are POSIX.
+
+```bash
+for u in http://localhost:8080 http://localhost:80; do
+  printf '%s ' "$u"; curl -s -o /dev/null -w '%{http_code}\n' --max-time 3 "$u/setup/alive"   # 204 → RavenDB here
+done
+docker ps --format '{{.Names}}\t{{.Image}}\t{{.Ports}}' | grep -i raven                       # running container + its published port
+docker ps -a --format '{{.Names}}\t{{.Image}}\t{{.Status}}' | grep -i raven                   # stopped one: `docker start <name>` beats a fresh install
+pgrep -af 'Raven.Server' | head                                                               # native process; Windows: Get-Service RavenDB
+ss -tlnp | grep -E ':(80|8080|8081|8090|9090|38888|38889)\b'                                  # macOS: lsof -i :8080
+```
+
+**A port list is not a discovery protocol.** A server on a port nobody guessed is invisible to every probe above, so enumerate what is actually listening (`ss -tln`, no filter) and curl `/setup/alive` on each candidate — 8090 in particular, since it is the remap this file itself recommends. A native server on an odd port is found this way or not at all.
+
+A native process and a container often both look like "the server on 8080" while only one holds the port. **`docker port <name>` is the reliable tie-breaker**: the process column of `ss -tlnp` is blank for sockets owned by another user unless you are root, so it usually resolves nothing. And a containerised server appears in the host's `pgrep -af Raven.Server` output like a native one — check process ownership or `docker top` before telling the user they have a native install.
+
+Also read what the project already declares — `appsettings*.json`, `.env`, `docker-compose*.yml` often name a URL and database that must be used verbatim, including a non-default port.
+
+Then, in one interaction:
+
+- **Something answered** — report each URL found, with its `GET /build/version`, `GET /databases` and `GET /license/status` so the user sees version, database names, each database's declared `Environment`, and licence, then ask which server and database to use and wait for the answer. The licence belongs in that report: a licensed server that is shared and an unlicensed one that is yours lead to opposite recommendations. Reuse and plain-dev-install are not the only options either — say so when the task needs a *different kind* of server than the ones running (secured, isolated, a specific version). **Finding exactly one server is not an answer to that question** — one server plus one plausible database still gets asked, because the user may want an isolated instance, a different port, or a database you would never have guessed. A running server on a non-standard port is normal; do not assume 8080.
+- **A RavenDB process or container exists but answers nothing** — offer to start it (`docker start <name>`, `systemctl start ravendb`) before offering to install. Report why it looked unreachable (wrong port, wizard mode, dead container).
+- **Nothing found** — say so and ask whether to install a local dev server, naming the method you would use (Docker if the daemon is up, otherwise native) and the port. Install only after the user agrees. If they have a server elsewhere — a cloud instance, a team dev box — ask for its URL, database, and certificate instead. For a throwaway experiment, offer `http://live-test.ravendb.net` as the no-install option, and say plainly that it is a free **shared, public, periodically wiped** server — fine for a spike, never for real or private data.
+
+Never overwrite or reconfigure a server that is already running, and never repurpose a database that already holds data without asking. **Permission to use a database is not permission to change its record**: enabling revisions or expiration, or creating a data subscription, changes behaviour for every client of that database and can consume a licensed slot — ask for those the same way you would ask before creating one.
+
+**A server whose `GET /databases` lists databases you did not create is a shared server.** Creating a database on it, changing server settings, or registering a license there affects other people's work — say what you found and get a yes first. "It was the only server running" is not consent.
+
+## Installing a dev server
+
+Target: **one unsecured single-node server on `http://localhost:8080`**, Docker if the daemon is up, native otherwise (`install-native.md`). Unsecured means no certificate and no auth — keep it on localhost, never on a routable address. Two host ports get published, **8080 and 38888** (the TCP/cluster port), and both must be free — another RavenDB container already publishing 38888 is the common case. The HTTP port can be remapped freely (`-p 8090:8080`) — report the URL you settled on. **The TCP port cannot, unless the server is told about it.** A client that needs a raw TCP connection (data subscriptions, cluster traffic) asks `GET /info/tcp`, and the server answers with its own bind port — it knows nothing about the Docker publish mapping. So `-p 38889:38888` alone leaves clients dialling 38888 on the host, where they reach whichever *other* RavenDB holds that port, and the failure reads as a missing database rather than a wrong server. Publish the same number the server binds, or move both together — the same port number in all three places, and a number you checked is free rather than the one written here:
+
+```bash
+-p <free>:<free> -e RAVEN_ServerUrl_Tcp=tcp://0.0.0.0:<free>
+# add -e RAVEN_PublicServerUrl_Tcp=tcp://<host clients dial>:<free> when that hostname is not the bind address
+```
+
+Published ports are fixed when a container is created, so this is not an in-place repair: an existing container has to be `docker rm -f`'d and re-run with the same named volumes, which keeps the data.
+
+HTTP-only work (CRUD, queries, bulk insert) succeeds regardless, so a mismatch stays invisible until the first subscription. On a server you do not control — someone else's container, with its mapping off-limits — the answer is a server of your own with matching ports, not a client-side workaround: the TCP address is chosen by the server, and every honest fix is on that side.
+
+## Docker (development, unsecured)
+
+`docker-compose.ravendb.yml`:
+
+```yaml
+services:
+  ravendb:
+    image: ravendb/ravendb:latest
+    container_name: ravendb-dev
+    ports:
+      - "8080:8080"
+      - "38888:38888"
+    environment:
+      - RAVEN_Setup_Mode=None
+      - RAVEN_License_Eula_Accepted=true
+      - RAVEN_DATABASE=MyApp
+    volumes:
+      - ravendb-data:/var/lib/ravendb/data
+      - ravendb-config:/etc/ravendb
+
+volumes:
+  ravendb-data:
+  ravendb-config:
+```
+
+```bash
+docker compose -f docker-compose.ravendb.yml up -d     # stop / down -v to remove data
+```
+
+The image defaults to `Setup.Mode=Initial`, which boots into the setup wizard and serves no API — `RAVEN_Setup_Mode=None` is what makes a usable dev server. Any config key works as an env var with a `RAVEN_` prefix and dots as underscores (`RAVEN_Logs_Mode=Information`), or as `RAVEN_ARGS=--Setup.Mode=None`.
+
+`RAVEN_DATABASE` makes the entrypoint create that database once the server is up — no provisioning call needed. It lands a moment *after* `/setup/alive` starts answering, so poll for the database, not just for the server.
+
+The two volumes are what survive `docker rm`: `/var/lib/ravendb/data` holds the databases, `/etc/ravendb` the settings and any certificates. Pre-6.0 images used `/opt/RavenDB/Server/RavenData`; mounting that path on a current image silently persists nothing.
+
+Unsecured access needs no extra flag: the container binds `http://<container-hostname>:8080`, which falls inside the image's default `Security.UnsecuredAccessAllowed=PrivateNetwork`, and the published port is what keeps it on your localhost. `PublicNetwork` is for multi-node compose setups where nodes advertise a `PublicServerUrl` to each other.
+
+Single-shot equivalent:
+
+```bash
+docker run -d --name ravendb-dev -p 8080:8080 -p 38888:38888 \
+  -e RAVEN_Setup_Mode=None -e RAVEN_License_Eula_Accepted=true -e RAVEN_DATABASE=MyApp \
+  -v ravendb-data:/var/lib/ravendb/data -v ravendb-config:/etc/ravendb \
+  ravendb/ravendb:latest
+```
+
+## Wait for ready, then verify
+
+```bash
+for i in $(seq 1 20); do
+  [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://localhost:8080/setup/alive)" = "204" ] && break
+  sleep 3
+done
+curl -s http://localhost:8080/build/version                                            # {"BuildVersion":…,"ProductVersion":"7.2","FullVersion":"7.2.x",…}
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/databases/MyApp/stats    # 200 once the database exists
+```
+
+Never ready → `docker logs ravendb-dev` (native: the server's console output). The usual causes are a port already bound, a missing `RAVEN_Setup_Mode=None`, or a volume the container user cannot write.
+
+## Create a database explicitly
+
+```bash
+curl -s -X PUT http://localhost:8080/admin/databases \
+  -H 'Content-Type: application/json' -d '{"DatabaseName":"MyApp"}'
+```
+
+The body is a database record; `DatabaseName` is the only required field. Success returns `{"RaftCommandIndex":n,"Name":"MyApp","Topology":{…}}`. A name that already exists returns **409** with a `ConcurrencyException` — treat that as success so provisioning stays idempotent. Deleting takes `DELETE /admin/databases` with `{"DatabaseNames":["MyApp"],"HardDelete":true}`.
+
+Doing this from application startup instead of curl (the right place for it) — see `structure.md` and your language's `operations.md`. Writing and reading documents over plain HTTP, for a smoke test with no client library: `http-api.md`.
+
+## Version — pin it down once
+
+Two versions decide what compiles and what runs; check both before writing code, not after a 404 or a missing method.
+
+```bash
+curl -s http://localhost:8080/build/version
+# {"BuildVersion":…,"ProductVersion":"<major.minor>","FullVersion":"<full>","CommitHash":"..."}
+```
+
+The client library version is in the project, not on the server — `package.json` (`ravendb`), `.csproj` or `Directory.Packages.props` (`RavenDB.Client`), `requirements.txt`/`pyproject.toml` (`ravendb`). A `7.2` server does not give an app pinned to `6.2` the 7.2 client APIs, and a current client talking to an older server gets a 404 on endpoints that server never had.
+
+State both versions to the user when they differ from what the task assumes, and when a feature you need is marked `(7.0+)`/`(7.1+)` above either one, say which side is short and what upgrading it involves — a package bump, or a server upgrade. Never write code against a version the deployment does not have.
+
+## Licensing — check it, and say something
+
+Check every server you connect to, whether you installed it or found it:
+
+```bash
+curl -s http://localhost:8080/license/status     # 6.2 / 7.0: /admin/license/status
+```
+
+`Type` is `None` on an unlicensed server, and a `Has*` boolean per feature says what is actually enabled (`HasAiAgent`, `HasEmbeddingsGeneration`, `HasGenAi`, `HasEncryption`, `HasRavenEtl`, …). Read this before relying on any feature marked `(license)`, rather than inferring from the version.
+
+The same response also carries **numeric `Max*` caps, and exceeding one is rejected with `LicenseLimitException` and HTTP 402** — not a feature that is off, but a number that is too big. Revisions to keep and their age, subscriptions per database, custom analyzers and sorters, cluster size and core/memory allowances all arrive as `Max*` numbers in that response. **Read the cap you are about to touch out of the response** before configuring revisions, subscriptions, analyzers or sorters — the unlicensed values are small and vary by version, and a boolean sweep of `Has*` will not warn you.
+
+**Cap enforcement does not start with the server.** For roughly the first minute after startup an over-cap configuration is accepted with a 200, persisted into the database record, and honoured afterwards — the same call rejected with 402 a minute later. A provisioning path that runs as the container comes up is exactly where this lands, so reading the cap first is the only defence; a 200 is not evidence you were inside the limit.
+
+A third category hides between the booleans and the numbers: `Can*` flags. `CanSetupDefaultRevisionsConfiguration` is `false` unlicensed, which refuses a database-wide **default** revisions configuration at any size ("Your license doesn't allow the creation of a default configuration for revisions") while per-collection configuration inside the caps is allowed. Sweeping only `Has*` and `Max*` misses it, and it blocks the obvious way to turn on revisions for a whole app.
+
+A cap on retention is a cap on the **configured number**, not on the history you end up with: `MinimumRevisionsToKeep` is a floor protecting recent revisions from pruning, and with an age limit also set, pruning is driven by age. Three writes under a cap of `2` legitimately keep three revisions — do not tell a user that an unlicensed server stores only two versions of a document.
+
+**When `Type` is `None`, or the license is expired, warn the user before building on it** — do not silently proceed and do not silently install a license either. State the limits that bite, reading the actual numbers out of the status response — cores, cores per node, memory, cluster size — and that every add-on feature is off — which means AI agents, embeddings generation, encryption, ETL, and cluster features fail at runtime, not at startup. Then ask whether they want you to obtain a **free Developer license** now, and continue only on their answer.
+
+If they say yes, `license.md` has the rest: who requests the key, the activation call, and the verification step.
+
+If they decline, note which features their plan can no longer use, and keep the design inside what an unlicensed server can do.
+
+## Connecting from the app
+
+The URL and database the user confirmed — `http://localhost:8080` and `MyApp` for the server above, whatever they named otherwise — and no certificate on an unsecured server. One `DocumentStore` per process — construction, index deployment, and seeding all belong in one startup path (`structure.md`), with the concrete calls in your language's `client.md`.
+
+## Secured / production
+
+**A license is required by the setup *wizard*, not by security itself.** An unlicensed server runs fully secured — HTTPS plus client-certificate authentication — when configured directly, which is the route to take for a local secured dev server:
+
+```bash
+-e RAVEN_Setup_Mode=None -e RAVEN_License_Eula_Accepted=true \
+-e RAVEN_ServerUrl=https://0.0.0.0:<port> -e RAVEN_PublicServerUrl=https://<host clients dial>:<port> \
+-e RAVEN_Security_Certificate_Path=/certs/server.pfx \
+-e RAVEN_Security_Certificate_Password=<password> \
+-e RAVEN_Security_WellKnownIssuers_Admin="$(openssl x509 -in ca.crt -outform DER | base64 -w0)"
+```
+
+- The server certificate needs a SAN matching the host clients dial (`DNS:localhost`, `IP:127.0.0.1` for a local one), and the certificate's own identity authenticates as cluster admin — which is what breaks the bootstrap chicken-and-egg of needing an admin certificate to register the first certificate.
+- `Security.WellKnownIssuers.Admin` takes **base64 of the issuer's DER bytes**, not a thumbprint; a thumbprint kills the server at boot with `Unable to parse the provided 'Security.WellKnownIssuers.Admin' value` → `ASN1 corrupted data`. Client certificates signed by that issuer are then admitted; anything else gets `403 InvalidAuth` naming the unknown certificate.
+- Once a certificate is configured, `Security.UnsecuredAccessAllowed` stops applying — every request is certificate-gated.
+- `RAVEN_DATABASE` does **not** work on a secured server: the image's entrypoint fails (`./cert-utils.sh: No such file or directory`) and the container exits 1. Create the database with `PUT /admin/databases` presenting your client certificate.
+- `rvn` cannot generate certificates; it only consumes them (`put-client-certificate`, `create-setup-package -m own-certificate`). Generate them with `openssl`, and note `put-client-certificate` accepts no password, so a pfx handed to it must be password-less.
+
+The wizard remains the route for a public-facing server: start with only `RAVEN_License_Eula_Accepted=true`, open the server URL, and follow it. It issues a Let's Encrypt certificate (RavenDB provides a free `*.development.run` domain) or takes your own, and hands back a client-certificate bundle. **That path needs a license key before it can complete.** Details: <https://ravendb.net/docs> → Start / Installation.
+
+Client-side wiring for either: the "Secured server" section of your language's `client.md`.

--- a/static/skills/ravendb/references/license.md
+++ b/static/skills/ravendb/references/license.md
@@ -1,0 +1,53 @@
+# Registering a license
+
+Read this only after the license check in `install.md` says the server is unlicensed **and** the user has said yes to licensing it. A license applies to the whole server, so on a server the user does not own the decision belongs to the owner.
+
+## Getting a key
+
+A free **Developer** key is requested at <https://ravendb.net/download> → *Developer*, and arrives by email at the address given. Which limits the key grants are carried in the key itself — read them off `/license/status` after activation rather than assuming. A Developer license is licensed for development, not production.
+
+**The details are the user's**: real name, email, company, country, job title, industry, intended use. Collect them in one interaction, say plainly that the key goes to the address they give and that the details reach RavenDB's sales team, and never invent, guess, or reuse details from elsewhere. Filling that form with anything the user did not supply is not an option, whoever is doing the typing.
+
+Then either they submit it themselves, or — with a browser tool — you drive it for them. If you have no browser tool, say so and offer the choice:
+
+> I can fill the license form for you, but I need Playwright to reach the page: `npm i playwright && npx playwright install chromium`. Otherwise, go to <https://ravendb.net/download>, pick *Developer*, fill in the form, and paste the key here when the email arrives.
+
+## Driving the form
+
+Three things about the page are structural rather than cosmetic, and worth knowing before you start: a cookie banner may sit in front of it and swallow the first click; **the license form does not exist until a license tier is chosen**, the fields rendering only after the tier card is clicked; and **the page carries other forms whose controls look like the license form's** — a site-wide search box, and a download-package section with its own terms checkbox and submit button.
+
+Everything else you derive from the page in front of you. This is a marketing page: any selector, label, or option list written down here would be stale before it was read.
+
+1. Pick the tier by the **text of its card**, never by position. Then confirm the license form rendered by a field only it has — a name or email input. A terms checkbox or a submit button proves nothing, since the download section has both already.
+2. **Scope the rest to the license form's own container**, then enumerate its visible inputs and read their `name`, `id`, and placeholder off the DOM; map the user's answers onto them by meaning, and read each value back to confirm it landed — a value that did not stick means you addressed something outside the form. Prefer `name` over a generated-looking `id`, which is a per-render value.
+3. For each dropdown, **open it and read the options that are actually there**, then choose the closest match to what the user said and tell them which one you picked. Never hardcode an option list; they are re-worded regularly, and picking a stale label silently sends the wrong answer. Do not assume a select-by-value helper works — check whether the control is a real `<select>` first; a scripted one needs its option clicked while the menu is open, because the options unmount on blur.
+4. Check the terms checkbox belonging to the license form, leave any marketing-consent checkbox alone unless the user asked for it, and submit with the button whose text offers to generate the license — a sibling button in the same form also submits, so the type alone does not identify it. A successful submission navigates away to a confirmation page rather than answering inline, so read the response there and report it back verbatim rather than declaring success yourself.
+
+If a handle you derived stops matching, read the page again rather than retrying it.
+
+**The form arrives with an invisible reCAPTCHA, which scores the session rather than asking anything, so finding one is not a failure.** It appears alongside the fields, sits in a body-level badge container outside the form, and needs no interaction. What ends the attempt is an interactive challenge or a rate limit — hand the user the manual path rather than working around either.
+
+## Why there is no headless route
+
+The server has endpoints for the same request (`POST /license/free/send-verification-code`, then `POST /license/free/download` with the emailed code, `LicenseType` `Developer` or `Community`), but both refuse outside **setup mode** — on a server already past setup they answer `403` with "RavenDB has already been setup". A dev server started with `Setup.Mode=None` is past setup by definition, so the website form is the only route to a new key.
+
+## Activating the key you were given
+
+The email carries a JSON object: `{"Id": "…", "Name": "…", "Keys": ["…"]}`. Either the user pastes it into Studio's *About* page, or you save it to a file and post **that object as the request body**, unwrapped — the endpoint deserializes the body itself, so a `{"License": …}` wrapper is not what it expects:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:8080/admin/license/activate \
+  -H 'Content-Type: application/json' --data-binary @license.json      # 204 on success
+```
+
+- `405` means the server runs with `License.CanActivate=false`; no body gets past that.
+- A key the server cannot validate comes back as **500** with `InvalidDataException: Could not validate license!` — not a 4xx, so a status-code check that only looks for `>= 400` reads it as a server fault. The wrapped form fails the same way with a different exception (`ArgumentNullException` from the validator), which is how a `{"License": …}` body announces itself. Neither attempt changes the server's license state.
+- Activation is a cluster-admin operation: on a secured server it needs a client certificate with that clearance.
+
+Then verify, and report what you find rather than assuming it worked:
+
+```bash
+curl -s http://localhost:8080/license/status      # expect Type to have changed, and the Has* flags the app needs to be true
+```
+
+An unchanged `Type` means the key did not apply — say so. Keep the key out of the repository and out of shell history: read it from a file, and delete the file when done.

--- a/static/skills/ravendb/references/modeling.md
+++ b/static/skills/ravendb/references/modeling.md
@@ -1,0 +1,44 @@
+# Document modeling
+
+How to shape documents, ids, and relationships in RavenDB — the decisions that make queries cheap.
+
+## Documents and collections
+
+- A document is a JSON object; its `@metadata.@collection` names its collection. Collections are just labels — no schema, no migration step.
+- Model around **aggregates**: one document = one unit of change and load. A deal with its line items is one document; a deal and its client are two.
+- Prefer plural PascalCase collection names (`Clients`, `Contracts`); field casing is whatever you store — queries use the literal property names.
+
+## Ids
+
+| Form | Meaning |
+|---|---|
+| `clients/1-A` | Standard server-generated id (`collection/number-node`) |
+| `clients/` suffix | Server assigns the tail on store |
+| `clients|` suffix | Cluster-wide sequential identity |
+| `clients/acme` | Semantic id — pick when the natural key is stable and known |
+
+Ids are strings and globally unique across collections. Semantic ids make cross-references self-documenting and enable direct `load()` without a query.
+
+## References vs embedding
+
+- **Embed** what is owned and always read together (deal → its lines).
+- **Reference by id** what lives independently or is shared (deal → `clientId: "clients/1-A"`).
+- Follow references with `include`/`load` (one round-trip), never a query per reference. See `rql-cheatsheet.md` (include/load) and your language's `client.md`.
+- Denormalize a *stable* display field into the referrer (e.g. `clientName` next to `clientId`) when it saves a lookup on a hot path; skip it for anything that changes often.
+
+## Relationship patterns
+
+- one-to-many, child-owned: array of embedded objects in the parent.
+- one-to-many, independent children: each child stores `parentId`; query children by it (auto-index) rather than keeping an id array on the parent that grows unbounded.
+- many-to-many: array of ids on the lighter side (`triggerSignals: ["signals/m-and-a"]`); index it with `where 'signals/m-and-a' in triggerSignals`.
+- Aggregations over many documents (counts per status, sums per client) belong in a **map-reduce index** (your language's `indexes.md`), not in a document you update on every write.
+
+## Metadata
+
+`@metadata` carries `@id`, `@collection`, `@change-vector`, `@last-modified`; you may add custom keys. `@change-vector` is the concurrency token — send it back on writes to detect conflicting updates.
+
+## Anti-patterns
+
+- One giant document holding a whole collection (unbounded growth, write contention).
+- SQL-style row-per-fact splitting that forces multi-document joins for every read.
+- Storing derived rankings/scores that a query or map-reduce index can compute. The exception is a derived value that is also a **write-time invariant** — a seat counter checked against a room's capacity, stock against a reorder floor. Indexes are eventually consistent, so an index total cannot gate a write; keep that counter on the document and defend it with optimistic concurrency (`operations.md`). Read-optimization is the thing to avoid duplicating, not enforcement.

--- a/static/skills/ravendb/references/nodejs/ai-agents.md
+++ b/static/skills/ravendb/references/nodejs/ai-agents.md
@@ -1,0 +1,47 @@
+# AI Agents from Node.js (client 7.2+)
+
+The npm client wraps the AI-agent HTTP surface under `store.ai` — prefer it over raw HTTP. Concepts, endpoint shapes, and embeddings setup: `../ai-agents.md`.
+
+## Define the agent
+
+```js
+const result = await store.ai.createAgent({
+    name: "dealadvisor",
+    connectionStringName: "open-ai-chat",
+    systemPrompt: "You are a deal advisor. ...",
+    parameters: [{ name: "clientId", description: "Client document id" }],
+    queries: [{
+        name: "clientDeals",
+        description: "Open deals for the client",
+        query: "from Deals where ClientId == $clientId",
+        parametersSampleObject: "{}"
+    }],
+    actions: [],
+}, { recommendation: "narrative text", riskLevel: "low|medium|high" });   // sampleObject → output schema
+const agentId = result.identifier;
+```
+
+Connection string setup uses the standard `PutConnectionStringOperation` with `{ type: "Ai", modelType: "Chat", name, openAiSettings: { apiKey, endpoint, model } }` via `store.maintenance.send(...)`.
+
+## Converse
+
+```js
+const chat = store.ai.conversation(agentId, "chats/dealadvisor|", {
+    parameters: { clientId: "clients/1-A" }
+});
+chat.setUserPrompt("Summarize this deal and recommend next steps.");
+chat.handle("sendQuote", async (args) => ({ sent: true }));   // one handler per configured action
+const answer = await chat.run();       // loops tool calls until status "Done"
+// answer.answer = typed object per sampleObject; answer.usage, answer.elapsed
+// follow-up: chat.setUserPrompt("What about pricing?"); await chat.run();
+```
+
+Streaming variant: `chat.stream("recommendation", chunk => ...)`.
+
+## Vector search
+
+```js
+session.query({ collection: "Deals" })
+    .vectorSearch(f => f.withText("Summary").usingTask("deals-embeddings"),
+                  v => v.byText("late delivery"));
+```

--- a/static/skills/ravendb/references/nodejs/client.md
+++ b/static/skills/ravendb/references/nodejs/client.md
@@ -1,0 +1,133 @@
+# RavenDB Node.js client — core usage
+
+Verified against `ravendb` npm package v7.2.0 source. Covers store/session lifecycle, CRUD, querying, includes, bulk insert.
+
+## Setup
+
+```js
+const { DocumentStore } = require("ravendb");
+
+const store = new DocumentStore("http://127.0.0.1:8080", "ConsultingDeals");
+store.conventions.findCollectionNameForObjectLiteral = e => e["collection"];
+store.initialize();
+// on shutdown:
+store.dispose();
+```
+
+- One `DocumentStore` per app. `initialize()` is mandatory before any use; conventions are frozen at that point.
+- `findCollectionNameForObjectLiteral` MUST be set before `initialize()` when storing plain object literals; otherwise all literals land in the `@empty` collection. Class instances don't need it (collection derives from class name).
+
+## Secured server (certificate)
+
+A secured server needs an X.509 client certificate on the store — a third constructor argument, not a convention:
+
+```js
+const fs = require("fs");
+
+const store = new DocumentStore("https://a.myapp.ravendb.cloud", "ConsultingDeals", {
+    certificate: fs.readFileSync("./client.pfx"),   // pfx: Buffer; pem: the file's text
+    type: "pfx",                                    // "pem" | "pfx"
+    password: process.env.RAVENDB_CERT_PASSWORD,    // omit if unprotected
+    ca: fs.readFileSync("./ca.crt")                 // only for a self-signed CA
+});
+store.initialize();
+```
+
+- `type: "pem"` expects one PEM holding **both** the certificate and its private key (that is what RavenDB's `.pem` download is); `type: "pfx"` expects the raw bytes as a `Buffer`.
+- Also settable as `store.authOptions = {...}` before `initialize()`.
+- URL must be `https://` when a certificate is used; the mismatch is rejected by the client at initialization, not by the server. Never commit the certificate or its password — read both from the environment.
+
+## Session lifecycle
+
+```js
+const session = store.openSession();
+
+await session.store({ collection: "Clients", name: "Acme" });   // id auto: "clients/1-A" — the prefix is lower-cased
+await session.store(doc, "clients/42");                          // explicit id
+await session.store(doc, "clients/");                            // "/" suffix: server assigns the id tail
+await session.store(doc, "clients|");                            // "|" suffix: cluster-wide identity number
+
+await session.saveChanges();   // one batch request; nothing hits the server before this
+session.dispose();
+```
+
+- A session is a unit of work with an identity map. It holds every document it received in full (`load`, an include, a query without `selectFields`), keyed by id, with a copy of the JSON as it arrived. `saveChanges()` diffs the tracked documents against those copies and sends the differences, plus anything stored or deleted, in one batch; nothing else reaches the server.
+- Not in the map, so not tracked: projections (`selectFields`), streams, aggregations, facets. Mutating one and calling `saveChanges()` writes nothing and raises nothing (`session.advanced.hasChanges()` stays false); `getDocumentId` and `getMetadataFor` cannot see it either. To change documents without loading them in full, patch (`operations.md`).
+- Limit: 30 requests per session (`store.conventions.maxNumberOfRequestsPerSession`); exceeding throws. Open a new session instead of raising it.
+- `session.delete(entity)` or `session.delete("clients/1-A")`, then `saveChanges()`.
+- Loading a missing id returns `null`. Loading the same id twice in one session hits the cache (no second request).
+- Load many: `await session.load(["clients/1-A", "clients/2-A"])` returns `{ id: entity|null }` object.
+
+## Metadata / collections
+
+```js
+await session.store({ name: "x", "@metadata": { "@expires": iso } }); // metadata on store
+const md = session.advanced.getMetadataFor(entity);  // tracked entity only
+md["@collection"];               // collection name
+md["customKey"] = "v";           // mutate + saveChanges() persists
+```
+
+## Querying
+
+```js
+const results = await session.query({ collection: "Clients" })
+    .whereEquals("status", "active")
+    .whereIn("region", ["EU", "US"])
+    .whereBetween("signedAt", new Date(2025, 0, 1), new Date())
+    .orderBy("name")        // orderByDescending(...) for descending
+    .skip(20).take(10)
+    .all();
+
+const n = await session.query({ collection: "Clients" }).count();
+const one = await query.first();          // also firstOrNull / single / singleOrNull
+```
+
+- `query({ indexName: "Clients/ByName" })` targets a static index; `query({ collection })` is a dynamic query (auto index).
+- **Sorting on a number or a date needs the ordering type as a second argument.** `orderBy`/`orderByDescending` name the field as a string, and a string field name sorts as a **string** unless you say otherwise: `.orderByDescending("amount")` puts `99952` above `243889170`. Pass `"Double"`, `"Long"` or `"AlphaNumeric"` whenever the field is not text: `.orderByDescending("amount", "Double")`. This returns wrong rows with no error.
+- **That second argument is a case-sensitive exact match and an unrecognised value is discarded in silence.** `"double"`, `"DOUBLE"` and `"banana"` all behave exactly like passing nothing, so the sort falls back to lexical and you get the same wrong rows you were trying to avoid. Only `"Long"`, `"Double"`, `"AlphaNumeric"` and `"String"` count. Read a number back off the top row and check it is the largest one, because the call site looks correct either way.
+- Query stats: `.statistics(s => stats = s)` anywhere in the chain, then `stats.totalResults` (how many the query matched overall, regardless of `skip`/`take`) and `stats.isStale`. There is no other way to get the total without running a second query.
+- Default operator between `where*` clauses is AND; `.usingDefaultOperator("OR")` must come before any condition. Explicit: `.andAlso()` / `.orElse()` / `.not()` / `.openSubclause()...closeSubclause()`.
+- Full-text: `.search("description", "term1 term2")` (terms OR-ed within the field).
+- Projection: `.selectFields("name")` returns values; `.selectFields(["name", "age"])` returns objects with just those fields.
+- `.distinct()`, `.whereStartsWith`, `.whereGreaterThan(OrEqual)`, `.whereLessThan(OrEqual)`, `.whereExists`, `.containsAny`/`.containsAll` all exist.
+- Field names in queries are the literal JSON property names — the client does no case conversion by default, so use exactly what you stored.
+- Raw RQL: `session.advanced.rawQuery("from Clients where status = $s").addParameter("s", "active")` — the escape hatch when the query is RQL text, e.g. copied from Studio.
+- Lazy: `.lazily()` / `.countLazily()` defer; batch executes on first `.getValue()`.
+- Large result sets: `await session.advanced.stream(query)` returns a `DocumentResultStream` — a Node readable you consume with `for await`; results are not tracked. `streamInto(query, writable)` pipes straight into a `Writable` instead.
+
+## include() — avoid N+1
+
+```js
+const client = await session.include("dealIds").load("clients/1-A");
+const deal = await session.load(client.dealIds[0]);  // already cached, no extra request
+```
+
+Query-side: `session.query({ collection: "Deals" }).include("clientId")`.
+
+Include paths are resolved on what the query returns. On a projected query the include is silently dropped unless the field it walks is in the projection: `select DealName, AccountId include AccountId` includes the accounts, `select DealName include AccountId` includes nothing and every later load is a request.
+
+## Bulk insert
+
+```js
+const bulk = store.bulkInsert();
+for (const row of rows) {
+    await bulk.store({ collection: "Deals", ...row });      // needs findCollectionNameForObjectLiteral (see Setup) or this lands in @empty
+}
+await bulk.finish();   // mandatory; flushes remaining batch
+```
+
+- Streams to the server in batches; orders of magnitude faster than session `store` loops for seeding.
+- Ids ending in `|` are rejected in bulk insert. `bulk.store(entity, metadataDictionary)` sets metadata.
+- `findCollectionNameForObjectLiteral` applies here too.
+
+## Staleness
+
+Queries run on indexes that update asynchronously; a query right after `saveChanges()` may return stale results. Details and wait patterns: `indexes.md`. Test-suite discipline: `../testing.md`; the driver and per-test database call forms: `testing.md`.
+
+## Gotchas
+
+- Forgetting `store.initialize()` → errors on first operation; forgetting `findCollectionNameForObjectLiteral` → documents in `@empty`.
+- Nothing persists without `saveChanges()` (or `bulk.finish()`).
+- `id` property on the entity is populated by the client after `store()`; it is not stored inside the document body. It is also populated on entities returned by a query, so `results[0].id` is the document id; `session.advanced.getDocumentId(entity)` does the same. Projections are not tracked and carry no `id`, so project `id()` in the query instead.
+- 30-requests-per-session cap; `session.advanced.numberOfRequests` shows the current count.
+- Dates round-trip as `Date` for class entities; when comparing in queries pass `Date` objects, not strings, unless you stored ISO strings.

--- a/static/skills/ravendb/references/nodejs/indexes.md
+++ b/static/skills/ravendb/references/nodejs/indexes.md
@@ -1,0 +1,180 @@
+# RavenDB indexes from the Node.js client
+
+Verified against `ravendb` npm package v7.2.0 source. Covers auto vs static indexes, defining/deploying JS indexes, map-reduce, related documents, full-text, staleness.
+
+## Auto vs static
+
+| | Auto index | Static index |
+|---|---|---|
+| Created by | server, on first dynamic query (`query({ collection })` with a filter/order) | you, deployed from code |
+| Named | `Auto/Collection/By...` | class name, `_` → `/` (`Deals_ByClient` → `Deals/ByClient`) |
+| Capabilities | equality/range/basic search over stored fields | computed fields, map-reduce, LoadDocument, analyzers, stored fields |
+
+Dynamic queries are fine for simple filters — the server builds and reuses auto indexes. Write a static index when you need full-text analyzers, aggregation, or indexing across related documents.
+
+## Defining a static index
+
+`AbstractJavaScriptIndexCreationTask` (in the `ravendb` package). Subclass, call `this.map(collection, fn)` in the constructor. The map function is stringified and shipped to the server: it must be self-contained (no closure captures).
+
+```js
+const { AbstractJavaScriptIndexCreationTask } = require("ravendb");
+
+class Deals_ByClientName extends AbstractJavaScriptIndexCreationTask {
+    constructor() {
+        super();
+        this.map("Deals", d => ({
+            clientName: d.clientName,
+            value: d.value
+        }));
+        this.index("clientName", "Search");     // full-text
+        this.store("value", "Yes");             // retrievable from index w/o doc load
+    }
+}
+```
+
+- `this.index(field, "Search" | "Exact" | "No" | "Default")`, `this.store(field, "Yes" | "No")`, `this.analyze(field, "StandardAnalyzer")`.
+
+**Reading a computed field takes two things — store it, and project it.** A field the map computes does not exist on the source document, so `this.store("total", "Yes")` plus an explicit `.selectFields([...])` is what makes the server answer from the index; without the store the projection is `null` on every row, silently. Filtering and sorting on the computed field work either way, which is why this reads as a client bug rather than a missing store. Map-reduce indexes are exempt: reduce results always come from the index, stored or not.
+
+A stored numeric field comes back from the index as a **string** (`"650"`, not `650`) — the store keeps the indexed term, not the JSON type. It prints identically, so the bug surfaces later as `"650" + 10 === "65010"`; wrap it in `Number(...)` before any arithmetic or comparison. Map-reduce results keep their numeric type.
+
+- Multi-map: `AbstractJavaScriptMultiMapIndexCreationTask` (multiple `this.map` calls).
+- Raw C#-syntax maps exist via `AbstractCsharpIndexCreationTask` (`this.map = "from d in docs.Deals select new {...}"`) — prefer the JS task in a Node app.
+
+## Deploying
+
+```js
+await store.executeIndex(new Deals_ByClientName());
+// or all at once:
+const { IndexCreation } = require("ravendb");
+await IndexCreation.createIndexes([new Deals_ByClientName(), new Deals_ByStatus()], store);
+```
+
+Idempotent: re-deploying an unchanged definition is a no-op; a changed one rebuilds side-by-side.
+
+## Querying a static index
+
+```js
+const hot = await session.query({ indexName: "Deals/ByClientName" })
+    .search("clientName", "acme consulting")
+    .all();
+// or by class: session.query({ index: Deals_ByClientName })
+```
+
+Only fields emitted by the map are queryable. `search()` on a field requires `indexing: "Search"` on it; equality on a Search field matches analyzed terms, not the exact string.
+
+## Map-reduce
+
+```js
+class Deals_CountByStatus extends AbstractJavaScriptIndexCreationTask {
+    constructor() {
+        super();
+        this.map("Deals", d => ({ status: d.status, count: 1, total: d.value }));
+        this.reduce(r => r.groupBy(x => x.status).aggregate(g => ({
+            status: g.key,
+            count: g.values.reduce((c, v) => c + v.count, 0),
+            total: g.values.reduce((t, v) => t + v.total, 0)
+        })));
+    }
+}
+
+const rows = await session.query({ indexName: "Deals/CountByStatus" })
+    .whereEquals("status", "won")
+    .all();   // rows are { status, count, total } aggregates, not documents
+```
+
+Map output shape and reduce output shape must match. Optional: `this.outputReduceToCollection = "StatusCounts"` materializes results as documents.
+
+## Indexing related documents (LoadDocument)
+
+```js
+class Deals_ByClientRegion extends AbstractJavaScriptIndexCreationTask {
+    constructor() {
+        super();
+        const { load } = this.mapUtils();
+        this.map("Deals", d => ({
+            region: load(d.clientId, "Clients").region,
+            value: d.value
+        }));
+    }
+}
+```
+
+`load(id, collection)` inside the map creates a reference: when the Client changes, affected Deal entries re-index automatically. `this.mapUtils()` only exposes stubs so the stringified function resolves; the real `load` runs server-side.
+
+## Full-text field, end to end
+
+```js
+this.map("Deals", d => ({ notes: d.notes }));
+this.index("notes", "Search");
+this.analyze("notes", "StandardAnalyzer");   // optional; Search implies a default analyzer
+```
+
+```js
+await session.query({ indexName: "Deals/ByNotes" })
+    .search("notes", "renewal risk")      // any term matches
+    .all();
+```
+
+## Vector / semantic search
+
+RavenDB 7.0+. Define a vector field in a (multi-)map static index; the app sends raw text and RavenDB embeds it with its built-in model (no external embedding service). The map wraps the source in a vector function — `CreateVector(...)` in a C#-syntax task, `createVector(...)` from the JS map utilities in a JavaScript task (same utilities that carry `load`, `createSpatialField`, `loadVector`). Either task type works; the C#-syntax form below is the one the samples use.
+
+```js
+const { AbstractCsharpMultiMapIndexCreationTask } = require("ravendb");
+
+class Books_And_Authors_Vector_Search extends AbstractCsharpMultiMapIndexCreationTask {
+    constructor() {
+        super();
+        this.addMap(`from b in docs.Books select new { NameVector = CreateVector(b.Title), Name = b.Title }`);
+        this.addMap(`from a in docs.Authors select new { NameVector = CreateVector(a.FirstName + " " + a.LastName), Name = a.FirstName + " " + a.LastName }`);
+
+        // CreateVector(text) in the map + vectorField(...) marks a server-side text-embedding field.
+        this.vectorField("NameVector", { sourceEmbeddingType: "Text", destinationEmbeddingType: "Single" });
+
+        // Vector fields require the Corax engine (Lucene unsupported); the SDK auto-sets it when a vector field is present.
+        this.searchEngineType = "Corax";
+    }
+}
+```
+
+Query — target the static-index field with `withField`:
+
+```js
+const hits = await session
+    .query({ indexName: "Books/And/Authors/Vector/Search" })
+    .vectorSearch(f => f.withField("NameVector"), query, { similarity: 0.2 })   // → vector.search(NameVector, $p0)
+    .take(20)
+    .selectFields(["Name", "Type", "DocId"])
+    .all();
+```
+
+`withField` → static-index `vector.search(Field, $p)`; `withText` → the auto-index `embedding.text(...)` form — use `withField` against a static index. Passing the query string as the value factory sets `$p` to the raw text; RavenDB embeds it server-side. RQL background: `../rql-advanced.md`.
+
+No client workaround needed — the Node SDK's `AbstractCsharpMultiMapIndexCreationTask` propagates vector field options correctly (contrast the .NET/Python 7.2 multi-map gotcha).
+
+## Staleness
+
+Indexes (auto and static) update asynchronously after writes. A query immediately following `saveChanges()` may return results from before the write — the response is marked stale, not delayed. Tests that write-then-query MUST wait:
+
+```js
+await session.query({ collection: "Deals" })
+    .waitForNonStaleResults(5000)   // per-query, timeout in ms
+    .whereEquals("status", "won")
+    .all();
+```
+
+Global wait (after bulk seeding or index deploy):
+
+```js
+const { GetStatisticsOperation } = require("ravendb");
+async function waitForIndexing(store) {
+    while (true) {
+        const stats = await store.maintenance.send(new GetStatisticsOperation());
+        if (stats.indexes.every(i => i.state === "Disabled" || !i.isStale)) return;
+        await new Promise(r => setTimeout(r, 100));
+    }
+}
+```
+
+Never use `waitForNonStaleResults` on hot production paths — it trades latency for consistency; design UIs to tolerate slightly stale query results instead.

--- a/static/skills/ravendb/references/nodejs/operations.md
+++ b/static/skills/ravendb/references/nodejs/operations.md
@@ -1,0 +1,254 @@
+# RavenDB Node.js client — operations beyond CRUD
+
+Verified against `ravendb` npm package v7.2.0 source. Covers self-provisioning databases, subscriptions, patching, attachments/counters/time series/revisions, cluster-wide transactions, and the call form for advanced queries.
+
+All named types below are imported from the top-level package: `const { CreateDatabaseOperation, ... } = require("ravendb")`.
+
+## Database management (self-provision)
+
+```js
+const { CreateDatabaseOperation, DeleteDatabasesOperation, GetDatabaseNamesOperation } = require("ravendb");
+
+// ensure-exists: create only if missing (idempotent app startup)
+const names = await store.maintenance.server.send(new GetDatabaseNamesOperation(0, 100));
+if (names.includes("ConsultingDeals") === false) {
+    await store.maintenance.server.send(new CreateDatabaseOperation({ databaseName: "ConsultingDeals" }, 1));
+}
+
+// delete (hardDelete: true also erases data files, not just the record)
+await store.maintenance.server.send(new DeleteDatabasesOperation({
+    databaseNames: ["ConsultingDeals"], hardDelete: true
+}));
+```
+
+- `store.maintenance.server.send(...)` targets the cluster; `store.maintenance.send(...)` (no `.server`) targets the store's database. Server-level ops (create/delete DB) MUST go through `.server`.
+- `CreateDatabaseOperation(record, replicationFactor)` — the record is a `DatabaseRecord`; only `databaseName` is required. Second overload takes a builder: `new CreateDatabaseOperation(b => b.regular("Name"))`.
+- Sending an op against a nonexistent DB throws `DatabaseDoesNotExistException` (catch by `err.name`).
+- `GetDatabaseRecordOperation(name)` returns the full record (`null` if absent) — heavier than the names list; use the names list for a plain existence check.
+
+## Data subscriptions
+
+Server-side query defines what to stream; a worker consumes batches and acks per batch. A single worker per subscription needs no license; **concurrent** workers on one subscription are license-gated (`HasConcurrentDataSubscriptions` — verify via `GET /license/status`).
+
+```js
+const subscriptionName = await store.subscriptions.create({
+    query: "from Deals where value > 10000"
+});
+
+const worker = store.subscriptions.getSubscriptionWorker({
+    subscriptionName,
+    maxDocsPerBatch: 20,        // default hands you everything matching in one batch
+    closeWhenNoDocsLeft: false  // true: drain, then end with SubscriptionClosedException — for a one-shot job
+});
+
+worker.on("batch", (batch, callback) => {
+    try {
+        for (const item of batch.items) {
+            // item.id, item.result (typed doc), item.rawResult, item.rawMetadata, item.changeVector
+            process(item.result);
+        }
+        callback();          // ack -> server sends the next batch
+    } catch (err) {
+        callback(err);       // nack -> batch is retried
+    }
+});
+
+worker.on("error", err => { /* connection/processing errors */ });
+// other events: "end", "unexpectedSubscriptionError", "afterAcknowledgment", "connectionRetry"
+// "end" fires with no argument on a clean dispose and after a fatal error alike, so it tells you
+// nothing about why; a wrong-address failure ends the worker instead of entering "connectionRetry",
+// so a supervisor that only watches "connectionRetry" waits forever.
+
+// worker.dispose() to stop consuming; delete server-side task:
+// await store.subscriptions.delete(subscriptionName);
+```
+**A named subscription is create-once, not upsert.** The example above lets the server generate the name. Pass your own `name` and the call is rejected on the second run (the name is "already in use in a subscription with different Id"), so bootstrap code that reruns must list first and create only when missing.
+
+
+- `create()` returns the generated name; pass `{ name, query }` to name it yourself. Options also accept a document type for typed items. There is no create-if-missing overload: on a named subscription check `getSubscriptions(0, 100)` (each returned state carries the name as `subscriptionName`) or `getSubscriptionState(name)` first, and use `update({ name, query })` to change an existing one — a re-`create()` on a taken name is not idempotent. Unlicensed servers cap subscriptions per database — read `MaxNumberOfSubscriptionsPerDatabase` from `GET /license/status`.
+- The subscription connects over the server's **TCP** port, not HTTP: the client reads `GET /info/tcp` and dials what the server advertises there. A server whose TCP port is published on a different host port than it binds (a Docker remap) sends the client to the wrong place, and the error names a missing database rather than a wrong port — `../install.md` has the fix.
+- Progress is server-tracked per subscription: a new worker resumes after the last acked document. Exactly-once-ish — a crash before ack replays the batch, so make `process()` idempotent.
+- One active worker per subscription by default; a second connection waits or fails depending on the subscription's strategy.
+
+## Live change notifications (Changes API)
+
+`store.changes()` is an ephemeral pub/sub feed of document/index changes — no server-side task, no license gate, no resume-after-restart (contrast the durable subscriptions above). It is the right tool for pushing live updates to connected clients (SSE, WebSocket); use a data subscription instead when you need durable, acked, exactly-once-ish processing.
+
+```js
+const changes = store.changes();
+const sub = changes
+    .forDocumentsInCollection("Products")     // or forDocument(id) / forDocumentsStartingWith(prefix) / forAllDocuments() / forIndex(name)
+    .on("data", change => {
+        // change.id, change.type ("Put" | "Delete"), change.collectionName
+        pushToClient(change);
+    });
+changes.on("error", err => { /* connection-level errors */ });
+await changes.ensureConnectedNow();           // optional: await the initial connection
+```
+
+Disposal is mandatory and is the part that is easy to get wrong:
+
+```js
+// When the consumer goes away (e.g. SSE request closes):
+sub.dispose();        // stop THIS observable
+// dispose the whole connection only when no observable on it is still needed:
+// changes.dispose();
+```
+
+- Keep the handle returned by `.on(...)` and call `sub.dispose()`. Calling `emitter.off("data", () => {})` with a **fresh** function removes nothing — the original listener (and the underlying connection observer) leaks. Every connect/disconnect cycle that fails to dispose leaks a subscription.
+- One `store.changes()` multiplexes many observables over a single connection; dispose each observable you created. In an SSE handler, register the `dispose()` calls on the request's `close` event.
+
+## Patching (server-side, no document load)
+
+Session-level shorthands batch into `saveChanges()`:
+
+```js
+session.advanced.increment("users/1", "age", 1);        // atomic numeric delta
+session.advanced.patch("users/1", "underAge", false);   // set a single field
+await session.saveChanges();
+```
+
+Script patch (single doc) and conditional bulk patch (by query) via operations:
+
+```js
+const { PatchOperation, PatchRequest, PatchByQueryOperation } = require("ravendb");
+
+// one document, arbitrary JS script
+await store.operations.send(new PatchOperation(
+    "users/1", null, PatchRequest.forScript(`this.name = "Patched"`)));
+
+// bulk conditional update — RQL update clause, runs server-side over matches
+const op = await store.operations.send(
+    new PatchByQueryOperation(`from Users where age < 18 update { this.underAge = true }`));
+await op.waitForCompletion();   // background operation; await it in tests
+```
+
+- `PatchOperation(id, changeVector, patchRequest)` — pass a change vector for optimistic concurrency, `null` to skip.
+- `PatchByQueryOperation` runs asynchronously on the server and returns an operation handle; `waitForCompletion()` blocks until done and surfaces script errors. It resolves to `undefined`, not a count of patched documents — verify with a fresh query if you need the number.
+
+## Attachments / counters / time series / revisions
+
+Attachments (binary streams tied to a document):
+
+```js
+session.advanced.attachments.store(doc, "photo.png", fileStream, "image/png"); // or (docId, ...)
+await session.saveChanges();
+const att = await session.advanced.attachments.get("users/1", "photo.png");    // att.data is a Readable
+await session.advanced.attachments.exists("users/1", "photo.png");
+session.advanced.attachments.delete("users/1", "photo.png");                    // then saveChanges()
+```
+
+Counters (distributed atomic numbers):
+
+```js
+session.countersFor("users/1").increment("Likes", 10);   // delta defaults to 1
+await session.saveChanges();
+const likes = await session.countersFor("users/1").get("Likes");   // getAll() for the map
+session.countersFor("users/1").delete("Likes");
+```
+
+Time series (append `(timestamp, value(s), tag?)`):
+
+```js
+const tsf = session.timeSeriesFor("users/1", "heartbeat");
+tsf.append(new Date(), 120, "watches/fitbit");   // value may be a number or number[]
+await session.saveChanges();
+const entries = await tsf.get();                 // get(from, to) to bound the range
+```
+
+Revisions (read-only history; enable via config first):
+
+```js
+const revisions = await session.advanced.revisions.getFor("users/1");   // newest-first array
+const meta = await session.advanced.revisions.getMetadataFor("users/1");
+```
+
+Revisions only appear for documents that landed in a real collection — an object literal stored without `findCollectionNameForObjectLiteral` (see `client.md`) goes to `@empty`, and `getFor` then returns an empty array with no error to explain it.
+
+Enable revisions per database (maintenance op, not per-session):
+
+```js
+const { ConfigureRevisionsOperation, RevisionsConfiguration, RevisionsCollectionConfiguration } = require("ravendb");
+const configuration = Object.assign(new RevisionsConfiguration(), {
+    defaultConfig: Object.assign(new RevisionsCollectionConfiguration(), { disabled: false, minimumRevisionsToKeep: 2 }),
+    collections: new Map([["Users", Object.assign(new RevisionsCollectionConfiguration(), { disabled: false })]])
+});
+await store.maintenance.send(new ConfigureRevisionsOperation(configuration));
+```
+
+`minimumRevisionsToKeep` above the licensed cap is refused with HTTP 402 and a message ending "exceeds the licensed one", and the unlicensed cap is low enough that any round number trips it — read `MaxNumberOfRevisionsToKeep` from `GET /license/status` and stay inside it. There is no `LicenseLimitException` in this client's error names, so there is nothing to match on by type: check the cap up front rather than catching. A `defaultConfig` is refused outright on an unlicensed server whatever the number (`CanSetupDefaultRevisionsConfiguration` is `false` there) — configure per collection instead.
+
+Reading a specific revision, and reverting:
+
+```js
+const revisions = await session.advanced.revisions.getFor("contracts/1");        // newest first
+const metadata  = await session.advanced.revisions.getMetadataFor("contracts/1"); // change vectors live here
+const asOf      = await session.advanced.revisions.get(changeVector);             // or .get(id, date)
+const bytes     = await session.advanced.attachments.getRevision("contracts/1", "contract.pdf", changeVector);
+```
+
+There is no revert operation in the client: reverting means loading the revision, copying its fields onto the live document, and calling `saveChanges()`. Deleting a document deletes its live attachments and adds a `DeleteRevision`-flagged tombstone revision carrying none, while earlier content revisions keep their own attachment copies — `attachments.getRevision` still retrieves those bytes.
+
+## Cluster-wide transactions & concurrency
+
+```js
+const session = store.openSession({ transactionMode: "ClusterWide" });
+
+// compare-exchange: cluster-consistent key/value, ideal for uniqueness/reservations
+const cmp = session.advanced.clusterTransaction.createCompareExchangeValue("emails/john@x.com", "users/1");
+await session.store({ name: "John" }, "users/1");
+await session.saveChanges();   // whole tx is Raft-committed atomically across the cluster
+
+const existing = await session.advanced.clusterTransaction.getCompareExchangeValue("emails/john@x.com"); // .value, .index
+// session.advanced.clusterTransaction.deleteCompareExchangeValue(existing); // or (key, index)
+```
+
+Optimistic concurrency (single-node, change-vector based):
+
+```js
+session.advanced.useOptimisticConcurrency = true;   // whole session; saveChanges throws ConcurrencyException on stale write
+```
+
+- Cluster-wide sessions are the only place compare-exchange values participate in a document transaction; a normal session can still read/write them via `store.operations` compare-exchange ops.
+- Optimistic concurrency compares the loaded change vector on save; conflicts throw rather than overwrite. `PatchOperation`/`session.delete` can take an explicit change vector for the same guarantee on a single call. The boolean above is the only form in the Node client — the `OptimisticConcurrencyMode` enum the .NET and Python clients gained in 7.2.2 has no Node equivalent, so do not port that shape across.
+
+## Advanced queries — call form only
+
+RQL syntax for each lives in the shared files; only the client call shape is shown here.
+
+Faceted / aggregation — see `../rql-facets.md`:
+
+```js
+const result = await session.query({ index: Orders_All })
+    .aggregateBy(f => f.byField("region").sumOn("total").maxOn("total"))
+    .execute();                       // result["region"].values -> [{ range, count, sum, max }]
+// or from a stored FacetSetup document: .aggregateUsing("facets/orders")
+```
+
+Suggestions — see `../rql-advanced.md`:
+
+```js
+const suggestions = await session.query({ index: Users_ByName })
+    .suggestUsing(b => b.byField("name", "Oren").withOptions(opts))
+    .execute();
+```
+
+More-like-this — see `../rql-advanced.md`:
+
+```js
+await session.query({ index: Articles_ByBody })
+    .moreLikeThis(f => f.usingDocument(x => x.whereEquals("id()", "articles/1")).withOptions(opts))
+    .all();
+```
+
+Spatial — see `../rql-spatial.md`:
+
+```js
+const { PointField, WktField } = require("ravendb");
+await session.query({ index: Events_ByLocation })
+    .spatial(new PointField("latitude", "longitude"), c => c.withinRadius(20, 32.56, 34.95))
+    .all();
+// dynamic field form: .spatial("location", c => c.withinRadius(...))
+```
+
+Projections/aggregation over query results: `.selectFields(...)` (see `client.md`); grouped aggregation is map-reduce index territory (see `indexes.md`).

--- a/static/skills/ravendb/references/nodejs/testing.md
+++ b/static/skills/ravendb/references/nodejs/testing.md
@@ -1,0 +1,27 @@
+# Testing RavenDB code — Node.js
+
+Routes and the language-neutral discipline (staleness, what to test, CI): `../testing.md`.
+
+**There is no Node.js test driver** — no embedded server, no `RavenTestDriver` equivalent. Route 2 is the only route: run a server once for the suite (`../install.md`) and give each test its own database.
+
+```js
+const { DocumentStore, CreateDatabaseOperation, DeleteDatabasesOperation } = require("ravendb");
+
+async function testStore(name) {
+    const store = new DocumentStore(process.env.RAVENDB_URL || "http://127.0.0.1:8080", name);
+    store.conventions.findCollectionNameForObjectLiteral = e => e["collection"];   // literals land in @empty without this
+    store.initialize();
+    await store.maintenance.server.send(new CreateDatabaseOperation({ databaseName: name }, 1));
+    return store;
+}
+// teardown:
+await store.maintenance.server.send(new DeleteDatabasesOperation({ databaseNames: [name], hardDelete: true }));
+store.dispose();
+```
+
+- `DatabaseRecord` is a plain object type in the Node client, not a class — pass `{ databaseName }`. The delete operation is plural (`DeleteDatabasesOperation`) and parameter-object shaped; there is no singular form.
+- Name databases uniquely per test (`test-${suite}-${Date.now()}`), hard-delete on teardown, and delete leftovers at suite start.
+- Creating and deleting databases is server-level work, so keep **one** long-lived store for it (any database name; `maintenance.server` ignores it) alongside the short-lived per-test stores — `GetDatabaseNamesOperation` at suite start finds the leftovers to sweep.
+- Point the suite at the server with an env var, never a hardcoded URL. Docker for CI: `../install.md`.
+- Waiting out staleness has no driver helper here: `.waitForNonStaleResults()` on the query, or the `indexes.md` wait patterns.
+- A suite that tests **subscriptions** needs the server's TCP port reachable at the address the server advertises in `GET /info/tcp`, not just the HTTP port — see the port note in `../install.md`, which is the difference between a working suite and a `database does not exist` error against someone else's server.

--- a/static/skills/ravendb/references/python/ai-agents.md
+++ b/static/skills/ravendb/references/python/ai-agents.md
@@ -1,0 +1,88 @@
+# AI Agents from Python (client 7.2+; sub-agents and typed parameters client 7.2.3+)
+
+The Python client wraps the AI-agent HTTP surface under `store.ai` — prefer it over raw HTTP. Concepts, endpoint shapes, and embeddings setup: `../ai-agents.md`.
+
+## Connection string
+
+```python
+from ravendb.documents.operations.ai import AiConnectionString, AiModelType
+from ravendb.documents.operations.ai.open_ai_settings import OpenAiSettings
+from ravendb.documents.operations.connection_string.put_connection_string_operation import (
+    PutConnectionStringOperation,
+)
+
+store.maintenance.send(PutConnectionStringOperation(AiConnectionString(
+    name="open-ai-chat",
+    identifier="open-ai-chat",
+    model_type=AiModelType.CHAT,
+    openai_settings=OpenAiSettings(api_key="sk-...", endpoint="https://api.openai.com/v1", model="gpt-4o-mini"),
+)))
+```
+
+## Define the agent
+
+```python
+from ravendb import AiAgentConfiguration, AiAgentParameter, AiAgentToolQuery, AiAgentToolAction
+
+result = store.ai.add_or_update_agent(AiAgentConfiguration(
+    name="dealadvisor",
+    connection_string_name="open-ai-chat",
+    system_prompt="You are a deal advisor. ...",
+    sample_object='{"recommendation": "narrative text", "riskLevel": "low|medium|high"}',
+    parameters=[AiAgentParameter("clientId", "Client document id")],
+    queries=[AiAgentToolQuery(
+        name="clientDeals",
+        description="Open deals for the client",
+        query="from Deals where ClientId == $clientId",
+        parameters_sample_object="{}",
+    )],
+    actions=[AiAgentToolAction(
+        name="sendQuote",
+        description="Send a quote to the client",
+        parameters_sample_object='{"amount": 100}',
+    )],
+))
+agent_id = result.identifier
+```
+
+Output shape is `sample_object` (JSON string) or `output_schema`. Other knobs: `max_model_iterations_per_call`, `chat_trimming`, `sub_agents`. `store.ai.get_agents()` / `store.ai.delete_agent(identifier)` manage existing agents.
+
+## Converse
+
+```python
+from ravendb import AiConversationCreationOptions
+from ravendb.documents.ai.ai_conversation import AiHandleErrorStrategy
+
+chat = store.ai.conversation(
+    agent_id, "chats/dealadvisor/",       # trailing "/": server assigns the id tail
+    creation_options=AiConversationCreationOptions(parameters={"clientId": "clients/1-A"}),
+)
+chat.set_user_prompt("Summarize this deal and recommend next steps.")
+# one handler per configured action; return value is sent back to the model
+chat.handle("sendQuote", lambda args: {"sent": True}, AiHandleErrorStrategy.SEND_ERRORS_TO_MODEL)
+
+answer = chat.run()      # loops tool calls until status DONE
+# answer.answer = dict per sample_object; answer.status, answer.usage, answer.elapsed
+# follow-up on same chat: chat.set_user_prompt("What about pricing?"); chat.run()
+```
+
+- `handle(name, fn, error_strategy)` — the error-strategy argument is required (`SEND_ERRORS_TO_MODEL` or `RAISE_IMMEDIATELY`).
+- `receive(name, fn(request, args))` gives the raw `AiAgentActionRequest`; respond with `chat.add_action_response(request.tool_id, result)`.
+- Streaming: `chat.stream("recommendation", on_chunk=lambda s: ...)`.
+- Attachments: `chat.add_attachment(name, bytes_or_stream)`, `chat.copy_attachment_from(doc_id, file_name)`.
+- Continue an existing conversation: `store.ai.conversation(agent_id, conversation_id)`; history via `store.ai.get_conversation_messages(conversation_id)`.
+- Requires RavenDB 7.1+ server and a license with the AI-agents feature; a missing agent parameter raises `MissingAiAgentParameterException`.
+
+## Vector search
+
+Server-side embeddings task: `AddEmbeddingsGenerationOperation(EmbeddingsGenerationConfiguration(...))` via `store.maintenance.send` (needs a second connection string with `model_type=AiModelType.TEXT_EMBEDDINGS`). Then:
+
+```python
+results = list(
+    session.query_collection("Deals", Deal)
+    .vector_search_text("Summary", "late delivery",
+                        embedding_generation_task_identifier="deals-embeddings")
+)
+```
+
+`vector_search(field, [0.1, ...])` queries a float32 embedding field directly; `_i8` / `_i1` / `_with_base64` variants cover quantized and pre-encoded vectors. Static-index vector fields: `self._vector(field, VectorOptions(...))` on an `AbstractIndexCreationTask` with `CreateVector(...)` in the C# map.

--- a/static/skills/ravendb/references/python/client.md
+++ b/static/skills/ravendb/references/python/client.md
@@ -1,0 +1,125 @@
+# RavenDB Python client — core usage
+
+Verified against `ravendb` PyPI package v7.2.3 source (requires Python >= 3.9). Covers store/session lifecycle, CRUD, querying, includes, bulk insert.
+
+## Setup
+
+```python
+from ravendb import DocumentStore
+
+store = DocumentStore("http://127.0.0.1:8080", "ConsultingDeals")
+store.initialize()
+# on shutdown:
+store.close()
+```
+
+- One `DocumentStore` per app; also usable as a context manager (`with DocumentStore(...) as store:`). `initialize()` is mandatory before any use; conventions are frozen at that point.
+
+## Secured server (certificate)
+
+```python
+store = DocumentStore("https://a.myapp.ravendb.cloud", "ConsultingDeals")
+store.certificate_pem_path = os.environ["RAVENDB_CERT_PEM"]   # cert + key in ONE .pem
+store.trust_store_path = os.environ.get("RAVENDB_CA_PEM")     # only for a self-signed CA
+store.initialize()
+```
+
+- **PEM only** — the setter raises `ValueError` on a `.pfx` path, and also on a PEM missing either the `BEGIN CERTIFICATE` or the `PRIVATE KEY` block, so the certificate and its key must live in the same file. Convert a pfx once: `openssl pkcs12 -in client.pfx -out client.pem -nodes`.
+- Both must be set before `initialize()` (`certificate_pem_path` asserts it). URL must be `https://` — the mismatch is rejected by the client at initialization, not by the server. Never commit the pem — path from the environment.
+
+## Entities: classes vs dicts
+
+- **Class instances**: collection = pluralized class name (`User` → `Users`, via `inflect`). Deserialization calls `YourClass(**fields)` — the `__init__` keyword args must match the stored JSON property names, or define a `from_json` classmethod.
+- The identity property is the attribute `Id` (capital I). The client sets it after `store()`; it is not part of the document body.
+- To read the id of a document you **queried** rather than stored, use `session.advanced.get_document_id(entity)`. It works on any tracked entity, including a plain `dict` result, which has no `Id` key of its own. Projections are not tracked, so project `id()` in the query instead.
+- **Plain dicts**: collection is derived from the pluralized document-key prefix (`session.store({...}, "clients/1")` → collection `clients`). A dict stored *without* an explicit key lands in collection `dicts` — always pass an explicit `"collection/..."` id for dicts.
+
+## Session lifecycle
+
+```python
+with store.open_session() as session:
+    session.store(User(name="Acme"))            # id auto: "users/1-A" — the prefix is lower-cased
+    session.store(user, "users/42")             # explicit id
+    session.store(user, "users/")               # "/" suffix: server assigns id tail
+    session.save_changes()                      # one batch request; nothing hits the server before this
+```
+
+- A session is a unit of work with an identity map. It holds every document it received in full (`load`, an include, a query without `select_fields`), keyed by id, with a copy of the JSON as it arrived. `save_changes()` diffs the tracked documents against those copies and sends the differences, plus anything stored or deleted, in one batch; nothing else reaches the server.
+- Not in the map, so not tracked: projections (`select_fields`, `raw_query` with `select`), streams, aggregations, facets. Mutating one and calling `save_changes()` writes nothing and raises nothing; `get_document_id` and `get_metadata_for` cannot see it either. To change documents without loading them in full, patch (`operations.md`).
+- Limit: 30 requests per session (`store.conventions.max_number_of_requests_per_session`); exceeding raises. Open a new session instead of raising it. Current count: `session.advanced.number_of_requests`.
+- `session.delete(entity)` or `session.delete("users/1-A")`, then `save_changes()`.
+- `session.load("users/1-A", User)` returns the entity or `None`; same id twice in one session hits the cache. Load many: `session.load(["users/1-A", "users/2-A"], User)` returns `{id: entity_or_None}`.
+- `session.load_starting_with("users/", User, page_size=25)` pages by id prefix.
+
+## Metadata
+
+```python
+md = session.advanced.get_metadata_for(entity)   # tracked entity only
+md["@collection"]                                # collection name
+md["customKey"] = "v"                            # mutate + save_changes() persists
+```
+
+## Querying
+
+```python
+results = list(
+    session.query_collection("Users", User)
+    .where_equals("status", "active")
+    .where_in("region", ["EU", "US"])
+    .where_between("age", 18, 65)
+    .order_by("name")            # order_by_descending(...) for descending
+    .skip(20).take(10)
+)
+
+n = session.query_collection("Users").count()
+one = session.query_collection("Users", User).first()   # also .single()
+```
+
+- `session.query()` takes only `source` and `object_type`. There is no `collection_name` or `index_name` keyword on it, and passing one raises `TypeError: DocumentSession.query() got an unexpected keyword argument`. Name a collection with `query_collection`, an index with `query_index`.
+- `query_collection(name, Type)` is a dynamic query (auto index); `query_index("Users/ByName", Type)` targets a static index; `session.query(object_type=User)` infers collection from the class; `session.advanced.raw_query("from users where age > $a", User).add_parameter("a", 18)` runs raw RQL.
+- Execute by iterating (`list(query)`), or `.first()` / `.single()` / `.count()`.
+- **Sorting on a number or a date needs the ordering type as a second argument.** `order_by`/`order_by_descending` name the field as a string and default to `OrderingType.STRING`, so `.order_by_descending("amount")` puts `99952` above `243889170`. Pass `OrderingType.FLOAT` for numbers (the member is `FLOAT`, there is no `DOUBLE`), `OrderingType.LONG`, or `OrderingType.ALPHA_NUMERIC`: `.order_by_descending("amount", OrderingType.FLOAT)`. Import it from `ravendb`. This returns wrong rows with no error. Do **not** pass the ordering as a plain string: the second argument is `sorter_name_or_ordering_type`, so `.order_by_descending("amount", "Double")` (the form that is correct in the Node client) is read as the name of a custom sorter and the server answers `NotSupportedInCoraxException: Corax doesn't support Custom OrderBy`.
+- Query stats: `.statistics(lambda st: ...)` takes a callback, not an out-parameter; the `QueryStatistics` it hands you has `.total_results` (how many the query matched overall, regardless of `skip`/`take`) and `.is_stale`. Import `QueryStatistics` from `ravendb`.
+- `raw_query` needs `object_type` whenever the RQL projects (`select ...`). Without it the client raises `AttributeError: 'NoneType' object has no attribute '__dict__'` from inside its deserializer, which names neither the query nor the missing argument. `session.advanced.raw_query(rql, dict)` is the general form.
+- Large result sets: `session.advanced.stream(query)` returns a plain **iterator**, not a context manager, so iterate it directly rather than with `with`. Each item is a `StreamResult` read by attribute (`item.document`, `item.key`, `item.metadata`), not by subscript. Results are not tracked.
+- Default operator between `where_*` clauses is AND; `.using_default_operator(QueryOperator.OR)` must come before any condition. Explicit: `.and_also()` / `.or_else()` / `.not_()` / `.open_subclause()...close_subclause()`.
+- `where(name="John", age=3)` sugar exists but joins the kwargs with OR — prefer explicit `where_equals` chains.
+- Full-text: `.search("description", "term1 term2")` (terms OR-ed; `SearchOperator.AND` as third arg, imported from `ravendb.documents.queries.misc`).
+- Projection: `.select_fields(UserProjection, "name", "age")` — fields default to the projection class's `__init__` fields when omitted.
+- Also available: `.distinct()`, `.where_starts_with`, `.where_greater_than(_or_equal)`, `.where_less_than(_or_equal)`, `.where_exists`, `.contains_any` / `.contains_all`, `.group_by(...)`, `.of_type(Cls)`, `.lazily()`.
+- Field names in queries are the literal JSON property names — the client does no case conversion; use exactly what you stored.
+
+## include — avoid N+1
+
+```python
+clients = session.include("deal_ids").load("clients/1-A", Client)   # returns {id: entity}
+client = clients["clients/1-A"]
+deal = session.load(client.deal_ids[0], Deal)   # already cached, no extra request
+```
+
+Query-side: `session.query_collection("Deals", Deal).include("client_id")`.
+
+Include paths are resolved on what the query returns. On a projected query the include is silently dropped unless the field it walks is in the projection: `select DealName, AccountId include AccountId` includes the accounts, `select DealName include AccountId` includes nothing and every later load is a request.
+
+## Bulk insert
+
+```python
+with store.bulk_insert() as bulk:
+    for row in rows:
+        bulk.store(entity)                 # returns the assigned key
+        bulk.store_as(entity, "deals/7")   # explicit key
+```
+
+Streams to the server; far faster than session `store()` loops for seeding. Exiting the `with` block flushes and finishes the operation.
+
+## Staleness
+
+Queries run on indexes that update asynchronously; a query right after `save_changes()` may return stale results. Details and wait patterns: `indexes.md`. Test-suite discipline: `../testing.md`; the driver and per-test database call forms: `testing.md`.
+
+## Gotchas
+
+- Forgetting `store.initialize()` → errors on first operation. Nothing persists without `save_changes()` (or leaving the bulk-insert block).
+- Entity classes whose `__init__` params don't match document fields fail to deserialize (`Utils.initialize_object` calls `Type(**fields)`).
+- Dicts without an explicit `"collection/..."` id land in the `dicts` collection.
+- 30-requests-per-session cap.
+- Without `object_type`, both `load` and queries return a `DynamicStructure`, whose fields are read as **attributes** (`d.Amount`); it is not a dict and subscripting it raises `TypeError: 'DynamicStructure' object is not subscriptable`. Pass `dict` explicitly to get plain dicts, or a class to get instances.

--- a/static/skills/ravendb/references/python/indexes.md
+++ b/static/skills/ravendb/references/python/indexes.md
@@ -1,0 +1,155 @@
+# RavenDB indexes from the Python client
+
+Verified against `ravendb` PyPI package v7.2.3 source. Covers auto vs static indexes, defining/deploying, map-reduce, full-text, staleness.
+
+## Auto vs static
+
+| | Auto index | Static index |
+|---|---|---|
+| Created by | server, on first dynamic query (`query_collection(...)` with a filter/order) | you, deployed from code |
+| Named | `Auto/Collection/By...` | class name, `_` → `/` (`Deals_ByClient` → `Deals/ByClient`) |
+| Capabilities | equality/range/basic search over stored fields | computed fields, map-reduce, analyzers, stored fields, vector fields |
+
+Dynamic queries are fine for simple filters — the server builds and reuses auto indexes. Write a static index when you need full-text analyzers, aggregation, or computed fields.
+
+## Defining a static index
+
+Subclass `AbstractIndexCreationTask` and set `self.map` in `__init__`. The map/reduce are **C# LINQ syntax strings** shipped to the server — the Python client has no Python-syntax index definitions.
+
+```python
+from ravendb import AbstractIndexCreationTask
+from ravendb.documents.indexes.definitions import FieldIndexing, FieldStorage
+
+class Deals_ByClientName(AbstractIndexCreationTask):
+    def __init__(self):
+        super().__init__()
+        self.map = "from d in docs.Deals select new { d.clientName, d.value }"
+        self._index("clientName", FieldIndexing.SEARCH)   # full-text
+        self._store("value", FieldStorage.YES)            # retrievable from index w/o doc load
+```
+
+**Reading a computed field takes two things — store it, and project it.** A field the map computes does not exist on the source document, so `self._store("total", FieldStorage.YES)` plus an explicit `.select_fields(...)` is what makes the server answer from the index; without the store the projection is `None` on every row, silently. Filtering and sorting on the computed field work either way, which is why this reads as a client bug rather than a missing store. Map-reduce indexes are exempt: reduce results always come from the index, stored or not.
+
+A stored numeric field comes back from the index as a **string** (`"650.0"`, not `650.0`) — the store keeps the indexed term, not the JSON type. Cast in the projection class (`float(total)`); formatting it with `:.2f` or doing arithmetic on it raises instead. Map-reduce results keep their numeric type.
+
+- Field config: `self._index(field, FieldIndexing.SEARCH | EXACT | NO | DEFAULT)`, `self._store(field, FieldStorage.YES)`, `self._analyze(field, "StandardAnalyzer")`, `self._index_suggestions.add(field)`, `self._vector(field, VectorOptions(...))`.
+- Multi-map: `AbstractMultiMapIndexCreationTask` with `self._add_map("...")` per collection.
+- JS-syntax indexes: `AbstractJavaScriptIndexCreationTask` (set `self.maps` to a list of JS map strings).
+
+## Deploying
+
+```python
+store.execute_index(Deals_ByClientName())
+# or all at once:
+store.execute_indexes([Deals_ByClientName(), Deals_ByStatus()])
+# one round trip for the whole set, falling back to per-index execute:
+# IndexCreation.create_indexes([...], store)   from ravendb.documents.indexes.index_creation
+```
+
+Idempotent: re-deploying an unchanged definition is a no-op; a changed one rebuilds side-by-side.
+
+## Querying a static index
+
+```python
+hot = list(
+    session.query_index("Deals/ByClientName", Deal)
+    .search("clientName", "acme consulting")
+)
+# or by class: session.query_index_type(Deals_ByClientName, Deal)
+```
+
+Only fields emitted by the map are queryable. `search()` on a field requires `FieldIndexing.SEARCH` on it; equality on a Search field matches analyzed terms, not the exact string.
+
+## Map-reduce
+
+```python
+class Users_CountByName(AbstractIndexCreationTask):
+    def __init__(self):
+        super().__init__()
+        self.map = "from u in docs.Users select new { u.name, count = 1 }"
+        self.reduce = (
+            "from result in results "
+            "group result by result.name into g "
+            "select new { name = g.Key, count = g.Sum(x => x.count) }"
+        )
+
+class NameCount:
+    def __init__(self, name: str = None, count: int = None):
+        self.name = name
+        self.count = count
+
+rows = list(session.query_index("Users/CountByName", NameCount).order_by_descending("count"))
+# rows are aggregates, not documents
+```
+
+Map output shape and reduce output shape must match. Optional: set `self._output_reduce_to_collection = "NameCounts"` to materialize results as documents.
+
+Dynamic aggregation without a static index also works: `session.query(object_type=User).group_by("name").select_key().select_count().of_type(NameCount)`.
+
+## Vector / semantic search
+
+RavenDB 7.0+. Define a vector field in a (multi-)map static index; the app sends raw text and RavenDB embeds it with its built-in model (no external embedding service).
+
+```python
+from ravendb.documents.indexes.vector.options import VectorOptions
+from ravendb.documents.indexes.vector.embedding import VectorEmbeddingType
+from ravendb.documents.indexes.definitions import SearchEngineType
+
+class Books_And_Authors_Vector_Search(AbstractMultiMapIndexCreationTask):
+    def __init__(self):
+        super().__init__()
+        self._add_map("from b in docs.Books select new { NameVector = CreateVector(b.Title), Name = b.Title }")
+        self._add_map('from a in docs.Authors select new { NameVector = CreateVector(a.FirstName + " " + a.LastName), Name = a.FirstName + " " + a.LastName }')
+
+        # CreateVector(text) in the map + _vector(...) marks a server-side text-embedding field.
+        self._vector("NameVector", VectorOptions(source_embedding_type=VectorEmbeddingType.TEXT))
+
+        # Vector fields require the Corax engine (Lucene unsupported); scoped to this index only.
+        self.search_engine_type = SearchEngineType.CORAX
+```
+
+Query — target the static-index field by name:
+
+```python
+hits = list(
+    session.query_index("Books/And/Authors/Vector/Search", IndexEntry)
+    .vector_search_with_text_field("NameVector", query, minimum_similarity=0.2)  # → vector.search(NameVector, $p0, 0.2, null)
+    .take(20)
+)
+```
+
+`vector_search_with_text_field(field, text, ...)` sends raw text against the static-index field; RavenDB embeds it server-side with the model used at index time (the static-index `vector.search(Field, $p)` form, not the auto-index `embedding.text(...)` form). RQL background: `../rql-advanced.md`.
+
+Client gotcha: `AbstractMultiMapIndexCreationTask.create_index_definition()` does not propagate `_vector_indexes_strings`; override it to set `definition.fields[field].vector` from each entry.
+
+## Staleness
+
+Indexes (auto and static) update asynchronously after writes. A query immediately following `save_changes()` may return results from before the write — the response is marked stale, not delayed. Tests that write-then-query MUST wait:
+
+```python
+from datetime import timedelta
+
+list(
+    session.query_collection("Deals", Deal)
+    .wait_for_non_stale_results(timedelta(seconds=5))   # per-query
+    .where_equals("status", "won")
+)
+```
+
+Global wait (after bulk seeding or index deploy):
+
+```python
+import time
+from ravendb import GetStatisticsOperation
+from ravendb.documents.indexes.definitions import IndexState
+
+def wait_for_indexing(store):
+    while True:
+        stats = store.maintenance.send(GetStatisticsOperation())
+        indexes = [i for i in stats.indexes if i.state != str(IndexState.DISABLED)]
+        if all(not i.stale for i in indexes):
+            return
+        time.sleep(0.1)
+```
+
+Never use `wait_for_non_stale_results` on hot production paths — it trades latency for consistency; design UIs to tolerate slightly stale query results instead.

--- a/static/skills/ravendb/references/python/operations.md
+++ b/static/skills/ravendb/references/python/operations.md
@@ -1,0 +1,187 @@
+# RavenDB Python client — operations beyond CRUD/query
+
+Verified against `ravendb` PyPI package v7.2.3.post1 source (requires Python >= 3.9, `requests`-based). Covers database management, subscriptions, patching, attachments/counters/time-series/revisions, cluster-wide transactions, and advanced-query call forms.
+
+## Two dispatch surfaces
+
+| Executor | Reached via | Scope |
+|---|---|---|
+| `store.maintenance.send(op)` | database-level maintenance ops (indexes, stats, revisions config) | current (or `.for_database(name)`) db |
+| `store.maintenance.server.send(op)` | server/cluster ops (create/delete db, db names) | whole server |
+| `store.operations.send(op)` | data ops (patch, compare-exchange, attachments) | current db |
+
+`store.operations.send_async(op)` returns an `Operation`; call `.wait_for_completion()` for long-running ops (patch-by-query, delete-by-query).
+
+## Database management from the client
+
+```python
+from ravendb import CreateDatabaseOperation, GetDatabaseNamesOperation
+from ravendb.serverwide.database_record import DatabaseRecord
+from ravendb.serverwide.operations.common import DeleteDatabaseOperation
+
+record = DatabaseRecord("ConsultingDeals")
+store.maintenance.server.send(CreateDatabaseOperation(record, replication_factor=1))
+
+# ensure-exists:
+if "ConsultingDeals" not in store.maintenance.server.send(GetDatabaseNamesOperation(0, 100)):
+    store.maintenance.server.send(CreateDatabaseOperation(DatabaseRecord("ConsultingDeals")))
+
+store.maintenance.server.send(DeleteDatabaseOperation("ConsultingDeals", hard_delete=True))
+```
+
+- `DatabaseRecord(database_name)` — plain object; set `.disabled`, `.settings`, `.encrypted` etc. before create. Neither `DatabaseRecord` nor `DeleteDatabaseOperation` is re-exported at package root (`CreateDatabaseOperation` and `GetDatabaseNamesOperation` are) — import them from `ravendb.serverwide.database_record` and `ravendb.serverwide.operations.common`, or the import fails.
+- There is no separate `DeleteDatabasesOperation`. To delete several, pass `DeleteDatabaseOperation(parameters=DeleteDatabaseOperation.Parameters(database_names=[...], hard_delete=True))`.
+- `hard_delete=True` wipes files; `False` leaves them on disk. `from_node`/`from_nodes` remove from specific nodes only.
+
+## Data subscriptions
+
+Server-side query defines the stream; a worker consumes acknowledged batches. A single worker per subscription needs no license; **concurrent** workers on one subscription are license-gated (`HasConcurrentDataSubscriptions` — verify via `GET /license/status`).
+
+A subscription worker connects over the server's **TCP** port, not HTTP: the client reads `GET /info/tcp` and dials the address the server advertises there, so a server whose TCP port is published on a different host port than it binds sends the worker to the wrong place — the fix is in `../install.md`. Unlicensed servers cap subscriptions per database — read `MaxNumberOfSubscriptionsPerDatabase` from `GET /license/status`.
+
+```python
+from ravendb.documents.subscriptions.options import SubscriptionCreationOptions, SubscriptionWorkerOptions
+
+name = store.subscriptions.create_for_class(User)                       # all Users
+name = store.subscriptions.create_for_options(
+    SubscriptionCreationOptions(query="from Users where age > 18"))     # RQL filter/projection
+
+worker = store.subscriptions.get_subscription_worker(SubscriptionWorkerOptions(name), User)
+future = worker.run(lambda batch: [handle(item.result) for item in batch.items])
+future.result()          # blocks; batch loop runs on a background thread until closed
+worker.close()
+```
+
+- `create_for_class(cls, options=None)` / `create_for_options(options)` / `create_for_class` return the subscription name (str). Options `query` is RQL; `None` query on `create_for_options` raises.
+- `worker.run(process_batch)` returns a `concurrent.futures.Future`; the callback receives a `SubscriptionBatch` — iterate `batch.items`, each `item.result` is the deserialized entity (`item.key`, `item.change_vector`, `item.metadata` also available). Accessing `item.result` re-raises a per-item processing error.
+- `worker.add_after_acknowledgment(handler)` fires once a batch is acked. Server tracks progress by change vector, so a new worker resumes where the last left off.
+- **A named subscription is create-once, not upsert.** Calling `create_for_options` again with a name that already exists is rejected by the server (`RachisApplyException`, the name is "already in use in a subscription with different Id"), so bootstrap code that reruns must list first and create only when missing.
+- Other: `get_subscription_worker_by_name(name, cls)`, `get_subscription_worker_for_revisions(...)`, `store.subscriptions.get_subscriptions(start, take)`, `drop_connection(name)`, `delete(name)`. `SubscriptionCreationOptions`/`SubscriptionWorkerOptions` import from `ravendb.documents.subscriptions.options` (not top-level). `SubscriptionCreationOptions(name=…)` names a subscription deterministically, which is what makes the create-if-missing check above possible.
+
+## Patching
+
+Session-level sugar defers a patch into the next `save_changes()`:
+
+```python
+session.advanced.increment("users/1", "visits", 1)              # atomic numeric add
+session.advanced.patch("users/1", "name", "Patched")            # set a field
+session.advanced.patch_array("users/1", "tags", lambda a: a.add("vip"))
+session.advanced.patch_object("users/1", "props", lambda m: m.put("k", "v"))
+session.save_changes()
+```
+
+Operations-level, arbitrary JS, no session:
+
+```python
+from ravendb import PatchOperation, PatchByQueryOperation, PatchRequest
+
+store.operations.send(PatchOperation("users/1", None, PatchRequest.for_script('this.name = "Patched"')))
+
+op = store.operations.send_async(PatchByQueryOperation('from Users where age < 18 update { this.minor = true }'))
+op.wait_for_completion()
+```
+
+- `PatchRequest.for_script(js)` or set `.script` + `.values` (dict, referenced as `args.<key>` in the script). `PatchByQueryOperation` accepts a raw RQL `update {}` string or an `IndexQuery`; pass `QueryOperationOptions(allow_stale=False, retrieve_details=True)` as second arg. Server-side JS runs on the server, not in Python.
+
+## Attachments, counters, time series, revisions
+
+All present. Attachments hang off `session.advanced.attachments`; the others are direct session methods.
+
+```python
+# attachments
+session.advanced.attachments.store("users/1", "profile.png", stream, "image/png")
+result = session.advanced.attachments.get("users/1", "profile.png")   # .details + .data stream
+names = session.advanced.attachments.get_names(user)                  # from tracked entity
+exists = session.advanced.attachments.exists("users/1", "profile.png")
+session.advanced.attachments.delete("users/1", "profile.png")
+
+# counters
+session.counters_for("orders/1-A").increment("downloads", 100)
+val = session.counters_for("orders/1-A").get("downloads")             # int or None
+allc = session.counters_for("orders/1-A").get_all()                   # {name: value}
+session.counters_for("orders/1-A").delete("downloads")
+
+# time series
+tsf = session.time_series_for("users/1", "Heartrate")
+tsf.append_single(timestamp, 72.0, "watches/fitbit")                  # one value
+tsf.append(timestamp, [72.0, 0.5], "watches/fitbit")                  # multi-value entry
+entries = tsf.get(from_date, to_date)                                 # None,None = all
+tsf.delete(from_date, to_date)                                        # also delete_at / delete_all
+
+# revisions (requires revisions enabled for the collection)
+revs = session.advanced.revisions.get_for("users/1", User)            # newest first
+meta = session.advanced.revisions.get_metadata_for("users/1")
+```
+
+- `counters_for_entity(entity)` / `time_series_for_entity(entity, name)` take a tracked entity instead of an id. All of the above are staged in the session and flushed by `save_changes()` (attachment `store` streams the bytes on save).
+- Revisions must be enabled first via `ConfigureRevisionsOperation` (import from `ravendb`) sent to `store.maintenance`:
+
+```python
+from datetime import timedelta
+from ravendb import ConfigureRevisionsOperation
+from ravendb.documents.operations.revisions import RevisionsConfiguration, RevisionsCollectionConfiguration
+
+configuration = RevisionsConfiguration(collections={
+    "Orders": RevisionsCollectionConfiguration(
+        minimum_revisions_to_keep=2, minimum_revisions_age_to_keep=timedelta(days=45))
+})
+store.maintenance.send(ConfigureRevisionsOperation(configuration))
+```
+
+- `RevisionsConfiguration` / `RevisionsCollectionConfiguration` import from `ravendb.documents.operations.revisions`, **not** the package root.
+- Revision retention is license-capped: a configuration above `MaxNumberOfRevisionsToKeep` / `MaxNumberOfRevisionAgeToKeepInDays` is refused with HTTP 402 — read both from `GET /license/status` before choosing numbers. There is no `LicenseLimitException` symbol in this package: what you catch is `RavenException` (from `ravendb.exceptions.raven_exceptions`) whose message carries the server's `LicenseLimitException: … exceeds the licensed one '2'`, so match on the message or, better, check the cap up front.
+- `default_config` (a database-wide configuration rather than per-collection) is refused outright on an unlicensed server whatever the numbers — `CanSetupDefaultRevisionsConfiguration` is `false` there. Configure per collection instead.
+
+## Cluster-wide transactions & concurrency
+
+```python
+from ravendb import SessionOptions, TransactionMode, PutCompareExchangeValueOperation
+
+opts = SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
+with store.open_session(session_options=opts) as session:
+    session.advanced.cluster_transaction.create_compare_exchange_value("usernames/john", "users/1")
+    session.store(User(name="John"))
+    session.save_changes()          # atomic across the cluster (Raft)
+
+with store.open_session(session_options=opts) as session:
+    cev = session.advanced.cluster_transaction.get_compare_exchange_value("usernames/john", str)
+    session.advanced.cluster_transaction.delete_compare_exchange_value(cev)   # or (key, index)
+```
+
+- Compare-exchange = cluster-wide atomic key/value, ideal for uniqueness constraints. Session form requires `CLUSTER_WIDE`; operations form works anywhere: `store.operations.send(PutCompareExchangeValueOperation(key, value, index))` (index `0` = create), plus `GetCompareExchangeValueOperation`, `DeleteCompareExchangeValueOperation`.
+- Optimistic concurrency: `session.advanced.use_optimistic_concurrency = True` makes every `save_changes()` in that session fail on a change-vector mismatch (`ConcurrencyException`, imported from `ravendb.exceptions.raven_exceptions` — not re-exported at package root). Off by default, and available on every supported client. `store.conventions.use_optimistic_concurrency` sets the global default, but only **before** `store.initialize()` — conventions freeze there, and a store handed to you already initialized (the test driver's, for one) raises `RuntimeError: Conventions has been frozen`, so use the per-session flag instead. On conventions the boolean and the enum are mutually exclusive: setting both raises. **(client 7.2.2+)** adds `session.advanced.optimistic_concurrency_mode = OptimisticConcurrencyMode.WRITES` (`from ravendb.documents.session.misc import OptimisticConcurrencyMode`; also `WRITES_AND_READS`, default `NONE`) — the boolean stays as a derived view of it, not deprecated.
+- Cluster-wide sessions cannot use optimistic-concurrency change vectors on documents (they use the Raft log instead).
+
+## Advanced queries — call form only
+
+RQL semantics and full examples live in the shared RQL packs; here is only how the fluent builder reaches them. All four exist on the query object.
+
+```python
+# facets/aggregation → ../rql-facets.md
+agg = session.query_index("Products/ByCategory", Product).aggregate_by(
+    lambda b: b.by_field("category").sum_on("price")).execute()       # {field: FacetResult}
+# every FacetValue field ends in an underscore: count_ sum_ min_ max_ average_ range_
+for v in agg["category"].values: print(v.range_, v.count_, v.sum_)
+
+# suggestions → ../rql-advanced.md
+sug = session.query_index("Users/ByName", User).suggest_using(
+    lambda b: b.by_field("name", "johnn")).execute()
+
+# more-like-this → ../rql-advanced.md
+similar = list(session.query_index("Articles/Search", Article).more_like_this(
+    lambda b: b.using_document('{"body":"..."}').with_options(MoreLikeThisOptions())))
+
+# spatial → ../rql-spatial.md
+near = list(session.query_index("Events/BySpatial", Event).spatial(
+    "location", lambda c: c.within_radius(10, 32.07, 34.77)))
+```
+
+- Every field on a returned `FacetValue` ends in an underscore: `count_`, `sum_`, `min_`, `max_`, `average_`, `range_`. The bare names do not exist, so `value.average` raises `AttributeError: 'FacetValue' object has no attribute 'average'`.
+- `aggregate_by` / `suggest_using` take either a builder lambda or a prebuilt `FacetBase`/`SuggestionBase`; both return a specialized query whose `.execute()` yields the result dict. `spatial(field, clause)` and `within_radius_of(...)` build geo filters via `SpatialCriteriaFactory` (`within_radius`, `relates_to_shape`, `intersects`, `contains`, `disjoint`).
+- Field names are literal stored JSON property names — no case conversion.
+
+## Absent / gotchas
+
+- No `UpdateDatabaseOperation`, no distinct `DeleteDatabasesOperation` name (use `DeleteDatabaseOperation.Parameters`), no smuggler (`DatabaseSmuggler`) surface — listed as TODO, not implemented.
+- Subscription batch loop runs on a background thread; the `Future` from `worker.run` only completes on error/close — keep the worker alive.
+- Long-running server ops (`send_async`) need explicit `.wait_for_completion()`; nothing waits for you.

--- a/static/skills/ravendb/references/python/testing.md
+++ b/static/skills/ravendb/references/python/testing.md
@@ -1,0 +1,84 @@
+# Testing RavenDB code — Python
+
+Routes and the language-neutral discipline (staleness, what to test, CI): `../testing.md`.
+
+## Route 1 — test driver
+
+```python
+# pip install ravendb-test-driver
+from ravendb_test_driver import RavenTestDriver
+
+class TestDeals(TestCase):
+    def setUp(self):
+        self.driver = RavenTestDriver()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_won_deals(self):
+        with self.driver.get_document_store() as store:
+            with store.open_session() as session:
+                session.store({"Status": "won", "collection": "Deals"})
+                session.save_changes()
+            RavenTestDriver.wait_for_indexing(store)
+```
+
+- Database per call to `get_document_store()` — no cross-test leakage, no cleanup code.
+- Override `setup_database` to seed or configure revisions once per database.
+- `wait_for_indexing(store)` before any assertion that queries. It and `configure_server` are `@staticmethod`s on `RavenTestDriver`; calling them on the instance works but implies per-instance state that does not exist.
+- `configure_server(options)` must be called before the first `get_document_store()`; after that the server is up and it throws.
+- The driver pulls a server via `ravendb-embedded` and starts it as a real process, not an in-memory fake.
+
+### The bundled server pins an exact runtime patch, and a lower one on the machine will not do
+
+The embedded package's `RavenDBServer/Raven.Server.runtimeconfig.json` names the `Microsoft.NETCore.App` *and* `Microsoft.AspNetCore.App` version it requires; framework roll-forward only moves up, so a machine one patch behind fails at first use with `Could not find a matching runtime for '<version>+'`. Read the required version out of that file, install a matching ASP.NET Core runtime — `dotnet-install.sh --runtime aspnetcore --version <v> --install-dir <dir>` needs no root — and point the driver at it:
+
+```python
+from ravendb_embedded import ServerOptions
+from ravendb_test_driver import RavenTestDriver
+
+options = ServerOptions()
+options.dot_net_path = "<dir>/dotnet"
+RavenTestDriver.configure_server(options)
+```
+
+`framework_version` on the same options object becomes `--fx-version`, which covers only `Microsoft.NETCore.App` — it cannot satisfy the ASP.NET Core half, so it is not the fix for a too-old runtime.
+
+When no matching runtime can be installed at all, the driver still gives database-per-test against a server you already run — no embedded boot, nothing needing .NET:
+
+```python
+RavenTestDriver.configure_external_server(url, certificate_pem_path=None, trust_store_path=None)
+```
+
+Equivalent env vars are `RAVENDB_TEST_SERVER_URL` / `_CERT` / `_CA`. Call it before the first `get_document_store()`.
+
+## Route 2 — one server, database per test
+
+`configure_external_server` (above) is the easiest form of this route: the driver still names and hard-deletes a database per test, it just skips the embedded boot. Hand-rolled instead — `CreateDatabaseOperation` / `DeleteDatabaseOperation` from `operations.md`, one uniquely named database per test, hard-deleted on teardown — when the suite must control the names or the database record.
+
+Either way the store you get is already initialized, so store-level conventions cannot be changed on it; anything that must be set before `initialize()` belongs to a store you construct yourself.
+
+## Route 3 — embedded server, driven directly
+
+When the test needs to own server configuration or survive across many tests:
+
+```python
+from ravendb_embedded import EmbeddedServer, ServerOptions
+
+options = ServerOptions()
+options.data_directory = temp_dir
+options.server_url = "http://127.0.0.1:38712"   # omit and the server picks a free port
+server = EmbeddedServer()          # not enforced as a singleton: hold this instance, a second one has no server
+server.start_server(options)
+store = server.get_document_store("Tests")      # creates the database too
+try:
+    server.close()
+except RuntimeError:
+    pass                            # 7.2.5.post1: the server process is already down by now
+```
+
+Same trade-off as Route 1 — real server process, matching runtime required — but you control lifetime and settings. `open_studio_in_browser()` for a look inside.
+
+- `get_document_store(name)` **creates the database** unless you pass `DatabaseOptions` with `skip_creating_database = True` via `get_document_store_from_options`, so a following `CreateDatabaseOperation` is redundant.
+- `close()` in `ravendb-embedded` 7.2.5.post1 kills the server process first and then raises `RuntimeError: dictionary changed size during iteration` while closing the stores it tracks — the shutdown succeeded, the bookkeeping did not. Catch it rather than reading it as a failed teardown.
+- There is no public accessor for the server's pid; asserting the process is gone means checking the port or the process table.

--- a/static/skills/ravendb/references/rql-advanced.md
+++ b/static/skills/ravendb/references/rql-advanced.md
@@ -1,0 +1,83 @@
+# RQL — advanced (suggestions, more-like-this, highlighting, vector search)
+
+Version-correct details: ravendb.net/docs.
+
+## Suggestions — `suggest(field, term [, optionsJson]) [as alias]`
+"Did you mean" over an indexed field.
+```
+from Products
+select suggest(Name, 'chaig',
+  '{ "Accuracy": 0.4, "PageSize": 5, "Distance": "JaroWinkler", "SortMode": "Popularity" }') as 'Names'
+
+from Companies
+select suggest(Name, 'chop-soy china'), suggest(Contact.Name, 'maria larson')   # multiple fields
+
+from Products select suggest(Name, $terms) { "terms": ["chaig","tof"] }          # multiple terms via param
+```
+| Option | Values / default |
+|---|---|
+| `Accuracy` | float, default `0.5` |
+| `PageSize` | int, default `15` |
+| `Distance` | `Levenshtein` (default) · `JaroWinkler` · `NGram` · `None` |
+| `SortMode` | `Popularity` · `None` |
+
+## More-like-this — `morelikethis(seed, optionsJson)`
+Find documents similar to a seed doc; used in `where`, over an index.
+```
+from index 'Articles/MoreLikeThis'
+where morelikethis(id() = 'articles/1', '{ "Fields": ["Body"] }')
+
+from index 'Articles/MoreLikeThis'
+where morelikethis(id() = 'articles/1', '{ "Fields": ["Body"] }') and Category == 'IT'   # extra filter
+```
+| Option | Meaning |
+|---|---|
+| `Fields` | string[] — fields to compare |
+| `MinimumTermFrequency` | ignore terms rarer than this in the seed |
+| `MinimumDocumentFrequency` | ignore terms rarer than this across the corpus |
+| `MaximumQueryTerms` | cap generated query terms |
+| `Boost` / `BoostFactor` | weight terms by relevance |
+
+## Highlighting — `highlight(field, fragmentLength, fragmentCount [, optionsJson])`
+Return matched fragments; placed in an `include`, pairs with `search()`.
+```
+from index 'Employees/ByNotes'
+where search(EmployeeNotes, 'manager')
+include highlight(EmployeeNotes, 35, 2)                       # field, fragmentLength (chars), fragmentCount
+
+from index 'ContactDetailsPerCountry'
+where search(ContactDetails, 'agent')
+include highlight(ContactDetails, 35, 2, $opt) { "opt": { "GroupKey": "Country" } }   # map-reduce index
+```
+
+## Vector / AI search — `vector.search(...)`  (7.0+)
+```
+vector.search(<field | embedding-fn>, <queryValue> [, minimumSimilarity] [, numberOfCandidates])
+```
+- `minimumSimilarity`: float 0.0–1.0 (optional; server default).
+- `numberOfCandidates`: int, max vectors examined in graph search (optional; server default).
+```
+from Products where vector.search(embedding.text(Name), 'italian food', 0.82, 20)
+from Products where vector.search(embedding.text_i8(Name), $searchTerm)
+from Movies   where vector.search(TagsEmbeddedAsSingle, $queryVector, 0.85, 10)
+from Products where vector.search(embedding.text(Name), embedding.forDoc($docId), 0.82)
+from Products where (PricePerUnit > $min) and vector.search(embedding.text(Name), $term, 0.75, 16)
+from index MyIndex where vector.search(FieldName, $query, 0.8, 16)
+```
+Embedding wrappers (declare source type / quantization):
+| Wrapper | Source → storage |
+|---|---|
+| `embedding.text(f)` | text → float32 |
+| `embedding.text_i8(f)` | text → int8 |
+| `embedding.text_i1(f)` | text → binary |
+| `embedding.f32_i8(f)` / `embedding.f32_i1(f)` | float32 → int8 / binary |
+| `embedding.i8(f)` / `embedding.i1(f)` | pre-quantized (no re-quantization) |
+| bare `field` | raw float32 vector |
+
+Query-value forms: text literal / `$param` · raw vector `$queryVector` (JSON `@vector`) · base64 string · `embedding.forDoc($id)` · `embedding.text(Field, ai.task('task-id'))`. Requires server 7.0+.
+
+**No per-result score.** `vector.search` exposes no similarity number — `score()`/`@index-score` are empty and `boost(vector.search(...))` throws. Results are only *ordered* by similarity, gated by `minimumSimilarity`. To display a number, read the stored float32 vectors (`@embeddings/<Collection>` per source, `@embeddings-cache` for the query text — both as attachments) and compute cosine.
+
+**Keep the engine's ranking — don't re-rank in the client.** A `search() or vector.search()` query returns results in the engine's relevance order; take them in that order (`take`/paging on the query). Re-sorting the returned set in app code by naive token-overlap discards the semantic ranking entirely — the `vector.search` clause becomes decorative and the exact-but-lexically-thin match loses to an incidental keyword hit. If a single fused order across two clauses is needed, run them as separate queries and merge by rank (reciprocal-rank fusion), not by a hand-rolled word count.
+
+**Embed a composed field, never a single sparse one.** `embedding.text(Description, ...)` over a corpus where `Description` is null/empty for part of the collection gives those documents a degenerate vector that can never rank — they're invisible to semantic search regardless of the query. Embed a composed text (`Name` + sport/type + `Description`) so every document has a meaningful vector, and weight identity fields (name/notation) above free-text in any lexical component.

--- a/static/skills/ravendb/references/rql-cheatsheet.md
+++ b/static/skills/ravendb/references/rql-cheatsheet.md
@@ -1,0 +1,141 @@
+# RQL cheat-sheet
+
+Dense syntax reference. Method surface: `rql-functions.md`. Concepts: `rql-reference.md`. Version-correct details: ravendb.net/docs.
+
+## Clause order
+```
+declare <fn>
+from <source> [as alias]
+[ group by <fields> ]
+[ where <predicate> ]
+[ order by <field> [as <type>] [asc|desc] ]
+[ load <ref> as x ]
+[ filter <predicate> ]
+[ select <projection> ]
+[ include <related> ]
+[ limit <skip>, <take> | limit <take> offset <skip> ]
+[ filter_limit <n> ]
+```
+Each clause appears **at most once**. There is no second `where`: `where` runs against the index, before `load` resolves anything, so a condition on a loaded document goes in `filter`, not in another `where`.
+
+Comments: `// line`, `/* block */`. Strings: `'…'` or `"…"`. Literals: `true false null`, numbers. Params: `$name`. Quote names with special chars: `from "Order Lines"`.
+
+## from
+```
+from Users                     # collection
+from "Order Lines"             # quoted name
+from @all_docs                 # every document
+from index 'Orders/Totals'     # named static index
+from Users as u                # alias (needed for load / JS projections)
+```
+
+## where
+```
+where Age > 30 and IsActive = true          # = == , != <>, < <= > >=
+where Address.City = 'Albuquerque'          # nested path via dot
+where Age between 18 and 65
+where Country in ('US','UK')                 # any listed value
+where Lines[].Sku all in ('A','B')           # array field: all listed present
+where startsWith(Name,'Jo')  where endsWith(Email,'@acme.com')
+where exists(MiddleName)                      # anchor optional fields
+where regex(Sku,'^A-\d+$')
+where search(Bio,'raven database')            # full-text; see rql-fulltext.md
+where id() = 'users/1-A'
+where boost(Name = 'Bob', 10)
+```
+`not` cannot START a where clause — follow an expression: `exists(X) and not X in (…)`. Full method list: `rql-functions.md`.
+
+`id()` is asymmetric across clauses. In `where` it takes an alias or nothing, both fine. In `select` it is **always argument-less** and always returns the id of the *source* document: `select id(d)` and `select id(a)` both fail with `id(doc) must be called with an object argument`, whether the alias came from `from … as d` or from `load … as a`.
+
+A **loaded** document's id cannot be projected at all. Use the field you loaded through, which already holds it: after `load AccountId as a`, the id is `AccountId`, not `id(a)`. Do not reach for `a.Id`: it parses and returns 200 with the field silently missing from the results.
+
+## order by
+```
+order by Age                     # default asc
+order by Amount as double desc   # types: string | long | double | alphaNumeric
+order by UnitsInStock as long desc, score(), Name   # chained (Corax: max 16)
+order by score()  |  random()  |  random(1234)       # relevance / random / seeded
+order by spatial.distance(...)                        # see rql-spatial.md
+order by custom(Field,'MySorter')                     # Lucene engine only
+```
+
+## select (projection) — applied last, results not session-tracked
+```
+select Name, Address.City as City         # fields + aliases
+select id() as Id                         # ALWAYS argument-less; the SOURCE doc's id
+select AccountId                          # a loaded doc's id: the field you loaded through
+select distinct Country
+select { Full: x.FirstName + ' ' + x.LastName,
+         Total: x.Lines.map(l => l.Price*l.Qty).reduce((a,b)=>a+b,0) }   # JS object
+select { Meta: getMetadata(x) }            # metadata access
+```
+- `include` after `select` is resolved on the projected result: `select DealName, AccountId include AccountId` includes the accounts, `select DealName include AccountId` silently includes nothing. Project the field the include walks, or do not project.
+
+## group by / aggregation
+
+**`group by` goes before `where`, the reverse of SQL.** Write `from Deals group by Stage where Stage = 'Closed Won'`. The SQL order is a parse error that does not name the fix: `Expected end of query but got: group`. That `where` may only reference the group key; any other condition, including one on an aggregate (`where count() = 3`), fails with `Field '...' is neither an aggregation operation nor part of the group by key` (the Python client shows only the status 500). To count distinct values under a filter on another field, `from Deals where Stage = 'Closed Won' select distinct AccountId` and count the rows; to filter groups by an aggregate, fetch all groups (`select key(), count()`) and filter client-side, or use a map-reduce index.
+
+```
+from Orders
+group by ShipTo.City
+select ShipTo.City as City, count() as N, sum(Amount) as Total
+```
+Dynamic `group by` supports **only `count()` and `sum()`** (avg/min/max error — use a facet, map-reduce index, or JS projection). `group by array(Tags)` keys on whole array; `key()` returns the group key. Sort aggregates: `order by count() as long`. Aggregation auto-creates an `Auto/…` index.
+
+## include / load (avoid N+1)
+```
+load o.CustomerId as c select o.Id, c.Name
+include CustomerId, Lines[].ProductId       # related docs, one round-trip
+include counters(o,'Views')
+include timeseries('HeartRate', $from, $to)
+include revisions('2026-02-23T07:40:54Z')
+```
+
+## filter (post-index scan)
+`filter <predicate>` runs AFTER the index query, scanning retrieved results server-side, for exact checks the index can't answer. `where` is the primary filter. Cap the scan with `filter_limit <n>`, which goes **last in the query**: `filter … select … filter_limit 2000` parses, `filter … filter_limit 2000 select …` does not.
+
+`TotalResults` is unusable on a filtered query: on an index query it reports the pre-filter index total; on a dynamic query it reports only the filtered rows found in the window scanned so far, so with `limit 5` it is 5 whatever the real total. There is no cheap total under `filter`; count the rows of a full (or `filter_limit`-bounded) result.
+
+## paging
+```
+limit 25            # take 25
+limit 50, 25        # skip 50, take 25
+limit 25 offset 50  # take 25, skip 50
+```
+
+## Coming from SQL
+
+RQL reads like SQL and then diverges. These have no RQL equivalent; most fail with a parse error that does not name the replacement.
+
+| SQL | RQL |
+|---|---|
+| `select *` | omit `select` entirely (`select *` is also accepted) |
+| `count(*)` | `count()`, and only inside a `group by` |
+| `where` before `group by` | reversed: `group by` comes **first**, `from Deals group by Stage where Stage = 'Closed Won'`. The SQL order fails with `Expected end of query but got: group` |
+| `sum(x)` on its own | needs `group by`, a map-reduce index, or a facet |
+| `like '%x%'` | `startsWith` / `endsWith`, or `search()` on an analyzed field |
+| `is null` / `is not null` | `where x = null` / `where exists(x)` |
+| `join` | `load` (projection) or `include` (one round-trip, no join) |
+| `update t set c = v` | `from t where ... update { ... }`, a write, on a different endpoint |
+
+`group by` works on a collection, never on a named index: `from index 'X' group by …` is rejected outright, because an index that aggregates has to already be map-reduce. Counting has four routes and picking the wrong one fails silently. A plain index or collection query: `limit 0` and read `TotalResults`. A `group by`: `count()`. **A query with `filter`: count the rows in `Results`.** On a filtered query `limit 0` still reports the pre-filter match count and returns no rows to notice it by, so the documented `limit 0` route gives the wrong number without erroring. A facet: the bucket already carries `Count`, so read it. `select count()` is rejected everywhere outside `group by`, **including inside `facet(...)`**, where adding it turns a working aggregate into an error. A `select distinct` query: count the rows; `TotalResults` is the count before deduplication (8 distinct stages, `TotalResults` 1200).
+
+To aggregate over a named index, use a facet. The aggregates are **arguments to `facet(...)`, not a block**:
+```
+from index 'Deals/ByAccount' where Stage = 'Closed Won' select facet(Stage, sum(Amount), avg(Amount))
+```
+`select facet() { sum(Amount) }` does not parse, and a bare `select sum(Amount)` is rejected as `sum may only be used in group by queries`. Buckets come back as lowercased index terms. Options and range facets: `rql-facets.md`.
+
+Running that RQL **through a client** needs the aggregation entry point, not the normal result path: `ExecuteAggregation()` in .NET, `executeAggregation()` in Node, `execute_aggregation()` in Python. Calling the ordinary one fails: the server answers `Raw query with aggregation by facet should be called by executeAggregation method`, and in .NET it does not even compile, because `IRawDocumentQuery<T>` has no `ToFacets`.
+
+Case runs the opposite way to most SQL. Field names are case-sensitive, so `type` against an index that stored `Type` is a hard error, while values are not, so `where Stage = 'closed won'` matches `'Closed Won'`.
+
+Two more that return wrong rows rather than failing: quoting a number makes the comparison lexical, so `where Amount > '10000'` matches almost everything; and `=` against a field the index stored as analyzed (`Indexing: Search`) matches single tokens, not the whole string, so `where Name = 'Acme Data Group'` finds nothing while `search(Name, 'Acme Data Group')` ORs the terms and floods. `diagnostics.md` has the `debug=entries` call that tells the two apart.
+
+## gotchas (these cause errors, not just bad results)
+- **Clause order is fixed:** `from → group by → where → order by → load → filter → select → include → limit → filter_limit`. `order by` **before** `load` and `select`, never after.
+- **`facet(...)` and `morelikethis(...)` need a static index** — `from index 'Name' select facet(...)`, never `from Collection`. `suggest()` and `highlight()` also work on dynamic queries (highlighting not with a dynamic `group by`).
+- Numeric/date `order by` needs a cast (`as double`/`as long`), else lexical order.
+
+## Next
+Concepts (dynamic vs index, staleness): `rql-reference.md`. Exact signatures for every method: `rql-functions.md`. One file per area — full-text, spatial, time series, facets, suggestions/MLT/vector — routed from `SKILL.md`. Official docs at ravendb.net/docs are the last resort.

--- a/static/skills/ravendb/references/rql-facets.md
+++ b/static/skills/ravendb/references/rql-facets.md
@@ -1,0 +1,65 @@
+# RQL — faceted (aggregated) search
+
+Bucketed counts/aggregations over indexed fields — the efficient way to summarize/navigate a large result set, and how to get `avg`/`min`/`max` over a collection (which dynamic `group by` cannot). Requires a **static index** on the faceted fields. Version-correct details: ravendb.net/docs.
+
+## Value facet
+```
+from index 'Cameras/ByFeatures'
+select facet(Brand) as 'Camera Brand'
+```
+Returns each distinct value of `Brand` with a document count.
+
+Facet values come back as **index terms, not stored values**: with the default indexing a string field is lowercased, so `facet(Stage)` returns `closed won`, not `Closed Won`. Map back to the original casing before displaying them.
+
+## Range facet
+```
+from index 'Cameras/ByFeatures'
+select facet(
+  Price < 200.0,
+  Price >= 200.0 and Price < 400.0,
+  Price >= 400.0 and Price < 600.0,
+  Price >= 600.0)
+```
+
+## Aggregations inside a facet
+`sum avg min max` per bucket. Every bucket already reports its own `Count`, so never pass `count()` as a facet argument: it is rejected with `count may only be used in group by queries` and takes the whole query down with it.
+```
+from index 'Cameras/ByFeatures'
+select facet(Brand,
+             sum(UnitsInStock),
+             avg(Price),
+             min(Price),
+             max(MegaPixels),
+             max(MaxFocalLength))
+```
+Range facet + aggregations, parameterized:
+```
+from index 'Cameras/ByFeatures'
+select facet(Price < $p0,
+             Price >= $p1 and Price < $p2,
+             sum(UnitsInStock), avg(Price), min(Price), max(MegaPixels))
+{ "p0": 200.0, "p1": 200.0, "p2": 400.0 }
+```
+
+## Options
+Pass a JSON parameter to a value facet:
+```
+from index 'Cameras/ByFeatures'
+select facet(Brand, $options)
+{ "options": { "PageSize": 3, "TermSortMode": "CountDesc" } }
+```
+| Option | Values |
+|---|---|
+| `PageSize` | int — cap the number of buckets returned |
+| `TermSortMode` | `ValueAsc` · `ValueDesc` · `CountAsc` · `CountDesc` |
+
+## From a stored FacetSetup document
+Reuse a `FacetSetup` document instead of inlining facets:
+```
+from index 'Cameras/ByFeatures'
+select facet(id('customFacetSetupId'))
+```
+
+## Notes & gotchas
+- Facets query a **static index**, not a collection — confirm the index exists (Studio or `GET /databases/<db>/indexes`) first.
+- Use facets for navigation/summary UIs and for avg/min/max over a collection; use dynamic `group by` (`rql-cheatsheet.md`) only for ad-hoc `count`/`sum`.

--- a/static/skills/ravendb/references/rql-fulltext.md
+++ b/static/skills/ravendb/references/rql-fulltext.md
@@ -1,0 +1,75 @@
+# RQL — full-text search
+
+Tokenized text search over analyzed fields. Case-insensitive with the default analyzer. Dynamic queries auto-create a full-text auto-index; for heavy or custom-analyzer use, define a static index and query it with `from index '…'`. Version-correct details: ravendb.net/docs.
+
+## search(field, terms [, and|or])
+```
+from Companies where search(Notes, 'University Sales Japanese')      # terms default to OR
+from Companies where search(Notes, 'College German', and)           # require ALL terms
+```
+- Third arg sets the operator **between the terms** in this one call (`or` default, or `and`).
+- The operand is an analyzed field; `search` tokenizes both the field value and the query string. This is different from `=`/`startsWith`, which match the raw (non-analyzed) value.
+- The mismatch is silent in both directions. `search()` against a static-index field that was not stored with `Indexing: Search` returns zero rows, and `=` against one that was matches single tokens instead of the whole string. Neither raises. `GET /databases/{db}/indexes?name=<index>` reports the `Indexing` mode per field.
+
+### Combining multiple search() calls
+Join separate `search()` calls with an explicit `or`/`and` (raw RQL requires the operator; only the client API defaults to OR):
+```
+from Companies where search(Address.Country,'France') or search(Name,'Markets')
+from Employees where search(Notes,'French') and (exists(Title) and not search(Title,'Manager'))
+```
+
+### Exact phrase (quotes inside the term string)
+```
+where search(Notes,'"raven black"')   # the two words adjacent, in this order
+```
+Double-quote the terms to match them as a phrase instead of independently. Word order is part of the match — with the same data, `'"raven black"'` and `'raven black'` both hit 52 documents while `'"black raven"'` hits 0. Unquoted terms default to OR, so a bare two-word string is *not* a phrase search.
+
+### Wildcards (inside the term string)
+```
+where search(Notes,'art*')     # prefix match
+where search(Notes,'*logy')    # postfix match — triggers a FULL INDEX SCAN (avoid on hot paths)
+where search(Notes,'*mark*')   # contains — also scan-heavy
+```
+
+## Relevance scoring
+```
+order by score()                              # sort best matches first (order by only — score() is NOT valid in select)
+```
+The score value itself lives in each result's `@metadata` under `@index-score` (project it with `select { Meta: getMetadata(x) }`).
+
+### boost(predicate, factor)
+Multiply the relevance contribution of a clause; results auto-order by score.
+```
+from Companies
+where boost(startsWith(Name,'O'), 10)
+   or boost(startsWith(Name,'P'), 50)
+   or boost(endsWith(Name,'OP'), 90)
+```
+
+## Approximate matching — Lucene-backed index only
+```
+where fuzzy(Name = 'Bob', 0.7)                      # edit-distance match, factor 0.0..1.0 (closer to 1 = stricter)
+where proximity(search(Bio,'raven database'), 3)    # the searched terms within 3 words of each other
+```
+
+## exact(predicate) — bypass the analyzer
+Force case-sensitive, non-analyzed matching:
+```
+from Employees where exact(FirstName == 'Robert')
+from Orders    where exact(Lines.ProductName == 'Teatime Chocolate Biscuits')
+```
+
+## lucene(field, 'query') — raw Lucene (Lucene engine only)
+```
+where lucene(Name, 'Jo* AND -Johnson')
+```
+
+## Notes & gotchas
+- **Engine matters, and it is decided per index.** `fuzzy()`, `proximity()` and `lucene()` run only on a
+  Lucene-backed index. On Corax (the default for new databases since 6.0) each is rejected outright with
+  `InvalidQueryException: Method 'Fuzzy' is not supported.` — a hard failure, not degraded behaviour. One database can
+  hold indexes of both engines, so check the index that will serve the query: `GET /databases/<db>/indexes/stats`
+  reports `SearchEngineType` per index. Analyzer and wildcard behaviour also differs between the two.
+- Postfix/contains wildcards force a full scan; prefer prefix (`term*`) or a purpose-built static index.
+- `search` ≠ `startsWith`/`=`: use `search` for analyzed text relevance, the others for exact/prefix on raw values.
+- For "did you mean" and similar-document retrieval see `rql-advanced.md` (suggestions, more-like-this).

--- a/static/skills/ravendb/references/rql-functions.md
+++ b/static/skills/ravendb/references/rql-functions.md
@@ -1,0 +1,82 @@
+# RQL — complete function/method reference
+
+Authoritative list of RQL methods the server's parser recognizes. Names are case-insensitive. For prose and version deltas fetch ravendb.net/docs; for focused syntax see the topic resources linked below.
+
+## Operators
+| Kind | Operators |
+|---|---|
+| Comparison | `=` `==` · `!=` `<>` · `<` `<=` `>` `>=` |
+| Logical | `and` · `or` · `not` (cannot start a `where`) · grouping `( )` |
+| Range | `field between x and y` (inclusive) |
+| Set | `field in (a,b,…)` (any) · `field all in (a,b,…)` (array field contains every listed value) |
+| Array/path | `Address.City` (nested) · `Lines[].Sku` (array element) |
+
+## Filtering / where methods
+| Method | Purpose | Example |
+|---|---|---|
+| `id()` | The document id field. `where` accepts an alias argument; `select` never does and always returns the source document's id, so `select id(d)` and `select id(a)` both fail with `id(doc) must be called with an object argument`. A loaded document's id is not projectable: use the field you loaded through | `where id() = 'users/1-A'` · `where id(d) = 'users/1-A'` · `select id() as Id` |
+| `startsWith(f,'x')` | Prefix match (index-efficient) | `where startsWith(Name,'Jo')` |
+| `endsWith(f,'x')` | Suffix match (full scan) | `where endsWith(Email,'@acme.com')` |
+| `exists(f)` | Field is present | `where exists(MiddleName)` |
+| `regex(f,'pat')` | Regex match | `where regex(Sku,'^A-\\d+$')` |
+| `search(f,'terms'[,and])` | Full-text (see `rql-fulltext.md`) | `where search(Bio,'raven db')` |
+| `exact(expr)` | Case-sensitive, non-analyzed | `where exact(Name == 'Bob')` |
+| `boost(expr,n)` | Weight for relevance | `where boost(Name='Bob',10)` |
+| `lucene(f,'q')` | Raw Lucene (Lucene engine) | `where lucene(Name,'Jo*')` |
+| `fuzzy(expr,f)` | Fuzzy, factor 0..1 | `where fuzzy(Name='Bob',0.7)` |
+| `proximity(search,n)` | Terms within n words | `where proximity(search(Bio,'a b'),3)` |
+| `intersect(a,b,…)` | Subquery intersection (meaningful on fanout static indexes; on a plain dynamic query it's just `and`) | `where intersect(A=1,B=2)` |
+| `cmpxchg('key')` | Compare-exchange value ref | `where Ref = cmpxchg('email/a@b.com')` |
+
+## Aggregation
+Dynamic `group by` supports **only** `count()` and `sum()` — `avg`/`min`/`max` error in a dynamic group-by select.
+| Method | Where usable |
+|---|---|
+| `count()` | dynamic `group by`, facets, time series |
+| `sum(f)` | dynamic `group by`, facets, time series |
+| `avg(f)`, `min(f)`, `max(f)` | facets, time series, map-reduce indexes, JS projections — NOT dynamic group-by |
+| `key()` | the group key in a `group by` select |
+| `array(f)` | group on whole array: `group by array(Tags)` |
+
+For avg/min/max over a collection use a facet (`rql-facets.md`), a static map-reduce index, or a JS `select` projection.
+
+## Ordering functions (see `rql-cheatsheet.md`)
+`order by score()` (relevance) · `random()` / `random(seed)` · `spatial.distance(...)` · `custom(f,'Sorter')` (Lucene only). Casts: `as string | long | double | alphaNumeric`.
+
+## Projection / include extensions
+| Method | Purpose |
+|---|---|
+| `highlight(f,frag,count[,opts])` | Highlighted fragments (see `rql-advanced.md`) |
+| `explanations()` | Per-result scoring explanation |
+| `timings()` | Server-side timing breakdown |
+| `counters(name?)` | Include counter values |
+| `revisions(...)` | Include document revisions |
+| `timeseries(...)` | Include/project time series (see `rql-timeseries.md`) |
+
+## Spatial (see `rql-spatial.md`)
+`spatial.point(lat,lng)`, `spatial.circle(r,lat,lng[,units])`, `spatial.wkt('…')`,
+`spatial.within|contains|intersects|disjoint(field,shape)`, `spatial.distance(field,point[,roundFactor])` (order by; units come from the shape/index config, default kilometers). Circle units: `kilometers` (default) | `miles`.
+
+## Relevance / similarity / vector (see `rql-advanced.md`)
+`moreLikeThis(seed,'{opts}')` · `suggest(f,term,'{opts}')` · `vector.search(field|embedding.*, query[,minSim][,candidates])` (7.0+).
+
+## Time series helpers
+`first <n> <unit>` / `last <n> <unit>` — earliest/most-recent window; range **clauses** right after `from` inside a `timeseries(...)` block (not functions, mutually exclusive with `between`). Aggregations: `min max sum avg first last count percentile(n) stddev slope`. Units: `ms|second|minute|hour|day|month|quarter|year`.
+
+## Worked examples
+```
+# filter + project + page
+from Orders where Freight > 500 and ShippedAt > '1998-01-01'
+order by Freight as double desc
+select Company, Freight limit 0, 25
+
+# aggregate pipeline value by stage
+from Deals group by Stage select Stage, count() as N, sum(Amount) as Total
+
+# join related doc into projection
+from Orders as o load o.Company as c select { Company: c.Name, Shipped: o.ShippedAt }
+```
+
+## Version notes
+- `vector.search(...)` / `embedding.*` require server 7.0+.
+- Engine matters: Lucene vs Corax differ on `lucene()`, order-by chaining (Corax ≤16), and analyzer behavior.

--- a/static/skills/ravendb/references/rql-reference.md
+++ b/static/skills/ravendb/references/rql-reference.md
@@ -1,0 +1,52 @@
+# RQL reference — concepts
+
+How querying works across supported versions. Syntax: `rql-cheatsheet.md`; every method: `rql-functions.md`; version-correct details: ravendb.net/docs.
+
+## Query anatomy
+Full clause order:
+```
+declare <fn>  from <source> [as alias]  [group by …]  where …  order by …  [load …]  [filter …]  [select …]  [include …]  [limit …]
+```
+Every query executes against an **index**. The client query builders (LINQ and `DocumentQuery` in .NET, the query API in Node and Python) compile to RQL; every client also has a raw-query call that sends RQL directly — see your language's `client.md`.
+
+## Dynamic vs index queries
+- **Dynamic** — `from Collection where …`: the server auto-creates/reuses an `Auto/…` index. First run of a new field combination may build the index (watch `IsStale`).
+- **Index** — `from index 'Name' …`: queries a named static index directly. Use for map/reduce, computed/stored fields, full-text with a custom analyzer, facets, spatial, more-like-this.
+
+## Auto-indexes
+- Filtering, sorting, and aggregation on new field combinations create/extend auto-indexes; aggregations produce `Auto/<Coll>/By…ReducedBy…`.
+- Auto-indexes merge over time — a feature, not a leak. A one-off exotic query still pays the build cost.
+
+## Staleness
+- Indexing is asynchronous. Results carry `IsStale`; `true` means the index hasn't caught up to the latest writes.
+- `IndexName` in the result tells you which index (auto or static) served the query.
+
+## Projections
+- `select f, …` returns only those fields (smaller payloads); applied **last**, after filter/sort/paging.
+- JS object projections `select { … }` and `declare function` run server-side JS: `.map/.filter/.reduce/.length`, string `.substr`, `Date`/`Date.parse`, `getMetadata(doc)`.
+- Projected results are **not** session-tracked (read shapes, not entities).
+- RQL has no scalar date/math operators in `where`; do scalar transforms in projections. To *filter or sort* on a derived value, compute it in a static index map (`DiscountedPrice = p.Price * 0.9`) and query that index — a projection is evaluated after filtering, so it cannot feed a `where`.
+
+## Includes vs load (avoid N+1)
+- `load o.Ref as x` — resolves a referenced id for use inside `select`.
+- `include Ref` / `include Lines[].ProductId` — side-loads related documents in one round-trip; a later `Load()` of those ids hits the session cache. Also `include counters()`, `timeseries()`, `revisions()`, cmpxchg. Streaming queries do not support includes.
+
+## Parameters
+Prefer `$p` params over string interpolation: `where Name = $name`. Safer and lets the server cache the query plan. Values follow the query as a JSON object.
+
+## Paging
+`limit <take>` · `limit <skip>,<take>` · `limit <take> offset <skip>` · `offset <skip>`.
+
+## Common gotchas
+- Strings use single quotes; quote names with special chars (`from "Order Lines"`). Comments: `// line`, `/* block */`.
+- Numeric/date ordering needs a cast: `order by Amount as double` (lexical otherwise).
+- `search()` needs an analyzed field — not `startsWith`/`=`.
+- `in` matches any; `all in` requires every array element to match.
+- Dynamic `group by` supports only `count()`/`sum()` — avg/min/max need a facet, map-reduce index, or JS projection.
+- `not` cannot start a `where`; anchor optional fields with `exists(field)`.
+- Engine matters: Corax caps `order by` at 16 clauses; custom sorters are Lucene-only.
+
+## Discovery loop (write good queries)
+1. `from <Coll> limit 1` → learn the real field names/shapes; never guess casing.
+2. List existing static indexes (Studio, or `GET /databases/<db>/indexes`) — query them directly instead of forcing a new auto-index.
+3. Build the real query; page with `limit`/`offset`; pass values as `$params`.

--- a/static/skills/ravendb/references/rql-spatial.md
+++ b/static/skills/ravendb/references/rql-spatial.md
@@ -1,0 +1,42 @@
+# RQL — spatial
+
+Geospatial filtering and distance sorting over point/shape fields. Dynamic spatial queries auto-create a spatial auto-index; for heavy use define a static spatial index and query `from index '…'`. Version-correct details: ravendb.net/docs.
+
+## Shape & point constructors
+| Constructor | Meaning |
+|---|---|
+| `spatial.point(lat, lng)` | a point — argument order is **latitude, longitude** |
+| `spatial.circle(radius, lat, lng [, units])` | a circle; `units` = `kilometers` (default) or `miles` |
+| `spatial.wkt('POLYGON((…))')` | any shape from Well-Known Text |
+
+## Relation predicates (WHERE)
+`spatial.within(field, shape)` · `spatial.contains(field, shape)` · `spatial.intersects(field, shape)` · `spatial.disjoint(field, shape)`
+
+```
+# within a radius
+from Restaurants
+where spatial.within(spatial.point(Latitude, Longitude),
+                     spatial.circle(5, 40.7128, -74.0060))          # 5 km around the point
+
+# within a radius in miles
+where spatial.within(spatial.point(Latitude, Longitude),
+                     spatial.circle(5, 40.7128, -74.0060, 'miles'))
+
+# within an arbitrary polygon
+where spatial.within(spatial.point(Lat, Lng),
+                     spatial.wkt('POLYGON((-74.1 40.6, -73.9 40.6, -73.9 40.8, -74.1 40.8, -74.1 40.6))'))
+```
+
+## Sort by distance
+```
+from Events
+where spatial.within(Coordinates, spatial.circle(20, 47.623473, -122.3060097))
+order by spatial.distance(Coordinates, spatial.point(47.623473, -122.3060097))
+```
+- `spatial.distance(field, point [, roundFactor])` — ascending = closest first. The optional third argument ROUNDS the distance (grouping nearby results), it is NOT units — units follow the shape/index config, default **kilometers**. Combine with `asc`/`desc` and other sort keys.
+
+## Notes & gotchas
+- Argument order is **lat, lng** for `spatial.point`/`spatial.circle` — but **WKT is `x y` = lng lat** (see the POLYGON above). Swapping either is the classic mistake.
+- The distance value is in kilometers unless the filtering shape specified `'miles'`.
+- Point fields must be indexable as spatial; a dynamic query builds a spatial auto-index on first use. Define a static spatial index for repeated/large workloads.
+- `spatial.contains`/`disjoint`/`intersects` are documented primarily via the client on some versions — confirm exact behavior at ravendb.net/docs.

--- a/static/skills/ravendb/references/rql-timeseries.md
+++ b/static/skills/ravendb/references/rql-timeseries.md
@@ -1,0 +1,71 @@
+# RQL — time series
+
+Query time series attached to documents, inline or via a named declaration. Version-correct details: ravendb.net/docs.
+
+## Two entry forms
+Inline projection:
+```
+from Employees as e
+where Birthday < '1994-01-01'
+select timeseries( from HeartRates )
+```
+Named declaration (reusable, with range/aggregation):
+```
+declare timeseries ts(jogger) {
+  from jogger.HeartRates
+  between '2020-05-27T00:00:00Z' and '2020-06-23T00:00:00Z'
+  group by '1 hour'
+  select min(), max(), avg(), first(), last()
+}
+from Users as jogger
+where Age > 30
+select ts(jogger)
+```
+
+## Inner time-series query language
+| Part | Purpose |
+|---|---|
+| `from <SeriesName>` | the series source (`from doc.Series` inside a declared block) |
+| `between <ts> and <ts>` | ISO-8601 range; or params `$from` / `$to` |
+| `first <n> <unit>` / `last <n> <unit>` | earliest / most-recent window (e.g. `last 30 minutes`); mutually exclusive with `between` |
+| `where Values[n] <op> x` | filter by the n-th value in each entry |
+| `where Tag == '…'` | filter by entry tag |
+| `group by '<n> <unit>'` | time buckets; secondary group by tag: `group by '1 hour', tag` |
+| `select <aggregations>` | per-bucket aggregation |
+| `scale <double>` | multiply every value |
+| `offset <timespan>` | shift timestamps to a timezone (client-exposed on some versions) |
+
+Bucket units: `ms`/`milliseconds` · `second` · `minute` · `hour` · `day` · `month` · `quarter` · `year` (e.g. `'7 days'`, `'1 hour'`).
+
+## Aggregations
+`min() max() sum() avg() first() last() count() percentile(<n>) stddev() slope()`
+
+**The result field names are not the function names.** Each bucket comes back as `{From, To, Key, Count, Min, Max, Average, First, Last}` — `avg()` reads back as **`Average`**, and every aggregate is an **array**, one element per value column, so a single-value series is `Average[0]`. Indexing `Avg` or `avg` gives `undefined`/`None`, which looks like a broken query rather than a wrong field name.
+
+## Filtering documents by series or counter values
+
+`where` on the document cannot see time-series or counter values, and `include timeseries(...)` / `include counters(...)` only side-load them onto results already selected. To *filter or sort documents* by those values, index them: a time-series index (`AbstractTimeSeriesIndexCreationTask` and its JS/multi-map variants) maps over series entries, and `AbstractCountersIndexCreationTask` over counter values; both exist in the .NET, Node, and Python clients. Query that index like any static index.
+
+## Worked examples
+Filter by a value column, weekly max/min:
+```
+from Companies as c
+select timeseries(
+  from StockPrices
+  where Values[4] > 500000
+  group by '7 days'
+  select max(), min()
+)
+```
+Most-recent window with the `last` clause (a range clause right after `from` — NOT a function, NOT in `where`):
+```
+declare timeseries recent(u) {
+  from u.HeartRates
+  last 30 minutes                   # or: first 7 days
+  select avg(), max()
+}
+from Users as u select recent(u)
+```
+
+## Fetch one document's raw series
+When you want a single document's series (not a query projection), prefer `get_document_data` with `include=TimeSeries` + `timeSeriesName` (and optional `from`/`to`).

--- a/static/skills/ravendb/references/samples.md
+++ b/static/skills/ravendb/references/samples.md
@@ -1,0 +1,51 @@
+# Official sample code — what to read for what
+
+Use these when you need to see a feature **wired into a real application** — project layout, startup, background tasks, how the pieces talk. For syntax, stay in this pack; a sample shows shape, not exact signatures, and each is pinned to whatever version it was written against. Everything listed is a public `github.com/ravendb/…` repo.
+
+## Full applications, by the feature you care about
+
+| Repo | Stack | Showcases |
+|---|---|---|
+| `samples-library` | .NET 10 + Aspire, Svelte | The clearest starting point. `include` for related documents in one request, document **refresh** used as a timeout mechanism, Azure Queue **ETL** driven off `@refresh`, and **vector search** over similar books |
+| `samples-hr` | .NET 10 + Aspire, React | **AI agents** with tool calling and conversation management, **vector search** via `vector.search(embedding.text(...))`, **time series** used for rate limiting, attachments for signature images, counters for token accounting, expiration for session cleanup |
+| `samples-fit` | .NET 10 + Aspire, React | The densest feature set: a parent **AI agent with four sub-agents** plus streaming, **GenAI tasks** producing structured output deduped via `@ai-hashes`, **time series with rollups** (raw/hourly/daily/monthly, query picks the tier), **subscriptions** fanning events to followers, RabbitMQ **Queue ETL**, **OLAP ETL** to Parquet, **Changes API** for a push-driven ticker |
+| `samples-verity` | .NET 10 + Aspire, Svelte | Governance and document lifecycle: **GenAI tasks** over documents larger than the model's context window, **AI agents**, **remote attachments** in Azure/S3, **revisions** as an audit trail, **archival** and **expiration**, hub/sink replication, subscriptions driving a live CLI |
+| `samples-brain-slop` | .NET 10 + Aspire, Next.js | Small, focused **AI agent** app — free-form text interpreted into actions, plus GenAI for chat titles |
+| `samples-properties` | .NET 8 + ASP.NET Core, React, Telegram bot | The only sample with **spatial indexing** in an application, plus a **GenAI ETL** that turns an uploaded photo into a maintenance description, **AI agents** reached through a Telegram bot, **subscriptions** for push notifications, and time series for utility usage |
+| `samples-crypto-app` | .NET + Node.js Azure Functions, TS frontend | **Time series** end to end, with the *same* ingestion implemented in both the .NET and Node.js clients — the best side-by-side of the two APIs. Live at crypto.samples.ravendb.net, with database exports in the repo |
+
+`ravendb/docs` → `samples/` holds the maintained gallery page for each of these; check it before assuming a sample is current.
+
+**A sample's pinned version is not evidence of what is current.** Client versions in these repos are bumped in batches, and the upgrade PR is often still open — `samples-properties`, `samples-fit` and `samples-hugin` all have a 7.2.5 upgrade in flight. Take API shape from a sample, take the version gate from `install.md`.
+
+## Node.js / TypeScript
+
+| Repo | What it gives you |
+|---|---|
+| `samples-nextjs`, `samples-sveltekit` | The smallest honest examples of the Node client in a framework — a single store module (`src/db/store.ts` / `src/lib/store.ts`) plus CRUD and query routes. Both point at `live-test.ravendb.net` by default |
+| `template-cloudflare-worker` | `npm init cloudflare my-project https://github.com/ravendb/template-cloudflare-worker`. Read it before writing any Worker/edge code — the runtime has no Node `https` agent, so client-certificate auth uses a Cloudflare mTLS binding, not `authOptions` |
+
+## The definitive API examples: client repos
+
+When this pack does not cover a call, the client's own repository beats the docs for exactness — it is what actually ships.
+
+| Where | Why |
+|---|---|
+| `ravendb-nodejs-client` → `README.md` | ~85 KB, effectively the Node client manual, with a worked example per area |
+| `ravendb-nodejs-client` → `test/` | Grouped by area (`Documents/`, `ServerWide/`, `Issues/`). Search here for any method you are unsure about; the tests are executable proof of the signature |
+| `ravendb-python-client` → `ravendb/tests/` | The **only** Python examples of the AI surface: `ai_agent_tests/`, `gen_ai_tests/`, `embeddings_generation_tests/`. Also `session_tests/`, `operations_tests/` |
+| `ravendb/ravendb` → `test/` | The server's own test suite — the last word on behavior when a sample and the docs disagree |
+
+There is **no Python sample application**. For a Python app, take structure from `samples-library` and API usage from the Python client's tests.
+
+## Learning material and playgrounds
+
+| Resource | Use it for |
+|---|---|
+| demo.ravendb.net (source: `ravendb/demo`) | Runnable per-feature demos against your own database, each with a code walkthrough. Multiple languages, Northwind data |
+| live-test.ravendb.net | A free shared 7.2 server — no install, create a database and go. **Public and periodically wiped**: never put real or private data there |
+| `ravendb/bootcamp` | Four self-directed units, .NET, Northwind. Written for RavenDB 4.0, so the concepts hold and the API details do not |
+| `ravendb/book` | Source of *Inside RavenDB* — the reference for **why** the engine behaves as it does (storage, clustering, indexing internals). Also 4.0-era |
+| `ravendb/awesome-ravendb` | Community integrations: DI, health checks, Serilog sinks, ASP.NET Identity |
+| `samples-hugin` | RavenDB on **ARM / a Raspberry Pi**, serving full-text search over Stack Exchange dumps offline — the pointer for embedded or constrained deployments and for a large full-text dataset. Node client, pinned `^5.4.2` on `main` |
+| `samples-jvm`, `samples-php-laravel` | Only if the task is Java or PHP — outside this pack's three languages |

--- a/static/skills/ravendb/references/structure.md
+++ b/static/skills/ravendb/references/structure.md
@@ -1,0 +1,49 @@
+# Structuring a RavenDB codebase
+
+How the pieces wire together, regardless of language. Syntax for each call lives in your language's `client.md` / `indexes.md` — this file is only the shape.
+
+## One store, created once
+
+`DocumentStore` is the single entry point and is thread-safe. Construct and `initialize()` it **once per process**, hold it for the app's lifetime, and open every session from it. Never `new` a store per request/query — that leaks the request executor and connection pool.
+
+- C#: register the initialized store as a DI singleton and the session as scoped, so each request gets one unit of work — the wiring is in `dotnet/client.md`.
+- Node/Python: a module-level instance created at boot, imported where needed.
+- Conventions (id conventions, serializers, and Node's `findCollectionNameForObjectLiteral`) are frozen at initialization — set them before.
+
+## Startup does the provisioning, in order
+
+One startup path takes a bare server to a ready app, idempotently:
+
+1. Create + `initialize()` the store.
+2. Ensure the database exists (`CreateDatabase`, swallow "already exists").
+3. **Deploy every static index** — the client's bulk helper (`IndexCreation.CreateIndexes` / `createIndexes` / `create_indexes`) or each task's own execute call; exact form in your language's `indexes.md`. Idempotent: an unchanged definition is a no-op, a changed one rebuilds side-by-side. This is the only correct place to register indexes; do not deploy them lazily from a query path.
+4. Enable any server-side features the app relies on (Refresh, ETL, expiration, AI connection strings/agents).
+5. Seed idempotently — check for existing data and skip. Bulk insert assigns a fresh auto-id per call and never upserts, so a second run silently doubles the collection rather than overwriting it. Use explicit ids when a re-run must be a no-op.
+6. Wait once for indexes to be non-stale (poll `GetStatisticsOperation`) **after** deploy and seed — never before. A wait placed ahead of the deploy returns immediately (the index doesn't exist yet) and the first queries hit a stale index.
+
+A static index only exists for the queries that name it. Query a collection instead (`query(collection)`, raw `from Collection where …`) and the server quietly builds a *separate* auto-index while the static one sits unused; name an index that was never deployed and the query falls back to an auto-index or errors. Deploy it at startup **and** query it by name, or don't deploy it.
+
+## Indexes are defined code, in one place
+
+Every static index is a class (`AbstractIndexCreationTask` / `AbstractJavaScriptIndexCreationTask` / C#-syntax task), kept in a dedicated indexes module (`indexes.ts`, `app/indexes.py`, index classes in the assembly) — not inline string literals scattered across handlers. The class name *is* the index name (`_` → `/`). One definition, deployed once, queried by name everywhere.
+
+## Session per unit of work
+
+Open a session at the start of a unit of work (typically one request/operation), do the loads/queries/changes, save once, dispose. Sessions are cheap and short-lived — never share one across requests or hold one open for the process.
+
+- Scope it (`using` / `with` / try-finally) so it always disposes.
+- Reads and writes for one logical operation share the session so `include()` and the identity map avoid N+1 and repeat loads.
+- The 30-request-per-session cap is a smell detector: hitting it means the unit of work is too big, not that the cap should be raised.
+
+## Where query code lives
+
+Queries run inside the session, in the data-access/handler layer — targeting a **deployed static index** for anything beyond a trivial filter, a dynamic `query(collection)` only for simple ad-hoc equality/range. Keep RQL/query-builder code out of view/render code; a route/handler opens a session, queries, projects to the shape the caller needs, and returns it.
+
+## Smells
+
+- A `DocumentStore` constructed anywhere but startup, or more than one.
+- Index definitions as inline strings in a request handler, or created on first query instead of at startup.
+- `query(indexName: "X")` with no `X` class deployed anywhere — or the inverse, a deployed index no query ever names.
+- A session opened at module scope, reused across requests, or never disposed.
+- Query/RQL strings embedded in rendering/UI code.
+- A document collection whose fields disagree on casing/shape between the seeder and the write path (one writes `Qty`, the other `Quantity`) — the API must own one canonical wire shape and normalize at the boundary, not leak raw docs whose field names drift by origin.

--- a/static/skills/ravendb/references/testing.md
+++ b/static/skills/ravendb/references/testing.md
@@ -1,0 +1,35 @@
+# Testing code that talks to RavenDB
+
+Test against a **real server**. RavenDB's semantics that break code — id generation, change vectors, index staleness, cluster transactions, RQL — are exactly the parts a mock cannot reproduce, so a mocked `IDocumentStore`/`session` proves nothing. Write state-based tests: seed documents, run the code, assert on what the database holds.
+
+## Pick a route, then read your language's file
+
+| Route | What it is | Available in |
+|---|---|---|
+| **1 — test driver** | Boots an embedded server on first use and hands each test its own fresh database; teardown is automatic. The default choice where it exists. Needs a matching .NET runtime on the machine. | .NET, Python |
+| **2 — one server, database per test** | A server you run once for the suite (`install.md`), each test creating and hard-deleting its own database. No runtime dependency, and the only route for Node.js. | any language |
+| **3 — embedded server, driven directly** | The same embedded server as Route 1, but you own its lifetime, data directory, and settings. | .NET, Python |
+
+The call forms, the driver's own gotchas, and the runtime requirement in each language: `dotnet/testing.md`, `python/testing.md`, `nodejs/testing.md`. Read one.
+
+Whichever route: give every test its own database — the drivers name and delete one per test for you, and a hand-rolled Route 2 names it (`test-<suite>-<n>`) — a shared database makes tests order-dependent, which is the classic RavenDB test flake — hard-delete on teardown, and delete leftovers at suite start, because a crashed run leaves databases behind.
+
+## Staleness is the #1 test flake
+
+A query issued right after the session saves may legitimately see pre-write results: indexes update asynchronously and the response is flagged stale rather than delayed. Every write-then-query test must wait — the drivers expose a wait-for-indexing helper, otherwise the query's wait-for-non-stale-results call (per-language spelling in each `client.md`). A test that passes locally and fails in CI under load is almost always a missing wait, not a real bug.
+
+Loading a document by id needs no wait — document reads are immediately consistent. Only queries go through indexes.
+
+A test that must *prove* the stale window rather than avoid it cannot rely on losing the race: on a local server the index often catches up before the query. Pause indexing for the database, write, query (now deterministically stale), then resume and wait — `StopIndexingOperation` / `StartIndexingOperation`, sent as database-level maintenance operations, exist under that name in all three clients.
+
+## What to test, and what not to
+
+| Worth a test | Skip it |
+|---|---|
+| Static index output: seed the edge cases, assert the aggregate/projection | That the client can round-trip a document — that's the client's own test suite |
+| RQL that filters or projects non-trivially, including the paging boundary | Getter/setter mapping |
+| Cluster-transaction / compare-exchange uniqueness under a real conflict | Mocked session interactions (they assert your mock, not RavenDB) |
+| Subscription handlers — feed a batch, assert the effect | |
+| Optimistic-concurrency paths: two sessions, same document, expect a concurrency exception | |
+
+CI: run the server as a service container, set `RAVENDB_URL` from the environment, and keep it unsecured on localhost — certificates in a test harness buy nothing unless the certificate handling is what you are testing.

--- a/static/skills/ravendb/references/version-gate.md
+++ b/static/skills/ravendb/references/version-gate.md
@@ -1,0 +1,21 @@
+# Version & license gate
+
+A feature marked `(7.0+)`, `(client 7.2.2+)` or `(license)` needs three things to be true before you write code
+against it. Each is one cheap check, and doing them up front costs far less than a runtime failure.
+
+| Gate | Check |
+|---|---|
+| Server version | `GET /build/version` → `{"BuildVersion":…,"ProductVersion":"<major.minor>","FullVersion":"<full>"}`. Read it once and remember it. |
+| Client library version | The project's manifest, not the docs: `package.json` (`ravendb`), `.csproj`/`Directory.Packages.props` (`RavenDB.Client`), `requirements.txt`/`pyproject.toml` (`ravendb`). A new server with an old client still fails — `store.ai` needs client 7.2+, vector search 7.0+. To settle whether a specific type exists without compiling first, look in the installed package: `strings ~/.nuget/packages/ravendb.client/<v>/lib/<tfm>/Raven.Client.dll \| grep <TypeName>`, `grep -r <name> node_modules/ravendb/dist/`, or `grep -r` the installed Python package. |
+| License | `GET /license/status` → `Type` plus a boolean per feature (`HasAiAgent`, `HasEmbeddingsGeneration`, `HasGenAi`, `HasConcurrentDataSubscriptions`, `HasTimeSeriesRollupsAndRetention`, …). No client wrapper — hit the endpoint directly. |
+
+The two version marks fail differently: a server gap is a 404 or a missing endpoint, a client gap is a name that does
+not exist or an obsolete-API warning. An API can also move on the client alone while every supported server handles it.
+
+If any gate fails, say which one and what it would take to pass it, then ask. Do not silently substitute a different
+approach, and do not write code that needs a feature the deployment cannot run. `install.md` has the wording for both
+cases, plus the free Developer license flow.
+
+Feature support can also depend on the search engine backing the index that serves a query, not on the server version:
+one database can hold both Corax and Lucene indexes. `GET /databases/<db>/indexes/stats` reports `SearchEngineType`
+per index. See the engine note in `rql-fulltext.md`.

--- a/static/skills/ravendb/references/windows.md
+++ b/static/skills/ravendb/references/windows.md
@@ -1,0 +1,67 @@
+# RavenDB on Windows
+
+Everything in `install.md` and `install-native.md` applies; the commands there are POSIX. Use the forms below on Windows, and read the rules — several are not a matter of translating a command.
+
+## Probing for an existing server
+
+```powershell
+foreach ($u in 'http://localhost:8080','http://localhost:80') {
+  try { $r = Invoke-WebRequest "$u/setup/alive" -UseBasicParsing -TimeoutSec 3; "$u $($r.StatusCode)" }
+  catch { "$u unreachable" }
+}
+Get-Service RavenDB* -ErrorAction SilentlyContinue | Select-Object Name, Status
+Get-Process Raven.Server -ErrorAction SilentlyContinue | Select-Object Id, Path
+Get-NetTCPConnection -LocalPort 8080,80 -State Listen -ErrorAction SilentlyContinue |
+  ForEach-Object { "{0} ← {1}" -f $_.LocalPort, (Get-Process -Id $_.OwningProcess).ProcessName }
+docker ps -a --format '{{.Names}} {{.Image}} {{.Status}}' | Select-String raven
+```
+
+`Invoke-WebRequest` **throws** on any non-2xx, so a 404 from `/databases/<db>/stats` is an exception, not a status code — wrap probes in `try/catch` (PowerShell 7 also has `-SkipHttpErrorCheck`). In PowerShell 5.1 `curl` is an *alias* for `Invoke-WebRequest` and ignores POSIX curl flags; write `curl.exe` explicitly when you want the real thing (it ships with Windows 10 1803+).
+
+## Docker Desktop
+
+`ravendb/ravendb:latest` is a Linux image: it needs the WSL2 (or Hyper-V) backend, which is the default. Ports published from a Linux container reach `http://localhost:8080` on the Windows host normally, so the compose file in `install.md` works unchanged — write it with LF endings and let Docker mount named volumes rather than host paths (a bind-mounted Windows directory gives the container's non-root `ravendb` user permission errors on the data path).
+
+Windows containers are a different image family — `ravendb/ravendb:<version>-windows-ltsc2022` or `-windows-1809`. Only reach for those if the Docker daemon is in Windows-container mode; the Linux image cannot run there and the tag will look mysteriously absent.
+
+## Native install
+
+```powershell
+Invoke-WebRequest -Uri "https://hibernatingrhinos.com/downloads/RavenDB%20for%20Windows%20x64/latest" -OutFile ravendb.zip
+Expand-Archive -Path ravendb.zip -DestinationPath C:\RavenDB -Force ; Remove-Item ravendb.zip
+& 'C:\RavenDB\Server\Raven.Server.exe' --Setup.Mode=None --ServerUrl=http://127.0.0.1:8080 --ServerUrl.Tcp=tcp://127.0.0.1:38888
+```
+
+The zip holds a single top-level `RavenDB\` directory, so extracting to `C:\RavenDB` yields `C:\RavenDB\RavenDB\Server\...` unless you extract to the parent or move the contents up. Always quote paths in `&`-invocation; anything under `C:\Program Files` breaks unquoted. Background it with `Start-Process -FilePath … -ArgumentList … -WindowStyle Hidden`.
+
+## Run as a service
+
+There is **no** `Raven.Server.exe` service flag. Two supported routes, both requiring an **elevated** PowerShell:
+
+```powershell
+.\setup-as-service.ps1                                    # ships in the package; prompts for port, ACLs the dir, registers
+& '<package>\Server\rvn.exe' windows-service register --service-name RavenDB -- --Setup.Mode=None --ServerUrl=http://127.0.0.1:8080
+Start-Service RavenDB                                      # rvn windows-service start|stop also work
+Get-Service RavenDB
+```
+
+`rvn.exe` ships with the server binaries — look in the package's `Server\` directory. Default service name is `RavenDB`; `--service-user-name` / `--service-user-password` run it as a specific account, `--server-dir` points at a server directory other than the one holding `rvn.exe`, and arguments after `--` are passed through to the server. `rvn.exe windows-service unregister --service-name RavenDB` removes it.
+
+## WSL2
+
+- **Windows → WSL:** a server started inside WSL is reachable at `http://localhost:8080` from Windows (localhost forwarding is on by default).
+- **WSL → Windows:** `localhost` does **not** reach the Windows host. Use the host IP — `ip route show default | awk '{print $3}'` — or turn on mirrored networking (`networkingMode=mirrored` in `%UserProfile%\.wslconfig`, Windows 11 22H2+), after which `localhost` works both ways.
+- A server bound to `127.0.0.1` inside WSL is invisible to Windows regardless; bind `0.0.0.0` when it must be shared, and remember that widens `Security.UnsecuredAccessAllowed` beyond `Local` — only do it for a dev server on a trusted machine.
+- Writing a `.sh` helper from Windows or a Windows-mounted path produces CRLF line endings, and a `#!/bin/bash\r` shebang fails with a confusing "No such file or directory". Strip them: `sed -i 's/\r$//' <file>`.
+
+## Firewall
+
+Localhost needs nothing. Another machine reaching a **secured** server needs the port opened, from an elevated shell:
+
+```powershell
+New-NetFirewallRule -DisplayName "RavenDB" -Direction Inbound -Port 8080 -Protocol TCP -Action Allow
+```
+
+## Paths
+
+Native install: `DataDir` defaults to `Databases/{name}` **relative to the server directory**, so a database lands in `<package>\Server\Databases\<database-name>`, with settings at `<package>\Server\settings.json`. Pass `--DataDir=D:\RavenData` to move it — and do move it off the install directory before an upgrade replaces that tree. Docker (Linux image) uses `/var/lib/ravendb/data` and `/etc/ravendb` inside the container instead, as in `install.md`.


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-4091
https://issues.hibernatingrhinos.com/issue/RDoc-4100

### Additional description

Two commits, one per ticket.

**RDoc-4091** serves the agent skill from `static/skills/ravendb/` at `/skills/ravendb/`, verbatim, no plugin. Needs `md` in `staticAssetRegex` or every skill URL 404s.

**RDoc-4100** makes deploy phase 3 publish the edge function and the CSP. Both needed a manual step that fails silently when skipped: the site deploys green while the edge stays old. The CSP moves from an uncommitted JS generator to `scripts/lib/csp-policy.js`.

### Type of change

- [ ] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [ ] Content - guides
- [ ] Content - start pages/other
- [x] New docs feature (consider updating `/templates` or readme)
- [ ] Bug fix
- [ ] Optimization
- [ ] Other


### Changes in docs URLs

- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)
