### PR TITLE
RDoc-4099 [Quill documentation] Raven.Client => Raven Client API

### DIFF
--- a/quill/dashboard/my-apps.mdx
+++ b/quill/dashboard/my-apps.mdx
@@ -99,7 +99,7 @@ Hovering over a point shows the bucket's date; in the Day view, it also shows th
 5. **WRU**  
    **Write Request Unit** - a measure of write activity in each app's RavenDB database.
      * WRU includes writes made when Quill [mirrors](../overview.mdx#mirroring) changes from source databases, records conversations,  
-       and when applications write [directly with RavenDB.Client](../overview.mdx#working-with-quill-using-code).
+       and when applications write [directly with the RavenDB Client API](../overview.mdx#working-with-quill-using-code).
      * Write usage is reported every 15 minutes, so recent writes may not be included yet.
 
 <Admonition type="note" title="">

--- a/quill/dashboard/usage.mdx
+++ b/quill/dashboard/usage.mdx
@@ -72,7 +72,7 @@ Sources of write activity include:
 
 * Quill [mirroring](../overview.mdx#mirroring) changes from a source relational database to an app's RavenDB database.
 * Quill storing conversations in an app's RavenDB database.
-* Applications writing directly to an app database with [RavenDB.Client](../overview.mdx#working-with-quill-using-code).
+* Applications writing directly to an app database with [the RavenDB Client API](../overview.mdx#working-with-quill-using-code).
 * Quill writing to its own configuration storage, shown in the table as [@system](#usage-per-app).
 
 Usage is reported every 15 minutes, so recent write activity may not appear immediately.

--- a/quill/developer-access/overview.mdx
+++ b/quill/developer-access/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Developer Access: Overview"
 sidebar_label: "Overview"
-description: "How users and applications can access a Quill app through a channel and its assigned agent, or connect directly to the app's mirrored data with RavenDB.Client."
+description: "How users and applications can access a Quill app through a channel and its assigned agent, or connect directly to the app's mirrored data with the RavenDB Client API."
 sidebar_position: 1
 ---
 
@@ -20,8 +20,8 @@ import Panel from '@site/src/components/Panel';
     Quill processes the messages through the agent, its configured LLM, and the conversation system.  
     The agent can query the mirrored data when needed.
 
-  * **Direct data access with RavenDB.Client:**  
-    Your application uses `RavenDB.Client` to connect directly to the RavenDB database that contains the app's mirrored data
+  * **Direct data access with the RavenDB Client API:**  
+    Your application uses the RavenDB Client API to connect directly to the RavenDB database that contains the app's mirrored data
     and execute queries defined by your code, without going through a Quill agent, an LLM, or the conversation system.
 
 * The two methods are independent. An application can use both.
@@ -29,7 +29,7 @@ import Panel from '@site/src/components/Panel';
 * In this article:
   * [Choose an access method](#choose-an-access-method)
   * [Use a channel for conversations with an agent](#use-a-channel-for-conversations-with-an-agent)
-  * [Use RavenDB.Client to query mirrored data directly](#use-ravendbclient-to-query-mirrored-data-directly)
+  * [Use the RavenDB Client API to query mirrored data directly](#use-the-ravendb-client-api-to-query-mirrored-data-directly)
 
 </Admonition>
 
@@ -40,7 +40,7 @@ Choose an access method based on whether users need conversational answers or yo
 | Access method    | Use when                                                                  | How it works                                                                              | Uses an agent and LLM | Detailed documentation                                                        |
 | ---------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------------------- |
 | Channel          | Users should ask questions in natural language and receive agent replies. | Messages are routed to the assigned agent, which can query the mirrored data when needed. | Yes                   | Channels overview {/* TODO RDoc-4085: Link "Channels overview" once that article is added to the documentation tree. */}                                              |
-| `RavenDB.Client` | Application code needs to query or process the mirrored data directly.    | The application connects directly to and queries the app's mirrored RavenDB database.     | No                    | [Access the Mirrored Database with RavenDB.Client](ravendb-client-access.mdx) |
+| RavenDB Client API | Application code needs to query or process the mirrored data directly.    | The application connects directly to and queries the app's mirrored RavenDB database.     | No                    | [Access the Mirrored Database with the RavenDB Client API](ravendb-client-access.mdx) |
 
 </Panel>
 
@@ -52,7 +52,7 @@ Users send messages through the channel, and the agent's replies return through 
 When the agent handles a message, it can use the query tools defined in its configuration to query the app's mirrored data when needed. 
 The request goes through the assigned agent, the configured LLM, and Quill's conversation system.
 
-Unlike direct access with `RavenDB.Client`, neither the user nor your application defines the database query.  
+With a channel, neither the user nor your application defines the database query.  
 The agent decides whether to query the data and which of its configured query tools to use.
 
 **To integrate Quill chat into your own application or website, use a web widget channel.**  
@@ -65,9 +65,9 @@ For a comparison of all available channel types and their setup guides, see the 
 
 </Panel>
 
-<Panel heading="Use RavenDB.Client to query mirrored data directly">
+<Panel heading="Use the RavenDB Client API to query mirrored data directly">
 
-Use `RavenDB.Client` when your application code needs to query or process the app's mirrored documents directly, rather than receive an answer composed by a Quill agent.
+Use the RavenDB Client API when your application code needs to query or process the app's mirrored documents directly, rather than receive an answer composed by a Quill agent.
 Your code defines the queries and handles the results.
 
 Connect to the RavenDB server in the Quill deployment at `https://db.<domain>`,  
@@ -78,12 +78,12 @@ Authenticate with a **client certificate** generated on the dashboard's **Certif
 For a **User** certificate, its per-app permissions determine which app databases the application can access and whether it has **Read/Write** or **Admin** access. 
 The current dashboard does not offer a **Read-only** grant.
 
-Requests made with `RavenDB.Client` reach RavenDB directly.  
+Requests made with the RavenDB Client API reach RavenDB directly.  
 They do not pass through a Quill channel, agent, LLM, conversation system, or the Quill API.
 
 This connection reaches the app's **mirrored RavenDB database**, not the source relational database.  
 Changes made directly to the mirrored database are never written back to the source database.
 
-For the complete connection procedure and query examples, see [Access the Mirrored Database with RavenDB.Client](ravendb-client-access.mdx).
+For the complete connection procedure and query examples, see [Access the Mirrored Database with the RavenDB Client API](ravendb-client-access.mdx).
 
 </Panel>

--- a/quill/developer-access/ravendb-client-access.mdx
+++ b/quill/developer-access/ravendb-client-access.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Access the Mirrored Database with RavenDB.Client"
-sidebar_label: "RavenDB.Client Access"
-description: "How to connect an application directly to a Quill app's mirrored database with RavenDB.Client and a scoped client certificate."
+title: "Access the Mirrored Database with the RavenDB Client API"
+sidebar_label: "RavenDB Client API Access"
+description: "How to connect an application directly to a Quill app's mirrored database with the RavenDB Client API and a scoped client certificate."
 sidebar_position: 3
 ---
 
@@ -13,7 +13,7 @@ import Panel from '@site/src/components/Panel';
 * Quill mirrors selected data from your source relational database into a separate RavenDB database for each Quill app.  
   Quill agents use the mirrored data to compose answers to users' questions.    
     
-* Your application can also query the mirrored data directly in RavenDB with `RavenDB.Client`.      
+* Your application can also query the mirrored data directly in RavenDB with the RavenDB Client API.      
   These queries do not pass through a Quill agent, an LLM, any Quill channel, or the Quill API.
     
 * Direct access uses a client certificate generated on the dashboard's **Certificates** page.  
@@ -42,12 +42,12 @@ import Panel from '@site/src/components/Panel';
 
 <Panel heading="When to use direct access">
 
-Use `RavenDB.Client` when your application needs to query or process the mirrored documents directly,  
+Use the RavenDB Client API when your application needs to query or process the mirrored documents directly,  
 rather than receive an answer composed by a Quill agent.
 
 Typical examples include application search, reporting, scheduled processing, and queries whose exact shape is controlled by your code.
 
-With `RavenDB.Client`, your application accesses the **mirrored data in RavenDB**, not the source relational database:
+With the RavenDB Client API, your application accesses the **mirrored data in RavenDB**, not the source relational database:
 
   * The source relational database remains the source of truth.
   * Quill's CDC task applies source changes to the mirrored documents asynchronously,  
@@ -55,7 +55,7 @@ With `RavenDB.Client`, your application accesses the **mirrored data in RavenDB*
   * Querying the mirrored data does not add query load to the source database.
   * Changes made directly in RavenDB are not written back to the source database.
     
-`RavenDB.Client` connects to RavenDB through `https://db.<domain>` without passing through the Quill web application.  
+The RavenDB Client API connects to RavenDB through `https://db.<domain>` without passing through the Quill web application.  
 For details about this connection path and its TLS handling, see [Direct database access](../security-and-architecture/network-architecture.mdx#direct-database-access).
     
 </Panel>
@@ -101,7 +101,7 @@ Because that connection string can contain source database credentials, reserve 
 #### Protect the downloaded archive    
 
 * The downloaded archive contains a `.pfx`, a `.crt`, and a `.key` file.  
-  `RavenDB.Client` uses the `.pfx`.  
+  The RavenDB Client API uses the `.pfx`.  
     
 * The optional certificate password encrypts only the `.pfx`.  
   The `.key` contains the same private key in unencrypted PEM form, so protect the complete archive as a secret.
@@ -223,7 +223,7 @@ Applications targeting .NET 8 or earlier can load the certificate with `new X509
 `X509CertificateLoader` is the recommended API in .NET 9 and later.
 
 The explicit `collectionName` makes the query target the mapped collection exactly.
-Without it, RavenDB.Client derives the collection name from the .NET type—for example, `Query<Customer>()` targets `Customers` by default.
+Without it, the RavenDB Client API derives the collection name from the .NET type—for example, `Query<Customer>()` targets `Customers` by default.
 
 The `collectionName` argument applies only to this query.
 To override the collection convention throughout the application, configure `FindCollectionName` before calling `Initialize()`, which freezes the store conventions.
@@ -323,7 +323,7 @@ A **User** certificate with **Read** or **Read/Write** access can inspect the ta
 #### Do not modify the CDC task directly    
     
 Quill reads the task configuration from the app database.  
-Changes made in RavenDB Studio or through `RavenDB.Client` therefore affect the task used by the Quill app.
+Changes made in RavenDB Studio or through the RavenDB Client API therefore affect the task used by the Quill app.
 
 | Direct change                            | Effect |
 | ---------------------------------------- | ------ |
@@ -345,7 +345,7 @@ This prevents the application from changing either the mirrored documents or Qui
 
 #### Writes do not update the source database
 
-Changes made through `RavenDB.Client` affect only the app's RavenDB database.  
+Changes made through the RavenDB Client API affect only the app's RavenDB database.  
 They are never written back to the source relational database.
 
 Do not modify mirrored documents or documents used internally by Quill, including the CDC progress documents in the `@cdc-states` collection.    
@@ -381,7 +381,7 @@ Monitor the task's CDC health and errors rather than relying only on its enabled
 
 Use `https://db.<domain>` as the initial server URL.
 
-After connecting, RavenDB.Client reads the server topology.
+After connecting, the RavenDB Client API reads the server topology.
 RavenDB advertises its node as `https://a.<domain>`, so the client may send subsequent requests through that hostname.
 
 In a standard Quill deployment:
@@ -422,7 +422,7 @@ Document loads, queries, and the Changes API require no additional inbound Raven
 The Changes API uses WebSockets through the same HTTPS endpoint.
 
 The Quill container does not expose RavenDB's native TCP listener or publish a corresponding TCP hostname.
-RavenDB.Client features that open a native TCP connection - most notably data subscription workers - therefore cannot connect from outside the Quill container.
+RavenDB Client API features that require a native TCP connection, such as data subscription workers, are therefore unavailable to applications running outside the Quill container.
 
 </Panel>
 
@@ -431,7 +431,7 @@ RavenDB.Client features that open a native TCP connection - most notably data su
 A Quill deployment runs a single RavenDB node.
 The topology-discovered `a.<domain>` hostname provides another route to that same node, not a second node for failover.
 
-If the Quill deployment is unavailable, RavenDB.Client cannot switch to another RavenDB node.
+If the Quill deployment is unavailable, the RavenDB Client API cannot switch to another RavenDB node.
 
 If the Quill host moves to another IP address, update all Quill DNS records so that `db.<domain>`, `a.<domain>`,  
 and the other Quill hostnames resolve to the new address.
@@ -441,7 +441,7 @@ See [Moving your Quill to a new IP](../networking-and-dns.mdx#moving-your-quill-
 
 <Panel heading="Summary">
 
-* `RavenDB.Client` provides a direct path to the mirrored documents and can be used in addition to Quill agents and channels.
+* The RavenDB Client API provides a direct path to the mirrored documents and can be used in addition to Quill agents and channels.
     
 * Generate a **User** client certificate on the dashboard's Certificates page and grant it access only to the intended app.
   Prefer **Read** access when the application only queries data.
@@ -449,7 +449,7 @@ See [Moving your Quill to a new IP](../networking-and-dns.mdx#moving-your-quill-
 * Configure the `DocumentStore` with `https://db.<domain>`, the app database name, and the downloaded `.pfx` certificate.
     
 * Inspect the mapped collections, document structure, and attachments before defining application classes and queries.
-  Use the exact mapped collection name when it differs from RavenDB.Client's naming convention.
+  Use the exact mapped collection name when it differs from the RavenDB Client API's naming convention.
     
 * Treat both mirrored documents and documents used internally by Quill as read-only.
   Direct writes are not sent to the source database and can be overwritten by CDC or prevent the mirror from advancing.

--- a/quill/home.mdx
+++ b/quill/home.mdx
@@ -123,7 +123,7 @@ import CardWithIcon from "@site/src/components/Common/CardWithIcon";
         url="/quill/developer-access/embed-the-chat-widget"
     />
     <CardWithIcon
-        title="RavenDB.Client access"
+        title="RavenDB Client API access"
         icon="database-client-configuration"
         description="Connect an application directly to the mirrored database with a scoped client certificate."
         url="/quill/developer-access/ravendb-client-access"

--- a/quill/networking-and-dns.mdx
+++ b/quill/networking-and-dns.mdx
@@ -61,7 +61,7 @@ By default, all five resolve to the IP address provided during sign-up:
 | `api.<domain>`       | Programmatic access to the Quill API and health checks, without the dashboard UI.        |
 | `public.<domain>`    | Embedded chat pages, widget assets, chat requests, and public channel webhooks.          |
 | `db.<domain>`        | Direct RavenDB access for applications authenticated with a client certificate.          |
-| `a.<domain>`         | RavenDB's advertised node URL, which RavenDB.Client may receive through topology discovery. |
+| `a.<domain>`         | RavenDB's advertised node URL, which the RavenDB Client API may receive through topology discovery. |
 
 The first four hostnames expose Quill's customer-facing service surfaces.  
 `a.<domain>` identifies the RavenDB node rather than a separate Quill web surface.
@@ -100,7 +100,7 @@ As a result, communication between Quill and RavenDB remains on loopback without
 
 * It does not represent a separate dashboard, API, or chat surface.
 * Applications should use `https://db.<domain>` as their initial address for direct RavenDB access.
-* A RavenDB.Client that updates its topology may subsequently receive `https://a.<domain>` as the RavenDB node address.
+* An application using the RavenDB Client API with topology updates enabled may subsequently receive `https://a.<domain>` as the RavenDB node address.
 * DNS updates include `a.<domain>` together with the other four records.
 
 For more information about direct RavenDB connections and your Quill's network limitations,  

--- a/quill/security-and-architecture/network-architecture.mdx
+++ b/quill/security-and-architecture/network-architecture.mdx
@@ -129,7 +129,7 @@ In the examples below, `<domain>` represents this base domain.
 | `dashboard.acme.myquill.ai`      | Quill web application | The operator dashboard, the Quill API, and `/healthz` | Operators using a browser           |
 | `api.acme.myquill.ai`            | Quill web application | The Quill API and `/healthz`; no dashboard UI         | Scripts and monitoring tools        |
 | `public.acme.myquill.ai`         | Quill web application | Embedded chat pages, widget assets, and Slack webhooks | End users and Slack                 |
-| `db.acme.myquill.ai`             | RavenDB               | Direct RavenDB access over mutual TLS                 | Applications using `RavenDB.Client` |
+| `db.acme.myquill.ai`             | RavenDB               | Direct RavenDB access over mutual TLS                 | Applications using the RavenDB Client API |
 
 nginx restricts which web routes each hostname can expose:
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RDoc-4099/Quill-documentation-Raven.Client-Raven-Client-API

### Additional description
* The Quill docs should refer to the RavenDB Client API, not "RavenDB.Client".

### Type of change
- [x] Content - docs
- [ ] Content - cloud
- [ ] Content - Quill
- [ ] Content - guides
- [ ] Content - start pages/other
- [ ] New docs feature (consider updating `/templates` or readme) 
- [ ] Bug fix
- [ ] Optimization
- [ ] Other

### Changes in docs URLs
- [x] No changes in docs URLs
- [ ] Articles are restructured, URLs will change, mapping is required (update `/scripts/redirects.json` file, set `Documents Moved` PR label)

### Changes in UX/UI
- [x] No changes in UX/UI
- [ ] Changes in UX/UI (include screenshots and description)

